### PR TITLE
Fix: Transform obect - Work with array

### DIFF
--- a/packages/transform-to-vanilla/src/transform-keys/at-rules.ts
+++ b/packages/transform-to-vanilla/src/transform-keys/at-rules.ts
@@ -1,0 +1,42 @@
+export function atRuleKeyInfo(key: string) {
+  const spaceIndex = key.indexOf(" ");
+
+  const isRules = key.startsWith("@");
+  const isToplevelRules = isRules && spaceIndex !== -1;
+
+  return {
+    isRules,
+    isToplevelRules,
+    atRuleKey: isRules
+      ? isToplevelRules
+        ? key.substring(0, spaceIndex)
+        : key
+      : "",
+    atRuleNestedKey: isToplevelRules ? key.substring(spaceIndex + 1) : ""
+  };
+}
+
+// == Tests ====================================================================
+if (import.meta.vitest) {
+  const { describe, it, expect } = import.meta.vitest;
+
+  describe.concurrent("Toplevel atRule", () => {
+    it("Is Toplevel", () => {
+      const { isRules, isToplevelRules, atRuleKey, atRuleNestedKey } =
+        atRuleKeyInfo("@media screen and (min-width: 768px)");
+      expect(isRules).toBeTruthy();
+      expect(isToplevelRules).toBeTruthy();
+      expect(atRuleKey).toBe("@media");
+      expect(atRuleNestedKey).toBe("screen and (min-width: 768px)");
+    });
+
+    it("Nested atRule", () => {
+      const { isRules, isToplevelRules, atRuleKey, atRuleNestedKey } =
+        atRuleKeyInfo("@media");
+      expect(isRules).toBeTruthy();
+      expect(isToplevelRules).toBeFalsy();
+      expect(atRuleKey).toBe("@media");
+      expect(atRuleNestedKey).toBe("");
+    });
+  });
+}

--- a/packages/transform-to-vanilla/src/transform-keys/at-rules.ts
+++ b/packages/transform-to-vanilla/src/transform-keys/at-rules.ts
@@ -1,17 +1,15 @@
+export function isRuleKey(key: string) {
+  return key.startsWith("@");
+}
+
 export function atRuleKeyInfo(key: string) {
   const spaceIndex = key.indexOf(" ");
 
-  const isRules = key.startsWith("@");
-  const isToplevelRules = isRules && spaceIndex !== -1;
+  const isToplevelRules = spaceIndex !== -1;
 
   return {
-    isRules,
     isToplevelRules,
-    atRuleKey: isRules
-      ? isToplevelRules
-        ? key.substring(0, spaceIndex)
-        : key
-      : "",
+    atRuleKey: isToplevelRules ? key.substring(0, spaceIndex) : key,
     atRuleNestedKey: isToplevelRules ? key.substring(spaceIndex + 1) : ""
   };
 }
@@ -40,11 +38,18 @@ if (import.meta.vitest) {
   const { describe, it, expect } = import.meta.vitest;
 
   describe.concurrent("Toplevel atRule", () => {
+    it("Is AtRule", () => {
+      expect(isRuleKey("@media screen and (min-width: 768px)")).toBeTruthy();
+      expect(isRuleKey("@media")).toBeTruthy();
+
+      expect(isRuleKey("screen and (min-width: 768px)")).toBeFalsy();
+      expect(isRuleKey("_hover")).toBeFalsy();
+    });
+
     it("Is Toplevel", () => {
       expect(
         atRuleKeyInfo("@media screen and (min-width: 768px)")
       ).toStrictEqual({
-        isRules: true,
         isToplevelRules: true,
         atRuleKey: "@media",
         atRuleNestedKey: "screen and (min-width: 768px)"
@@ -53,7 +58,6 @@ if (import.meta.vitest) {
 
     it("Nested atRule", () => {
       expect(atRuleKeyInfo("@media")).toStrictEqual({
-        isRules: true,
         isToplevelRules: false,
         atRuleKey: "@media",
         atRuleNestedKey: ""

--- a/packages/transform-to-vanilla/src/transform-keys/at-rules.ts
+++ b/packages/transform-to-vanilla/src/transform-keys/at-rules.ts
@@ -16,27 +16,86 @@ export function atRuleKeyInfo(key: string) {
   };
 }
 
+export function anonymousKeyInfo(keyStr: string) {
+  const isAnimationName = isAnonymousSymbol("animationName", keyStr);
+  const isFontFamily = isAnonymousSymbol("fontFamily", keyStr);
+
+  return {
+    isAnimationName,
+    isFontFamily,
+    isAnonymousSymbol: isAnimationName || isFontFamily
+  };
+}
+
+function isAnonymousSymbol(anonymousKey: string, keyStr: string) {
+  return (
+    keyStr === anonymousKey ||
+    keyStr === `${anonymousKey}$` ||
+    keyStr === `${anonymousKey}_`
+  );
+}
+
 // == Tests ====================================================================
 if (import.meta.vitest) {
   const { describe, it, expect } = import.meta.vitest;
 
   describe.concurrent("Toplevel atRule", () => {
     it("Is Toplevel", () => {
-      const { isRules, isToplevelRules, atRuleKey, atRuleNestedKey } =
-        atRuleKeyInfo("@media screen and (min-width: 768px)");
-      expect(isRules).toBeTruthy();
-      expect(isToplevelRules).toBeTruthy();
-      expect(atRuleKey).toBe("@media");
-      expect(atRuleNestedKey).toBe("screen and (min-width: 768px)");
+      expect(
+        atRuleKeyInfo("@media screen and (min-width: 768px)")
+      ).toStrictEqual({
+        isRules: true,
+        isToplevelRules: true,
+        atRuleKey: "@media",
+        atRuleNestedKey: "screen and (min-width: 768px)"
+      });
     });
 
     it("Nested atRule", () => {
-      const { isRules, isToplevelRules, atRuleKey, atRuleNestedKey } =
-        atRuleKeyInfo("@media");
-      expect(isRules).toBeTruthy();
-      expect(isToplevelRules).toBeFalsy();
-      expect(atRuleKey).toBe("@media");
-      expect(atRuleNestedKey).toBe("");
+      expect(atRuleKeyInfo("@media")).toStrictEqual({
+        isRules: true,
+        isToplevelRules: false,
+        atRuleKey: "@media",
+        atRuleNestedKey: ""
+      });
+    });
+
+    it("Anonymous atRule", () => {
+      expect(anonymousKeyInfo("animationName")).toStrictEqual({
+        isAnimationName: true,
+        isFontFamily: false,
+        isAnonymousSymbol: true
+      });
+
+      expect(anonymousKeyInfo("animationName_")).toStrictEqual({
+        isAnimationName: true,
+        isFontFamily: false,
+        isAnonymousSymbol: true
+      });
+
+      expect(anonymousKeyInfo("animationName$")).toStrictEqual({
+        isAnimationName: true,
+        isFontFamily: false,
+        isAnonymousSymbol: true
+      });
+
+      expect(anonymousKeyInfo("fontFamily")).toStrictEqual({
+        isAnimationName: false,
+        isFontFamily: true,
+        isAnonymousSymbol: true
+      });
+
+      expect(anonymousKeyInfo("fontFamily_")).toStrictEqual({
+        isAnimationName: false,
+        isFontFamily: true,
+        isAnonymousSymbol: true
+      });
+
+      expect(anonymousKeyInfo("fontFamily$")).toStrictEqual({
+        isAnimationName: false,
+        isFontFamily: true,
+        isAnonymousSymbol: true
+      });
     });
   });
 }

--- a/packages/transform-to-vanilla/src/transform-keys/complex-selectors.ts
+++ b/packages/transform-to-vanilla/src/transform-keys/complex-selectors.ts
@@ -1,4 +1,4 @@
-export function complexKeyInfo(key: string) {
+export function isComplexKey(key: string) {
   return key.includes("&");
 }
 
@@ -8,12 +8,12 @@ if (import.meta.vitest) {
 
   describe.concurrent("Is complex selector", () => {
     it("complex selector", () => {
-      expect(complexKeyInfo("&:hover:not(:active)")).toBeTruthy();
-      expect(complexKeyInfo("nav li > &")).toBeTruthy();
+      expect(isComplexKey("&:hover:not(:active)")).toBeTruthy();
+      expect(isComplexKey("nav li > &")).toBeTruthy();
     });
 
     it("Not complex selecot", () => {
-      expect(complexKeyInfo(":hover")).toBeFalsy();
+      expect(isComplexKey(":hover")).toBeFalsy();
     });
   });
 }

--- a/packages/transform-to-vanilla/src/transform-keys/complex-selectors.ts
+++ b/packages/transform-to-vanilla/src/transform-keys/complex-selectors.ts
@@ -1,0 +1,19 @@
+export function complexKeyInfo(key: string) {
+  return key.includes("&");
+}
+
+// == Tests ====================================================================
+if (import.meta.vitest) {
+  const { describe, it, expect } = import.meta.vitest;
+
+  describe.concurrent("Is complex selector", () => {
+    it("complex selector", () => {
+      expect(complexKeyInfo("&:hover:not(:active)")).toBeTruthy();
+      expect(complexKeyInfo("nav li > &")).toBeTruthy();
+    });
+
+    it("Not complex selecot", () => {
+      expect(complexKeyInfo(":hover")).toBeFalsy();
+    });
+  });
+}

--- a/packages/transform-to-vanilla/src/transform-keys/merge-key.ts
+++ b/packages/transform-to-vanilla/src/transform-keys/merge-key.ts
@@ -1,19 +1,17 @@
-import { NonNullableString } from "../types/string";
-
-// == Type ================================================================
-type HasSignInString = `${NonNullableString}$` | `${NonNullableString}_`;
-type InputKeyValue = NonNullableString | HasSignInString;
-
 // == Interface ================================================================
-export function removeSignSimbol(keyStr: InputKeyValue) {
-  return hasSignSimbol(keyStr)
-    ? keyStr.substring(0, keyStr.length - 1)
-    : keyStr;
+export function removeMergeSymbol(keyStr: string) {
+  return keyStr.substring(0, keyStr.length - 1);
 }
 
-// == Utils ====================================================================
-function hasSignSimbol(value: InputKeyValue): value is HasSignInString {
-  return value.endsWith("$") || value.endsWith("_");
+export function mergeKeyInfo(keyStr: string) {
+  const isMergeToComma = keyStr.endsWith("$");
+  const isMergeToSpace = keyStr.endsWith("_");
+
+  return {
+    isMergeToComma,
+    isMergeToSpace,
+    isMergeSymbol: isMergeToComma || isMergeToSpace
+  };
 }
 
 // == Tests ====================================================================
@@ -21,18 +19,53 @@ if (import.meta.vitest) {
   const { describe, it, expect } = import.meta.vitest;
 
   describe.concurrent("Remove Key Sign Symbol", () => {
+    it("Has Sign Symbol to the end", () => {
+      expect(removeMergeSymbol("boxShadow$")).toBe("boxShadow");
+      expect(removeMergeSymbol("transform_")).toBe("transform");
+    });
+  });
+
+  describe.concurrent("Get key info has merge symbol", () => {
     it("No Sign Symbol", () => {
-      expect(removeSignSimbol("boxShadow")).toBe("boxShadow");
+      expect(mergeKeyInfo("boxShadow")).toStrictEqual({
+        isMergeToComma: false,
+        isMergeToSpace: false,
+        isMergeSymbol: false
+      });
     });
     it("Has Sign Symbol to the end", () => {
-      expect(removeSignSimbol("boxShadow$")).toBe("boxShadow");
-      expect(removeSignSimbol("transform_")).toBe("transform");
+      expect(mergeKeyInfo("boxShadow$")).toStrictEqual({
+        isMergeToComma: true,
+        isMergeToSpace: false,
+        isMergeSymbol: true
+      });
+      expect(mergeKeyInfo("transform_")).toStrictEqual({
+        isMergeToComma: false,
+        isMergeToSpace: true,
+        isMergeSymbol: true
+      });
     });
     it("Has Sign Symbol in the middle or at the first", () => {
-      expect(removeSignSimbol("box$Shadow")).toBe("box$Shadow");
-      expect(removeSignSimbol("trans_form")).toBe("trans_form");
-      expect(removeSignSimbol("$boxShadow")).toBe("$boxShadow");
-      expect(removeSignSimbol("_transform")).toBe("_transform");
+      expect(mergeKeyInfo("box$Shadow")).toStrictEqual({
+        isMergeToComma: false,
+        isMergeToSpace: false,
+        isMergeSymbol: false
+      });
+      expect(mergeKeyInfo("trans_form")).toStrictEqual({
+        isMergeToComma: false,
+        isMergeToSpace: false,
+        isMergeSymbol: false
+      });
+      expect(mergeKeyInfo("$boxShadow")).toStrictEqual({
+        isMergeToComma: false,
+        isMergeToSpace: false,
+        isMergeSymbol: false
+      });
+      expect(mergeKeyInfo("_transform")).toStrictEqual({
+        isMergeToComma: false,
+        isMergeToSpace: false,
+        isMergeSymbol: false
+      });
     });
   });
 }

--- a/packages/transform-to-vanilla/src/transform-object/index.ts
+++ b/packages/transform-to-vanilla/src/transform-object/index.ts
@@ -1,3 +1,6 @@
+import { replacePseudoSelectors } from "@/transform-keys/simple-pseudo-selectors";
+import { removeMergeSymbol, mergeKeyInfo } from "@/transform-keys/merge-key";
+import { mergeToComma, mergeToSpace } from "@/transform-values/merge-values";
 import { simplyImportant } from "@/transform-values/simply-important";
 import type { StyleRule } from "@vanilla-extract/css";
 import type {
@@ -6,7 +9,6 @@ import type {
   CSSRuleValue,
   VanillaStyleRuleValue
 } from "@/types/style-rule";
-import { replacePseudoSelectors } from "@/transform-keys/simple-pseudo-selectors";
 
 // == Interface ================================================================
 export function transformStyle(style: CSSRule) {
@@ -22,18 +24,43 @@ export function transformStyle(style: CSSRule) {
     CSSRuleKey,
     CSSRuleValue
   ][]) {
+    const { isMergeToComma, isMergeToSpace, isMergeSymbol } = mergeKeyInfo(key);
+
     const transformedValue =
       typeof value === "object"
         ? Array.isArray(value)
-          ? value
-          : transformStyle(value as CSSRule) // TODO: Array
-        : typeof value === "string"
-        ? simplyImportant(value)
-        : value;
-    const transformedKey = replacePseudoSelectors(key);
+          ? transformArrayValue(value, isMergeToComma, isMergeToSpace)
+          : transformStyle(value as CSSRule)
+        : transformCommonValue(value);
+    const transformedKey = replacePseudoSelectors(
+      isMergeSymbol ? removeMergeSymbol(key) : key
+    );
     result[transformedKey] = transformedValue as VanillaStyleRuleValue;
   }
   return result as StyleRule;
+}
+
+// == Utils ====================================================================
+function transformArrayValue(
+  value: CSSRuleValue,
+  isMergeToComma: boolean,
+  isMergeToSpace: boolean
+): CSSRuleValue {
+  const transformed = isMergeToComma
+    ? mergeToComma(value as string[])
+    : isMergeToSpace
+    ? mergeToSpace(value as string[])
+    : value;
+
+  return Array.isArray(transformed)
+    ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore: error TS2590: Expression produces a union type that is too complex to represent
+      (transformed.map(transformCommonValue) as CSSRuleValue)
+    : transformed;
+}
+
+function transformCommonValue(value: CSSRuleValue) {
+  return typeof value === "string" ? simplyImportant(value) : value;
 }
 
 // == Tests ====================================================================
@@ -48,7 +75,33 @@ if (import.meta.vitest) {
         })
       ).toStrictEqual({
         overflow: ["auto", "overlay"]
-      });
+      } satisfies StyleRule);
+    });
+
+    it("Merge Values", () => {
+      expect(
+        transformStyle({
+          boxShadow$: ["inset 0 0 10px #555", "0 0 20px black"],
+          transform_: ["scale(2)", "rotate(15deg)"]
+        })
+      ).toStrictEqual({
+        boxShadow: "inset 0 0 10px #555, 0 0 20px black",
+        transform: "scale(2) rotate(15deg)"
+      } satisfies StyleRule);
+
+      expect(
+        transformStyle({
+          transform_: [
+            // Apply to all
+            "scale(2)",
+
+            //  Fallback style
+            ["rotate(28.64deg)", "rotate(0.5rad)"]
+          ]
+        })
+      ).toStrictEqual({
+        transform: ["scale(2) rotate(28.64deg)", "scale(2) rotate(0.5rad)"]
+      } satisfies StyleRule);
     });
 
     it("Simply Important", () => {
@@ -58,6 +111,14 @@ if (import.meta.vitest) {
         })
       ).toStrictEqual({
         color: "red !important"
+      } satisfies StyleRule);
+
+      expect(
+        transformStyle({
+          overflow: ["auto !", "overlay"]
+        })
+      ).toStrictEqual({
+        overflow: ["auto !important", "overlay"]
       } satisfies StyleRule);
     });
 

--- a/packages/transform-to-vanilla/src/transform-object/index.ts
+++ b/packages/transform-to-vanilla/src/transform-object/index.ts
@@ -37,6 +37,12 @@ export function transformStyle(style: CSSRule) {
   ][]) {
     if (isComplexKey(key)) {
       transformComplexStyle(result, key, value);
+    } else if (key === "selectors") {
+      for (const [selector, style] of Object.entries(value)) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore: error TS2345
+        transformComplexStyle(result, selector, style);
+      }
     } else if (isRuleKey(key)) {
       transformRuleStyle(result, key, value);
     } else {
@@ -247,6 +253,11 @@ if (import.meta.vitest) {
           },
           "nav li > &": {
             textDecoration: "underline"
+          },
+          selectors: {
+            "a:nth-of-type(2) &": {
+              opacity: 1
+            }
           }
         })
       ).toStrictEqual({
@@ -256,6 +267,9 @@ if (import.meta.vitest) {
           },
           "nav li > &": {
             textDecoration: "underline"
+          },
+          "a:nth-of-type(2) &": {
+            opacity: 1
           }
         }
       } satisfies StyleRule);

--- a/packages/transform-to-vanilla/src/transform-object/index.ts
+++ b/packages/transform-to-vanilla/src/transform-object/index.ts
@@ -24,7 +24,9 @@ export function transformStyle(style: CSSRule) {
   ][]) {
     const transformedValue =
       typeof value === "object"
-        ? transformStyle(value as CSSRule) // TODO: Array
+        ? Array.isArray(value)
+          ? value
+          : transformStyle(value as CSSRule) // TODO: Array
         : typeof value === "string"
         ? simplyImportant(value)
         : value;
@@ -39,6 +41,16 @@ if (import.meta.vitest) {
   const { describe, it, expect } = import.meta.vitest;
 
   describe.concurrent("transform", () => {
+    it("Fallback style", () => {
+      expect(
+        transformStyle({
+          overflow: ["auto", "overlay"]
+        })
+      ).toStrictEqual({
+        overflow: ["auto", "overlay"]
+      });
+    });
+
     it("Simply Important", () => {
       expect(
         transformStyle({

--- a/packages/transform-to-vanilla/src/types/style-rule.ts
+++ b/packages/transform-to-vanilla/src/types/style-rule.ts
@@ -426,7 +426,7 @@ if (import.meta.vitest) {
         fontFamily: "sans-serif"
       });
 
-      // Anonymouse AtRules
+      // Anonymous AtRules
       assertType<CSSRule>({
         animationName: {
           from: {


### PR DESCRIPTION
## Description

Stabilize the type of input received as `CSSRule`.

All type inference should work according to the RFCs.

## Related RFC
- https://github.com/mincho-js/working-group/blob/main/text/000-css-literals.md

## Checklist
- [ ] Merge values
- [ ] Toplevel Complex Selector
- [ ] Toplevel AtRules
- [ ] Anonymous AtRules
- [ ] supported `selector` property