### PR TITLE
Accurate merge properties with type file generation

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -9,3 +9,5 @@ plugins:
     spec: "@yarnpkg/plugin-typescript"
 
 yarnPath: .yarn/releases/yarn-3.6.4.cjs
+
+checksumBehavior: reset

--- a/configs/tsconfig-custom/tsconfig.json
+++ b/configs/tsconfig-custom/tsconfig.json
@@ -41,7 +41,7 @@
     ],
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    "resolveJsonModule": true,                           /* Enable importing .json files. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 
     /* JavaScript Support */

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "g:clean": "cd $INIT_CWD && yarn run -T rimraf dist coverage .turbo tsconfig.tsbuildinfo node_modules/.vite",
     "g:build": "cd $INIT_CWD && yarn run -T vite build",
     "g:build-watch": "cd $INIT_CWD && yarn run build --watch",
+    "g:generate": "cd $INIT_CWD && yarn run -T vite-node src/index.ts",
     "g:test": "cd $INIT_CWD && yarn run -T vitest run",
     "g:test-watch": "cd $INIT_CWD && yarn run -T vitest",
     "g:coverage": "yarn g:test --coverage",
@@ -55,6 +56,7 @@
     "turbo": "^1.10.16",
     "typescript": "^5.2.2",
     "vite": "^4.5.1",
+    "vite-node": "^1.3.1",
     "vitest": "^0.34.6"
   },
   "dependencies": {

--- a/packages/css-additional-types/.editorconfig
+++ b/packages/css-additional-types/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{js,json,yml}]
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/packages/css-additional-types/.vscode/extensions.json
+++ b/packages/css-additional-types/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+  // List of extensions which should be recommended for users of this workspace.
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "rvest.vs-code-prettier-eslint"
+  ],
+  // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+  "unwantedRecommendations": []
+}

--- a/packages/css-additional-types/.vscode/settings.json
+++ b/packages/css-additional-types/.vscode/settings.json
@@ -1,0 +1,26 @@
+{
+  "git.openRepositoryInParentFolders": "always",
+  "editor.insertSpaces": true,
+  "editor.tabSize": 2,
+  "editor.defaultFormatter": "rvest.vs-code-prettier-eslint",
+  "editor.formatOnPaste": false, // required
+  "editor.formatOnType": false, // required
+  "editor.formatOnSave": true, // optional
+  "editor.formatOnSaveMode": "file", // required to format on save
+  "files.autoSave": "onFocusChange", // optional but recommended
+  "vs-code-prettier-eslint.prettierLast": false, // set as "true" to run 'prettier' last not first
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "vscode-color-picker.languages": [
+    "html",
+    "css",
+    "python",
+    "jsonc",
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact",
+    "vue"
+  ]
+}

--- a/packages/css-additional-types/global.d.ts
+++ b/packages/css-additional-types/global.d.ts
@@ -1,0 +1,27 @@
+// https://github.com/frenic/csstype/blob/master/typings/mdn-data.d.ts
+
+declare namespace MDN {
+  interface Property {
+    syntax: string;
+    media: string;
+    inherited: boolean;
+    animationType: string;
+    percentages: string;
+    groups: string[];
+    initial: string;
+    appliesto: string;
+    computed: string | string[];
+    order: string;
+    status: string;
+    mdn_url?: string;
+  }
+
+  interface Properties {
+    [property: string]: Property;
+  }
+}
+
+declare module "mdn-data/css/properties.json" {
+  const properties: MDN.Properties;
+  export default properties;
+}

--- a/packages/css-additional-types/package.json
+++ b/packages/css-additional-types/package.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json.schemastore.org/package.json",
+  "name": "@mincho/css-additional-types",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "typings": "./dist/index.ts",
+  "main": "./dist/index.ts",
+  "module": "./dist/index.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.ts",
+      "require": "./dist/index.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "yarn g:clean",
+    "build": "yarn g:generate ",
+    "lint": "yarn g:lint",
+    "fix": "yarn g:fix",
+    "check": "yarn g:check"
+  },
+  "prettier": "prettier-config-custom",
+  "eslintConfig": {
+    "extends": [
+      "custom"
+    ],
+    "parserOptions": {
+      "project": [
+        "./tsconfig.json",
+        "./tsconfig.node.json"
+      ]
+    }
+  },
+  "devDependencies": {
+    "eslint-config-custom": "workspace:^",
+    "mdn-data": "git+https://github.com/mdn/data.git#7f0c865a3c4b5d891285c93308ee5c25cb5cfee8",
+    "prettier-config-custom": "workspace:^",
+    "tsconfig-custom": "workspace:^",
+    "vite-config-custom": "workspace:^"
+  },
+  "dependencies": {
+    "csstype": "^3.1.3"
+  }
+}

--- a/packages/css-additional-types/src/index.ts
+++ b/packages/css-additional-types/src/index.ts
@@ -1,0 +1,85 @@
+import { accessSync, mkdirSync, createWriteStream } from "fs";
+import { join } from "path";
+import { cwd } from "process";
+import properties from "mdn-data/css/properties.json";
+import {
+  kebabToCamel,
+  isArray,
+  stringify,
+  removeFirstString,
+  firstCharToLower
+} from "./utils";
+
+const cssProperties = Object.entries(properties);
+interface ShorthandEntries {
+  [key: string]: string[];
+}
+const shorthanded: ShorthandEntries = cssProperties.reduce(
+  (acc: ShorthandEntries, [key, value]) => {
+    const initial = value.initial;
+    if (isArray(initial)) {
+      acc[kebabToCamel(key)] = initial.map(kebabToCamel);
+    }
+    return acc;
+  },
+  {} as ShorthandEntries
+);
+
+function makeNestedKey(originKey: string, shorthandKey: string) {
+  return firstCharToLower(
+    kebabToCamel(removeFirstString(originKey, shorthandKey))
+  );
+}
+const nested: ShorthandEntries = cssProperties.reduce(
+  (acc: ShorthandEntries, [key]) => {
+    const nestedEntries = cssProperties.filter(([originKey]) =>
+      originKey.startsWith(`${key}-`)
+    );
+    if (nestedEntries.length > 0) {
+      acc[kebabToCamel(key)] = nestedEntries.map(([originKey]) =>
+        makeNestedKey(originKey, key)
+      );
+    }
+    return acc;
+  },
+  {} as ShorthandEntries
+);
+
+const result = `// https://stackoverflow.com/questions/42999983/typescript-removing-readonly-modifier
+type DeepWriteable<T> = { -readonly [P in keyof T]: DeepWriteable<T[P]> };
+export const shorthandProperties = ${stringify(shorthanded)} as const;
+export type ShorthandProperties = DeepWriteable<typeof shorthandProperties>;
+
+export const nestedProperties = ${stringify(nested)} as const;
+export type NestedProperties = DeepWriteable<typeof nestedProperties>;
+`;
+
+const saveDir = join(cwd(), "dist");
+const savePath = join(saveDir, "index.ts");
+
+interface FileError {
+  code: string;
+}
+function main() {
+  try {
+    accessSync(saveDir);
+  } catch (error) {
+    const err = error as FileError;
+    if (err.code === "ENOENT") {
+      try {
+        mkdirSync(saveDir);
+      } catch (error) {
+        const err = error as FileError;
+        if (err.code !== "EEXIST") {
+          throw err;
+        }
+      }
+    }
+  }
+
+  const stream = createWriteStream(savePath);
+  stream.write(result);
+  stream.end();
+}
+
+main();

--- a/packages/css-additional-types/src/index.ts
+++ b/packages/css-additional-types/src/index.ts
@@ -2,6 +2,7 @@ import { accessSync, mkdirSync, createWriteStream } from "fs";
 import { join } from "path";
 import { cwd } from "process";
 import properties from "mdn-data/css/properties.json";
+import syntaxes from "mdn-data/css/syntaxes.json";
 import {
   kebabToCamel,
   isArray,
@@ -10,19 +11,120 @@ import {
   firstCharToLower
 } from "./utils";
 
+// == Common ===================================================================
 const cssProperties = Object.entries(properties);
-interface ShorthandEntries {
+const syntaxProperties = Object.entries(syntaxes);
+
+interface CssEntries {
   [key: string]: string[];
 }
-const shorthanded: ShorthandEntries = cssProperties.reduce(
-  (acc: ShorthandEntries, [key, value]) => {
+
+// == Merge Values =============================================================
+// -- Utils --------------------------------------------------------------------
+function isComma(syntax: string) {
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/Value_definition_syntax
+  return syntax.includes(", ") || syntax.includes("#");
+}
+
+const spaceRegex = /<?[\w-]+>? <?[\w-]+>?/;
+function isSpace(syntax: string) {
+  return (
+    syntax.includes("&&") ||
+    syntax.includes("||") ||
+    syntax.includes("*") ||
+    syntax.includes("+") ||
+    syntax.includes("?") ||
+    spaceRegex.test(syntax)
+  );
+}
+
+function isNotFn(keyedSyntax: string) {
+  return !keyedSyntax.endsWith("()");
+}
+
+function isNotSpaceKey(key: string) {
+  return key !== "--*";
+}
+
+// -- Syntax filter ------------------------------------------------------------
+const [level1CommaSyntaxes, level1SpaceSyntaxes]: [string[], string[]] =
+  syntaxProperties.reduce(
+    (acc: [string[], string[]], [key, value]) => {
+      if (isNotFn(key)) {
+        const syntax = value.syntax;
+        if (isComma(syntax)) {
+          acc[0].push(key);
+        } else if (isSpace(syntax)) {
+          acc[1].push(key);
+        }
+      }
+      return acc;
+    },
+    [[], []] as [string[], string[]]
+  );
+function syntaxFilter(syntaxes: string[], syntaxSet = new Set<string>()) {
+  const newSyntaxes = new Set([...syntaxSet, ...syntaxes]);
+  const result = syntaxes.reduce((acc: string[], syntax) => {
+    for (const [key, value] of syntaxProperties) {
+      if (
+        isNotFn(key) &&
+        value.syntax.includes(`<${syntax}>`) &&
+        !newSyntaxes.has(key)
+      ) {
+        acc.push(key);
+      }
+    }
+    return acc;
+  }, [] as string[]);
+
+  if (result.length > 0) {
+    return syntaxFilter(result, newSyntaxes);
+  } else {
+    return [...newSyntaxes, ...result];
+  }
+}
+
+const commaSyntaxes = syntaxFilter(level1CommaSyntaxes);
+const spaceSyntaxes = syntaxFilter(level1SpaceSyntaxes);
+
+function syntaxIncludes(targetSyntax: string, syntaxes: string[]) {
+  return syntaxes.some((syntax) => targetSyntax.includes(syntax));
+}
+
+// -- Inteface -----------------------------------------------------------------
+const [comma, whiteSpace]: [CssEntries, CssEntries] = cssProperties.reduce(
+  (acc: [CssEntries, CssEntries], [key, value]) => {
+    const syntax = value.syntax;
+    if (isComma(syntax) || syntaxIncludes(syntax, commaSyntaxes)) {
+      acc[0][kebabToCamel(key)] = [syntax]; // For debugging
+    } else if (
+      isNotSpaceKey(key) &&
+      (isSpace(syntax) || syntaxIncludes(syntax, spaceSyntaxes))
+    ) {
+      acc[1][kebabToCamel(key)] = [syntax];
+    }
+
+    return acc;
+  },
+  [{}, {}] as [CssEntries, CssEntries]
+);
+
+function makeMergeTypes(entries: CssEntries) {
+  return Object.keys(entries)
+    .map((key) => `"${key}"`)
+    .join("\n  | ");
+}
+
+// == Shorthanded & Nested =====================================================
+const shorthanded: CssEntries = cssProperties.reduce(
+  (acc: CssEntries, [key, value]) => {
     const initial = value.initial;
     if (isArray(initial)) {
       acc[kebabToCamel(key)] = initial.map(kebabToCamel);
     }
     return acc;
   },
-  {} as ShorthandEntries
+  {} as CssEntries
 );
 
 function makeNestedKey(originKey: string, shorthandKey: string) {
@@ -30,23 +132,29 @@ function makeNestedKey(originKey: string, shorthandKey: string) {
     kebabToCamel(removeFirstString(originKey, shorthandKey))
   );
 }
-const nested: ShorthandEntries = cssProperties.reduce(
-  (acc: ShorthandEntries, [key]) => {
-    const nestedEntries = cssProperties.filter(([originKey]) =>
-      originKey.startsWith(`${key}-`)
+const nested: CssEntries = cssProperties.reduce((acc: CssEntries, [key]) => {
+  const nestedEntries = cssProperties.filter(([originKey]) =>
+    originKey.startsWith(`${key}-`)
+  );
+  if (nestedEntries.length > 0) {
+    acc[kebabToCamel(key)] = nestedEntries.map(([originKey]) =>
+      makeNestedKey(originKey, key)
     );
-    if (nestedEntries.length > 0) {
-      acc[kebabToCamel(key)] = nestedEntries.map(([originKey]) =>
-        makeNestedKey(originKey, key)
-      );
-    }
-    return acc;
-  },
-  {} as ShorthandEntries
-);
+  }
+  return acc;
+}, {} as CssEntries);
+
+// == Main =====================================================================
+// -- Setup --------------------------------------------------------------------
+const saveDir = join(cwd(), "dist");
+const savePath = join(saveDir, "index.ts");
 
 const result = `// https://stackoverflow.com/questions/42999983/typescript-removing-readonly-modifier
 type DeepWriteable<T> = { -readonly [P in keyof T]: DeepWriteable<T[P]> };
+
+export type SpacePropertiesKey = ${makeMergeTypes(whiteSpace)};
+export type CommaPropertiesKey = ${makeMergeTypes(comma)};
+
 export const shorthandProperties = ${stringify(shorthanded)} as const;
 export type ShorthandProperties = DeepWriteable<typeof shorthandProperties>;
 
@@ -54,9 +162,7 @@ export const nestedProperties = ${stringify(nested)} as const;
 export type NestedProperties = DeepWriteable<typeof nestedProperties>;
 `;
 
-const saveDir = join(cwd(), "dist");
-const savePath = join(saveDir, "index.ts");
-
+// -- Run ----------------------------------------------------------------------
 interface FileError {
   code: string;
 }

--- a/packages/css-additional-types/src/utils.ts
+++ b/packages/css-additional-types/src/utils.ts
@@ -1,6 +1,15 @@
 const kebabCaseRegex = /-./g;
 export function kebabToCamel(kebabCase: string) {
-  return kebabCase.replace(kebabCaseRegex, (match) => match[1].toUpperCase());
+  const camel = kebabCase.replace(kebabCaseRegex, (match) =>
+    match[1].toUpperCase()
+  );
+
+  // Vender Prefix for IE
+  // https://github.com/frenic/csstype/issues/192
+  if (camel.startsWith("Ms")) {
+    return firstCharToLower(camel);
+  }
+  return camel;
 }
 
 export function isArray<T>(value: T | T[]): value is T[] {

--- a/packages/css-additional-types/src/utils.ts
+++ b/packages/css-additional-types/src/utils.ts
@@ -1,0 +1,20 @@
+const kebabCaseRegex = /-./g;
+export function kebabToCamel(kebabCase: string) {
+  return kebabCase.replace(kebabCaseRegex, (match) => match[1].toUpperCase());
+}
+
+export function isArray<T>(value: T | T[]): value is T[] {
+  return Array.isArray(value);
+}
+
+export function stringify(object: object) {
+  return JSON.stringify(object, null, 2);
+}
+
+export function removeFirstString(str: string, remove: string) {
+  return str.replace(remove, "");
+}
+
+export function firstCharToLower(str: string) {
+  return str.charAt(0).toLowerCase() + str.slice(1);
+}

--- a/packages/css-additional-types/tsconfig.json
+++ b/packages/css-additional-types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "tsconfig-custom/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./"
+  },
+  "include": ["src/**/*.ts",  "__tests__/**/*.ts"],
+  "exclude": ["dist"],
+  "references": [{ "path": "tsconfig.node.json" }]
+}

--- a/packages/css-additional-types/tsconfig.node.json
+++ b/packages/css-additional-types/tsconfig.node.json
@@ -1,0 +1,4 @@
+{
+  "extends": "tsconfig-custom/tsconfig.json",
+  "include": ["vite.config.ts"]
+}

--- a/packages/css-additional-types/vite.config.ts
+++ b/packages/css-additional-types/vite.config.ts
@@ -1,0 +1,8 @@
+import type { ConfigEnv } from "vite";
+import { NodeConfig } from "vite-config-custom";
+
+// == Vite Config =============================================================
+// https://vitejs.dev/config/#build-lib
+export default (viteConfigEnv: ConfigEnv) => {
+  return NodeConfig(viteConfigEnv);
+};

--- a/packages/transform-to-vanilla/package.json
+++ b/packages/transform-to-vanilla/package.json
@@ -52,6 +52,7 @@
     "vite-config-custom": "workspace:^"
   },
   "dependencies": {
+    "@mincho/css-additional-types": "workspace:^",
     "csstype": "^3.1.3"
   }
 }

--- a/packages/transform-to-vanilla/src/types/style-rule.ts
+++ b/packages/transform-to-vanilla/src/types/style-rule.ts
@@ -1,5 +1,9 @@
 import type { StyleRule, fontFace } from "@vanilla-extract/css";
 import type { Properties, Property } from "csstype";
+import type {
+  SpacePropertiesKey,
+  CommaPropertiesKey
+} from "@mincho/css-additional-types";
 import type { NonNullableString } from "./string";
 import type { SimplePseudos, CamelPseudos } from "./simple-pseudo";
 import type { IntRange, ExcludeArray, Arr } from "./utils";
@@ -96,15 +100,25 @@ export type CSSVarFunction =
   | `$${string}`
   | `$${string}(${CSSVarValue})`;
 
-// TODO: Instead of enabling all properties, we recommend enabling only some properties.
+// Instead of enabling all properties, we recommend enabling only some properties.
 // https://github.com/mincho-js/working-group/blob/main/text/000-css-literals.md#7-merge-values
 // https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties
 // https://github.com/mdn/data/blob/main/css/README.md
-export type CSSMergeProperties = {
-  [Property in keyof CSSProperties as `${Property}$` | `${Property}_`]: Array<
-    CSSProperties[Property]
+interface SpaceProperties extends Pick<CSSProperties, SpacePropertiesKey> {}
+interface CommaProperties extends Pick<CSSProperties, CommaPropertiesKey> {}
+type SpaceMergeProperties = {
+  [SpaceProperty in keyof SpaceProperties as `${SpaceProperty}_`]: Array<
+    SpaceProperties[SpaceProperty]
   >;
 };
+type CommaMergeProperties = {
+  [CommaProperty in keyof CommaProperties as `${CommaProperty}$`]: Array<
+    CommaProperties[CommaProperty]
+  >;
+};
+export interface CSSMergeProperties
+  extends SpaceMergeProperties,
+    CommaMergeProperties {}
 
 type CSSTypeProperties = WithAnonymousCSSProperty & ContainerProperties;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1019,7 +1019,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mincho/css-additional-types@workspace:packages/css-additional-types":
+"@mincho/css-additional-types@workspace:^, @mincho/css-additional-types@workspace:packages/css-additional-types":
   version: 0.0.0-use.local
   resolution: "@mincho/css-additional-types@workspace:packages/css-additional-types"
   dependencies:
@@ -1051,6 +1051,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@mincho/transform-to-vanilla@workspace:packages/transform-to-vanilla"
   dependencies:
+    "@mincho/css-additional-types": "workspace:^"
     "@vanilla-extract/css": ^1.13.0
     csstype: ^3.1.3
     eslint-config-custom: "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1019,6 +1019,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mincho/css-additional-types@workspace:packages/css-additional-types":
+  version: 0.0.0-use.local
+  resolution: "@mincho/css-additional-types@workspace:packages/css-additional-types"
+  dependencies:
+    csstype: ^3.1.3
+    eslint-config-custom: "workspace:^"
+    mdn-data: "git+https://github.com/mdn/data.git#7f0c865a3c4b5d891285c93308ee5c25cb5cfee8"
+    prettier-config-custom: "workspace:^"
+    tsconfig-custom: "workspace:^"
+    vite-config-custom: "workspace:^"
+  languageName: unknown
+  linkType: soft
+
 "@mincho/css@workspace:^, @mincho/css@workspace:packages/css":
   version: 0.0.0-use.local
   resolution: "@mincho/css@workspace:packages/css"
@@ -4153,6 +4166,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdn-data@git+https://github.com/mdn/data.git#7f0c865a3c4b5d891285c93308ee5c25cb5cfee8":
+  version: 2.3.0
+  resolution: "mdn-data@https://github.com/mdn/data.git#commit=7f0c865a3c4b5d891285c93308ee5c25cb5cfee8"
+  checksum: 2c95ed357fe6fab3e774af90b0205c565c2303c74352a0d36a751214fd470999df52e3ca2e599acd749f58a89ee6accbde75d1d00d21cc7b11adfe6379206d88
+  languageName: node
+  linkType: hard
+
 "media-query-parser@npm:^2.0.2":
   version: 2.0.2
   resolution: "media-query-parser@npm:2.0.2"
@@ -4223,6 +4243,7 @@ __metadata:
     turbo: ^1.10.16
     typescript: ^5.2.2
     vite: ^4.5.1
+    vite-node: ^1.3.1
     vitest: ^0.34.6
   languageName: unknown
   linkType: soft
@@ -5712,7 +5733,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-node@npm:^1.2.0":
+"vite-node@npm:^1.2.0, vite-node@npm:^1.3.1":
   version: 1.3.1
   resolution: "vite-node@npm:1.3.1"
   dependencies:


### PR DESCRIPTION
## Description
Generate types to improve type inference performance and automatically detect `CSSMergeProperties`.
(Previously, all CSS properties were allowed to merge spaces and commas.)

It uses the [same version](https://github.com/frenic/csstype/blob/fb448e21733ac5cb52523d3b678fdbbe1f9b42f2/package.json#L32) of the [mdn-data](https://www.npmjs.com/package/mdn-data) package as csstype.

## Related RFC
- https://github.com/mincho-js/working-group/blob/main/text/000-css-literals.md#7-merge-values

## Checklist
- [ ] Make merging only possible for properties that use space and comma, not all CSS properties