### PR TITLE
Type - Nested property

### DIFF
--- a/packages/transform-to-vanilla/src/types/string.ts
+++ b/packages/transform-to-vanilla/src/types/string.ts
@@ -1,4 +1,5 @@
 // == Interface ================================================================
+// It has a string properties
 export type NonNullableString = string & NonNullable<unknown>;
 
 export type ToKebabCase<


### PR DESCRIPTION
## Description
Define the types of Nested properties through type creation.

## Related RFC
- https://github.com/mincho-js/working-group/blob/main/text/001-css-nesting.md#2-nested-properties

## Checklist
- [ ] `Nested property` type should be created correctly.