### PR TITLE
Fix: DebugLog - print box align, same contents #40

### DIFF
--- a/packages/debug-log/src/index.ts
+++ b/packages/debug-log/src/index.ts
@@ -19,7 +19,12 @@ const consola = {
     console.log(
       boxen(isExistArgs ? args.join(" ") : (arg1 as string), {
         title: isExistArgs ? (arg1 as string) : undefined,
-        padding: 1,
+        padding: {
+          top: 1,
+          bottom: 1,
+          left: 2,
+          right: 2
+        },
         borderStyle: "round"
       })
     );
@@ -62,18 +67,28 @@ export function jsonLog(arg1: unknown, obj?: unknown) {
 export function jsonExpect(arg1: unknown, obj1?: unknown, obj2?: unknown) {
   if (obj2 === undefined) {
     debugLog();
-    jsonPrint("Expected", arg1);
-    jsonPrint("Real", obj1);
-
     const changes = diff(arg1, obj1);
-    console.log(pretifyDeepDiff(changes ?? []));
+
+    if (changes === undefined) {
+      jsonPrint("Same Contents", arg1);
+    } else {
+      jsonPrint("Expected", arg1);
+      jsonPrint("Real", obj1);
+
+      console.log(pretifyDeepDiff(changes ?? []));
+    }
   } else {
     debugLog(arg1);
-    jsonPrint("Expected", obj1);
-    jsonPrint("Real", obj2);
-
     const changes = diff(obj1, obj2);
-    console.log(pretifyDeepDiff(changes ?? []));
+
+    if (changes === undefined) {
+      jsonPrint("Same Contents", obj1);
+    } else {
+      jsonPrint("Expected", obj1);
+      jsonPrint("Real", obj2);
+
+      console.log(pretifyDeepDiff(changes ?? []));
+    }
   }
 }
 


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->

Adjust the type and print of `@mincho/debug-log` pacakge.

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->

- #40

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced type safety for logging functions, allowing only JSON-compatible objects.
	- Updated `debugLog`, `jsonPrint`, `jsonLog`, and `jsonExpect` functions with improved signatures for flexibility.
	- Introduced multiple overloads for functions to better accommodate different input types.

- **Improvements**
	- Enhanced visual formatting of log outputs through modified padding options. 
	- Clearer output for comparisons in the `jsonExpect` function, improving usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

