### PR TITLE
Fix: Synchronize by checking until merge #69

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -42,16 +42,44 @@ jobs:
           fi
 
           GITHUB_PR=$(mktemp)
-          curl --silent --show-error --location \
+          function get_pr_info {
+            curl --silent --show-error --location \
                  -X GET \
                  -H "Accept: application/vnd.github+json" \
                  -H "Authorization: Bearer $GITHUB_TOKEN" \
                  -H "X-GitHub-Api-Version: 2022-11-28" \
                  "$PR_URL" >$GITHUB_PR
+          }
 
+          function check_pr_merged {
+            local merged_status="false"
+            local attempt=1
+            local max_attempts=30
+            local sleep_duration=1
+
+            while [ "$merged_status" != "true" ] && [ $attempt -le $max_attempts ]; do
+              get_pr_info
+              merged_status=$(jq -r ".merged" <$GITHUB_PR)
+
+              if [ "$merged_status" = "true" ]; then
+                break
+              else
+                sleep $sleep_duration
+                ((attempt++))
+              fi
+            done
+
+            if [ $attempt -gt $max_attempts ]; then
+              echo "The maximum number of attempts has been reached. The pull request was not merged."
+              exit 1
+            fi
+          }
+
+          get_pr_info
           BASE_REF=$(jq -r ".base.ref" <$GITHUB_PR)
           if [ "$BASE_REF" = "main" ]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
+            check_pr_merged
           else
             echo "should_run=false" >> $GITHUB_OUTPUT
           fi
@@ -73,6 +101,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: main
 
       - name: Setup
         uses: ./.github/actions/node-setup


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->
#77, it will be a clone based on the commit before it was merged.
So we have to wait for merged to become `true`.

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced GitHub Actions workflow for better handling of pull request merge status.
	- Introduced a feature to repeatedly check if a pull request has been merged, improving robustness.
  
- **Improvements**
	- Improved code organization and readability with dedicated functions for pulling PR information and checking merge status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
