### PR TITLE
Fix: Try to publish without `build:release`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:release": "yarn build && yarn forallpackages exec rimraf _release && yarn forallpackages pack && yarn forallpackages exec \"mkdir _release && tar zxvf package.tgz --directory _release && rm package.tgz\"",
     "changeset": "changeset",
     "version": "changeset version",
-    "publish": "yarn build:release && changeset publish",
+    "publish": "yarn build && changeset publish",
     "g:clean": "cd $INIT_CWD && yarn run -T rimraf _release dist coverage .turbo tsconfig.tsbuildinfo node_modules/.vite",
     "g:build": "cd $INIT_CWD && yarn run -T vite build",
     "g:build-watch": "cd $INIT_CWD && yarn run build --watch",

--- a/packages/debug-log/CHANGELOG.md
+++ b/packages/debug-log/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @mincho-js/debug-log
 
+## 1.0.2
+
+### Patch Changes
+
+- Bumpup test
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/debug-log/package.json
+++ b/packages/debug-log/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@mincho-js/debug-log",
   "description": "A utility library for easier console debugging and comparison of JavaScript object values",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "sideEffects": true,
   "type": "module",
   "license": "MIT",
@@ -38,9 +38,6 @@
     "./importMeta": {
       "types": "./importMeta.d.ts"
     }
-  },
-  "publishConfig": {
-    "directory": "_release/package"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->

I noticed that the following action runs the publish command defined in package.json.
https://github.com/mincho-js/mincho/actions/runs/10431916517/job/28892091665
```
> @mincho-js/css@0.0.2 publish
> yarn g:publish
```

So it's an experiment to remove the complexity of `build:release`.

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the publish script for a more streamlined build process prior to publishing.
	- Introduced version `1.0.2` for the `@mincho-js/debug-log` package, indicating minor adjustments.

- **Documentation**
	- Added a new changelog entry for version `1.0.2` noting a minor testing update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
