### PR TITLE
Chore: Revert #79 and Show logs on failure

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -118,3 +118,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Show log on failure
+        if: failure()
+        run: |
+          cd /home/runner/.npm/_logs/
+          for file in *; do
+            echo "=== File: $file ==="
+            cat "$file"
+            echo -e "\n\n"
+          done

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:release": "yarn build && yarn forallpackages exec rimraf _release && yarn forallpackages pack && yarn forallpackages exec \"mkdir _release && tar zxvf package.tgz --directory _release && rm package.tgz\"",
     "changeset": "changeset",
     "version": "changeset version",
-    "publish": "yarn build && changeset publish",
+    "publish": "yarn build:release && changeset publish",
     "g:clean": "cd $INIT_CWD && yarn run -T rimraf _release dist coverage .turbo tsconfig.tsbuildinfo node_modules/.vite",
     "g:build": "cd $INIT_CWD && yarn run -T vite build",
     "g:build-watch": "cd $INIT_CWD && yarn run build --watch",

--- a/packages/debug-log/CHANGELOG.md
+++ b/packages/debug-log/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @mincho-js/debug-log
 
+## 1.0.3
+
+### Patch Changes
+
+- Publish test again
+
 ## 1.0.2
 
 ### Patch Changes

--- a/packages/debug-log/package.json
+++ b/packages/debug-log/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@mincho-js/debug-log",
   "description": "A utility library for easier console debugging and comparison of JavaScript object values",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "sideEffects": true,
   "type": "module",
   "license": "MIT",
@@ -38,6 +38,9 @@
     "./importMeta": {
       "types": "./importMeta.d.ts"
     }
+  },
+  "publishConfig": {
+    "directory": "_release/package"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->
Now that `^workspace` is included, it's clear that we need to go back.
- https://www.npmjs.com/package/@mincho-js/debug-log/v/1.0.2

It also includes a step to output a log when the action fails so you know what happened.

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #79

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced GitHub Actions workflow to display logs on failure for improved debugging.
	- Updated build process to execute a comprehensive build prior to publishing the package.
  
- **Bug Fixes**
	- Version `1.0.3` of the `@mincho-js/debug-log` package includes re-publication of a test.

- **Documentation**
	- Updated changelog to reflect the new version entry for the `@mincho-js/debug-log` package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
