### PR TITLE
Fix: Prevent paths from triggering #81 & publish test

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   fast-forward:
     # Only run if the comment contains the /fast-forward command.
-    if: ${{ contains(github.event.comment.body, '/fast-forward')
+    if: ${{ matches(github.event.comment.body, '(^|\s)/fast-forward($|\s)')
       && github.event.issue.pull_request }}
     runs-on: ubuntu-latest
 

--- a/packages/debug-log/CHANGELOG.md
+++ b/packages/debug-log/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @mincho-js/debug-log
 
+## 1.0.4
+
+### Patch Changes
+
+- Publish test again
+
 ## 1.0.3
 
 ### Patch Changes

--- a/packages/debug-log/package.json
+++ b/packages/debug-log/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@mincho-js/debug-log",
   "description": "A utility library for easier console debugging and comparison of JavaScript object values",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "sideEffects": true,
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->
Preventing invalid triggers

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #81

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced command detection for triggering the fast-forward job in GitHub Actions to improve accuracy.
  
- **Documentation**
  - Added a new version entry (1.0.4) to the changelog for the `@mincho-js/debug-log` package, noting the re-publication of a test.

- **Chores**
  - Updated the version number of the `@mincho-js/debug-log` package from 1.0.3 to 1.0.4 in the package.json file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
