### PR TITLE
Feat: Move recipe files from vanilla extract

### DIFF
--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -30,6 +30,8 @@ export {
   keyframes,
   layer
 } from "@vanilla-extract/css";
+export { rules } from "./rules";
+export type { RulesVariants, RecipeVariants, RuntimeFn } from "./rules/types";
 
 export type { CSSProperties, ComplexCSSRule, GlobalCSSRule, CSSRule };
 export type ComplexStyleRule = ComplexCSSRule;

--- a/packages/css/src/rules/createRuntimeFn.ts
+++ b/packages/css/src/rules/createRuntimeFn.ts
@@ -3,14 +3,14 @@ import type {
   RecipeClassNames,
   RuntimeFn,
   VariantGroups,
-  VariantSelection,
-} from './types';
-import { mapValues } from './utils';
+  VariantSelection
+} from "./types";
+import { mapValues } from "./utils";
 
 const shouldApplyCompound = <Variants extends VariantGroups>(
   compoundCheck: VariantSelection<Variants>,
   selections: VariantSelection<Variants>,
-  defaultVariants: VariantSelection<Variants>,
+  defaultVariants: VariantSelection<Variants>
 ) => {
   for (const key of Object.keys(compoundCheck)) {
     if (compoundCheck[key] !== (selections[key] ?? defaultVariants[key])) {
@@ -22,14 +22,14 @@ const shouldApplyCompound = <Variants extends VariantGroups>(
 };
 
 export const createRuntimeFn = <Variants extends VariantGroups>(
-  config: PatternResult<Variants>,
+  config: PatternResult<Variants>
 ): RuntimeFn<Variants> => {
   const runtimeFn: RuntimeFn<Variants> = (options) => {
     let className = config.defaultClassName;
 
     const selections: VariantSelection<Variants> = {
       ...config.defaultVariants,
-      ...options,
+      ...options
     };
     for (const variantName in selections) {
       const variantSelection =
@@ -38,17 +38,18 @@ export const createRuntimeFn = <Variants extends VariantGroups>(
       if (variantSelection != null) {
         let selection = variantSelection;
 
-        if (typeof selection === 'boolean') {
-          // @ts-expect-error
-          selection = selection === true ? 'true' : 'false';
+        if (typeof selection === "boolean") {
+          // @ts-expect-error - Needed to convert boolean to string
+          selection = selection === true ? "true" : "false";
         }
 
         const selectionClassName =
-          // @ts-expect-error
-          config.variantClassNames[variantName][selection];
+          config.variantClassNames[variantName]?.[
+            selection as keyof (typeof config.variantClassNames)[typeof variantName]
+          ];
 
         if (selectionClassName) {
-          className += ' ' + selectionClassName;
+          className += " " + selectionClassName;
         }
       }
     }
@@ -57,7 +58,7 @@ export const createRuntimeFn = <Variants extends VariantGroups>(
       if (
         shouldApplyCompound(compoundCheck, selections, config.defaultVariants)
       ) {
-        className += ' ' + compoundClassName;
+        className += " " + compoundClassName;
       }
     }
 
@@ -68,14 +69,14 @@ export const createRuntimeFn = <Variants extends VariantGroups>(
 
   runtimeFn.classNames = {
     get base() {
-      return config.defaultClassName.split(' ')[0];
+      return config.defaultClassName.split(" ")[0];
     },
 
     get variants() {
       return mapValues(config.variantClassNames, (classNames) =>
-        mapValues(classNames, (className) => className.split(' ')[0]),
-      ) as RecipeClassNames<Variants>['variants'];
-    },
+        mapValues(classNames, (className) => className.split(" ")[0])
+      ) as RecipeClassNames<Variants>["variants"];
+    }
   };
 
   return runtimeFn;

--- a/packages/css/src/rules/index.ts
+++ b/packages/css/src/rules/index.ts
@@ -1,47 +1,47 @@
-import { addRecipe } from '@vanilla-extract/css/recipe';
-import { style, styleVariants } from '@vanilla-extract/css';
+import { addFunctionSerializer } from "@vanilla-extract/css/functionSerializer";
+import { style, styleVariants } from "@vanilla-extract/css";
 
-import { createRuntimeFn } from './createRuntimeFn';
+import { createRuntimeFn } from "./createRuntimeFn";
 import type {
   PatternOptions,
   PatternResult,
   RuntimeFn,
   VariantGroups,
-  VariantSelection,
-} from './types';
-import { mapValues } from './utils';
+  VariantSelection
+} from "./types";
+import { mapValues } from "./utils";
 
-export type { RecipeVariants, RuntimeFn } from './types';
+export type { RecipeVariants, RuntimeFn } from "./types";
 
 export function recipe<Variants extends VariantGroups>(
   options: PatternOptions<Variants>,
-  debugId?: string,
+  debugId?: string
 ): RuntimeFn<Variants> {
   const {
     variants = {},
     defaultVariants = {},
     compoundVariants = [],
-    base,
+    base
   } = options;
 
   let defaultClassName;
 
-  if (!base || typeof base === 'string') {
+  if (!base || typeof base === "string") {
     const baseClassName = style({});
     defaultClassName = base ? `${baseClassName} ${base}` : baseClassName;
   } else {
     defaultClassName = style(base, debugId);
   }
 
-  // @ts-expect-error
-  const variantClassNames: PatternResult<Variants>['variantClassNames'] =
+  // @ts-expect-error - Temporarily ignoring the error as the PatternResult type is not fully defined
+  const variantClassNames: PatternResult<Variants>["variantClassNames"] =
     mapValues(variants, (variantGroup, variantGroupName) =>
       styleVariants(
         variantGroup,
         (styleRule) =>
-          typeof styleRule === 'string' ? [styleRule] : styleRule,
-        debugId ? `${debugId}_${variantGroupName}` : variantGroupName,
-      ),
+          typeof styleRule === "string" ? [styleRule] : styleRule,
+        debugId ? `${debugId}_${variantGroupName}` : variantGroupName
+      )
     );
 
   const compounds: Array<[VariantSelection<Variants>, string]> = [];
@@ -49,9 +49,9 @@ export function recipe<Variants extends VariantGroups>(
   for (const { style: theStyle, variants } of compoundVariants) {
     compounds.push([
       variants,
-      typeof theStyle === 'string'
+      typeof theStyle === "string"
         ? theStyle
-        : style(theStyle, `${debugId}_compound_${compounds.length}`),
+        : style(theStyle, `${debugId}_compound_${compounds.length}`)
     ]);
   }
 
@@ -59,13 +59,13 @@ export function recipe<Variants extends VariantGroups>(
     defaultClassName,
     variantClassNames,
     defaultVariants,
-    compoundVariants: compounds,
+    compoundVariants: compounds
   };
 
-  return addRecipe(createRuntimeFn(config), {
-    importPath: '@vanilla-extract/recipes/createRuntimeFn',
-    importName: 'createRuntimeFn',
-    // @ts-expect-error
-    args: [config],
+  return addFunctionSerializer(createRuntimeFn(config), {
+    importPath: "@vanilla-extract/recipes/createRuntimeFn",
+    importName: "createRuntimeFn",
+    // @ts-expect-error - Mismatch between return type of createRuntimeFn and argument type of addFunctionSerializer
+    args: [config]
   });
 }

--- a/packages/css/src/rules/index.ts
+++ b/packages/css/src/rules/index.ts
@@ -1,5 +1,5 @@
 import { addFunctionSerializer } from "@vanilla-extract/css/functionSerializer";
-import { style, styleVariants } from "@vanilla-extract/css";
+import { css, cssVariants } from "../index";
 
 import { createRuntimeFn } from "./createRuntimeFn";
 import type {
@@ -11,9 +11,7 @@ import type {
 } from "./types";
 import { mapValues } from "./utils";
 
-export type { RecipeVariants, RuntimeFn } from "./types";
-
-export function recipe<Variants extends VariantGroups>(
+export function rules<Variants extends VariantGroups>(
   options: PatternOptions<Variants>,
   debugId?: string
 ): RuntimeFn<Variants> {
@@ -27,16 +25,16 @@ export function recipe<Variants extends VariantGroups>(
   let defaultClassName;
 
   if (!base || typeof base === "string") {
-    const baseClassName = style({});
+    const baseClassName = css({});
     defaultClassName = base ? `${baseClassName} ${base}` : baseClassName;
   } else {
-    defaultClassName = style(base, debugId);
+    defaultClassName = css(base, debugId);
   }
 
   // @ts-expect-error - Temporarily ignoring the error as the PatternResult type is not fully defined
   const variantClassNames: PatternResult<Variants>["variantClassNames"] =
     mapValues(variants, (variantGroup, variantGroupName) =>
-      styleVariants(
+      cssVariants(
         variantGroup,
         (styleRule) =>
           typeof styleRule === "string" ? [styleRule] : styleRule,
@@ -51,7 +49,7 @@ export function recipe<Variants extends VariantGroups>(
       variants,
       typeof theStyle === "string"
         ? theStyle
-        : style(theStyle, `${debugId}_compound_${compounds.length}`)
+        : css(theStyle, `${debugId}_compound_${compounds.length}`)
     ]);
   }
 

--- a/packages/css/src/rules/types.ts
+++ b/packages/css/src/rules/types.ts
@@ -1,4 +1,4 @@
-import type { ComplexStyleRule } from '@vanilla-extract/css';
+import type { ComplexStyleRule } from "@vanilla-extract/css";
 
 type Resolve<T> = {
   [Key in keyof T]: T[Key];
@@ -8,7 +8,7 @@ type RecipeStyleRule = ComplexStyleRule | string;
 
 export type VariantDefinitions = Record<string, RecipeStyleRule>;
 
-type BooleanMap<T> = T extends 'true' | 'false' ? boolean : T;
+type BooleanMap<T> = T extends "true" | "false" ? boolean : T;
 
 export type VariantGroups = Record<string, VariantDefinitions>;
 export type VariantSelection<Variants extends VariantGroups> = {
@@ -48,7 +48,7 @@ export type RecipeClassNames<Variants extends VariantGroups> = {
 };
 
 export type RuntimeFn<Variants extends VariantGroups> = ((
-  options?: Resolve<VariantSelection<Variants>>,
+  options?: Resolve<VariantSelection<Variants>>
 ) => string) & {
   variants: () => (keyof Variants)[];
   classNames: RecipeClassNames<Variants>;

--- a/packages/css/src/rules/types.ts
+++ b/packages/css/src/rules/types.ts
@@ -1,10 +1,10 @@
-import type { ComplexStyleRule } from "@vanilla-extract/css";
+import type { ComplexCSSRule } from "@mincho-js/transform-to-vanilla";
 
 type Resolve<T> = {
   [Key in keyof T]: T[Key];
 } & {};
 
-type RecipeStyleRule = ComplexStyleRule | string;
+type RecipeStyleRule = ComplexCSSRule | string;
 
 export type VariantDefinitions = Record<string, RecipeStyleRule>;
 
@@ -54,6 +54,8 @@ export type RuntimeFn<Variants extends VariantGroups> = ((
   classNames: RecipeClassNames<Variants>;
 };
 
-export type RecipeVariants<RecipeFn extends RuntimeFn<VariantGroups>> = Resolve<
-  Parameters<RecipeFn>[0]
+export type RulesVariants<RuleFn extends RuntimeFn<VariantGroups>> = Resolve<
+  Parameters<RuleFn>[0]
 >;
+export type RecipeVariants<RecipeFn extends RuntimeFn<VariantGroups>> =
+  RulesVariants<RecipeFn>;

--- a/packages/css/src/rules/utils.ts
+++ b/packages/css/src/rules/utils.ts
@@ -1,8 +1,8 @@
-export function mapValues<Input extends Record<string, any>, OutputValue>(
+export function mapValues<Input extends Record<string, unknown>, OutputValue>(
   input: Input,
-  fn: (value: Input[keyof Input], key: keyof Input) => OutputValue,
+  fn: (value: Input[keyof Input], key: keyof Input) => OutputValue
 ): Record<keyof Input, OutputValue> {
-  const result: any = {};
+  const result = {} as Record<keyof Input, OutputValue>;
 
   for (const key in input) {
     result[key] = fn(input[key], key);


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->
Port from https://github.com/vanilla-extract-css/vanilla-extract/tree/master/packages/recipes/src

> [!WARNING]  
> Since the interface has only been built to avoid blocking team members' work, it is not actually operational yet.

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #94

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a utility for generating runtime class names based on variant selections.
  - Added functionality for creating CSS rules with support for variants and compound variants.
  - Expanded type definitions for better management of CSS rules and variants.

- **Bug Fixes**
  - Improved type safety and clarity when working with CSS rules and their variants.

- **Documentation**
  - Updated documentation to reflect new exports and functionalities related to CSS rules and variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->
Combine the commit history with the following command.

```shell
# Vanilla Extract
git clone https://github.com/vanilla-extract-css/vanilla-extract.git
cd vanilla-extract
git filter-repo --subdirectory-filter packages/recipes/src

# Mincho
cd ../mincho
git subtree add --prefix=packages/css/src/rules/ ../vanilla-extract master
```

## Checklist
<!-- Tell us what reviewers should look for. -->
