### PR TITLE
Test: core types about Rules(corresponding to Recipe)

### DIFF
--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -64,6 +64,8 @@
     "clean": "yarn g:clean",
     "build": "yarn g:build",
     "build:watch": "yarn g:build-watch",
+    "test": "yarn g:test",
+    "test:watch": "yarn g:test-watch",
     "lint": "yarn g:lint",
     "fix": "yarn g:fix",
     "check": "yarn g:check"


### PR DESCRIPTION
## Description

The core types test about [Rules](https://github.com/mincho-js/mincho/blob/main/packages/css/src/rules/index.ts) corresponding to [Recipe](https://vanilla-extract.style/documentation/packages/recipes/#recipes).

## Related Issue

- #93

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced type safety for variant selection and compound variants.
	- Added validation tests for variant-related structures to ensure correct configurations.
	- Implemented tests for pattern options to validate their structure and type compliance.
	- Added new script commands for executing tests and watching for changes.

- **Bug Fixes**
	- Improved error handling for invalid variant configurations, ensuring TypeScript correctly enforces constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context

It remain about `RecipeClassNames`, `RuntimeFn` Type Test (24.09.18).
I'm still thinking about type tests about these. I'll finish soon.

## Checklist
<!-- Tell us what reviewers should look for. -->
