### PR TITLE
Feat: Rules - Flatten base style support #102

### DIFF
--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -60,6 +60,7 @@
   },
   "prettier": "prettier-config-custom",
   "dependencies": {
+    "@fastify/deepmerge": "^2.0.0",
     "@mincho-js/transform-to-vanilla": "workspace:^"
   },
   "devDependencies": {

--- a/packages/css/src/rules/index.ts
+++ b/packages/css/src/rules/index.ts
@@ -1,3 +1,4 @@
+import deepmerge from "@fastify/deepmerge";
 import { addFunctionSerializer } from "@vanilla-extract/css/functionSerializer";
 import { css, cssVariants } from "../index";
 
@@ -11,6 +12,8 @@ import type {
 } from "./types";
 import { mapValues } from "./utils";
 
+const mergeObject = deepmerge();
+
 export function rules<Variants extends VariantGroups>(
   options: PatternOptions<Variants>,
   debugId?: string
@@ -19,16 +22,22 @@ export function rules<Variants extends VariantGroups>(
     variants = {},
     defaultVariants = {},
     compoundVariants = [],
-    base
+    base,
+    ...baseStyles
   } = options;
 
   let defaultClassName;
 
   if (!base || typeof base === "string") {
-    const baseClassName = css({});
+    const baseClassName = css(baseStyles);
     defaultClassName = base ? `${baseClassName} ${base}` : baseClassName;
   } else {
-    defaultClassName = css(base, debugId);
+    defaultClassName = css(
+      Array.isArray(base)
+        ? [baseStyles, ...base]
+        : mergeObject(baseStyles, base),
+      debugId
+    );
   }
 
   // @ts-expect-error - Temporarily ignoring the error as the PatternResult type is not fully defined

--- a/packages/css/src/rules/types.ts
+++ b/packages/css/src/rules/types.ts
@@ -1,4 +1,4 @@
-import type { ComplexCSSRule } from "@mincho-js/transform-to-vanilla";
+import type { ComplexCSSRule, CSSRule } from "@mincho-js/transform-to-vanilla";
 
 type Resolve<T> = {
   [Key in keyof T]: T[Key];
@@ -35,7 +35,7 @@ export interface CompoundVariant<Variants extends VariantGroups> {
   style: RecipeStyleRule;
 }
 
-export type PatternOptions<Variants extends VariantGroups> = {
+export type PatternOptions<Variants extends VariantGroups> = CSSRule & {
   base?: RecipeStyleRule;
   variants?: Variants;
   defaultVariants?: VariantSelection<Variants>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,6 +1192,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@mincho-js/css@workspace:packages/css"
   dependencies:
+    "@fastify/deepmerge": "npm:^2.0.0"
     "@mincho-js/transform-to-vanilla": "workspace:^"
     "@vanilla-extract/css": "npm:^1.15.5"
     eslint-config-custom: "workspace:^"


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->
Support flatten base style.

**Before**
```typescript
const myRules = rules({
  base: {
    color: "red",
    // ...styles
  }
});
```

**After**
```typescript
const myRules = rules({
  color: "red",
  // ...styles
});
```

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #102

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new dependency for enhanced object merging capabilities.
	- Enhanced the `rules` function to support flexible base style combinations.
	- Updated `PatternOptions` to integrate CSS rule functionalities for improved type definitions.

These changes improve styling flexibility and expand the functionality available for managing styles within the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
