### PR TITLE
Fix: Rules - Export `rules()` as `recipe()` #94

### DIFF
--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -30,7 +30,7 @@ export {
   keyframes,
   layer
 } from "@vanilla-extract/css";
-export { rules } from "./rules";
+export { rules, recipe } from "./rules";
 export type { RulesVariants, RecipeVariants, RuntimeFn } from "./rules/types";
 
 export type { CSSProperties, ComplexCSSRule, GlobalCSSRule, CSSRule };

--- a/packages/css/src/rules/index.ts
+++ b/packages/css/src/rules/index.ts
@@ -109,3 +109,4 @@ export function rules<
     }
   );
 }
+export const recipe = rules;


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->
`rules()` alised with `recipe()` for compatibility.

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #94

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new export, `recipe`, enhancing usability by providing an alternative name for the existing `rules` function.
- **Bug Fixes**
	- Updated comments in the `globalCss` function regarding TypeScript errors for better clarity on potential type mismatches.
- **Improvements**
	- Enhanced the `cssVariants` function for greater flexibility in style processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
