### PR TITLE
Feat: Transform - Execute a function that returns className #114

### DIFF
--- a/packages/transform-to-vanilla/src/transform.ts
+++ b/packages/transform-to-vanilla/src/transform.ts
@@ -22,6 +22,9 @@ export function transform(
       if (isClassNames(eachStyle)) {
         return eachStyle;
       }
+      if (typeof eachStyle === "function") {
+        return eachStyle();
+      }
 
       const tempContext = structuredClone(context);
       const result = transformStyle(eachStyle, tempContext);
@@ -61,6 +64,15 @@ if (import.meta.vitest) {
       expect(resultNestedClassNames).toStrictEqual(nestedClassNames);
     });
 
+    it("Functions", () => {
+      const classNameFunctions = [
+        () => "myClassName1",
+        (_arg: number) => "myClassName2"
+      ];
+      const result = transform(classNameFunctions);
+      expect(result).toStrictEqual(["myClassName1", "myClassName2"]);
+    });
+
     it("Style", () => {
       const style = {
         color: "red",
@@ -94,6 +106,10 @@ if (import.meta.vitest) {
         ["nestedClassName2", "nestedClassName3"],
         "nestedClassName4"
       ];
+      const classNameFunctions = [
+        () => "myClassName3",
+        (_arg: number) => "myClassName4"
+      ];
       const style1 = {
         color: "red",
         borderRadius: 5
@@ -102,16 +118,19 @@ if (import.meta.vitest) {
         background: "blue"
       };
 
-      expect([classNames, nestedClassNames, style1, style2]).toStrictEqual([
-        classNames,
-        nestedClassNames,
+      const result = transform([
+        ...classNames,
+        ...nestedClassNames,
+        ...classNameFunctions,
         style1,
         style2
       ]);
-      expect([style1, nestedClassNames, classNames, style2]).toStrictEqual([
+      expect(result).toStrictEqual([
+        ...classNames,
+        ...nestedClassNames,
+        "myClassName3",
+        "myClassName4",
         style1,
-        nestedClassNames,
-        classNames,
         style2
       ]);
     });

--- a/packages/transform-to-vanilla/src/types/style-rule.ts
+++ b/packages/transform-to-vanilla/src/types/style-rule.ts
@@ -24,7 +24,11 @@ export type VanillaClassNames = ClassNames;
 
 // == Interface ===============================================================
 export type ComplexCSSRule = CSSRule | Array<ComplexCSSItem>;
-export type ComplexCSSItem = CSSRule | ClassNames;
+export type ComplexCSSItem =
+  | CSSRule
+  | ClassNames
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  | ((...args: any[]) => ClassNames);
 
 export interface CSSRule
   extends CSSPropertiesWithConditions,
@@ -524,6 +528,59 @@ if (import.meta.vitest) {
           }
         }
       });
+    });
+  });
+
+  describe.concurrent("Complex CSS Rules", () => {
+    it("className", () => {
+      assertType<ComplexCSSRule>(["className1", "className2"]);
+    });
+
+    it("function", () => {
+      assertType<ComplexCSSRule>([
+        () => "className1",
+        (_arg: number) => "className2",
+        (_arg: CSSRule, _debugId: string) => "className3"
+      ]);
+    });
+
+    it("CSS Rules", () => {
+      assertType<ComplexCSSRule>({
+        padding: 10,
+        marginTop: 25
+      });
+      assertType<ComplexCSSRule>([
+        {
+          padding: 10,
+          marginTop: 25
+        },
+        {
+          color: "red",
+          _hover: {
+            color: "blue"
+          }
+        }
+      ]);
+    });
+
+    it("Complex", () => {
+      assertType<ComplexCSSRule>([
+        "className1",
+        "className2",
+        () => "className3",
+        (_arg: number) => "className4",
+        (_arg: CSSRule, _debugId: string) => "className5",
+        {
+          padding: 10,
+          marginTop: 25
+        },
+        {
+          color: "red",
+          _hover: {
+            color: "blue"
+          }
+        }
+      ]);
     });
   });
 }


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->
Execute a function at `css()`

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #114

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the `transform` function to process arrays containing both class names and functions that return class names.
	- Expanded the `ComplexCSSItem` type to support function-based class name generation.

- **Bug Fixes**
	- Updated the test suite with new cases to validate the handling of function inputs and complex CSS rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
