### PR TITLE
Fix: CI - Hard Reset at changeset versioning #118

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -16,6 +16,7 @@ jobs:
 
     outputs:
       should_run: ${{ steps.check_branch.outputs.should_run }}
+      pr_sha: ${{ steps.check_branch.outputs.pr_sha }}
 
     steps:
       - name: Check comment
@@ -56,6 +57,7 @@ jobs:
 
           GITHUB_PR=$(mktemp)
           function get_pr_info {
+            # https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request
             curl --silent --show-error --location \
                  -X GET \
                  -H "Accept: application/vnd.github+json" \
@@ -93,6 +95,9 @@ jobs:
           if [ "$BASE_REF" = "main" ]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
             check_pr_merged
+
+            HEAD_SHA=$(jq -r ".head.sha" <$GITHUB_PR)
+            echo "pr_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
           else
             echo "should_run=false" >> $GITHUB_OUTPUT
           fi
@@ -119,13 +124,23 @@ jobs:
       - name: Setup
         uses: ./.github/actions/node-setup
 
+      - name: Is versioning PR
+        run: |
+          cd ./.changeset || exit
+          md_files=$(find . -maxdepth 1 -type f -name "*.md" ! -name "README.md")
+          if [ -n "$md_files" ]; then
+          git branch changeset-release/main $PR_SHA
+          fi
+        env:
+          PR_SHA: ${{ needs.fast-forward.outputs.pr_sha }}
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
           commit: "Chore: Version Packages"
           publish: yarn run publish
-          version: yarn run changeset:version
+          version: git reset --hard changeset-release/main && yarn run changeset:version
           setupGitUser: true
           createGithubReleases: true
         env:
@@ -135,7 +150,7 @@ jobs:
       - name: Show log on failure
         if: failure()
         run: |
-          cd /home/runner/.npm/_logs/
+          cd /home/runner/.npm/_logs/ || exit
           for file in *; do
             echo "=== File: $file ==="
             cat "$file"


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->
1. Create `changeset-release/main` branch with PR_SHA
2. Perform a hard reset when versioning.

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #118

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced PR merging checks with a retry mechanism.
	- Introduced a new step to identify versioning PRs based on changeset files.
  
- **Improvements**
	- Added output variable to capture PR commit SHA.
	- Improved error handling for better workflow stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->
Even if this PR is merged, you cannot be sure that it will be fixed, so you should not close it.

## Checklist
<!-- Tell us what reviewers should look for. -->
