### PR TITLE
Test: css(), cssVariants(), rules() #93 

### DIFF
--- a/packages/css/src/css/index.ts
+++ b/packages/css/src/css/index.ts
@@ -1,0 +1,95 @@
+import {
+  transform,
+  replaceVariantReference,
+  initTransformContext,
+  type TransformContext
+} from "@mincho-js/transform-to-vanilla";
+import type {
+  CSSRule,
+  ComplexCSSRule,
+  GlobalCSSRule
+} from "@mincho-js/transform-to-vanilla";
+import { style as vStyle, globalStyle as gStyle } from "@vanilla-extract/css";
+
+// == Global CSS ===============================================================
+export function globalCss(selector: string, rule: GlobalCSSRule) {
+  gStyle(selector, transform(rule));
+}
+export const globalStyle = globalCss;
+
+// == CSS ======================================================================
+export function css(style: ComplexCSSRule, debugId?: string) {
+  return vStyle(transform(style), debugId);
+}
+export const style = css;
+
+// == CSS Variants =============================================================
+// TODO: Need to optimize
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get#smart_self-overwriting_lazy_getters
+// https://github.com/vanilla-extract-css/vanilla-extract/blob/master/packages/css/src/style.ts
+export function cssVariants<
+  StyleMap extends Record<string | number, ComplexCSSRule>
+>(styleMap: StyleMap, debugId?: string): Record<keyof StyleMap, string>;
+export function cssVariants<
+  Data extends Record<string | number, unknown>,
+  Key extends keyof Data,
+  MapData extends (value: Data[Key], key: Key) => ComplexCSSRule
+>(data: Data, mapData: MapData, debugId?: string): Record<keyof Data, string>;
+export function cssVariants<
+  StyleMap extends Record<string | number, ComplexCSSRule>,
+  Data extends Record<string | number, unknown>,
+  MapData extends (value: unknown, key: string | number) => ComplexCSSRule
+>(
+  styleMapOrData: StyleMap | Data,
+  mapDataOrDebugId?: MapData | string,
+  debugId?: string
+): Record<string | number, string> {
+  if (isMapDataFunction(mapDataOrDebugId)) {
+    const data = styleMapOrData as Data;
+    const mapData = mapDataOrDebugId;
+    return processVariants(data, mapData, debugId);
+  } else {
+    const styleMap = styleMapOrData as StyleMap;
+    const debugId = mapDataOrDebugId;
+    return processVariants(styleMap, (style) => style, debugId);
+  }
+}
+export const styleVariants = cssVariants;
+
+function isMapDataFunction<
+  Data extends Record<string | number, unknown>,
+  Key extends keyof Data,
+  MapData extends (value: Data[Key], key: Key) => ComplexCSSRule
+>(mapDataOrDebugId?: MapData | string): mapDataOrDebugId is MapData {
+  return typeof mapDataOrDebugId === "function";
+}
+function processVariants<T>(
+  items: Record<string | number, T>,
+  transformItem: (item: T, key: string | number) => ComplexCSSRule,
+  debugId?: string
+): Record<string | number, string> {
+  const contexts: TransformContext[] = [];
+  const variantMap: Record<string, string> = {};
+  const classMap: Record<string | number, string> = {};
+
+  for (const key in items) {
+    const context = structuredClone(initTransformContext);
+    const className = vStyle(
+      transform(transformItem(items[key], key), context),
+      debugId ? `${debugId}_${key}` : key
+    );
+    contexts.push(context);
+    variantMap[`%${key}`] = className;
+    classMap[key] = className;
+  }
+
+  for (const context of contexts) {
+    context.variantMap = variantMap;
+    replaceVariantReference(context);
+    for (const [key, value] of Object.entries(context.variantReference)) {
+      globalCss(key, value as CSSRule);
+    }
+  }
+
+  return classMap;
+}

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -1,16 +1,10 @@
-import {
-  transform,
-  replaceVariantReference,
-  initTransformContext,
-  type TransformContext
-} from "@mincho-js/transform-to-vanilla";
 import type {
   CSSProperties,
   ComplexCSSRule,
   GlobalCSSRule,
   CSSRule
 } from "@mincho-js/transform-to-vanilla";
-import { style as vStyle, globalStyle as gStyle } from "@vanilla-extract/css";
+
 export type { Adapter, FileScope } from "@vanilla-extract/css";
 export {
   assignVars,
@@ -30,6 +24,15 @@ export {
   keyframes,
   layer
 } from "@vanilla-extract/css";
+
+export {
+  globalCss,
+  globalStyle,
+  css,
+  style,
+  cssVariants,
+  styleVariants
+} from "./css";
 export { rules, recipe } from "./rules";
 export type { RulesVariants, RecipeVariants, RuntimeFn } from "./rules/types";
 
@@ -37,85 +40,3 @@ export type { CSSProperties, ComplexCSSRule, GlobalCSSRule, CSSRule };
 export type ComplexStyleRule = ComplexCSSRule;
 export type GlobalStyleRule = GlobalCSSRule;
 export type StyleRule = CSSRule;
-
-export function globalCss(selector: string, rule: GlobalCSSRule) {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore: error TS2345 Argument of type 'ComplexStyleRule' is not assignable to parameter of type 'GlobalStyleRule'
-  gStyle(selector, transform(rule));
-}
-export const globalStyle = globalCss;
-
-export function css(style: ComplexCSSRule, debugId?: string) {
-  return vStyle(transform(style), debugId);
-}
-export const style = css;
-
-// TODO: Need to optimize
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get#smart_self-overwriting_lazy_getters
-// https://github.com/vanilla-extract-css/vanilla-extract/blob/master/packages/css/src/style.ts
-export function cssVariants<
-  StyleMap extends Record<string | number, ComplexCSSRule>
->(styleMap: StyleMap, debugId?: string): Record<keyof StyleMap, string>;
-export function cssVariants<
-  Data extends Record<string | number, unknown>,
-  Key extends keyof Data,
-  MapData extends (value: Data[Key], key: Key) => ComplexCSSRule
->(data: Data, mapData: MapData, debugId?: string): Record<keyof Data, string>;
-export function cssVariants<
-  StyleMap extends Record<string | number, ComplexCSSRule>,
-  Data extends Record<string | number, unknown>,
-  MapData extends (value: unknown, key: string | number) => ComplexCSSRule
->(
-  styleMapOrData: StyleMap | Data,
-  mapDataOrDebugId?: MapData | string,
-  debugId?: string
-): Record<string | number, string> {
-  if (isMapDataFunction(mapDataOrDebugId)) {
-    const data = styleMapOrData as Data;
-    const mapData = mapDataOrDebugId;
-    return processVariants(data, mapData, debugId);
-  } else {
-    const styleMap = styleMapOrData as StyleMap;
-    const debugId = mapDataOrDebugId;
-    return processVariants(styleMap, (style) => style, debugId);
-  }
-}
-export const styleVariants = cssVariants;
-
-function isMapDataFunction<
-  Data extends Record<string | number, unknown>,
-  Key extends keyof Data,
-  MapData extends (value: Data[Key], key: Key) => ComplexCSSRule
->(mapDataOrDebugId?: MapData | string): mapDataOrDebugId is MapData {
-  return typeof mapDataOrDebugId === "function";
-}
-function processVariants<T>(
-  items: Record<string | number, T>,
-  transformItem: (item: T, key: string | number) => ComplexCSSRule,
-  debugId?: string
-): Record<string | number, string> {
-  const contexts: TransformContext[] = [];
-  const variantMap: Record<string, string> = {};
-  const classMap: Record<string | number, string> = {};
-
-  for (const key in items) {
-    const context = structuredClone(initTransformContext);
-    const className = vStyle(
-      transform(transformItem(items[key], key), context),
-      debugId ? `${debugId}_${key}` : key
-    );
-    contexts.push(context);
-    variantMap[`%${key}`] = className;
-    classMap[key] = className;
-  }
-
-  for (const context of contexts) {
-    context.variantMap = variantMap;
-    replaceVariantReference(context);
-    for (const [key, value] of Object.entries(context.variantReference)) {
-      globalCss(key, value as StyleRule);
-    }
-  }
-
-  return classMap;
-}

--- a/packages/css/src/rules/index.ts
+++ b/packages/css/src/rules/index.ts
@@ -1,8 +1,10 @@
 import deepmerge from "@fastify/deepmerge";
 import { addFunctionSerializer } from "@vanilla-extract/css/functionSerializer";
+import { setFileScope } from "@vanilla-extract/css/fileScope";
 import type { ComplexCSSRule } from "@mincho-js/transform-to-vanilla";
 
-import { css, cssVariants } from "../index";
+import { css, cssVariants } from "../css";
+import { className } from "../utils";
 import { createRuntimeFn } from "./createRuntimeFn";
 import type {
   PatternOptions,
@@ -39,10 +41,9 @@ export function rules<
     ...baseStyles
   } = options;
 
-  let defaultClassName;
-
+  let defaultClassName: string;
   if (!base || typeof base === "string") {
-    const baseClassName = css(baseStyles);
+    const baseClassName = css(baseStyles, debugId);
     defaultClassName = base ? `${baseClassName} ${base}` : baseClassName;
   } else {
     defaultClassName = css(
@@ -77,7 +78,6 @@ export function rules<
 
   const compounds: Array<[VariantObjectSelection<CombinedVariants>, string]> =
     [];
-
   for (const { style: theStyle, variants } of compoundVariants) {
     compounds.push([
       transformVariantSelection<CombinedVariants>(
@@ -92,7 +92,7 @@ export function rules<
   const config: PatternResult<CombinedVariants> = {
     defaultClassName,
     variantClassNames,
-    defaultVariants,
+    defaultVariants: transformVariantSelection(defaultVariants),
     compoundVariants: compounds
   };
 
@@ -110,3 +110,429 @@ export function rules<
   );
 }
 export const recipe = rules;
+
+if (import.meta.vitest) {
+  const { describe, it, assert, expect } = import.meta.vitest;
+
+  const debugId = "myCSS";
+  setFileScope("test");
+
+  describe.concurrent("rules()", () => {
+    it("base style", () => {
+      const result = rules({ base: { color: "red" } }, debugId);
+
+      assert.isFunction(result);
+      assert.hasAllKeys(result, ["variants", "classNames"]);
+      assert.hasAllKeys(result.classNames, ["base", "variants"]);
+
+      expect(result()).toMatch(className(debugId));
+      expect(result.classNames.base).toMatch(className(debugId));
+      expect(result.classNames.variants).toEqual({});
+      expect(result.variants()).toEqual([]);
+    });
+
+    it("base flatten style", () => {
+      const result = rules({ color: "red" }, debugId);
+
+      assert.isFunction(result);
+      assert.hasAllKeys(result, ["variants", "classNames"]);
+      assert.hasAllKeys(result.classNames, ["base", "variants"]);
+
+      expect(result()).toMatch(className(debugId));
+      expect(result.classNames.base).toMatch(className(debugId));
+      expect(result.classNames.variants).toEqual({});
+      expect(result.variants()).toEqual([]);
+    });
+
+    it("variants", () => {
+      const result = rules(
+        {
+          variants: {
+            color: {
+              brand: { color: "#FFFFA0" },
+              accent: { color: "#FFE4B5" }
+            },
+            size: {
+              small: { padding: 12 },
+              medium: { padding: 16 },
+              large: { padding: 24 }
+            },
+            outlined: {
+              true: { border: "1px solid black" },
+              false: { border: "1px solid transparent" }
+            }
+          }
+        },
+        debugId
+      );
+
+      // Base check
+      assert.isFunction(result);
+      assert.hasAllKeys(result, ["variants", "classNames"]);
+      assert.hasAllKeys(result.classNames, ["base", "variants"]);
+
+      expect(result()).toMatch(className(debugId));
+      expect(result.classNames.base).toMatch(className(debugId));
+      assert.hasAllKeys(result.classNames.variants, [
+        "color",
+        "size",
+        "outlined"
+      ]);
+      expect(result.variants()).toEqual(["color", "size", "outlined"]);
+
+      // Each variant className check
+      assert.hasAllKeys(result.classNames.variants.color, ["brand", "accent"]);
+      expect(result.classNames.variants.color.brand).toMatch(
+        className(`${debugId}_color_brand`)
+      );
+      expect(result.classNames.variants.color.accent).toMatch(
+        className(`${debugId}_color_accent`)
+      );
+
+      assert.hasAllKeys(result.classNames.variants.size, [
+        "small",
+        "medium",
+        "large"
+      ]);
+      expect(result.classNames.variants.size.small).toMatch(
+        className(`${debugId}_size_small`)
+      );
+      expect(result.classNames.variants.size.medium).toMatch(
+        className(`${debugId}_size_medium`)
+      );
+      expect(result.classNames.variants.size.large).toMatch(
+        className(`${debugId}_size_large`)
+      );
+
+      assert.hasAllKeys(result.classNames.variants.outlined, ["true", "false"]);
+      expect(result.classNames.variants.outlined.true).toMatch(
+        className(`${debugId}_outlined_true`)
+      );
+      expect(result.classNames.variants.outlined.false).toMatch(
+        className(`${debugId}_outlined_false`)
+      );
+
+      // Compose variant className check
+      expect(result()).toMatch(className(debugId));
+      expect(result({ color: "brand" })).toMatch(
+        className(debugId, `${debugId}_color_brand`)
+      );
+      expect(result({ size: "small" })).toMatch(
+        className(debugId, `${debugId}_size_small`)
+      );
+      expect(result({ outlined: true })).toMatch(
+        className(debugId, `${debugId}_outlined_true`)
+      );
+      expect(result(["outlined"])).toMatch(
+        className(debugId, `${debugId}_outlined_true`)
+      );
+
+      expect(result({ color: "brand", size: "small" })).toMatch(
+        className(debugId, `${debugId}_color_brand`, `${debugId}_size_small`)
+      );
+      expect(result({ size: "small", color: "brand" })).toMatch(
+        className(debugId, `${debugId}_size_small`, `${debugId}_color_brand`)
+      );
+      expect(result(["outlined", { color: "brand" }])).toMatch(
+        className(debugId, `${debugId}_outlined_true`, `${debugId}_color_brand`)
+      );
+      expect(result([{ color: "brand" }, "outlined"])).toMatch(
+        className(debugId, `${debugId}_color_brand`, `${debugId}_outlined_true`)
+      );
+
+      expect(result([{ color: "brand" }, { color: "accent" }])).toMatch(
+        className(debugId, `${debugId}_color_accent`)
+      );
+      expect(result(["outlined", { outlined: false }])).toMatch(
+        className(debugId, `${debugId}_outlined_false`)
+      );
+      expect(result(["outlined", { outlined: false }, "outlined"])).toMatch(
+        className(debugId, `${debugId}_outlined_true`)
+      );
+    });
+
+    it("toggle variants", () => {
+      const result = rules(
+        {
+          toggles: {
+            disabled: { textDecoration: "line-through" },
+            rounded: { borderRadius: 999 }
+          }
+        },
+        debugId
+      );
+
+      // Base check
+      assert.isFunction(result);
+      assert.hasAllKeys(result, ["variants", "classNames"]);
+      assert.hasAllKeys(result.classNames, ["base", "variants"]);
+
+      expect(result()).toMatch(className(debugId));
+      expect(result.classNames.base).toMatch(className(debugId));
+      assert.hasAllKeys(result.classNames.variants, ["disabled", "rounded"]);
+      expect(result.variants()).toEqual(["disabled", "rounded"]);
+
+      // Each variant className check
+      assert.hasAllKeys(result.classNames.variants.disabled, ["true"]);
+      expect(result.classNames.variants.disabled.true).toMatch(
+        className(`${debugId}_disabled_true`)
+      );
+
+      assert.hasAllKeys(result.classNames.variants.rounded, ["true"]);
+      expect(result.classNames.variants.rounded.true).toMatch(
+        className(`${debugId}_rounded_true`)
+      );
+
+      // Compose variant className check
+      expect(result()).toMatch(className(debugId));
+      expect(result({ disabled: true })).toMatch(
+        className(debugId, `${debugId}_disabled_true`)
+      );
+      expect(result(["disabled"])).toMatch(
+        className(debugId, `${debugId}_disabled_true`)
+      );
+      expect(result({ rounded: true })).toMatch(
+        className(debugId, `${debugId}_rounded_true`)
+      );
+      expect(result(["rounded"])).toMatch(
+        className(debugId, `${debugId}_rounded_true`)
+      );
+
+      expect(result(["disabled", "rounded"])).toMatch(
+        className(
+          debugId,
+          `${debugId}_disabled_true`,
+          `${debugId}_rounded_true`
+        )
+      );
+      expect(result(["rounded", "disabled"])).toMatch(
+        className(
+          debugId,
+          `${debugId}_rounded_true`,
+          `${debugId}_disabled_true`
+        )
+      );
+    });
+
+    it("defaultVariants", () => {
+      const result = rules(
+        {
+          defaultVariants: ["disabled"],
+          toggles: {
+            disabled: { textDecoration: "line-through" },
+            rounded: { borderRadius: 999 }
+          }
+        },
+        debugId
+      );
+
+      // Base check
+      assert.isFunction(result);
+      assert.hasAllKeys(result, ["variants", "classNames"]);
+      assert.hasAllKeys(result.classNames, ["base", "variants"]);
+
+      expect(result()).toMatch(className(debugId, `${debugId}_disabled_true`));
+      expect(result.classNames.base).toMatch(className(debugId));
+      assert.hasAllKeys(result.classNames.variants, ["disabled", "rounded"]);
+      expect(result.variants()).toEqual(["disabled", "rounded"]);
+
+      // Each variant className check
+      assert.hasAllKeys(result.classNames.variants.disabled, ["true"]);
+      expect(result.classNames.variants.disabled.true).toMatch(
+        className(`${debugId}_disabled_true`)
+      );
+
+      assert.hasAllKeys(result.classNames.variants.rounded, ["true"]);
+      expect(result.classNames.variants.rounded.true).toMatch(
+        className(`${debugId}_rounded_true`)
+      );
+
+      // Compose variant className check
+      expect(result()).toMatch(className(debugId, `${debugId}_disabled_true`));
+      expect(result({ disabled: true })).toMatch(
+        className(debugId, `${debugId}_disabled_true`)
+      );
+      expect(result(["disabled"])).toMatch(
+        className(debugId, `${debugId}_disabled_true`)
+      );
+      expect(result({ rounded: true })).toMatch(
+        className(
+          debugId,
+          `${debugId}_disabled_true`,
+          `${debugId}_rounded_true`
+        )
+      );
+      expect(result(["rounded"])).toMatch(
+        className(
+          debugId,
+          `${debugId}_disabled_true`,
+          `${debugId}_rounded_true`
+        )
+      );
+
+      expect(result(["disabled", "rounded"])).toMatch(
+        className(
+          debugId,
+          `${debugId}_disabled_true`,
+          `${debugId}_rounded_true`
+        )
+      );
+      expect(result(["rounded", "disabled"])).toMatch(
+        className(
+          debugId,
+          // disabled: true already exist
+          `${debugId}_disabled_true`,
+          `${debugId}_rounded_true`
+        )
+      );
+    });
+
+    it("compoundVariants", () => {
+      const result = rules(
+        {
+          compoundVariants: [
+            {
+              variants: ["outlined", { color: "brand" }],
+              style: {
+                color: "red"
+              }
+            },
+            {
+              variants: {
+                color: "brand",
+                size: "medium",
+                outlined: true
+              },
+              style: {
+                color: "red"
+              }
+            }
+          ],
+          variants: {
+            color: {
+              brand: { color: "#FFFFA0" },
+              accent: { color: "#FFE4B5" }
+            },
+            size: {
+              small: { padding: 12 },
+              medium: { padding: 16 },
+              large: { padding: 24 }
+            },
+            outlined: {
+              true: { border: "1px solid black" },
+              false: { border: "1px solid transparent" }
+            }
+          }
+        },
+        debugId
+      );
+
+      // Base check
+      assert.isFunction(result);
+      assert.hasAllKeys(result, ["variants", "classNames"]);
+      assert.hasAllKeys(result.classNames, ["base", "variants"]);
+
+      expect(result()).toMatch(className(debugId));
+      expect(result.classNames.base).toMatch(className(debugId));
+      assert.hasAllKeys(result.classNames.variants, [
+        "color",
+        "size",
+        "outlined"
+      ]);
+      expect(result.variants()).toEqual(["color", "size", "outlined"]);
+
+      // Each variant className check
+      assert.hasAllKeys(result.classNames.variants.color, ["brand", "accent"]);
+      expect(result.classNames.variants.color.brand).toMatch(
+        className(`${debugId}_color_brand`)
+      );
+      expect(result.classNames.variants.color.accent).toMatch(
+        className(`${debugId}_color_accent`)
+      );
+
+      assert.hasAllKeys(result.classNames.variants.size, [
+        "small",
+        "medium",
+        "large"
+      ]);
+      expect(result.classNames.variants.size.small).toMatch(
+        className(`${debugId}_size_small`)
+      );
+      expect(result.classNames.variants.size.medium).toMatch(
+        className(`${debugId}_size_medium`)
+      );
+      expect(result.classNames.variants.size.large).toMatch(
+        className(`${debugId}_size_large`)
+      );
+
+      assert.hasAllKeys(result.classNames.variants.outlined, ["true", "false"]);
+      expect(result.classNames.variants.outlined.true).toMatch(
+        className(`${debugId}_outlined_true`)
+      );
+      expect(result.classNames.variants.outlined.false).toMatch(
+        className(`${debugId}_outlined_false`)
+      );
+
+      // Compose variant className check
+      expect(result()).toMatch(className(debugId));
+      expect(result({ color: "brand" })).toMatch(
+        className(debugId, `${debugId}_color_brand`)
+      );
+      expect(result({ size: "small" })).toMatch(
+        className(debugId, `${debugId}_size_small`)
+      );
+      expect(result({ outlined: true })).toMatch(
+        className(debugId, `${debugId}_outlined_true`)
+      );
+      expect(result(["outlined"])).toMatch(
+        className(debugId, `${debugId}_outlined_true`)
+      );
+
+      expect(result({ color: "brand", size: "small" })).toMatch(
+        className(debugId, `${debugId}_color_brand`, `${debugId}_size_small`)
+      );
+      expect(result({ size: "small", color: "brand" })).toMatch(
+        className(debugId, `${debugId}_size_small`, `${debugId}_color_brand`)
+      );
+      expect(result(["outlined", { color: "brand" }])).toMatch(
+        className(
+          debugId,
+          `${debugId}_outlined_true`,
+          `${debugId}_color_brand`,
+          // Compound
+          `${debugId}_compound_0`
+        )
+      );
+      expect(result([{ color: "brand" }, "outlined"])).toMatch(
+        className(
+          debugId,
+          `${debugId}_color_brand`,
+          `${debugId}_outlined_true`,
+          // Compound
+          `${debugId}_compound_0`
+        )
+      );
+      expect(result(["outlined", { color: "brand", size: "medium" }])).toMatch(
+        className(
+          debugId,
+          `${debugId}_outlined_true`,
+          `${debugId}_color_brand`,
+          `${debugId}_size_medium`,
+          // Compound
+          `${debugId}_compound_0`,
+          `${debugId}_compound_1`
+        )
+      );
+
+      expect(result([{ color: "brand" }, { color: "accent" }])).toMatch(
+        className(debugId, `${debugId}_color_accent`)
+      );
+      expect(result(["outlined", { outlined: false }])).toMatch(
+        className(debugId, `${debugId}_outlined_false`)
+      );
+      expect(result(["outlined", { outlined: false }, "outlined"])).toMatch(
+        className(debugId, `${debugId}_outlined_true`)
+      );
+    });
+  });
+}

--- a/packages/css/src/rules/index.ts
+++ b/packages/css/src/rules/index.ts
@@ -1,8 +1,8 @@
 import deepmerge from "@fastify/deepmerge";
 import { addFunctionSerializer } from "@vanilla-extract/css/functionSerializer";
-import { css, cssVariants } from "../index";
 import type { ComplexCSSRule } from "@mincho-js/transform-to-vanilla";
 
+import { css, cssVariants } from "../index";
 import { createRuntimeFn } from "./createRuntimeFn";
 import type {
   PatternOptions,

--- a/packages/css/src/utils.ts
+++ b/packages/css/src/utils.ts
@@ -1,0 +1,5 @@
+export function className(...debugIds: string[]) {
+  const hashRegex = "[a-zA-Z0-9]+";
+  const classStr = debugIds.map((id) => `${id}__${hashRegex}`).join(" ");
+  return new RegExp(`^${classStr}$`);
+}


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->
1. Split `index.ts` to `./css/index.ts`: `index.ts` focuses only on export.
2. Write test codes for `css()`, `cssVariants()`, `rules()`
3. Some bug fixes:
   - `rules()`'s base style debugId
   - `defaultVariants` resolve at buildtime

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #93

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new CSS module for defining global and component-specific styles using Vanilla Extract.
	- Added functions for global styles, component-specific styles, and style variants.
	- New utility function `className` for constructing class name patterns.

- **Bug Fixes**
	- Updated imports and method signatures to ensure proper functionality and type safety.

- **Tests**
	- Added comprehensive test coverage for the new CSS functionality and rules processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
