### PR TITLE
Test: core types about Rules corresponding to Recipe (2)

### DIFF
--- a/packages/css/src/rules/types.ts
+++ b/packages/css/src/rules/types.ts
@@ -213,6 +213,32 @@ if (import.meta.vitest) {
     });
   });
 
+  describe.concurrent("RecipeClassNames Type Test", () => {
+    function assertValidClassNames<Variants extends VariantGroups>(
+      classNames: RecipeClassNames<Variants>
+    ) {
+      assertType(classNames);
+      return classNames;
+    }
+
+    it("Valid ClassNames Type Check", () => {
+      assertValidClassNames({
+        base: "base-class",
+        variants: {
+          color: {
+            brand: "color-brand-class",
+            accent: "color-accent-class"
+          },
+          size: {
+            small: "size-small-class",
+            medium: "size-medium-class",
+            large: "size-large-class"
+          }
+        }
+      });
+    });
+  });
+
   describe.concurrent("Types related to Rules", () => {
     function assertValidOptions<
       Variants extends VariantGroups | undefined = undefined,

--- a/packages/css/src/rules/types.ts
+++ b/packages/css/src/rules/types.ts
@@ -108,7 +108,7 @@ export type RecipeVariants<RecipeFn extends RuntimeFn<VariantGroups>> =
 
 // == Tests ====================================================================
 if (import.meta.vitest) {
-  const { describe, it, assertType } = import.meta.vitest;
+  const { describe, it, assertType, expectTypeOf } = import.meta.vitest;
 
   describe.concurrent("ConditionVariants Type Test", () => {
     it("Conditional Type", () => {
@@ -236,6 +236,59 @@ if (import.meta.vitest) {
           }
         }
       });
+    });
+  });
+
+  describe.concurrent("RuntimeFn Type Test", () => {
+    type TestVariantsType = {
+      color: {
+        brand: { color: string };
+        accent: { color: string };
+      };
+      size: {
+        small: { padding: number };
+        medium: { padding: number };
+        large: { padding: number };
+      };
+      outlined: {
+        true: { border: string };
+        false: { border: string };
+      };
+    };
+
+    it("RuntimeFn Type Check", () => {
+      type ExpectedResultType = RuntimeFn<TestVariantsType>;
+      expectTypeOf<ExpectedResultType>().toBeFunction();
+      expectTypeOf<ExpectedResultType["variants"]>().toBeFunction();
+      expectTypeOf<ExpectedResultType["classNames"]>().toBeObject();
+
+      const expectedResult = Object.assign(
+        (_options?: ResolveComplex<VariantSelection<TestVariantsType>>) =>
+          "my-class",
+        {
+          variants: () =>
+            ["color", "size", "outlined"] satisfies (keyof TestVariantsType)[],
+          classNames: {
+            base: "basic-class",
+            variants: {
+              color: {
+                brand: "color-brand",
+                accent: "color-accent"
+              },
+              size: {
+                small: "size-small",
+                medium: "size-medium",
+                large: "size-large"
+              },
+              outlined: {
+                true: "outlined-true",
+                false: "outlined-false"
+              }
+            }
+          } satisfies RecipeClassNames<TestVariantsType>
+        }
+      );
+      assertType<ExpectedResultType>(expectedResult);
     });
   });
 


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->

The core types test about [Rules](https://github.com/mincho-js/mincho/blob/main/packages/css/src/rules/index.ts) corresponding to [Recipe](https://vanilla-extract.style/documentation/packages/recipes/#recipes).

- `RecipeClassNames`
- `RuntimeFn`

It's following the #99 merged PR

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->

- #93 

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new test suites for validating `RecipeClassNames` and `RuntimeFn` types.
- **Bug Fixes**
	- Enhanced existing type assertions and expanded test cases for better type validation.
- **Chores**
	- Added utility for asserting expected types in the `RuntimeFn` test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
