### PR TITLE
Feat: Rules - Props type #131

### DIFF
--- a/packages/css/src/rules/index.ts
+++ b/packages/css/src/rules/index.ts
@@ -14,6 +14,8 @@ import type {
   VariantDefinitions,
   VariantSelection,
   VariantObjectSelection,
+  ComplexPropDefinitions,
+  PropTarget,
   ConditionalVariants,
   Serializable
 } from "./types";
@@ -27,9 +29,10 @@ const mergeObject = deepmerge();
 
 export function rules<
   Variants extends VariantGroups | undefined = undefined,
-  ToggleVariants extends VariantDefinitions | undefined = undefined
+  ToggleVariants extends VariantDefinitions | undefined = undefined,
+  Props extends ComplexPropDefinitions<PropTarget> | undefined = undefined
 >(
-  options: PatternOptions<Variants, ToggleVariants>,
+  options: PatternOptions<Variants, ToggleVariants, Props>,
   debugId?: string
 ): RuntimeFn<ConditionalVariants<Variants, ToggleVariants>> {
   const {

--- a/packages/transform-to-vanilla/src/index.ts
+++ b/packages/transform-to-vanilla/src/index.ts
@@ -5,3 +5,4 @@ export {
 } from "@/transform-object";
 export { replaceVariantReference } from "@/transform-object/variant-reference";
 export type * from "./types/style-rule";
+export type { NonNullableString } from "./types/string";

--- a/packages/transform-to-vanilla/src/types/style-rule.ts
+++ b/packages/transform-to-vanilla/src/types/style-rule.ts
@@ -244,7 +244,8 @@ export interface AnonymousProperty {
 }
 export type AnonymousPropertyKey = keyof AnonymousProperty;
 
-interface ResolvedProperties extends Properties<number | NonNullableString> {}
+export interface ResolvedProperties
+  extends Properties<number | NonNullableString> {}
 
 type CSSKeyframeFromTo =
   | "from"


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->
This is the type for `rules`'s `prop`.

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #131

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced type definitions for handling complex properties in CSS rules.
  - Added new types to improve flexibility in property definitions.

- **Bug Fixes**
  - Updated existing types to ensure better type-checking and usability.

- **Documentation**
  - Improved export visibility of key types and interfaces for broader accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->
The API types handled by Prop have been reduced due to TypeScript inference and autocompletion.
- https://github.com/mincho-js/working-group/pull/14

## Checklist
<!-- Tell us what reviewers should look for. -->
