### PR TITLE
Fix: CSS - Support for styles that return CSSRule

### DIFF
--- a/packages/transform-to-vanilla/src/types/style-rule.ts
+++ b/packages/transform-to-vanilla/src/types/style-rule.ts
@@ -28,7 +28,7 @@ export type ComplexCSSItem =
   | CSSRule
   | ClassNames
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  | ((...args: any[]) => ClassNames);
+  | ((...args: any[]) => ClassNames | CSSRule);
 
 export interface CSSRule
   extends CSSPropertiesWithConditions,
@@ -546,7 +546,8 @@ if (import.meta.vitest) {
       assertType<ComplexCSSRule>([
         () => "className1",
         (_arg: number) => "className2",
-        (_arg: CSSRule, _debugId: string) => "className3"
+        (_arg: CSSRule, _debugId: string) => "className3",
+        (_arg: CSSRule, _debugId: string) => ({ padding: 10 }) satisfies CSSRule
       ]);
     });
 
@@ -576,10 +577,8 @@ if (import.meta.vitest) {
         () => "className3",
         (_arg: number) => "className4",
         (_arg: CSSRule, _debugId: string) => "className5",
-        {
-          padding: 10,
-          marginTop: 25
-        },
+        (_arg: CSSRule, _debugId: string) =>
+          ({ padding: 10, marginTop: 25 }) satisfies CSSRule,
         {
           color: "red",
           _hover: {


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->

Support for styles that return CSSRule

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #114

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced style transformation now supports both direct and dynamically computed styling, enabling more flexible and advanced appearance options.

- **Refactor**
  - Streamlined the logic for processing style values to ensure consistent and accurate application of styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
