### PR TITLE
Feat: `rules()` props runtime #131

### DIFF
--- a/packages/css/src/utils.ts
+++ b/packages/css/src/utils.ts
@@ -1,5 +1,63 @@
+import { createVar } from "@vanilla-extract/css";
+import { setFileScope } from "@vanilla-extract/css/fileScope";
+import type { PureCSSVarKey } from "@mincho-js/transform-to-vanilla";
+
 export function className(...debugIds: string[]) {
   const hashRegex = "[a-zA-Z0-9]+";
   const classStr = debugIds.map((id) => `${id}__${hashRegex}`).join(" ");
   return new RegExp(`^${classStr}$`);
+}
+
+// Optimized version
+// https://github.com/vanilla-extract-css/vanilla-extract/blob/master/packages/private/src/getVarName.ts
+const VAR_PREFIX_LENGTH = "var(".length;
+export function getVarName(variable: string): PureCSSVarKey {
+  if (variable.startsWith("var(") && variable.endsWith(")")) {
+    const inside = variable.slice(VAR_PREFIX_LENGTH, -1);
+    const commaIndex = inside.indexOf(",");
+    return (
+      commaIndex === -1 ? inside : inside.slice(0, commaIndex)
+    ) as PureCSSVarKey;
+  }
+  return variable as PureCSSVarKey;
+}
+
+// == Tests ====================================================================
+// Ignore errors when compiling to CommonJS.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+  const { describe, it, expect } = import.meta.vitest;
+
+  setFileScope("test");
+
+  describe("getVarName", () => {
+    it("string", () => {
+      expect(getVarName("--my-var-name")).toBe("--my-var-name");
+      expect(getVarName("just string")).toBe("just string");
+    });
+
+    it("var string", () => {
+      expect(getVarName("var(--my-var-name)")).toBe("--my-var-name");
+      expect(getVarName("var(--myCss-var-name23)")).toBe("--myCss-var-name23");
+    });
+
+    it("fallback", () => {
+      expect(getVarName("var(--my-var-name, 1px)")).toBe("--my-var-name");
+      expect(getVarName("var(--myCss-var-name23, none)")).toBe(
+        "--myCss-var-name23"
+      );
+    });
+
+    it("createVar", () => {
+      expect(getVarName(createVar("my-var-name"))).toMatch(
+        className(`--my-var-name`)
+      );
+      expect(getVarName(createVar("myCss-var-name23"))).toMatch(
+        className(`--myCss-var-name23`)
+      );
+    });
+  });
 }

--- a/packages/transform-to-vanilla/src/types/style-rule.ts
+++ b/packages/transform-to-vanilla/src/types/style-rule.ts
@@ -126,13 +126,16 @@ interface TopLevelVar {
   [key: CSSVarKey]: CSSVarValue;
 }
 
-export type CSSVarKey = `--${string}` | `$${string}`;
+export type PureCSSVarKey = `--${string}`;
+export type CSSVarKey = PureCSSVarKey | `$${string}`;
 export type CSSVarValue = `${string | number}`;
 
 // https://github.com/vanilla-extract-css/vanilla-extract/blob/master/packages/private/src/types.ts
-export type CSSVarFunction =
+export type PureCSSVarFunction =
   | `var(--${string})`
-  | `var(--${string}, ${CSSVarValue})`
+  | `var(--${string}, ${CSSVarValue})`;
+export type CSSVarFunction =
+  | PureCSSVarFunction
   | `$${string}`
   | `$${string}(${CSSVarValue})`;
 


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->
Implement `rules()` props.

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #131

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced CSS styling configuration to support dynamic mapping of property values to CSS variables.
  - Introduced a utility for extracting CSS variable identifiers from style declarations.
  
- **Tests**
  - Added tests to verify the new CSS variable extraction functionality.

- **Refactor**
  - Improved internal type consistency and API signatures for more robust styling and enhanced error prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
