### PR TITLE
Fix: Rules - Identifier when `debugId` is `undefined` #109

### DIFF
--- a/packages/css/src/css/index.ts
+++ b/packages/css/src/css/index.ts
@@ -12,7 +12,7 @@ import type {
 import { setFileScope } from "@vanilla-extract/css/fileScope";
 import { style as vStyle, globalStyle as gStyle } from "@vanilla-extract/css";
 
-import { className } from "../utils";
+import { className, getDebugName } from "../utils";
 
 // == Global CSS ===============================================================
 export function globalCss(selector: string, rule: GlobalCSSRule) {
@@ -79,7 +79,7 @@ function processVariants<T>(
     const context = structuredClone(initTransformContext);
     const className = vStyle(
       transform(transformItem(items[key], key), context),
-      debugId ? `${debugId}_${key}` : key
+      getDebugName(debugId, key)
     );
     contexts.push(context);
     variantMap[`%${key}`] = className;

--- a/packages/css/src/rules/utils.ts
+++ b/packages/css/src/rules/utils.ts
@@ -5,8 +5,6 @@ import type {
   VariantSelection,
   VariantObjectSelection
 } from "./types";
-import type { ComplexCSSRule } from "@mincho-js/transform-to-vanilla";
-import { css } from "../css";
 
 export function mapValues<Input extends Record<string, unknown>, OutputValue>(
   input: Input,
@@ -19,16 +17,6 @@ export function mapValues<Input extends Record<string, unknown>, OutputValue>(
   }
 
   return result;
-}
-
-export function processCompoundStyle(
-  style: ComplexCSSRule | string,
-  debugId: string | undefined,
-  index: number
-): string {
-  return typeof style === "string"
-    ? style
-    : css(style, `${debugId}_compound_${index}`);
 }
 
 export function transformVariantSelection<Variants extends VariantGroups>(

--- a/packages/css/src/utils.ts
+++ b/packages/css/src/utils.ts
@@ -2,10 +2,16 @@ import { createVar } from "@vanilla-extract/css";
 import { setFileScope } from "@vanilla-extract/css/fileScope";
 import type { PureCSSVarKey } from "@mincho-js/transform-to-vanilla";
 
-export function className(...debugIds: string[]) {
+export function className(...debugIds: Array<string | undefined>) {
   const hashRegex = "[a-zA-Z0-9]+";
-  const classStr = debugIds.map((id) => `${id}__${hashRegex}`).join(" ");
+  const classStr = debugIds
+    .map((id) => (id === undefined ? hashRegex : `${id}__${hashRegex}`))
+    .join(" ");
   return new RegExp(`^${classStr}$`);
+}
+
+export function getDebugName(debugId: string | undefined, name: string) {
+  return debugId ? `${debugId}_${name}` : name;
 }
 
 // Optimized version


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->
Generates an appropriate name when `debugId` is `undefined`.

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #109

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced debug naming for CSS, providing a consistent and centralized approach for generating debug class names.

- **Refactor**
  - Streamlined the logic for generating CSS class names and handling compound style definitions, resulting in clearer, more maintainable code.

- **Chores**
  - Removed obsolete internal functionality to simplify the overall styling process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
