### PR TITLE
Fix: CSS - Work comma selector with nested selectors

### DIFF
--- a/.changeset/full-bottles-join.md
+++ b/.changeset/full-bottles-join.md
@@ -1,0 +1,6 @@
+---
+"@mincho-js/transform-to-vanilla": patch
+---
+
+**Nested Selector with commas**
+- Support for global styles with nested selectors that contain commas.

--- a/packages/transform-to-vanilla/src/transform-object/index.ts
+++ b/packages/transform-to-vanilla/src/transform-object/index.ts
@@ -1013,6 +1013,28 @@ if (import.meta.vitest) {
       } satisfies StyleRule);
     });
 
+    it("Nested selectors with comma", () => {
+      expect(
+        transformStyle({
+          "nav li > &, .myClass li > &": {
+            color: "red",
+            _hover: {
+              color: "green"
+            }
+          }
+        })
+      ).toStrictEqual({
+        selectors: {
+          "nav li > &, .myClass li > &": {
+            color: "red"
+          },
+          "nav li > &:hover, .myClass li > &:hover": {
+            color: "green"
+          }
+        }
+      } satisfies StyleRule);
+    });
+
     it("Nested AtRules multiple", () => {
       expect(
         transformStyle({


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->

Support comma selector for global style.

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for global styles with nested selectors containing commas, allowing more complex CSS selector groupings.
- **Tests**
  - Introduced new test cases to verify correct handling of comma-separated nested selectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
