### PR TITLE
Fix: Global CSS using hoisting selectors

### DIFF
--- a/.changeset/sharp-ears-wear.md
+++ b/.changeset/sharp-ears-wear.md
@@ -1,0 +1,9 @@
+---
+"@mincho-js/css": patch
+---
+
+## New
+- Add `VariantStyle` type for constrained variant styles
+
+## Changes
+- Allow nested selector in `globalCss` function

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -36,6 +36,7 @@ export {
 export { rules, recipe } from "./rules/index.js";
 export { createRuntimeFn } from "./rules/createRuntimeFn.js";
 export type {
+  VariantStyle,
   RulesVariants,
   RecipeVariants,
   RuntimeFn,

--- a/packages/css/src/rules/index.ts
+++ b/packages/css/src/rules/index.ts
@@ -26,7 +26,8 @@ import type {
   PropTarget,
   PropVars,
   Serializable,
-  VariantStringMap
+  VariantStringMap,
+  VariantStyle
 } from "./types.js";
 import {
   mapValues,
@@ -264,16 +265,16 @@ if (import.meta.vitest) {
           color: {
             brand: { color: "#FFFFA0" },
             accent: { color: "#FFE4B5" }
-          },
+          } satisfies VariantStyle<"brand" | "accent">,
           size: {
             small: { padding: 12 },
             medium: { padding: 16 },
             large: { padding: 24 }
-          },
+          } satisfies VariantStyle<"small" | "medium" | "large">,
           outlined: {
             true: { border: "1px solid black" },
             false: { border: "1px solid transparent" }
-          }
+          } satisfies VariantStyle<"true" | "false">
         }
       } as const;
       const result = rules(variants, debugId);

--- a/packages/css/src/rules/types.ts
+++ b/packages/css/src/rules/types.ts
@@ -31,6 +31,14 @@ export type Serializable =
 
 type RecipeStyleRule = ComplexCSSRule | string;
 
+export type VariantStyle<
+  VariantNames extends string,
+  CssRule extends RecipeStyleRule = RecipeStyleRule
+> = {
+  [VariantName in VariantNames]: CssRule;
+};
+
+// Same of VariantMap but for fast type checking
 export type VariantDefinitions = Record<string, RecipeStyleRule>;
 
 type BooleanMap<T> = T extends "true" | "false" ? boolean : T;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    projects: ["packages/*/vite.config.ts"],
+  }
+});

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,3 +1,0 @@
-import { defineWorkspace } from "vitest/config";
-
-export default defineWorkspace(["packages/*"]);


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->
1. Global style allow nested selector using hoisting
2. Add `VariantStyle` type
3. Fix vitest workspace setup

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced global CSS styling capabilities with support for nested selectors.
  - Introduced a new type for more structured variant styles in styling definitions.

- **Chores**
  - Updated test configuration to use a new Vitest setup for managing multiple projects.
  - Removed obsolete Vitest workspace configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
