### PR TITLE
Chore: Seperate vanilla extract API to `./compat`

### DIFF
--- a/.changeset/calm-heads-care.md
+++ b/.changeset/calm-heads-care.md
@@ -1,0 +1,6 @@
+---
+"@mincho-js/babel": minor
+"@mincho-js/css": minor
+---
+
+Separate vanilla extract API to `./compat`

--- a/examples/react-swc/src/App.css.ts
+++ b/examples/react-swc/src/App.css.ts
@@ -1,13 +1,13 @@
-import { globalStyle, keyframes, style } from "@mincho-js/css"
+import { globalCss, keyframes, css } from "@mincho-js/css"
 
-globalStyle("#root", {
+globalCss("#root", {
   maxWidth: "1280px",
   margin: "0 auto",
   padding: "2rem",
   textAlign: "center",
 });
 
-export const react = style({
+export const react = css({
 });
 const logoSpin = keyframes({
   "from": {
@@ -18,7 +18,7 @@ const logoSpin = keyframes({
   },
 });
 
-export const logo = style({
+export const logo = css({
   height: "6em",
   padding: "1.5em",
   willChange: "filter",
@@ -40,11 +40,11 @@ export const logo = style({
   },
 });
 
-export const card = style({
+export const card = css({
   padding: "2em",
 });
 
-export const readTheDocs = style({
+export const readTheDocs = css({
   color: "#888",
 });
 

--- a/examples/react-swc/src/index.css.ts
+++ b/examples/react-swc/src/index.css.ts
@@ -1,6 +1,6 @@
-import { globalStyle } from "@mincho-js/css"
+import { globalCss } from "@mincho-js/css"
 
-globalStyle(":root", {
+globalCss(":root", {
   fontFamily: "Inter , system-ui , Avenir , Helvetica , Arial , sans-serif",
   lineHeight: "1.5",
   fontWeight: "400",
@@ -20,19 +20,19 @@ globalStyle(":root", {
   },
 });
 
-globalStyle("a", {
+globalCss("a", {
   fontWeight: "500",
   color: "#646cff",
   textDecoration: "inherit",
 });
-globalStyle("a:hover", {
+globalCss("a:hover", {
   color: "#535bf2",
   "@media (prefers-color-scheme: light)": {
     color: "#747bff",
   },
 });
 
-globalStyle("body", {
+globalCss("body", {
   margin: "0",
   display: "flex",
   placeItems: "center",
@@ -40,12 +40,12 @@ globalStyle("body", {
   minHeight: "100vh",
 });
 
-globalStyle("h1", {
+globalCss("h1", {
   fontSize: "3.2em",
   lineHeight: "1.1",
 });
 
-globalStyle("button", {
+globalCss("button", {
   borderRadius: "8px",
   border: "1px solid transparent",
   padding: "0.6em 1.2em",
@@ -60,11 +60,11 @@ globalStyle("button", {
   },
 });
 
-globalStyle("button:hover", {
+globalCss("button:hover", {
   borderColor: "#646cff",
 });
 
-globalStyle("button:focus, button:focus-visible", {
+globalCss("button:focus, button:focus-visible", {
   outline: "4px auto -webkit-focus-ring-color",
 });
 

--- a/packages/babel/src/styled.ts
+++ b/packages/babel/src/styled.ts
@@ -55,7 +55,7 @@ export function styledComponentPlugin(): PluginObj<PluginState> {
 
               const recipeIdentifier = registerImportMethod(
                 callPath,
-                "recipe",
+                "rules",
                 "@mincho-js/css"
               );
 

--- a/packages/babel/src/utils.ts
+++ b/packages/babel/src/utils.ts
@@ -70,6 +70,10 @@ export function getNearestIdentifier(path: NodePath<t.Node>) {
 export const extractionAPIs = [
   // @mincho-js/css
   "mincho$",
+  "css",
+  "cssVariants",
+  "globalCss",
+  "rules",
   // @vanilla-extract/css
   "style",
   "styleVariants",

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -42,6 +42,16 @@
         "default": "./dist/cjs/index.cjs"
       }
     },
+    "./compat": {
+      "import": {
+        "types": "./dist/esm/compat.d.ts",
+        "default": "./dist/esm/compat.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/compat.d.cts",
+        "default": "./dist/cjs/compat.cjs"
+      }
+    },
     "./rules/createRuntimeFn": {
       "import": {
         "types": "./dist/esm/rules/createRuntimeFn.d.ts",

--- a/packages/css/src/compat.ts
+++ b/packages/css/src/compat.ts
@@ -1,10 +1,3 @@
-export type {
-  CSSProperties,
-  ComplexCSSRule,
-  GlobalCSSRule,
-  CSSRule
-} from "@mincho-js/transform-to-vanilla";
-
 export type { Adapter, FileScope } from "@vanilla-extract/css";
 export {
   assignVars,
@@ -25,8 +18,12 @@ export {
   layer
 } from "@vanilla-extract/css";
 
-export { globalCss, css, cssVariants } from "./css/index.js";
-export { rules } from "./rules/index.js";
+export {
+  globalCss as globalStyle,
+  css as style,
+  cssVariants as styleVariants
+} from "./css/index.js";
+
 export type {
   VariantStyle,
   RulesVariants,
@@ -42,3 +39,11 @@ export type {
   VariantObjectSelection,
   ResolveComplex
 } from "./rules/types.js";
+export { rules as recipe } from "./rules/index.js";
+
+export type {
+  CSSProperties,
+  ComplexCSSRule as ComplexStyleRule,
+  CSSRule as StyleRule,
+  GlobalCSSRule as GlobalStyleRule
+} from "@mincho-js/transform-to-vanilla";

--- a/packages/css/src/css/index.ts
+++ b/packages/css/src/css/index.ts
@@ -38,7 +38,6 @@ export function globalCss(selector: string, rule: GlobalCSSRule) {
     });
   }
 }
-export const globalStyle = globalCss;
 
 // TODO: Make more type-safe
 type UnknownObject = Record<string, unknown>;
@@ -105,7 +104,6 @@ function hoistSelectors(input: CSSRule): HoistResult {
 export function css(style: ComplexCSSRule, debugId?: string) {
   return vStyle(transform(style), debugId);
 }
-export const style = css;
 
 // == CSS Variants =============================================================
 // TODO: Need to optimize
@@ -138,7 +136,6 @@ export function cssVariants<
     return processVariants(styleMap, (style) => style, debugId);
   }
 }
-export const styleVariants = cssVariants;
 
 function isMapDataFunction<
   Data extends Record<string | number, unknown>,
@@ -203,7 +200,7 @@ if (import.meta.vitest) {
     });
 
     it("composition", () => {
-      const base = style({ padding: 12 }, "base");
+      const base = css({ padding: 12 }, "base");
       const result = css([base, { color: "red" }], debugId);
 
       assert.isString(result);
@@ -244,7 +241,7 @@ if (import.meta.vitest) {
     });
 
     it("Mapping Variants with composition", () => {
-      const base = style({ padding: 12 }, "base");
+      const base = css({ padding: 12 }, "base");
       const result = cssVariants(
         {
           primary: "blue",

--- a/packages/css/src/rules/index.ts
+++ b/packages/css/src/rules/index.ts
@@ -184,7 +184,6 @@ export function rules<
     }
   );
 }
-export const recipe = rules;
 
 function processPropObject<Target extends PropTarget>(
   props: PropDefinition<Target>,

--- a/packages/css/vite.config.ts
+++ b/packages/css/vite.config.ts
@@ -10,7 +10,8 @@ export default (viteConfigEnv: ConfigEnv) => {
     build: {
       lib: {
         entry: {
-          // index: join(packageDir, "src", "index.ts"),
+          index: join(packageDir, "src", "index.ts"),
+          compat: join(packageDir, "src", "compat.ts"),
           "rules/createRuntimeFn": join(
             packageDir,
             "src",


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->
Separate API for Vanilla Extract into `/compat`.

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #218

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated usage of style functions in example projects to new API names for consistency.
  * Extended supported API list for extraction utilities.
  * Updated build configuration to include a new compatibility entry point.
  * Added a new export subpath for compatibility modules in the package exports.

* **Refactor**
  * Removed deprecated style function aliases and related exports.
  * Streamlined and reduced exported APIs, removing unused or duplicate exports.

* **New Features**
  * Introduced a compatibility module consolidating exports from multiple CSS utility libraries for easier integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
