### PR TITLE
Feat: CSS - css.multiple() API supports

### DIFF
--- a/.changeset/sad-meals-rescue.md
+++ b/.changeset/sad-meals-rescue.md
@@ -1,0 +1,6 @@
+---
+"@mincho-js/babel": minor
+"@mincho-js/css": minor
+---
+
+css.multiple() API

--- a/packages/babel/src/utils.ts
+++ b/packages/babel/src/utils.ts
@@ -71,7 +71,6 @@ export const extractionAPIs = [
   // @mincho-js/css
   "mincho$",
   "css",
-  "cssVariants",
   "globalCss",
   "rules",
   // @vanilla-extract/css

--- a/packages/css/src/css/index.ts
+++ b/packages/css/src/css/index.ts
@@ -101,9 +101,13 @@ function hoistSelectors(input: CSSRule): HoistResult {
 }
 
 // == CSS ======================================================================
-export function css(style: ComplexCSSRule, debugId?: string) {
+export function cssImpl(style: ComplexCSSRule, debugId?: string) {
   return vStyle(transform(style), debugId);
 }
+
+export const css = Object.assign(cssImpl, {
+  multiple: cssVariants
+});
 
 // == CSS Variants =============================================================
 // TODO: Need to optimize
@@ -208,9 +212,9 @@ if (import.meta.vitest) {
     });
   });
 
-  describe.concurrent("cssVariants()", () => {
+  describe.concurrent("css.multiple()", () => {
     it("Variants", () => {
-      const result = cssVariants(
+      const result = css.multiple(
         {
           primary: { background: "blue" },
           secondary: { background: "aqua" }
@@ -224,7 +228,7 @@ if (import.meta.vitest) {
     });
 
     it("Mapping Variants", () => {
-      const result = cssVariants(
+      const result = css.multiple(
         {
           primary: "blue",
           secondary: "aqua"
@@ -242,7 +246,7 @@ if (import.meta.vitest) {
 
     it("Mapping Variants with composition", () => {
       const base = css({ padding: 12 }, "base");
-      const result = cssVariants(
+      const result = css.multiple(
         {
           primary: "blue",
           secondary: "aqua"

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -25,7 +25,7 @@ export {
   layer
 } from "@vanilla-extract/css";
 
-export { globalCss, css, cssVariants } from "./css/index.js";
+export { globalCss, css } from "./css/index.js";
 export { rules } from "./rules/index.js";
 export type {
   VariantStyle,


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->
`cssVariant()` to `css.multiple()`. 

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #221

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a grouped API for CSS utilities, allowing access to multiple CSS variant functionality via `css.multiple()`.

* **Refactor**
  * Updated usage to reference `css.multiple()` instead of the previous `cssVariants` export.
  * Streamlined exports by removing the standalone `cssVariants` and grouping it under the main `css` API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
