### PR TITLE
Feat: CSS - `css.with()` API support #226

### DIFF
--- a/.changeset/calm-heads-care.md
+++ b/.changeset/calm-heads-care.md
@@ -3,4 +3,8 @@
 "@mincho-js/css": minor
 ---
 
-Separate vanilla extract API to `./compat`
+**Compatibility**
+
+## Changes
+
+- Separate vanilla extract API to `./compat`

--- a/.changeset/cold-mirrors-accept.md
+++ b/.changeset/cold-mirrors-accept.md
@@ -1,0 +1,9 @@
+---
+"@mincho-js/css": minor
+---
+
+**css**
+
+## New
+
+- Add `css.with()` API

--- a/.changeset/sad-meals-rescue.md
+++ b/.changeset/sad-meals-rescue.md
@@ -3,4 +3,6 @@
 "@mincho-js/css": minor
 ---
 
-css.multiple() API
+## New
+
+- Add `css.multiple()` API

--- a/.changeset/sharp-ears-wear.md
+++ b/.changeset/sharp-ears-wear.md
@@ -2,6 +2,8 @@
 "@mincho-js/css": patch
 ---
 
+**Types**
+
 ## New
 - Add `VariantStyle` type for constrained variant styles
 

--- a/packages/css/src/compat.ts
+++ b/packages/css/src/compat.ts
@@ -21,7 +21,7 @@ export {
 export {
   globalCss as globalStyle,
   css as style,
-  cssVariants as styleVariants
+  cssMultiple as styleVariants
 } from "./css/index.js";
 
 export type {

--- a/packages/css/src/css/types.ts
+++ b/packages/css/src/css/types.ts
@@ -1,0 +1,23 @@
+import type { CSSRule } from "@mincho-js/transform-to-vanilla";
+import type { Resolve } from "../types.js";
+
+type IsOptional<T, K extends keyof T> =
+  Record<string, never> extends Pick<T, K> ? true : false;
+type IsRequired<T, K extends keyof T> =
+  IsOptional<T, K> extends true ? false : true;
+
+export type RestrictCSSRule<T extends CSSRule> = {
+  [K in keyof T as T[K] extends false ? never : K]: T[K] extends true
+    ? K extends keyof CSSRule
+      ? CSSRule[K]
+      : never
+    : T[K];
+} extends infer U
+  ? Resolve<
+      {
+        [K in keyof U as IsRequired<U, K> extends true ? K : never]-?: U[K];
+      } & {
+        [K in keyof U as IsOptional<U, K> extends true ? K : never]?: U[K];
+      }
+    >
+  : never;

--- a/packages/css/src/rules/index.ts
+++ b/packages/css/src/rules/index.ts
@@ -8,7 +8,7 @@ import type {
   PureCSSVarKey
 } from "@mincho-js/transform-to-vanilla";
 
-import { css, cssVariants } from "../css/index.js";
+import { css } from "../css/index.js";
 import { className, getDebugName, getVarName } from "../utils.js";
 import { createRuntimeFn } from "./createRuntimeFn.js";
 import type {
@@ -110,7 +110,7 @@ export function rules<
   // @ts-expect-error - Temporarily ignoring the error as the PatternResult type is not fully defined
   const variantClassNames: PatternResult<CombinedVariants>["variantClassNames"] =
     mapValues(mergedVariants, (variantGroup, variantGroupName) =>
-      cssVariants(
+      css.multiple(
         variantGroup,
         (styleRule) =>
           typeof styleRule === "string"

--- a/packages/css/src/rules/types.ts
+++ b/packages/css/src/rules/types.ts
@@ -5,10 +5,8 @@ import type {
   ResolvedProperties,
   NonNullableString
 } from "@mincho-js/transform-to-vanilla";
+import type { Resolve } from "../types.js";
 
-type Resolve<T> = {
-  [Key in keyof T]: T[Key];
-} & {};
 export type ResolveComplex<T> =
   T extends Array<infer U> ? Array<Resolve<U>> : Resolve<T>;
 type RemoveUndefined<T> = T extends undefined ? never : T;

--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -1,0 +1,3 @@
+export type Resolve<T> = {
+  [Key in keyof T]: T[Key];
+} & {};

--- a/packages/css/tsconfig.lib.json
+++ b/packages/css/tsconfig.lib.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "rootDir": "./src",
     "baseUrl": "./",
+    "paths": {                                           /* Specify a set of entries that re-map imports to additional lookup locations. */
+      "@/*": ["src/*"]
+    },
     "tsBuildInfoFile": "./.cache/typescript/tsbuildinfo-esm",
     "outDir": "./dist/esm",
     "declarationDir": "./dist/esm"


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->
Support `css.with()` function

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #226

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new API method: `css.with()` for enhanced CSS function customization.
  * Introduced a utility type for restricting CSS rule types.

* **Improvements**
  * Renamed and updated the variant API for generating multiple CSS classes, now accessible as `css.multiple`.
  * Improved changelog formatting and structure for better clarity.
  * Enhanced type utilities for more robust type handling.
  * Added import path aliasing for simplified module resolution.

* **Bug Fixes**
  * No user-facing bug fixes included in this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
