### PR TITLE
Feat: Rules - `rules.raw()` API supports #231

### DIFF
--- a/.changeset/plenty-turkeys-retire.md
+++ b/.changeset/plenty-turkeys-retire.md
@@ -1,0 +1,7 @@
+---
+"@mincho-js/css": minor
+---
+
+**New**
+
+- Add `rules.raw()` API


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->
Implement `rules.raw()` API

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #231

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added rules.raw(): a non-breaking passthrough API that returns the provided options while preserving existing rules(...) behavior.

- Tests
  - Expanded test coverage to validate rules.raw() behavior and TypeScript type correctness.

- Chores
  - Added a changeset documenting the new public API and a minor version bump for the css package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
