### PR TITLE
 Feat: rules.with() API implement #234 

### DIFF
--- a/.changeset/eager-lemons-wink.md
+++ b/.changeset/eager-lemons-wink.md
@@ -1,0 +1,8 @@
+---
+"@mincho-js/css": minor
+---
+
+**css**
+
+## New
+- Add `rules.with()` API

--- a/packages/css/src/css/index.ts
+++ b/packages/css/src/css/index.ts
@@ -102,12 +102,18 @@ function hoistSelectors(input: CSSRule): HoistResult {
 }
 
 // == CSS ======================================================================
-export function cssImpl(style: ComplexCSSRule, debugId?: string) {
-  return vStyle(transform(style), debugId);
-}
+export const css = Object.assign(cssImpl, {
+  raw: cssRaw,
+  multiple: cssMultiple,
+  with: cssWith
+});
 
 function cssRaw(style: ComplexCSSRule) {
   return style;
+}
+
+export function cssImpl(style: ComplexCSSRule, debugId?: string) {
+  return vStyle(transform(style), debugId);
 }
 
 function cssWith<const T extends CSSRule>(
@@ -158,12 +164,6 @@ function cssWith<const T extends CSSRule>(
     multiple: cssWithMultiple
   });
 }
-
-export const css = Object.assign(cssImpl, {
-  raw: cssRaw,
-  multiple: cssMultiple,
-  with: cssWith
-});
 
 // == CSS Multiple =============================================================
 // TODO: Need to optimize

--- a/packages/css/src/css/index.ts
+++ b/packages/css/src/css/index.ts
@@ -134,8 +134,7 @@ function cssWith<const T extends CSSRule>(
   >(styleMap: StyleMap, debugId?: string): Record<keyof StyleMap, string>;
   function cssWithMultiple<
     Data extends Record<string | number, RestrictedCSSRule>,
-    Key extends keyof Data,
-    MapData extends (value: Data[Key], key: Key) => ComplexCSSRule
+    MapData extends (value: Data[keyof Data], key: keyof Data) => ComplexCSSRule
   >(data: Data, mapData: MapData, debugId?: string): Record<keyof Data, string>;
   function cssWithMultiple<
     Data extends Record<string | number, RestrictedCSSRule>,


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->

Implement `rules.with()` API

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #234 

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added rules.with() to compose and transform rule sets via callbacks.
  - Added a unified css export that bundles the primary CSS function with helpers (raw, multiple, with).
- Refactor
  - Consolidated CSS utilities under a single callable export for simpler imports and discovery.
  - Relaxed generics for multi-variant mapping to improve type ergonomics for consumers.
- Chores
  - Bumped @mincho-js/css in a minor release to publish the expanded API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
