### PR TITLE
Feat: `selector()` API implement #236

### DIFF
--- a/.changeset/great-buckets-clean.md
+++ b/.changeset/great-buckets-clean.md
@@ -1,0 +1,8 @@
+---
+"@mincho-js/css": minor
+---
+
+**css**
+
+### New
+- Add `selector()` utility for computed property names

--- a/.changeset/strong-cases-grin.md
+++ b/.changeset/strong-cases-grin.md
@@ -1,5 +1,5 @@
 ---
-"@mincho-js/css": patch
+"@mincho-js/css": minor
 ---
 
 **rules**

--- a/packages/css/src/compat.ts
+++ b/packages/css/src/compat.ts
@@ -21,7 +21,8 @@ export {
 export {
   globalCss as globalStyle,
   css as style,
-  cssMultiple as styleVariants
+  cssMultiple as styleVariants,
+  selector
 } from "./css/index.js";
 export type { CSSRuleWith as StyleRuleWith } from "./css/types.js";
 

--- a/packages/css/src/css/index.ts
+++ b/packages/css/src/css/index.ts
@@ -238,6 +238,11 @@ function processMultiple<T>(
 export function mincho$<T>(block: () => T) {
   return block();
 }
+
+export function selector(selector: string): `&` {
+  return selector as `&`;
+}
+
 // == Tests ====================================================================
 // Ignore errors when compiling to CommonJS.
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -25,7 +25,7 @@ export {
   layer
 } from "@vanilla-extract/css";
 
-export { globalCss, css } from "./css/index.js";
+export { globalCss, css, selector } from "./css/index.js";
 export type { CSSRuleWith } from "./css/types.js";
 export { rules } from "./rules/index.js";
 export type {


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->

Type inference doesn't work well for computed property names in TypeScript.
This type utility makes it easier to handle this.

```typescript
css({
  [selector(`.otherClass &`)]: {
    color: "red"
  }
});
```


## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #236

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added a selector utility in the CSS package to create computed selectors with improved type safety, exposed via the public API.

* Documentation
  * Added documentation describing the new selector utility under the CSS section.

* Chores
  * Updated release metadata and bumped the CSS package version to a minor release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
