### PR TITLE
Feat: `theme` - Support `fallbackVar` method #266

### DIFF
--- a/.changeset/bumpy-cloths-flash.md
+++ b/.changeset/bumpy-cloths-flash.md
@@ -1,0 +1,6 @@
+---
+"@mincho-js/css": minor
+---
+
+**theme**
+- Add `theme()` `this.fallbackVar()` API


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->

Support `this.fallbackVar()` for `theme` API

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #266

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `theme()` function to the CSS package API.
  * Added `fallbackVar()` method for managing CSS variable fallbacks in semantic tokens.
  * Enhanced semantic token resolution to support fallback references between tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
