### PR TITLE
Feat: `theme` - Support `alias` method

### DIFF
--- a/.changeset/honest-dingos-push.md
+++ b/.changeset/honest-dingos-push.md
@@ -1,0 +1,7 @@
+---
+"@mincho-js/css": minor
+---
+
+**theme**
+- Add `theme()` `this.fallbackVar()` API
+


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->
Implement `alias` method for theme

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #270

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended the theme API surface with theme() function and fallbackVar() method for greater customization flexibility
  * Introduced alias() utility for semantic tokens, allowing selective CSS variable generation based on token paths
  * Enhanced semantic token resolution to support alternative references through the new alias mechanism, providing more control over CSS variable creation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
