### PR TITLE
Feat: `cx.multiple()` for declare multiple classes

### DIFF
--- a/packages/css/src/classname/types.ts
+++ b/packages/css/src/classname/types.ts
@@ -24,3 +24,9 @@ export type ClassDictionary = Record<string, unknown>;
  * Array of class values (supports nesting)
  */
 export type ClassArray = ClassValue[];
+
+export type ClassMultipleInput = Record<string, ClassValue>;
+
+export type ClassMultipleResult<T extends ClassMultipleInput> = {
+  [K in keyof T]: string;
+};


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #289

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cx.multiple() to process multiple class mappings at once and return a mapped object of class strings.
  * Enhanced typing for the multi-mapping API so results are strongly typed per input keys.

* **Tests**
  * Added test coverage for multiple-mapping scenarios (various inputs, empty cases, and key handling).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
