### PR TITLE
chore: tsconfig - strict module syntax

### DIFF
--- a/configs/tsconfig-custom/tsconfig.base.json
+++ b/configs/tsconfig-custom/tsconfig.base.json
@@ -43,7 +43,7 @@
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
-    "rewriteRelativeImportExtensions": true,          /* Rewrite '.ts', '.tsx', '.mts', and '.cts' file extensions in relative import paths to their JavaScript equivalent in output files. */
+    // "rewriteRelativeImportExtensions": true,          /* Rewrite '.ts', '.tsx', '.mts', and '.cts' file extensions in relative import paths to their JavaScript equivalent in output files. */
     // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
     // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
     // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
@@ -84,7 +84,7 @@
 
     /* Interop Constraints */
     "isolatedModules": true,                             /* Ensure that each file can be safely transpiled without relying on other imports. */
-    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
     // "erasableSyntaxOnly": true,                       /* Do not allow runtime constructs that are not part of ECMAScript. */
     "allowSyntheticDefaultImports": true,                /* Allow 'import x from y' when a module doesn't have a default export. */

--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -1,9 +1,9 @@
-import { PluginObj, transformSync } from "@babel/core";
-import { transformCallExpression } from "@/transforms/callExpression.js";
-import postprocess from "@/transforms/postprocess.js";
-import preprocess from "@/transforms/preprocess.js";
-import { PluginOptions, PluginState } from "@/types.js";
-import { styledComponentPlugin } from "@/styled.js";
+import { type PluginObj, transformSync } from "@babel/core";
+import { transformCallExpression } from "./transforms/callExpression.js";
+import postprocess from "./transforms/postprocess.js";
+import preprocess from "./transforms/preprocess.js";
+import type { PluginOptions, PluginState } from "./types.js";
+import { styledComponentPlugin } from "./styled.js";
 
 export function minchoBabelPlugin(): PluginObj<PluginState> {
   return {
@@ -18,8 +18,8 @@ export function minchoBabelPlugin(): PluginObj<PluginState> {
   };
 }
 
-export { styledComponentPlugin as minchoStyledComponentPlugin } from "@/styled.js";
-export type { PluginOptions } from "@/types.js";
+export { styledComponentPlugin as minchoStyledComponentPlugin } from "./styled.js";
+export type { PluginOptions } from "./types.js";
 
 // == Tests ====================================================================
 // Ignore errors when compiling to CommonJS.

--- a/packages/babel/src/transforms/callExpression.ts
+++ b/packages/babel/src/transforms/callExpression.ts
@@ -1,10 +1,10 @@
-import type { ProgramScope } from "@/types.js";
+import { NodePath, types as t } from "@babel/core";
+import type { ProgramScope } from "../types.js";
 import {
   extractionAPIs,
   getNearestIdentifier,
   registerImportMethod
-} from "@/utils.js";
-import { NodePath, types as t } from "@babel/core";
+} from "../utils.js";
 
 /**
  * Transforms a call expression to import the CSS

--- a/packages/babel/src/transforms/postprocess.ts
+++ b/packages/babel/src/transforms/postprocess.ts
@@ -1,5 +1,5 @@
 import { NodePath, types as t, transformFromAstSync } from "@babel/core";
-import type { PluginState, ProgramScope } from "@/types.js";
+import type { PluginState, ProgramScope } from "../types.js";
 
 export default function postprocess(
   path: NodePath<t.Node>,

--- a/packages/babel/src/transforms/preprocess.ts
+++ b/packages/babel/src/transforms/preprocess.ts
@@ -1,6 +1,6 @@
-import type { ProgramScope } from "@/types.js";
 import { NodePath, types as t } from "@babel/core";
 import hash from "@emotion/hash";
+import type { ProgramScope } from "../types.js";
 
 /**
  * Process the program before Babel applies transformations

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -1,7 +1,7 @@
 import { dirname, join } from "node:path";
 import { processVanillaFile } from "@vanilla-extract/integration";
 import { vanillaExtractPlugin } from "@vanilla-extract/esbuild-plugin";
-import { Plugin as EsbuildPlugin } from "esbuild";
+import { type Plugin as EsbuildPlugin } from "esbuild";
 import { babelTransform, compile } from "@mincho-js/integration";
 
 interface MinchoEsbuildPluginOptions {

--- a/packages/integration/src/babel.ts
+++ b/packages/integration/src/babel.ts
@@ -1,6 +1,6 @@
-import { TransformOptions, transformFileAsync } from "@babel/core";
+import { type TransformOptions, transformFileAsync } from "@babel/core";
 import {
-  PluginOptions,
+  type PluginOptions,
   minchoBabelPlugin,
   minchoStyledComponentPlugin
 } from "@mincho-js/babel";

--- a/packages/integration/src/compile.ts
+++ b/packages/integration/src/compile.ts
@@ -1,7 +1,7 @@
 import { basename, dirname, join } from "node:path";
 import * as fs from "node:fs";
 import { addFileScope, getPackageInfo } from "@vanilla-extract/integration";
-import defaultEsbuild, { PluginBuild } from "esbuild";
+import defaultEsbuild, { type PluginBuild } from "esbuild";
 import { transformSync } from "@babel/core";
 import { minchoStyledComponentPlugin } from "@mincho-js/babel";
 

--- a/packages/integration/src/index.ts
+++ b/packages/integration/src/index.ts
@@ -1,2 +1,2 @@
-export { babelTransform, type BabelOptions } from "@/babel.js";
-export { compile } from "@/compile.js";
+export { babelTransform, type BabelOptions } from "./babel.js";
+export { compile } from "./compile.js";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -20,7 +20,7 @@ import type {
   RefAttributes
 } from "react";
 
-import { tags, SupportedElements } from "./tags.js";
+import { tags, type SupportedElements } from "./tags.js";
 
 export { $$styled } from "./runtime.js";
 

--- a/packages/react/src/runtime.ts
+++ b/packages/react/src/runtime.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ComplexPropDefinitions,
   PropTarget,
   RuntimeFn,
@@ -6,10 +6,10 @@ import {
   VariantObjectSelection
 } from "@mincho-js/css";
 import {
-  ComponentProps,
-  ComponentType,
+  type ComponentProps,
+  type ComponentType,
+  type ElementType,
   createElement,
-  ElementType,
   forwardRef,
   useMemo
 } from "react";

--- a/packages/transform-to-vanilla/src/index.ts
+++ b/packages/transform-to-vanilla/src/index.ts
@@ -2,8 +2,8 @@ export { transform } from "./transform.js";
 export {
   initTransformContext,
   type TransformContext
-} from "@/transform-object/index.js";
-export { replaceVariantReference } from "@/transform-object/variant-reference.js";
+} from "./transform-object/index.js";
+export { replaceVariantReference } from "./transform-object/variant-reference.js";
 export type * from "./types/style-rule.js";
 export type { NonNullableString } from "./types/string.js";
 export type {

--- a/packages/transform-to-vanilla/src/transform-object/index.ts
+++ b/packages/transform-to-vanilla/src/transform-object/index.ts
@@ -1,48 +1,54 @@
-import {
-  isSimplePseudoSelectorKey,
-  replacePseudoSelectors
-} from "@/transform-keys/simple-pseudo-selectors.js";
-import {
-  isSelectorsKey,
-  isComplexKey,
-  isSimpleSelectorKey,
-  nestedSelectorKey
-} from "@/transform-keys/complex-selectors.js";
-import {
-  isVarsKey,
-  isCSSVarKey,
-  isPureCSSVarKey,
-  replaceCSSVarKey
-} from "@/transform-keys/css-var.js";
-import { replaceCSSVar } from "@/transform-values/css-var.js";
-import {
-  isRuleKey,
-  atRuleKeyInfo,
-  anonymousKeyInfo,
-  atRuleKeyMerge
-} from "@/transform-keys/at-rules.js";
-import { removeMergeSymbol, mergeKeyInfo } from "@/transform-keys/merge-key.js";
-import { mergeToComma, mergeToSpace } from "@/transform-values/merge-values.js";
-import { simplyImportant } from "@/transform-values/simply-important.js";
-import { replacePropertyReference } from "@/transform-values/property-reference.js";
-import { isUppercase } from "@/utils/string.js";
-import { isEmptyObject, mergeObject } from "@/utils/object.js";
 import { keyframes, fontFace } from "@vanilla-extract/css";
 import { setFileScope } from "@vanilla-extract/css/fileScope";
+import type { Properties } from "@mincho-js/csstype";
 import {
   createNestedObject,
   createPathSetter,
   processNestedResult
 } from "./rule-context.js";
 import type { StyleRule } from "@vanilla-extract/css";
+import {
+  isSimplePseudoSelectorKey,
+  replacePseudoSelectors
+} from "../transform-keys/simple-pseudo-selectors.js";
+import {
+  isSelectorsKey,
+  isComplexKey,
+  isSimpleSelectorKey,
+  nestedSelectorKey
+} from "../transform-keys/complex-selectors.js";
+import {
+  isVarsKey,
+  isCSSVarKey,
+  isPureCSSVarKey,
+  replaceCSSVarKey
+} from "../transform-keys/css-var.js";
+import { replaceCSSVar } from "../transform-values/css-var.js";
+import {
+  isRuleKey,
+  atRuleKeyInfo,
+  anonymousKeyInfo,
+  atRuleKeyMerge
+} from "../transform-keys/at-rules.js";
+import {
+  removeMergeSymbol,
+  mergeKeyInfo
+} from "../transform-keys/merge-key.js";
+import {
+  mergeToComma,
+  mergeToSpace
+} from "../transform-values/merge-values.js";
+import { simplyImportant } from "../transform-values/simply-important.js";
+import { replacePropertyReference } from "../transform-values/property-reference.js";
+import { isUppercase } from "../utils/string.js";
+import { isEmptyObject, mergeObject } from "../utils/object.js";
 import type {
   CSSRule,
   CSSRuleKey,
   CSSRuleValue,
   VanillaStyleRuleValue,
   AtRulesKeywords
-} from "@/types/style-rule.js";
-import type { Properties } from "@mincho-js/csstype";
+} from "../types/style-rule.js";
 
 // == Interface ================================================================
 export type StyleResult = {

--- a/packages/transform-to-vanilla/src/transform-object/rule-context.ts
+++ b/packages/transform-to-vanilla/src/transform-object/rule-context.ts
@@ -1,9 +1,9 @@
 import { setFileScope } from "@vanilla-extract/css/fileScope";
-import { isRuleKey, atRuleKeyMerge } from "@/transform-keys/at-rules.js";
+import { isRuleKey, atRuleKeyMerge } from "../transform-keys/at-rules.js";
 import { initTransformContext } from "./index.js";
-import { mergeObject } from "@/utils/object.js";
+import { mergeObject } from "../utils/object.js";
 import type { StyleResult, AtRulesPrefix, TransformContext } from "./index.js";
-import type { VanillaStyleRuleValue } from "@/types/style-rule.js";
+import type { VanillaStyleRuleValue } from "../types/style-rule.js";
 
 const AT_RULE_ORDER: AtRulesPrefix[] = [
   "@layer",

--- a/packages/transform-to-vanilla/src/transform-object/variant-reference.ts
+++ b/packages/transform-to-vanilla/src/transform-object/variant-reference.ts
@@ -2,7 +2,7 @@ import {
   initTransformContext,
   type TransformContext,
   type StyleResult
-} from "@/transform-object/index.js";
+} from "./index.js";
 
 // == Interface ================================================================
 const VARIANT_REFERENCE_REGEX = /\B%[\w\-_]+/g;

--- a/packages/transform-to-vanilla/src/transform-values/property-reference.ts
+++ b/packages/transform-to-vanilla/src/transform-values/property-reference.ts
@@ -1,8 +1,8 @@
-import { initTransformContext } from "@/transform-object/index.js";
+import { initTransformContext } from "../transform-object/index.js";
 import type {
   TransformContext,
   CSSRuleExistValue
-} from "@/transform-object/index.js";
+} from "../transform-object/index.js";
 
 // == Interface ================================================================
 const LITERAL_PROPERTY_REFERENCE_REGEX = /^@[\w\-_]+$/;

--- a/packages/transform-to-vanilla/src/transform.ts
+++ b/packages/transform-to-vanilla/src/transform.ts
@@ -183,7 +183,7 @@ if (import.meta.vitest) {
       } satisfies Record<string, StyleRule>);
 
       const { replaceVariantReference } =
-        await import("@/transform-object/variant-reference.js");
+        await import("./transform-object/variant-reference.js");
       context.variantMap = {
         "%someVariant": ".myClass"
       };
@@ -267,7 +267,7 @@ if (import.meta.vitest) {
       } satisfies Record<string, StyleRule>);
 
       const { replaceVariantReference } =
-        await import("@/transform-object/variant-reference.js");
+        await import("./transform-object/variant-reference.js");
       context.variantMap = {
         "%someVariant": ".myClass"
       };

--- a/packages/transform-to-vanilla/src/types/simple-pseudo.ts
+++ b/packages/transform-to-vanilla/src/types/simple-pseudo.ts
@@ -1,4 +1,4 @@
-import { FromKebabCase, ColonToSnake } from "./string.js";
+import type { FromKebabCase, ColonToSnake } from "./string.js";
 
 // == Interface ================================================================
 export type SimplePseudos = keyof typeof _simplePseudoMap;

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,4 +1,8 @@
-import { BabelOptions, babelTransform, compile } from "@mincho-js/integration";
+import {
+  type BabelOptions,
+  babelTransform,
+  compile
+} from "@mincho-js/integration";
 import { processVanillaFile } from "@vanilla-extract/integration";
 import { normalizePath } from "@rollup/pluginutils";
 import { join, resolve } from "node:path";


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->

more strict typescript config.

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized internal module import paths by converting absolute path aliases to relative paths across multiple packages for improved maintainability.
  * Enhanced TypeScript type-only imports to better distinguish type-level usage from runtime imports.
  * Adjusted TypeScript configuration settings for improved module syntax handling and import extension rewriting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
