### PR TITLE
Chore: Mincho Docs Site CICD setting

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,45 @@
+name: Deploy Site
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Build site
+        run: yarn workspace mincho-docs build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site/out
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -20,14 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Setup
+        uses: ./.github/actions/node-setup
         with:
-          node-version: "20"
-      - name: Enable Corepack
-        run: corepack enable
-      - name: Install dependencies
-        run: yarn install --immutable
+          strict: false
       - name: Build site
         run: yarn workspace mincho-docs build
       - name: Upload artifact

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -3,6 +3,8 @@ name: Deploy Site
 on:
   push:
     branches: [main]
+    paths:
+      - 'site/**'
 
 permissions:
   contents: read

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -14,6 +14,8 @@ npmMinimalAgeGate: 7d
 
 npmPreapprovedPackages:
   - "@mincho-js/*"
+  - "next"
+  - "@next/*"
 
 npmAuditExcludePackages:
   - "deep-diff" # Deprecated but still functional, used by @mincho-js/debug-log

--- a/site/next-env.d.ts
+++ b/site/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/site/next.config.mjs
+++ b/site/next.config.mjs
@@ -1,9 +1,15 @@
-import nextra from 'nextra'
+import nextra from "nextra";
 
 const withNextra = nextra({
-  contentDirBasePath: '/docs'
-})
+  contentDirBasePath: "/docs"
+});
 
 export default withNextra({
-  reactStrictMode: true
-})
+  reactStrictMode: true,
+  output: "export",
+  basePath: "/mincho",
+  trailingSlash: true,
+  images: {
+    unoptimized: true
+  }
+});

--- a/site/package.json
+++ b/site/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "^15.5.10",
+    "next": "^16.1.7",
     "nextra": "^4.6.1",
     "nextra-theme-docs": "^4.6.1",
     "react": "^19.2.1",

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -1,26 +1,28 @@
+import Link from "next/link";
+
 export default function IndexPage() {
   return (
-    <div style={{ textAlign: 'center', padding: '100px 20px' }}>
-      <h1 style={{ fontSize: 48, fontWeight: 'bold', marginBottom: 16 }}>
+    <div style={{ textAlign: "center", padding: "100px 20px" }}>
+      <h1 style={{ fontSize: 48, fontWeight: "bold", marginBottom: 16 }}>
         Mincho.js
       </h1>
-      <p style={{ fontSize: 20, color: '#666', marginBottom: 32 }}>
+      <p style={{ fontSize: 20, color: "#666", marginBottom: 32 }}>
         Natural CSS in TypeScript
       </p>
-      <a
+      <Link
         href="/docs"
         style={{
-          display: 'inline-block',
-          padding: '12px 24px',
-          backgroundColor: '#0070f3',
-          color: 'white',
+          display: "inline-block",
+          padding: "12px 24px",
+          backgroundColor: "#0070f3",
+          color: "white",
           borderRadius: 8,
-          textDecoration: 'none',
+          textDecoration: "none",
           fontWeight: 500
         }}
       >
         Get Started
-      </a>
+      </Link>
     </div>
-  )
+  );
 }

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -19,9 +23,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2401,65 +2401,65 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:15.5.12":
-  version: 15.5.12
-  resolution: "@next/env@npm:15.5.12"
-  checksum: 10/1ec277290f8c54a547f1459cffe42b1dfc132c4583b21467cb9dba14583fe9d84a52a8213e8a698ffaaf50e75737520fc645a3d8b7a01ef604df7232a33f4727
+"@next/env@npm:16.1.7":
+  version: 16.1.7
+  resolution: "@next/env@npm:16.1.7"
+  checksum: 10/5f05c5e6e2ecfbfb1f2d828c25d916caf0eb6843d414f38916209f6439fa13b4aa942c317e65bf3c2bc7dee4601158ee505096b689f172c36048af8a9b66c6b0
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:15.5.12":
-  version: 15.5.12
-  resolution: "@next/swc-darwin-arm64@npm:15.5.12"
+"@next/swc-darwin-arm64@npm:16.1.7":
+  version: 16.1.7
+  resolution: "@next/swc-darwin-arm64@npm:16.1.7"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:15.5.12":
-  version: 15.5.12
-  resolution: "@next/swc-darwin-x64@npm:15.5.12"
+"@next/swc-darwin-x64@npm:16.1.7":
+  version: 16.1.7
+  resolution: "@next/swc-darwin-x64@npm:16.1.7"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:15.5.12":
-  version: 15.5.12
-  resolution: "@next/swc-linux-arm64-gnu@npm:15.5.12"
+"@next/swc-linux-arm64-gnu@npm:16.1.7":
+  version: 16.1.7
+  resolution: "@next/swc-linux-arm64-gnu@npm:16.1.7"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:15.5.12":
-  version: 15.5.12
-  resolution: "@next/swc-linux-arm64-musl@npm:15.5.12"
+"@next/swc-linux-arm64-musl@npm:16.1.7":
+  version: 16.1.7
+  resolution: "@next/swc-linux-arm64-musl@npm:16.1.7"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:15.5.12":
-  version: 15.5.12
-  resolution: "@next/swc-linux-x64-gnu@npm:15.5.12"
+"@next/swc-linux-x64-gnu@npm:16.1.7":
+  version: 16.1.7
+  resolution: "@next/swc-linux-x64-gnu@npm:16.1.7"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:15.5.12":
-  version: 15.5.12
-  resolution: "@next/swc-linux-x64-musl@npm:15.5.12"
+"@next/swc-linux-x64-musl@npm:16.1.7":
+  version: 16.1.7
+  resolution: "@next/swc-linux-x64-musl@npm:16.1.7"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:15.5.12":
-  version: 15.5.12
-  resolution: "@next/swc-win32-arm64-msvc@npm:15.5.12"
+"@next/swc-win32-arm64-msvc@npm:16.1.7":
+  version: 16.1.7
+  resolution: "@next/swc-win32-arm64-msvc@npm:16.1.7"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:15.5.12":
-  version: 15.5.12
-  resolution: "@next/swc-win32-x64-msvc@npm:15.5.12"
+"@next/swc-win32-x64-msvc@npm:16.1.7":
+  version: 16.1.7
+  resolution: "@next/swc-win32-x64-msvc@npm:16.1.7"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -4378,6 +4378,15 @@ __metadata:
   version: 4.0.4
   resolution: "balanced-match@npm:4.0.4"
   checksum: 10/fb07bb66a0959c2843fc055838047e2a95ccebb837c519614afb067ebfdf2fa967ca8d712c35ced07f2cd26fc6f07964230b094891315ad74f11eba3d53178a0
+  languageName: node
+  linkType: hard
+
+"baseline-browser-mapping@npm:^2.9.19":
+  version: 2.10.0
+  resolution: "baseline-browser-mapping@npm:2.10.0"
+  bin:
+    baseline-browser-mapping: dist/cli.cjs
+  checksum: 10/8145e076e4299f04c7a412e6ea63803e330153cd89c47b5303f9b56b58078f4c3d5a5b5332c1069da889e76facacca4d43f8940375f7e73ce0a4d96214332953
   languageName: node
   linkType: hard
 
@@ -8852,7 +8861,7 @@ __metadata:
   dependencies:
     "@types/node": "npm:^24.10.1"
     "@types/react": "npm:^19.2.7"
-    next: "npm:^15.5.10"
+    next: "npm:^16.1.7"
     nextra: "npm:^4.6.1"
     nextra-theme-docs: "npm:^4.6.1"
     react: "npm:^19.2.1"
@@ -9151,23 +9160,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:^15.5.10":
-  version: 15.5.12
-  resolution: "next@npm:15.5.12"
+"next@npm:^16.1.7":
+  version: 16.1.7
+  resolution: "next@npm:16.1.7"
   dependencies:
-    "@next/env": "npm:15.5.12"
-    "@next/swc-darwin-arm64": "npm:15.5.12"
-    "@next/swc-darwin-x64": "npm:15.5.12"
-    "@next/swc-linux-arm64-gnu": "npm:15.5.12"
-    "@next/swc-linux-arm64-musl": "npm:15.5.12"
-    "@next/swc-linux-x64-gnu": "npm:15.5.12"
-    "@next/swc-linux-x64-musl": "npm:15.5.12"
-    "@next/swc-win32-arm64-msvc": "npm:15.5.12"
-    "@next/swc-win32-x64-msvc": "npm:15.5.12"
+    "@next/env": "npm:16.1.7"
+    "@next/swc-darwin-arm64": "npm:16.1.7"
+    "@next/swc-darwin-x64": "npm:16.1.7"
+    "@next/swc-linux-arm64-gnu": "npm:16.1.7"
+    "@next/swc-linux-arm64-musl": "npm:16.1.7"
+    "@next/swc-linux-x64-gnu": "npm:16.1.7"
+    "@next/swc-linux-x64-musl": "npm:16.1.7"
+    "@next/swc-win32-arm64-msvc": "npm:16.1.7"
+    "@next/swc-win32-x64-msvc": "npm:16.1.7"
     "@swc/helpers": "npm:0.5.15"
+    baseline-browser-mapping: "npm:^2.9.19"
     caniuse-lite: "npm:^1.0.30001579"
     postcss: "npm:8.4.31"
-    sharp: "npm:^0.34.3"
+    sharp: "npm:^0.34.4"
     styled-jsx: "npm:5.1.6"
   peerDependencies:
     "@opentelemetry/api": ^1.1.0
@@ -9206,7 +9216,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 10/1499558193fdbc31e6b0d21d570c5a61d066ab70e55d6c020836c4248e7d73e65fe26be34e38debb6a873ffc53cb304f949f5c01847e6484e4ce4779bf8c0da5
+  checksum: 10/50bfebb84cbcf2091b950d77b78b8877c7de39de705785fe0231c828917a95baffe9c27e84e934b69e294f3e3c07f54a56b4e925b649cf5f5b3140ef3cca3962
   languageName: node
   linkType: hard
 
@@ -10686,7 +10696,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sharp@npm:^0.34.3":
+"sharp@npm:^0.34.4":
   version: 0.34.5
   resolution: "sharp@npm:0.34.5"
   dependencies:


### PR DESCRIPTION
## Description

Add GitHub Pages deployment CI/CD for the documentation site (`site/` workspace).

- Configure Next.js for static export with `basePath: /mincho` targeting `mincho-js.github.io/mincho`
- Add `deploy-site.yml` workflow that builds and deploys on push to `main`
- Only triggers when `site/**` files are changed to avoid unnecessary deployments
- Use Next.js `<Link>` instead of `<a>` for automatic basePath prefix support
- Upgrade Next.js 15.5.10 → 16.1.7 to resolve security vulnerabilities (GHSA-ggy3-7p47-pfv8, GHSA-3x4c-7xq6-9pg8)
- Add paths filter to deploy workflow to prevent unnecessary deployments

## Related Issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated site deployment workflow triggers on pushes to main for site updates.

* **Chores**
  * Configured site for static export with base path and trailing slashes; images served unoptimized.
  * Replaced plain anchor with framework link component for smoother navigation.
  * Updated framework version and adjusted build/tooling settings for the site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context

- Requires GitHub repo Settings → Pages → Source to be set to **"GitHub Actions"** (already configured)
- The site is a pure MDX documentation site (no library package imports), so `paths: ['site/**']` filter is safe
- If the site later imports `@mincho-js/*` packages directly, the paths filter should be revisited
- `next` and `@next/*` are temporarily added to `npmPreapprovedPackages` in `.yarnrc.yml` to bypass the 7-day `npmMinimalAgeGate` (Next.js 16.1.7 published on 2026-03-16)

> **⚠️ Do not merge before 2026-03-23:** After that date, remove `next` and `@next/*` from `npmPreapprovedPackages` in `.yarnrc.yml` before merging, as the age gate will no longer block installation.

## Checklist

- [x] Static export builds successfully (`yarn workspace mincho-docs build`)
- [x] `basePath` matches the deployment URL (`/mincho` for `mincho-js.github.io/mincho`)
- [x] `trailingSlash: true` and `images.unoptimized: true` set for GitHub Pages compatibility
- [x] Deployment only triggers on `site/**` changes
- [x] Internal links use Next.js `<Link>` for basePath support
- [x] Security vulnerabilities resolved via Next.js 16.1.7
- [ ] Remove `next`, `@next/*` from `npmPreapprovedPackages` after 2026-03-23
