### PR TITLE
Chore: remove temporary npmPreapprovedPackages for Next.js

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -14,8 +14,6 @@ npmMinimalAgeGate: 7d
 
 npmPreapprovedPackages:
   - "@mincho-js/*"
-  - "next"
-  - "@next/*"
 
 npmAuditExcludePackages:
   - "deep-diff" # Deprecated but still functional, used by @mincho-js/debug-log


### PR DESCRIPTION
## Description

Remove `next` and `@next/*` from `npmPreapprovedPackages` in `.yarnrc.yml`.

These were temporarily added to bypass the 7-day `npmMinimalAgeGate` during the Next.js 15 → 16.1.7 upgrade (PR #312). The age gate has since expired (published 2026-03-16), so the bypass is no longer needed.

## Related Issue

Follow-up from PR #312 checklist item.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package management configuration to refine dependency approval settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context

- `npmMinimalAgeGate: 7d` is a supply chain security measure that blocks packages published less than 7 days ago
- Next.js 16.1.7 was published on 2026-03-16, well over 7 days ago
- No other changes — `yarn install` passes without the preapproved entries

## Checklist

- [x] `yarn install` succeeds without age gate errors
- [x] No other `npmPreapprovedPackages` entries affected
