### PR TITLE
Feat: CSS - Add canonical defineRules style cache #316

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -17,6 +17,8 @@ npmMinimalAgeGate: 7d
 
 npmPreapprovedPackages:
   - "@mincho-js/*"
+  - "@turbo/*"
+  - turbo
 
 packageExtensions:
   nextra@*:

--- a/examples/react-swc/eslint.config.js
+++ b/examples/react-swc/eslint.config.js
@@ -26,7 +26,7 @@ export default defineConfig(
     },
   },
   {
-    files: ["*.{ts,tsx}"],
+    files: ["**/*.{ts,tsx}"],
     languageOptions: {
       parser: tsParser,
       parserOptions: {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "rimraf": "6.0.0",
     "terser": "^5.47.1",
     "tsconfig-custom": "workspace:^",
-    "turbo": "^2.9.12",
+    "turbo": "^2.9.14",
     "typescript": "^5.9.3",
     "vite": "^7.3.3",
     "vite-node": "^5.3.0",

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -83,6 +83,7 @@
   },
   "prettier": "prettier-config-custom",
   "dependencies": {
+    "@emotion/hash": "^0.9.2",
     "@fastify/deepmerge": "^3.2.1",
     "@mincho-js/transform-to-vanilla": "workspace:^",
     "clsx": "^2.1.1"

--- a/packages/css/src/defineRules/index.ts
+++ b/packages/css/src/defineRules/index.ts
@@ -1,4 +1,7 @@
 import type { CSSProperties } from "@mincho-js/transform-to-vanilla";
+import { setFileScope } from "@vanilla-extract/css/fileScope";
+import { createCanonicalStyleCache } from "./utils.js";
+import { identifierName } from "../utils.js";
 import type {
   DefineRulesComplexCssInput,
   DefineRulesCtx,
@@ -11,61 +14,184 @@ export function defineRules<
   const Properties extends DefineRulesProperties,
   const Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
 >(config: DefineRulesCtx<Properties, Shortcuts>) {
-  type DefineProperties = DefineRulesComplexCssInput<Properties, Shortcuts>;
-  function cssRaw(args: DefineProperties): CSSProperties {
-    const out: CSSProperties = {};
-    applyInput(config, out, args, []);
-    return out;
+  type CssInput = DefineRulesComplexCssInput<Properties, Shortcuts>;
+  const styleCache = createCanonicalStyleCache(config.debugId);
+
+  function resolveToFragments(args: CssInput): ResolvedStyleFragment[] {
+    const fragments: ResolvedStyleFragment[] = [];
+    applyInput(config, fragments, args, []);
+    return fragments;
   }
 
-  const css = Object.assign({}, { raw: cssRaw });
+  function cssRaw(args: CssInput): CSSProperties {
+    return flattenResolvedFragments(resolveToFragments(args));
+  }
+
+  function cssImpl(args: CssInput): string {
+    const fragments = resolveToFragments(args);
+    const emittedFragments = collectEmittedFragments(fragments);
+    const output: string[] = [];
+
+    for (const fragment of emittedFragments) {
+      const className = styleCache.addFragment(
+        fragment.inputIdentity.property,
+        fragment.inputIdentity.value,
+        fragment.style
+      );
+      output.push(className);
+    }
+    return output.join(" ");
+  }
+
+  const css = Object.assign(cssImpl, { raw: cssRaw });
   return { css };
 }
 
 // == Define Rules Impl ========================================================
+interface InputIdentity {
+  property: string;
+  value: unknown;
+}
+
+interface ResolvedStyleFragment {
+  source: {
+    key: string;
+    shortcutStack: string[];
+  };
+  inputIdentity: InputIdentity;
+  outputKeys: string[];
+  style: CSSProperties;
+}
+
+function collectEmittedFragments(
+  fragments: readonly ResolvedStyleFragment[]
+): ResolvedStyleFragment[] {
+  const occupiedKeys = new Set<string>();
+  const emittedFragments: ResolvedStyleFragment[] = [];
+
+  for (let index = fragments.length - 1; index >= 0; index -= 1) {
+    const fragment = fragments[index];
+    if (fragment == null) continue;
+
+    const emittedFragment = omitOccupiedKeys(fragment, occupiedKeys);
+    if (emittedFragment == null) {
+      continue;
+    }
+
+    emittedFragments.push(emittedFragment);
+
+    for (const key of emittedFragment.outputKeys) {
+      occupiedKeys.add(key);
+    }
+  }
+
+  return emittedFragments.reverse();
+}
+
+function omitOccupiedKeys(
+  fragment: ResolvedStyleFragment,
+  occupiedKeys: ReadonlySet<string>
+): ResolvedStyleFragment | undefined {
+  const remainingOutputKeys = fragment.outputKeys.filter(
+    (key) => !occupiedKeys.has(key)
+  );
+
+  if (remainingOutputKeys.length === 0) {
+    return undefined;
+  }
+
+  if (remainingOutputKeys.length === fragment.outputKeys.length) {
+    return fragment;
+  }
+
+  const nextStyle: Record<string, unknown> = {};
+
+  for (const key of remainingOutputKeys) {
+    nextStyle[key] = (fragment.style as Record<string, unknown>)[key];
+  }
+
+  return {
+    ...fragment,
+    outputKeys: remainingOutputKeys,
+    style: nextStyle as CSSProperties
+  };
+}
+
+function flattenResolvedFragments(
+  fragments: readonly ResolvedStyleFragment[]
+): CSSProperties {
+  const mergedStyle: CSSProperties = {};
+
+  for (const fragment of fragments) {
+    Object.assign(mergedStyle, fragment.style);
+  }
+
+  return mergedStyle;
+}
+
+function pushResolvedFragment(
+  fragmentsOut: ResolvedStyleFragment[],
+  inputIdentity: InputIdentity,
+  shortcutStack: readonly string[],
+  style: CSSProperties
+) {
+  const outputKeys = Object.keys(style);
+  if (outputKeys.length === 0) return;
+
+  fragmentsOut.push({
+    source: {
+      key: inputIdentity.property,
+      shortcutStack: [...shortcutStack]
+    },
+    inputIdentity,
+    outputKeys,
+    style
+  });
+}
+
 function applyInput<
   Properties extends DefineRulesProperties,
   Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
 >(
   ctx: DefineRulesCtx<Properties, Shortcuts>,
-  out: CSSProperties,
+  fragmentsOut: ResolvedStyleFragment[],
   input: unknown,
-  stack: string[]
+  shortcutStack: string[]
 ) {
   if (input == null || input === false) return;
 
   if (typeof input === "string") {
-    applyFixedStyle(ctx, out, input, stack);
+    applyInlineShortcut(ctx, fragmentsOut, input, shortcutStack);
     return;
   }
 
   if (Array.isArray(input)) {
-    applyArray(ctx, out, input, stack);
+    applyArray(ctx, fragmentsOut, input, shortcutStack);
     return;
   }
 
   if (isPlainObject(input)) {
-    applyObject(ctx, out, input, stack);
+    applyObject(ctx, fragmentsOut, input, shortcutStack);
     return;
   }
 
   throw new Error(`Unsupported css() argument: ${String(input)}`);
 }
 
-function applyFixedStyle<
+function applyInlineShortcut<
   Properties extends DefineRulesProperties,
   Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
 >(
   ctx: DefineRulesCtx<Properties, Shortcuts>,
-  out: CSSProperties,
-  inlineStyle: string,
-  stack: string[]
+  fragmentsOut: ResolvedStyleFragment[],
+  shortcutName: string,
+  shortcutStack: string[]
 ) {
-  if (hasOwn(ctx.shortcuts, inlineStyle)) {
-    applyShortcut(ctx, out, inlineStyle, undefined, stack);
+  if (hasOwn(ctx.shortcuts, shortcutName)) {
+    applyShortcut(ctx, fragmentsOut, shortcutName, undefined, shortcutStack);
     return;
   }
-  throw new Error(`Unknown fixed style: "${inlineStyle}"`);
+  throw new Error(`Unknown fixed style: "${shortcutName}"`);
 }
 
 function applyArray<
@@ -73,12 +199,12 @@ function applyArray<
   Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
 >(
   ctx: DefineRulesCtx<Properties, Shortcuts>,
-  out: CSSProperties,
+  fragmentsOut: ResolvedStyleFragment[],
   arr: readonly unknown[],
-  stack: string[]
+  shortcutStack: string[]
 ) {
   for (const item of arr) {
-    applyInput(ctx, out, item, stack);
+    applyInput(ctx, fragmentsOut, item, shortcutStack);
   }
 }
 
@@ -87,12 +213,12 @@ function applyObject<
   Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
 >(
   ctx: DefineRulesCtx<Properties, Shortcuts>,
-  out: CSSProperties,
+  fragmentsOut: ResolvedStyleFragment[],
   obj: Record<string, unknown>,
-  stack: string[]
+  shortcutStack: string[]
 ) {
   for (const [k, v] of Object.entries(obj)) {
-    applyEntry(ctx, out, k, v, stack);
+    applyEntry(ctx, fragmentsOut, k, v, shortcutStack);
   }
 }
 
@@ -101,17 +227,17 @@ function applyEntry<
   Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
 >(
   ctx: DefineRulesCtx<Properties, Shortcuts>,
-  out: CSSProperties,
+  fragmentsOut: ResolvedStyleFragment[],
   key: string,
   value: unknown,
-  stack: string[]
+  shortcutStack: string[]
 ) {
   if (hasOwn(ctx.shortcuts, key)) {
-    applyShortcut(ctx, out, key, value, stack);
+    applyShortcut(ctx, fragmentsOut, key, value, shortcutStack);
     return;
   }
 
-  applyProperty(ctx, out, key, value);
+  applyProperty(ctx, fragmentsOut, key, value, shortcutStack);
 }
 
 function applyProperty<
@@ -119,39 +245,84 @@ function applyProperty<
   Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
 >(
   ctx: DefineRulesCtx<Properties, Shortcuts>,
-  out: CSSProperties,
+  fragmentsOut: ResolvedStyleFragment[],
   prop: string,
-  value: unknown
+  value: unknown,
+  shortcutStack: string[]
 ) {
-  const propDef = ctx.properties?.[prop as keyof Properties];
+  const propertyDefinition = ctx.properties?.[prop as keyof Properties];
 
-  if (typeof propDef === "function") {
-    const result = propDef(value);
+  if (typeof propertyDefinition === "function") {
+    const result = propertyDefinition(value);
     if (isPlainObject(result)) {
-      Object.assign(out, result);
+      pushResolvedFragment(
+        fragmentsOut,
+        { property: prop, value },
+        shortcutStack,
+        result as CSSProperties
+      );
       return;
     } else {
-      (out as Record<string, unknown>)[prop] = result;
+      pushResolvedFragment(
+        fragmentsOut,
+        { property: prop, value },
+        shortcutStack,
+        {
+          [prop]: result
+        } as CSSProperties
+      );
       return;
     }
   }
 
   // just assign => last one wins
-  if (isPlainObject(propDef) === false) {
-    (out as Record<string, unknown>)[prop] = value;
+  if (isPlainObject(propertyDefinition) === false) {
+    pushResolvedFragment(
+      fragmentsOut,
+      { property: prop, value },
+      shortcutStack,
+      {
+        [prop]: value
+      } as CSSProperties
+    );
     return;
   }
 
-  const mapped = propDef[value as string];
+  const mappedValue = propertyDefinition[value as string];
 
   // Style object value => assign all
-  if (isPlainObject(mapped)) {
-    Object.assign(out, mapped);
+  if (isPlainObject(mappedValue)) {
+    pushResolvedFragment(
+      fragmentsOut,
+      { property: prop, value },
+      shortcutStack,
+      mappedValue as CSSProperties
+    );
     return;
   }
 
   // Mapped value => assign mapped value
-  (out as Record<string, unknown>)[prop] = mapped ?? value;
+  pushResolvedFragment(fragmentsOut, { property: prop, value }, shortcutStack, {
+    [prop]: mappedValue ?? value
+  } as CSSProperties);
+}
+
+function applyShortcutReference<
+  Properties extends DefineRulesProperties,
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
+>(
+  ctx: DefineRulesCtx<Properties, Shortcuts>,
+  fragmentsOut: ResolvedStyleFragment[],
+  targetName: string,
+  value: unknown,
+  shortcutStack: string[]
+) {
+  if (hasOwn(ctx.shortcuts, targetName)) {
+    applyShortcut(ctx, fragmentsOut, targetName, value, shortcutStack);
+    return;
+  }
+
+  applyProperty(ctx, fragmentsOut, targetName, value, shortcutStack);
 }
 
 function applyShortcut<
@@ -159,54 +330,66 @@ function applyShortcut<
   Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
 >(
   ctx: DefineRulesCtx<Properties, Shortcuts>,
-  out: CSSProperties,
+  fragmentsOut: ResolvedStyleFragment[],
   name: string,
   value: unknown,
-  stack: string[]
+  shortcutStack: string[]
 ) {
-  if (stack.includes(name)) {
+  if (shortcutStack.includes(name)) {
     throw new Error(
-      `Circular shortcut reference: ${[...stack, name].join(" -> ")}`
+      `Circular shortcut reference: ${[...shortcutStack, name].join(" -> ")}`
     );
   }
 
-  const def = ctx.shortcuts?.[name as keyof Shortcuts];
-  if (def == null) return;
+  const shortcutDefinition = ctx.shortcuts?.[name as keyof Shortcuts];
+  if (shortcutDefinition == null) return;
 
-  const nextStack = stack.concat(name);
+  const nextShortcutStack = shortcutStack.concat(name);
 
-  if (typeof def === "string") {
+  if (typeof shortcutDefinition === "string") {
     // single alias: pl -> paddingLeft
-    applyEntry(ctx, out, def, value, nextStack);
+    applyShortcutReference(
+      ctx,
+      fragmentsOut,
+      shortcutDefinition,
+      value,
+      nextShortcutStack
+    );
     return;
   }
 
-  if (Array.isArray(def)) {
+  if (Array.isArray(shortcutDefinition)) {
     // multi alias: px -> [pl, pr]
-    for (const alias of def) {
-      applyEntry(ctx, out, alias, value, nextStack);
+    for (const alias of shortcutDefinition) {
+      applyShortcutReference(
+        ctx,
+        fragmentsOut,
+        alias,
+        value,
+        nextShortcutStack
+      );
     }
     return;
   }
 
-  if (typeof def === "function") {
+  if (typeof shortcutDefinition === "function") {
     // fn shortcut
-    const produced = def(value);
-    applyInput(ctx, out, produced, nextStack);
+    const produced = shortcutDefinition(value);
+    applyInput(ctx, fragmentsOut, produced, nextShortcutStack);
     return;
   }
 
-  if (isPlainObject(def)) {
+  if (isPlainObject(shortcutDefinition)) {
     // fixed style shortcut
-    // - "inline" token (no value) => apply
+    // - "inline" shortcut flag (no value) => apply
     // - { inline: true } => apply
     // - { inline: false } => do not apply
     if (value === undefined || value === true) {
-      applyInput(ctx, out, def, nextStack);
+      applyInput(ctx, fragmentsOut, shortcutDefinition, nextShortcutStack);
       return;
     }
     if (!value) return;
-    applyInput(ctx, out, def, nextStack);
+    applyInput(ctx, fragmentsOut, shortcutDefinition, nextShortcutStack);
     return;
   }
 
@@ -230,6 +413,9 @@ if (import.meta.vitest) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
   const { describe, it, expect } = import.meta.vitest;
+
+  const debugId = "myCSS";
+  setFileScope("test");
 
   describe("defineRules", () => {
     describe.concurrent("DefineRules Properties", () => {
@@ -341,6 +527,52 @@ if (import.meta.vitest) {
         });
       });
 
+      it("css() canonicalize className", () => {
+        const { css } = defineRules({
+          debugId,
+          properties: {
+            color: true,
+            background: true
+          }
+        });
+        const colorRed = css({ color: "red" });
+        const backgroundBlue = css({ background: "blue" });
+        const combined = css({ color: "red", background: "blue" });
+
+        expect(colorRed).toMatch(identifierName(debugId));
+
+        expect(colorRed).toBe(css({ color: "red" }));
+        expect(backgroundBlue).toBe(css({ background: "blue" }));
+        expect(combined).toBe(css({ color: "red", background: "blue" }));
+      });
+
+      it("css() dedupes equivalent whole fragments when object key order differs", () => {
+        const alpha = "--alpha";
+        const { css } = defineRules({
+          properties: {
+            background(arg: { red: number; blue: number }) {
+              const value = `rgb(${arg.red}, 0, ${arg.blue})`;
+
+              if (Object.keys(arg)[0] === "red") {
+                return {
+                  vars: { [alpha]: "1" },
+                  background: value
+                } as const;
+              }
+
+              return {
+                background: value,
+                vars: { [alpha]: "1" }
+              } as const;
+            }
+          }
+        });
+
+        expect(css({ background: { red: 255, blue: 255 } })).toBe(
+          css({ background: { blue: 255, red: 255 } })
+        );
+      });
+
       it("Last one wins for properties", () => {
         const { css } = defineRules({
           properties: {
@@ -351,6 +583,58 @@ if (import.meta.vitest) {
         expect(css.raw([{ color: "red" }, { color: "blue" }])).toEqual({
           color: "blue"
         });
+        expect(css([{ color: "red" }, { color: "blue" }])).toBe(
+          css({ color: "blue" })
+        );
+      });
+
+      it("Last one wins for properties while preserving sibling vars", () => {
+        const alpha = "--alpha";
+        const createCss = () =>
+          defineRules({
+            properties: {
+              background: {
+                red: {
+                  vars: { [alpha]: "1" },
+                  background: `rgba(255, 0, 0, var(${alpha}))`
+                },
+                blue: "rgb(0, 0, 255)"
+              }
+            }
+          }).css;
+
+        const cssRaw = createCss();
+
+        expect(
+          cssRaw.raw([{ background: "red" }, { background: "blue" }])
+        ).toEqual({
+          vars: { [alpha]: "1" },
+          background: "rgb(0, 0, 255)"
+        });
+
+        const cssFullFirst = createCss();
+        const fullRed = cssFullFirst({ background: "red" }).split(" ");
+        const prunedAfterFull = cssFullFirst([
+          { background: "red" },
+          { background: "blue" }
+        ]).split(" ");
+
+        expect(fullRed).toHaveLength(1);
+        expect(prunedAfterFull).toHaveLength(2);
+        expect(prunedAfterFull[0]).not.toBe(fullRed[0]);
+
+        const cssPrunedFirst = createCss();
+        const prunedBeforeFull = cssPrunedFirst([
+          { background: "red" },
+          { background: "blue" }
+        ]).split(" ");
+        const fullAfterPruned = cssPrunedFirst({ background: "red" }).split(
+          " "
+        );
+
+        expect(prunedBeforeFull).toHaveLength(2);
+        expect(fullAfterPruned).toHaveLength(1);
+        expect(fullAfterPruned[0]).not.toBe(prunedBeforeFull[0]);
       });
     });
 
@@ -377,6 +661,7 @@ if (import.meta.vitest) {
         expect(css.raw({ paddingLeft: 8, pl: 4 })).toEqual({
           paddingLeft: 4
         });
+        expect(css({ pl: 4 })).toBe(css({ paddingLeft: 4 }));
       });
 
       it("Array shortcut referencing properties", () => {
@@ -474,6 +759,23 @@ if (import.meta.vitest) {
           paddingLeft: 0,
           paddingRight: 8
         });
+        expect(css({ p: 4, px: 8, pl: 0 })).toBe(
+          css([
+            {
+              paddingTop: 4,
+              paddingBottom: 4,
+              paddingLeft: 4,
+              paddingRight: 4
+            },
+            {
+              paddingLeft: 8,
+              paddingRight: 8
+            },
+            {
+              paddingLeft: 0
+            }
+          ])
+        );
       });
 
       it("Fixed object shortcut", () => {
@@ -532,6 +834,31 @@ if (import.meta.vitest) {
           paddingLeft: 4,
           paddingRight: 4
         });
+        expect(css({ center: "inline" })).toBe(
+          css({
+            display: "inline",
+            paddingLeft: 4,
+            paddingRight: 4
+          })
+        );
+        expect(css({ center: "inline" }).split(" ")).toHaveLength(3);
+      });
+
+      it("Circular shortcuts", () => {
+        const { css } = defineRules({
+          properties: {
+            paddingLeft: [0, 4, 8]
+          },
+          shortcuts: {
+            a: "b",
+            b: ["a"]
+          }
+        });
+
+        // @ts-expect-error Type of property 'a' circularly references itself in mapped type 'ShortcutsInput<PropertiesInput<{ readonly paddingLeft: readonly [0, 4, 8]; }>, { readonly a: "b"; readonly b: readonly ["a"]; }>'.
+        expect(() => css.raw({ a: 4 })).toThrow(
+          "Circular shortcut reference: a -> b -> a"
+        );
       });
     });
   });

--- a/packages/css/src/defineRules/index.ts
+++ b/packages/css/src/defineRules/index.ts
@@ -40,7 +40,7 @@ export function defineRules<
       );
       output.push(className);
     }
-    return output.join(" ");
+    return output.sort().join(" ");
   }
 
   const css = Object.assign(cssImpl, { raw: cssRaw });
@@ -232,6 +232,10 @@ function applyEntry<
   value: unknown,
   shortcutStack: string[]
 ) {
+  if (value == null) {
+    return;
+  }
+
   if (hasOwn(ctx.shortcuts, key)) {
     applyShortcut(ctx, fragmentsOut, key, value, shortcutStack);
     return;
@@ -254,6 +258,11 @@ function applyProperty<
 
   if (typeof propertyDefinition === "function") {
     const result = propertyDefinition(value);
+
+    if (result == null) {
+      return;
+    }
+
     if (isPlainObject(result)) {
       pushResolvedFragment(
         fragmentsOut,
@@ -527,6 +536,47 @@ if (import.meta.vitest) {
         });
       });
 
+      it("Nullish values are treated as no-op", () => {
+        const { css: cssProperty } = defineRules({
+          properties: {
+            color: true
+          }
+        });
+        const undefinedColor: { color?: "red" } = {};
+        const nullColor: { color?: "red" } = {};
+        Object.assign(undefinedColor, { color: undefined });
+        Object.assign(nullColor, { color: null });
+
+        expect(cssProperty.raw([{ color: "red" }, undefinedColor])).toEqual({
+          color: "red"
+        });
+        expect(cssProperty.raw([{ color: "red" }, nullColor])).toEqual({
+          color: "red"
+        });
+
+        const { css: cssResolver } = defineRules({
+          properties: {
+            optionalColor(arg: "primary" | "none") {
+              if (arg === "primary") {
+                return { color: "blue" } as const;
+              }
+              return undefined;
+            }
+          }
+        });
+
+        expect(cssResolver.raw({ optionalColor: "none" })).toEqual({});
+        expect(
+          cssResolver.raw([
+            { optionalColor: "primary" },
+            { optionalColor: "none" }
+          ])
+        ).toEqual({ color: "blue" });
+        expect(
+          cssResolver([{ optionalColor: "primary" }, { optionalColor: "none" }])
+        ).toBe(cssResolver({ optionalColor: "primary" }));
+      });
+
       it("css() canonicalize className", () => {
         const { css } = defineRules({
           debugId,
@@ -538,12 +588,14 @@ if (import.meta.vitest) {
         const colorRed = css({ color: "red" });
         const backgroundBlue = css({ background: "blue" });
         const combined = css({ color: "red", background: "blue" });
+        const reversedCombined = css({ background: "blue", color: "red" });
 
         expect(colorRed).toMatch(identifierName(debugId));
 
         expect(colorRed).toBe(css({ color: "red" }));
         expect(backgroundBlue).toBe(css({ background: "blue" }));
         expect(combined).toBe(css({ color: "red", background: "blue" }));
+        expect(reversedCombined).toBe(combined);
       });
 
       it("css() dedupes equivalent whole fragments when object key order differs", () => {

--- a/packages/css/src/defineRules/types.ts
+++ b/packages/css/src/defineRules/types.ts
@@ -6,7 +6,7 @@ import type {
 
 type CSSPropertiesKeys = keyof CSSProperties;
 
-type DefineRulesResolver<
+type DefineRulesValueResolver<
   Out = CSSPropertiesWithVars | undefined,
   Arg = unknown
 > = {
@@ -21,14 +21,14 @@ type DefineRulesCssProperties = {
 type DefineRulesCssPropertiesValue<Value> =
   | ReadonlyArray<Value>
   | Record<string, Value | CSSPropertiesWithVars>
-  | DefineRulesResolver<Value>
+  | DefineRulesValueResolver<Value>
   | true
   | false;
 
 type DefineRulesCustomProperties = Partial<
   Record<
     Exclude<NonNullableString, CSSPropertiesKeys>,
-    Record<string, CSSPropertiesWithVars> | DefineRulesResolver
+    Record<string, CSSPropertiesWithVars> | DefineRulesValueResolver
   >
 >;
 export type DefineRulesProperties =
@@ -44,7 +44,7 @@ type ShortcutValue<
   | Exclude<keyof Shortcuts, ShortcutsKey>
   | ReadonlyArray<keyof Properties | Exclude<keyof Shortcuts, ShortcutsKey>>
   | DefineRulesCssInput<Properties, Shortcuts>
-  | DefineRulesResolver<DefineRulesCssInput<Properties, Shortcuts>>;
+  | DefineRulesValueResolver<DefineRulesCssInput<Properties, Shortcuts>>;
 
 export type DefineRulesShortcuts<
   Properties extends DefineRulesProperties,
@@ -61,6 +61,7 @@ export interface DefineRulesCtx<
   Properties extends DefineRulesProperties,
   Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
 > {
+  debugId?: string;
   properties?: Properties;
   shortcuts?: Shortcuts;
 }
@@ -163,13 +164,13 @@ if (import.meta.vitest) {
   const { describe, it, assertType } = import.meta.vitest;
 
   describe.concurrent("DefineRules Type Test", () => {
-    function resolveDefineRules<
+    function createDefineRulesTypeCase<
       const Properties extends DefineRulesProperties,
       const Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
-    >(rules: DefineRulesCtx<Properties, Shortcuts>) {
+    >(defineRulesCtx: DefineRulesCtx<Properties, Shortcuts>) {
       return {
-        rules,
-        _props: rules as unknown as DefineRulesComplexCssInput<
+        defineRulesCtx,
+        cssInput: defineRulesCtx as unknown as DefineRulesComplexCssInput<
           Properties,
           Shortcuts
         >
@@ -178,24 +179,25 @@ if (import.meta.vitest) {
 
     describe.concurrent("DefineRulesProperties Type", () => {
       it("Array values for CSS properties", () => {
-        const { rules, _props } = resolveDefineRules({
-          properties: {
-            display: ["none", "inline", "block"],
-            paddingLeft: [0, 2, 4, 8, 16, 32, 64]
-          }
-        });
+        const { defineRulesCtx, cssInput: _cssInput } =
+          createDefineRulesTypeCase({
+            properties: {
+              display: ["none", "inline", "block"],
+              paddingLeft: [0, 2, 4, 8, 16, 32, 64]
+            }
+          });
         assertType<{
           properties?: {
             readonly display: readonly ["none", "inline", "block"];
             readonly paddingLeft: readonly [0, 2, 4, 8, 16, 32, 64];
           };
-        }>(rules);
+        }>(defineRulesCtx);
 
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           display: "inline",
           paddingLeft: 4
         });
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           // @ts-expect-error: invalid value
           display: "flex",
           // @ts-expect-error: invalid value
@@ -204,14 +206,15 @@ if (import.meta.vitest) {
       });
 
       it("Object values for CSS properties", () => {
-        const { rules, _props } = resolveDefineRules({
-          properties: {
-            color: {
-              "indigo-800": "rgb(55, 48, 163)",
-              "red-500": "rgb(239, 68, 68)"
+        const { defineRulesCtx, cssInput: _cssInput } =
+          createDefineRulesTypeCase({
+            properties: {
+              color: {
+                "indigo-800": "rgb(55, 48, 163)",
+                "red-500": "rgb(239, 68, 68)"
+              }
             }
-          }
-        });
+          });
         assertType<{
           properties?: {
             color: {
@@ -219,12 +222,12 @@ if (import.meta.vitest) {
               "red-500": string;
             };
           };
-        }>(rules);
+        }>(defineRulesCtx);
 
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           color: "indigo-800"
         });
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           // @ts-expect-error: invalid value
           color: "blue-500"
         });
@@ -232,16 +235,17 @@ if (import.meta.vitest) {
 
       it("Object values with CSSPropertiesWithVars", () => {
         const alpha = "--alpha";
-        const { rules, _props } = resolveDefineRules({
-          properties: {
-            background: {
-              red: {
-                vars: { [alpha]: "1" },
-                background: `rgba(255, 0, 0, var(${alpha}))`
+        const { defineRulesCtx, cssInput: _cssInput } =
+          createDefineRulesTypeCase({
+            properties: {
+              background: {
+                red: {
+                  vars: { [alpha]: "1" },
+                  background: `rgba(255, 0, 0, var(${alpha}))`
+                }
               }
             }
-          }
-        });
+          });
         assertType<{
           properties?: {
             background: {
@@ -251,50 +255,52 @@ if (import.meta.vitest) {
               };
             };
           };
-        }>(rules);
+        }>(defineRulesCtx);
 
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           background: "red"
         });
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           // @ts-expect-error: invalid value
           background: "blue"
         });
       });
 
       it("Boolean values for entire properties", () => {
-        const { rules, _props } = resolveDefineRules({
-          properties: {
-            border: false,
-            margin: true
-          }
-        });
+        const { defineRulesCtx, cssInput: _cssInput } =
+          createDefineRulesTypeCase({
+            properties: {
+              border: false,
+              margin: true
+            }
+          });
         assertType<{
           properties?: {
             border: false;
             margin: true;
           };
-        }>(rules);
+        }>(defineRulesCtx);
 
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           margin: "inherit"
         });
         // @ts-expect-error: `border` is false, so it should not accept any value.
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           border: "1px solid black"
         });
       });
 
       it("Custom properties with CSSPropertiesWithVars", () => {
         const alpha = "--alpha";
-        const { rules, _props } = resolveDefineRules({
-          properties: {
-            backgroundOpacity: {
-              full: { vars: { [alpha]: "1" } },
-              half: { vars: { [alpha]: "0.5" } }
+        const { defineRulesCtx, cssInput: _cssInput } =
+          createDefineRulesTypeCase({
+            properties: {
+              backgroundOpacity: {
+                full: { vars: { [alpha]: "1" } },
+                half: { vars: { [alpha]: "0.5" } }
+              }
             }
-          }
-        });
+          });
         assertType<{
           properties?: {
             backgroundOpacity: {
@@ -302,29 +308,30 @@ if (import.meta.vitest) {
               half: { vars: { "--alpha": string } };
             };
           };
-        }>(rules);
+        }>(defineRulesCtx);
 
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           backgroundOpacity: "full"
         });
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           // @ts-expect-error: invalid value
           backgroundOpacity: "quarter"
         });
       });
 
       it("Function values return CSS properties", () => {
-        const { rules, _props } = resolveDefineRules({
-          properties: {
-            color(arg: "primary" | "secondary") {
-              if (arg === "primary") {
-                return { color: "blue" } as const;
-              } else {
-                return { color: "gray" } as const;
+        const { defineRulesCtx, cssInput: _cssInput } =
+          createDefineRulesTypeCase({
+            properties: {
+              color(arg: "primary" | "secondary") {
+                if (arg === "primary") {
+                  return { color: "blue" } as const;
+                } else {
+                  return { color: "gray" } as const;
+                }
               }
             }
-          }
-        });
+          });
         assertType<{
           properties?: {
             color: (arg: "primary" | "secondary") =>
@@ -333,32 +340,33 @@ if (import.meta.vitest) {
                 }
               | undefined;
           };
-        }>(rules);
+        }>(defineRulesCtx);
 
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           color: "primary"
         });
       });
 
       it("Function values return Style objects", () => {
-        const { rules, _props } = resolveDefineRules({
-          properties: {
-            color(arg: "primary" | "secondary") {
-              if (arg === "primary") {
-                return "blue";
-              } else {
-                return "gray";
-              }
-            },
-            otherColor(arg: "primary" | "secondary") {
-              if (arg === "primary") {
-                return { color: "red" } as const;
-              } else {
-                return { color: "green" } as const;
+        const { defineRulesCtx, cssInput: _cssInput } =
+          createDefineRulesTypeCase({
+            properties: {
+              color(arg: "primary" | "secondary") {
+                if (arg === "primary") {
+                  return "blue";
+                } else {
+                  return "gray";
+                }
+              },
+              otherColor(arg: "primary" | "secondary") {
+                if (arg === "primary") {
+                  return { color: "red" } as const;
+                } else {
+                  return { color: "green" } as const;
+                }
               }
             }
-          }
-        });
+          });
         assertType<{
           properties?: {
             color: (arg: "primary" | "secondary") => "blue" | "gray";
@@ -368,9 +376,9 @@ if (import.meta.vitest) {
                 }
               | undefined;
           };
-        }>(rules);
+        }>(defineRulesCtx);
 
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           color: "primary"
         });
       });
@@ -378,16 +386,17 @@ if (import.meta.vitest) {
 
     describe.concurrent("DefineRulesShortcuts Type", () => {
       it("Single property shortcut", () => {
-        const { rules, _props } = resolveDefineRules({
-          properties: {
-            paddingLeft: [0, 4, 8],
-            paddingRight: [0, 4, 8]
-          },
-          shortcuts: {
-            pl: "paddingLeft",
-            pr: "paddingRight"
-          }
-        });
+        const { defineRulesCtx, cssInput: _cssInput } =
+          createDefineRulesTypeCase({
+            properties: {
+              paddingLeft: [0, 4, 8],
+              paddingRight: [0, 4, 8]
+            },
+            shortcuts: {
+              pl: "paddingLeft",
+              pr: "paddingRight"
+            }
+          });
         assertType<{
           properties?: {
             paddingLeft: readonly [0, 4, 8];
@@ -397,13 +406,13 @@ if (import.meta.vitest) {
             pl: "paddingLeft";
             pr: "paddingRight";
           };
-        }>(rules);
+        }>(defineRulesCtx);
 
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           pl: 4,
           pr: 8
         });
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           // @ts-expect-error: invalid value
           pl: 5,
           // @ts-expect-error: invalid value
@@ -412,15 +421,16 @@ if (import.meta.vitest) {
       });
 
       it("Array shortcut referencing properties", () => {
-        const { rules, _props } = resolveDefineRules({
-          properties: {
-            paddingLeft: [0, 4, 8],
-            paddingRight: [0, 4, 8, 12]
-          },
-          shortcuts: {
-            px: ["paddingLeft", "paddingRight"]
-          }
-        });
+        const { defineRulesCtx, cssInput: _cssInput } =
+          createDefineRulesTypeCase({
+            properties: {
+              paddingLeft: [0, 4, 8],
+              paddingRight: [0, 4, 8, 12]
+            },
+            shortcuts: {
+              px: ["paddingLeft", "paddingRight"]
+            }
+          });
         assertType<{
           properties?: {
             paddingLeft: readonly [0, 4, 8];
@@ -429,33 +439,34 @@ if (import.meta.vitest) {
           shortcuts?: {
             px: readonly ["paddingLeft", "paddingRight"];
           };
-        }>(rules);
+        }>(defineRulesCtx);
 
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           px: 4
         });
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           // @ts-expect-error: invalid value
           px: 5
         });
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           // @ts-expect-error: invalid value
           px: 12
         });
       });
 
       it("Shortcut referencing other shortcuts", () => {
-        const { rules, _props } = resolveDefineRules({
-          properties: {
-            paddingLeft: [0, 4, 8],
-            paddingRight: [0, 4, 8, 12]
-          },
-          shortcuts: {
-            pl: "paddingLeft",
-            pr: "paddingRight",
-            px: ["pl", "pr"]
-          }
-        });
+        const { defineRulesCtx, cssInput: _cssInput } =
+          createDefineRulesTypeCase({
+            properties: {
+              paddingLeft: [0, 4, 8],
+              paddingRight: [0, 4, 8, 12]
+            },
+            shortcuts: {
+              pl: "paddingLeft",
+              pr: "paddingRight",
+              px: ["pl", "pr"]
+            }
+          });
         assertType<{
           properties?: {
             paddingLeft: readonly [0, 4, 8];
@@ -466,23 +477,23 @@ if (import.meta.vitest) {
             pr: "paddingRight";
             px: readonly ["pl", "pr"];
           };
-        }>(rules);
+        }>(defineRulesCtx);
 
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           px: 4
         });
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           // @ts-expect-error: invalid value
           px: 5
         });
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           // @ts-expect-error: invalid value
           px: 12
         });
       });
 
       it("Mixed shortcuts with properties and other shortcuts", () => {
-        const { rules } = resolveDefineRules({
+        const { defineRulesCtx } = createDefineRulesTypeCase({
           properties: {
             paddingTop: [0, 4, 8],
             paddingBottom: [0, 4, 8],
@@ -515,18 +526,19 @@ if (import.meta.vitest) {
             px: readonly ["pl", "pr"];
             p: readonly ["py", "px"];
           };
-        }>(rules);
+        }>(defineRulesCtx);
       });
 
       it("Fixed object shortcut", () => {
-        const { rules, _props } = resolveDefineRules({
-          properties: {
-            display: ["none", "inline", "block"]
-          },
-          shortcuts: {
-            inline: { display: "inline" }
-          }
-        });
+        const { defineRulesCtx, cssInput: _cssInput } =
+          createDefineRulesTypeCase({
+            properties: {
+              display: ["none", "inline", "block"]
+            },
+            shortcuts: {
+              inline: { display: "inline" }
+            }
+          });
         assertType<{
           properties?: {
             display: readonly ["none", "inline", "block"];
@@ -534,31 +546,32 @@ if (import.meta.vitest) {
           shortcuts?: {
             inline: { readonly display: "inline" };
           };
-        }>(rules);
+        }>(defineRulesCtx);
 
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           inline: true
         });
-        assertType<typeof _props>(["inline"]);
+        assertType<typeof _cssInput>(["inline"]);
       });
 
       it("Function shortcut", () => {
-        const { rules, _props } = resolveDefineRules({
-          properties: {
-            display: ["none", "inline", "block"],
-            paddingLeft: [0, 4, 8],
-            paddingRight: [0, 4, 8]
-          },
-          shortcuts: {
-            px: ["paddingLeft", "paddingRight"],
-            center(arg: "none" | "inline" | "block") {
-              return {
-                display: arg,
-                px: 4
-              } as const;
+        const { defineRulesCtx, cssInput: _cssInput } =
+          createDefineRulesTypeCase({
+            properties: {
+              display: ["none", "inline", "block"],
+              paddingLeft: [0, 4, 8],
+              paddingRight: [0, 4, 8]
+            },
+            shortcuts: {
+              px: ["paddingLeft", "paddingRight"],
+              center(arg: "none" | "inline" | "block") {
+                return {
+                  display: arg,
+                  px: 4
+                } as const;
+              }
             }
-          }
-        });
+          });
         assertType<{
           properties?: {
             display: readonly ["none", "inline", "block"];
@@ -574,12 +587,12 @@ if (import.meta.vitest) {
                 }
               | undefined;
           };
-        }>(rules);
+        }>(defineRulesCtx);
 
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           center: "inline"
         });
-        assertType<typeof _props>({
+        assertType<typeof _cssInput>({
           // @ts-expect-error: invalid value
           center: "flex"
         });
@@ -588,7 +601,7 @@ if (import.meta.vitest) {
 
     describe.concurrent("Invalid Type Cases", () => {
       it("Invalid shortcut reference should error", () => {
-        resolveDefineRules({
+        createDefineRulesTypeCase({
           properties: {
             paddingLeft: [0, 4, 8]
           },
@@ -600,7 +613,7 @@ if (import.meta.vitest) {
       });
 
       it("Shortcut cannot reference itself", () => {
-        resolveDefineRules({
+        createDefineRulesTypeCase({
           properties: {
             paddingLeft: [0, 4, 8]
           },
@@ -612,7 +625,7 @@ if (import.meta.vitest) {
       });
 
       it("Array shortcut with invalid reference should error", () => {
-        resolveDefineRules({
+        createDefineRulesTypeCase({
           properties: {
             paddingLeft: [0, 4, 8],
             paddingRight: [0, 4, 8]
@@ -628,7 +641,7 @@ if (import.meta.vitest) {
     describe.concurrent("Complex DefineRules", () => {
       it("Full featured defineRules", () => {
         const alpha = "--alpha";
-        const { rules } = resolveDefineRules({
+        const { defineRulesCtx } = createDefineRulesTypeCase({
           properties: {
             // Array values
             display: ["none", "inline", "block", "flex", "grid"],
@@ -722,7 +735,7 @@ if (import.meta.vitest) {
             p: readonly ["px", "py"];
             inline: { readonly display: "inline" };
           };
-        }>(rules);
+        }>(defineRulesCtx);
       });
     });
   });

--- a/packages/css/src/defineRules/utils.ts
+++ b/packages/css/src/defineRules/utils.ts
@@ -1,5 +1,6 @@
 import type { CSSRule } from "@mincho-js/transform-to-vanilla";
 import { setFileScope } from "@vanilla-extract/css/fileScope";
+import hash from "@emotion/hash";
 import { css } from "../css/index.js";
 import { identifierName } from "../utils.js";
 
@@ -88,13 +89,18 @@ function pairCacheKey(key: unknown, value: unknown): string {
   return JSON.stringify(["pair", canonicalize(key), canonicalize(value)]);
 }
 
+function hashedCacheKey(parts: readonly CanonicalNode[]): string {
+  const input = JSON.stringify(parts);
+  return hash(input);
+}
+
 function fragmentCacheKey(
   key: unknown,
   value: unknown,
   fragment: unknown
 ): string {
-  return JSON.stringify([
-    "fragment",
+  return hashedCacheKey([
+    ["string", "fragment"],
     canonicalize(key),
     canonicalize(value),
     canonicalize(fragment)

--- a/packages/css/src/defineRules/utils.ts
+++ b/packages/css/src/defineRules/utils.ts
@@ -9,11 +9,7 @@ type CanonicalNode =
   | ["boolean", boolean]
   | ["number", string]
   | ["string", string]
-  | ["bigint", string]
-  | ["date", string]
   | ["array", CanonicalNode[]]
-  | ["set", CanonicalNode[]]
-  | ["map", Array<[CanonicalNode, CanonicalNode]>]
   | ["object", Array<[string, CanonicalNode]>];
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -23,13 +19,6 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
   const proto = Object.getPrototypeOf(value);
   return proto === Object.prototype || proto === null;
-}
-
-function sortByStableString<T>(items: readonly T[]): T[] {
-  return [...items]
-    .map((item) => ({ item, key: JSON.stringify(item) }))
-    .sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0))
-    .map(({ item }) => item);
 }
 
 function canonicalize(
@@ -56,9 +45,6 @@ function canonicalize(
       }
       return ["number", String(value)];
 
-    case "bigint":
-      return ["bigint", value.toString()];
-
     case "undefined":
       return ["undefined"];
 
@@ -67,10 +53,6 @@ function canonicalize(
 
     default:
       throw new TypeError(`Not supported type: ${typeof value}`);
-  }
-
-  if (value instanceof Date) {
-    return ["date", value.toISOString()];
   }
 
   if (stack.has(value)) {
@@ -85,23 +67,6 @@ function canonicalize(
       return ["array", value.map((item) => canonicalize(item, stack))];
     }
 
-    if (value instanceof Set) {
-      const items = [...value].map((item) => canonicalize(item, stack));
-      return ["set", sortByStableString(items)];
-    }
-
-    if (value instanceof Map) {
-      const entries = [...value.entries()].map(
-        ([k, v]) =>
-          [canonicalize(k, stack), canonicalize(v, stack)] as [
-            CanonicalNode,
-            CanonicalNode
-          ]
-      );
-
-      return ["map", sortByStableString(entries)];
-    }
-
     if (isPlainObject(value)) {
       const entries = Object.keys(value)
         .sort()
@@ -113,9 +78,7 @@ function canonicalize(
       return ["object", entries];
     }
 
-    throw new TypeError(
-      "Only plain objects, Arrays, Sets, Maps, and Dates are supported."
-    );
+    throw new TypeError("Only plain objects and Arrays are supported.");
   } finally {
     stack.delete(value);
   }
@@ -296,54 +259,18 @@ if (import.meta.vitest) {
       expect(cache.size).toBe(2);
     });
 
-    it("should ignore set element order", () => {
+    it("should reject Sets, Maps, and Dates", () => {
       const cache = createCanonicalStyleCache(debugId);
 
-      const s1 = new Set<unknown>([{ b: 2, a: 1 }, ["x", "y"]]);
-      const s2 = new Set<unknown>([["x", "y"], { a: 1, b: 2 }]);
-
-      expectClassName(cache.add("tags", s1));
-      expectClassName(cache.add("tags", s2));
-      expect(cache.size).toBe(1);
-    });
-
-    it("should ignore map entry order", () => {
-      const cache = createCanonicalStyleCache(debugId);
-
-      const m1 = new Map<unknown, unknown>([
-        ["k1", 1],
-        [
-          { b: 2, a: 1 },
-          { y: 2, x: 1 }
-        ]
-      ]);
-
-      const m2 = new Map<unknown, unknown>([
-        [
-          { a: 1, b: 2 },
-          { x: 1, y: 2 }
-        ],
-        ["k1", 1]
-      ]);
-
-      expectClassName(cache.add("map", m1));
-      expectClassName(cache.add("map", m2));
-      expect(cache.size).toBe(1);
-    });
-
-    it("should treat dates with the same timestamp as equal values", () => {
-      const cache = createCanonicalStyleCache(debugId);
-
-      expectClassName(
-        cache.add("createdAt", new Date("2024-01-01T00:00:00.000Z"))
+      expect(() => cache.has("tags", new Set(["a", "b"]))).toThrow(
+        /Only plain objects and Arrays are supported/
       );
-      expect(cache.has("createdAt", new Date("2024-01-01T00:00:00.000Z"))).toBe(
-        true
+      expect(() => cache.has("map", new Map([["k1", 1]]))).toThrow(
+        /Only plain objects and Arrays are supported/
       );
-      expectClassName(
-        cache.add("createdAt", new Date("2024-01-01T00:00:00.000Z"))
-      );
-      expect(cache.size).toBe(1);
+      expect(() =>
+        cache.has("createdAt", new Date("2024-01-01T00:00:00.000Z"))
+      ).toThrow(/Only plain objects and Arrays are supported/);
     });
 
     it("should treat NaN as equal and distinguish -0 from 0", () => {
@@ -498,13 +425,14 @@ if (import.meta.vitest) {
       expect(cache.size).toBe(1);
     });
 
-    it("should reject functions and symbols", () => {
+    it("should reject functions, symbols, and bigints", () => {
       const cache = createCanonicalStyleCache(debugId);
 
       expect(() => cache.has("fn", () => undefined)).toThrow(
         /Not supported type/
       );
       expect(() => cache.has("sym", Symbol("x"))).toThrow(/Not supported type/);
+      expect(() => cache.has("bigint", 1n)).toThrow(/Not supported type/);
     });
 
     it("should reject class instances", () => {
@@ -515,7 +443,7 @@ if (import.meta.vitest) {
       }
 
       expect(() => cache.has("user", new User("alice"))).toThrow(
-        /Only plain objects, Arrays, Sets, Maps, and Dates are supported/
+        /Only plain objects and Arrays are supported/
       );
     });
 

--- a/packages/css/src/defineRules/utils.ts
+++ b/packages/css/src/defineRules/utils.ts
@@ -1,0 +1,533 @@
+import type { CSSRule } from "@mincho-js/transform-to-vanilla";
+import { setFileScope } from "@vanilla-extract/css/fileScope";
+import { css } from "../css/index.js";
+import { identifierName } from "../utils.js";
+
+type CanonicalNode =
+  | ["null"]
+  | ["undefined"]
+  | ["boolean", boolean]
+  | ["number", string]
+  | ["string", string]
+  | ["bigint", string]
+  | ["date", string]
+  | ["array", CanonicalNode[]]
+  | ["set", CanonicalNode[]]
+  | ["map", Array<[CanonicalNode, CanonicalNode]>]
+  | ["object", Array<[string, CanonicalNode]>];
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function sortByStableString<T>(items: readonly T[]): T[] {
+  return [...items]
+    .map((item) => ({ item, key: JSON.stringify(item) }))
+    .sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0))
+    .map(({ item }) => item);
+}
+
+function canonicalize(
+  value: unknown,
+  stack: WeakSet<object> = new WeakSet()
+): CanonicalNode {
+  if (value === null) {
+    return ["null"];
+  }
+
+  switch (typeof value) {
+    case "string":
+      return ["string", value];
+
+    case "boolean":
+      return ["boolean", value];
+
+    case "number":
+      if (Number.isNaN(value)) {
+        return ["number", "NaN"];
+      }
+      if (Object.is(value, -0)) {
+        return ["number", "-0"];
+      }
+      return ["number", String(value)];
+
+    case "bigint":
+      return ["bigint", value.toString()];
+
+    case "undefined":
+      return ["undefined"];
+
+    case "object":
+      break;
+
+    default:
+      throw new TypeError(`Not supported type: ${typeof value}`);
+  }
+
+  if (value instanceof Date) {
+    return ["date", value.toISOString()];
+  }
+
+  if (stack.has(value)) {
+    throw new TypeError("Circular reference is not supported.");
+  }
+
+  stack.add(value);
+
+  try {
+    if (Array.isArray(value)) {
+      // Arrays maintain order.
+      return ["array", value.map((item) => canonicalize(item, stack))];
+    }
+
+    if (value instanceof Set) {
+      const items = [...value].map((item) => canonicalize(item, stack));
+      return ["set", sortByStableString(items)];
+    }
+
+    if (value instanceof Map) {
+      const entries = [...value.entries()].map(
+        ([k, v]) =>
+          [canonicalize(k, stack), canonicalize(v, stack)] as [
+            CanonicalNode,
+            CanonicalNode
+          ]
+      );
+
+      return ["map", sortByStableString(entries)];
+    }
+
+    if (isPlainObject(value)) {
+      const entries = Object.keys(value)
+        .sort()
+        .map(
+          (key) =>
+            [key, canonicalize(value[key], stack)] as [string, CanonicalNode]
+        );
+
+      return ["object", entries];
+    }
+
+    throw new TypeError(
+      "Only plain objects, Arrays, Sets, Maps, and Dates are supported."
+    );
+  } finally {
+    stack.delete(value);
+  }
+}
+
+function pairCacheKey(key: unknown, value: unknown): string {
+  return JSON.stringify(["pair", canonicalize(key), canonicalize(value)]);
+}
+
+function fragmentCacheKey(
+  key: unknown,
+  value: unknown,
+  fragment: unknown
+): string {
+  return JSON.stringify([
+    "fragment",
+    canonicalize(key),
+    canonicalize(value),
+    canonicalize(fragment)
+  ]);
+}
+
+export function createCanonicalStyleCache(debugId?: string) {
+  let classNameCache: Record<string, string> = {};
+
+  function hasCacheKey(cacheKey: string): boolean {
+    return cacheKey in classNameCache;
+  }
+
+  function getCachedClassName(cacheKey: string): string | undefined {
+    return classNameCache[cacheKey];
+  }
+
+  function cacheClassName(cacheKey: string, style: CSSRule): string {
+    const classNameOrUndefined = classNameCache[cacheKey];
+    if (classNameOrUndefined != null) {
+      return classNameOrUndefined;
+    }
+
+    const className = css(style, debugId);
+    classNameCache[cacheKey] = className;
+    return className;
+  }
+
+  function has(key: unknown, value: unknown): boolean {
+    return hasCacheKey(pairCacheKey(key, value));
+  }
+
+  function get(key: unknown, value: unknown): string | undefined {
+    return getCachedClassName(pairCacheKey(key, value));
+  }
+
+  function add(key: unknown, value: unknown): string {
+    return cacheClassName(pairCacheKey(key, value), {
+      [key as string]: value
+    } as CSSRule);
+  }
+
+  function hasFragment(
+    key: unknown,
+    value: unknown,
+    fragment: CSSRule
+  ): boolean {
+    return hasCacheKey(fragmentCacheKey(key, value, fragment));
+  }
+
+  function getFragment(
+    key: unknown,
+    value: unknown,
+    fragment: CSSRule
+  ): string | undefined {
+    return getCachedClassName(fragmentCacheKey(key, value, fragment));
+  }
+
+  function addFragment(
+    key: unknown,
+    value: unknown,
+    fragment: CSSRule
+  ): string {
+    return cacheClassName(fragmentCacheKey(key, value, fragment), fragment);
+  }
+
+  function clear(): void {
+    classNameCache = {};
+  }
+
+  return {
+    has,
+    get,
+    add,
+    hasFragment,
+    getFragment,
+    addFragment,
+    clear,
+    get size() {
+      return Object.keys(classNameCache).length;
+    }
+  };
+}
+
+// == Tests ====================================================================
+// Ignore errors when compiling to CommonJS.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+  const { describe, it, expect } = import.meta.vitest;
+  const debugId = "createCanonicalStyleCache";
+  setFileScope("test");
+
+  function expectClassName(value: string) {
+    expect(value).toMatch(identifierName(debugId));
+  }
+
+  describe("createCanonicalStyleCache", () => {
+    it("should ignore plain object key order in values", () => {
+      const cache = createCanonicalStyleCache(debugId);
+
+      expect(cache.has("user", { b: 2, a: 1 })).toBe(false);
+      expectClassName(cache.add("user", { b: 2, a: 1 }));
+      expect(cache.has("user", { a: 1, b: 2 })).toBe(true);
+      expectClassName(cache.add("user", { a: 1, b: 2 }));
+      expect(cache.size).toBe(1);
+    });
+
+    it("should compare keys using the same canonicalization rules", () => {
+      const cache = createCanonicalStyleCache(debugId);
+
+      expect(cache.has({ b: 2, a: 1 }, "value")).toBe(false);
+      expectClassName(cache.add({ b: 2, a: 1 }, "value"));
+      expect(cache.has({ a: 1, b: 2 }, "value")).toBe(true);
+      expect(cache.size).toBe(1);
+    });
+
+    it("should treat arrays with different order as different values", () => {
+      const cache = createCanonicalStyleCache(debugId);
+
+      expect(cache.has("list", ["a", "b"])).toBe(false);
+      expectClassName(cache.add("list", ["a", "b"]));
+      expect(cache.has("list", ["b", "a"])).toBe(false);
+      expectClassName(cache.add("list", ["a", "b"]));
+      expect(cache.size).toBe(1);
+    });
+
+    it("should ignore plain object key order inside arrays", () => {
+      const cache = createCanonicalStyleCache(debugId);
+
+      expect(cache.has("list", ["x", { b: 2, a: 1 }])).toBe(false);
+      expectClassName(cache.add("list", ["x", { b: 2, a: 1 }]));
+      expect(cache.has("list", ["x", { a: 1, b: 2 }])).toBe(true);
+      expect(cache.has("list", [{ a: 1, b: 2 }, "x"])).toBe(false);
+    });
+
+    it("should treat array keys with different order as different keys", () => {
+      const cache = createCanonicalStyleCache(debugId);
+
+      expect(cache.has(["a", "b"], "value")).toBe(false);
+      expectClassName(cache.add(["a", "b"], "value"));
+      expect(cache.has(["b", "a"], "value")).toBe(false);
+      expectClassName(cache.add(["a", "b"], "value"));
+      expect(cache.size).toBe(1);
+    });
+
+    it("should treat different keys with the same value as different pairs", () => {
+      const cache = createCanonicalStyleCache(debugId);
+
+      expectClassName(cache.add("user", { a: 1 }));
+      expectClassName(cache.add("admin", { a: 1 }));
+      expect(cache.size).toBe(2);
+    });
+
+    it("should treat different values with the same key as different pairs", () => {
+      const cache = createCanonicalStyleCache(debugId);
+
+      expectClassName(cache.add("user", { a: 1 }));
+      expectClassName(cache.add("user", { a: 2 }));
+      expect(cache.size).toBe(2);
+    });
+
+    it("should ignore set element order", () => {
+      const cache = createCanonicalStyleCache(debugId);
+
+      const s1 = new Set<unknown>([{ b: 2, a: 1 }, ["x", "y"]]);
+      const s2 = new Set<unknown>([["x", "y"], { a: 1, b: 2 }]);
+
+      expectClassName(cache.add("tags", s1));
+      expectClassName(cache.add("tags", s2));
+      expect(cache.size).toBe(1);
+    });
+
+    it("should ignore map entry order", () => {
+      const cache = createCanonicalStyleCache(debugId);
+
+      const m1 = new Map<unknown, unknown>([
+        ["k1", 1],
+        [
+          { b: 2, a: 1 },
+          { y: 2, x: 1 }
+        ]
+      ]);
+
+      const m2 = new Map<unknown, unknown>([
+        [
+          { a: 1, b: 2 },
+          { x: 1, y: 2 }
+        ],
+        ["k1", 1]
+      ]);
+
+      expectClassName(cache.add("map", m1));
+      expectClassName(cache.add("map", m2));
+      expect(cache.size).toBe(1);
+    });
+
+    it("should treat dates with the same timestamp as equal values", () => {
+      const cache = createCanonicalStyleCache(debugId);
+
+      expectClassName(
+        cache.add("createdAt", new Date("2024-01-01T00:00:00.000Z"))
+      );
+      expect(cache.has("createdAt", new Date("2024-01-01T00:00:00.000Z"))).toBe(
+        true
+      );
+      expectClassName(
+        cache.add("createdAt", new Date("2024-01-01T00:00:00.000Z"))
+      );
+      expect(cache.size).toBe(1);
+    });
+
+    it("should treat NaN as equal and distinguish -0 from 0", () => {
+      const cache = createCanonicalStyleCache(debugId);
+
+      expectClassName(cache.add("n", NaN));
+      expectClassName(cache.add("n", NaN));
+
+      expectClassName(cache.add("zero", -0));
+      expect(cache.has("zero", 0)).toBe(false);
+      expectClassName(cache.add("zero", 0));
+
+      expect(cache.size).toBe(3);
+    });
+
+    it("should support add, get, has, clear, and size", () => {
+      const cache = createCanonicalStyleCache(debugId);
+
+      expect(cache.size).toBe(0);
+      expect(cache.has("x", { a: 1 })).toBe(false);
+      expect(cache.get("x", { a: 1 })).toBe(undefined);
+      expect(cache.size).toBe(0);
+
+      const className = cache.add("x", { a: 1 });
+      expectClassName(className);
+      expect(cache.has("x", { a: 1 })).toBe(true);
+      expect(cache.get("x", { a: 1 })).toBe(className);
+      cache.add("x", { a: 1 });
+      expect(cache.size).toBe(1);
+
+      cache.clear();
+      expect(cache.size).toBe(0);
+      expect(cache.has("x", { a: 1 })).toBe(false);
+    });
+
+    it("should ignore plain object key order in whole fragment cache keys and fragments", () => {
+      const cache = createCanonicalStyleCache(debugId);
+
+      const className = cache.addFragment(
+        "background",
+        { b: 2, a: 1 },
+        {
+          vars: { "--b": "2", "--a": "1" },
+          background: "rgb(0, 0, 255)"
+        }
+      );
+
+      expectClassName(className);
+      expect(
+        cache.hasFragment(
+          "background",
+          { a: 1, b: 2 },
+          {
+            background: "rgb(0, 0, 255)",
+            vars: { "--a": "1", "--b": "2" }
+          }
+        )
+      ).toBe(true);
+      expect(
+        cache.getFragment(
+          "background",
+          { a: 1, b: 2 },
+          {
+            background: "rgb(0, 0, 255)",
+            vars: { "--a": "1", "--b": "2" }
+          }
+        )
+      ).toBe(className);
+      expect(
+        cache.addFragment(
+          "background",
+          { a: 1, b: 2 },
+          {
+            background: "rgb(0, 0, 255)",
+            vars: { "--a": "1", "--b": "2" }
+          }
+        )
+      ).toBe(className);
+      expect(cache.size).toBe(1);
+    });
+
+    it("should distinguish full and pruned fragments for the same property/value pair in the whole fragment cache", () => {
+      const cache = createCanonicalStyleCache(debugId);
+
+      const full = cache.addFragment("background", "red", {
+        vars: { "--alpha": "1" },
+        background: "rgba(255, 0, 0, var(--alpha))"
+      });
+      const pruned = cache.addFragment("background", "red", {
+        vars: { "--alpha": "1" }
+      });
+
+      expectClassName(full);
+      expectClassName(pruned);
+      expect(pruned).not.toBe(full);
+      expect(
+        cache.getFragment("background", "red", {
+          vars: { "--alpha": "1" }
+        })
+      ).toBe(pruned);
+      expect(cache.size).toBe(2);
+    });
+
+    it("should support get, clear, and stable cache identity in the whole fragment cache", () => {
+      const cache = createCanonicalStyleCache(debugId);
+
+      const firstFragment = {
+        vars: { "--alpha": "1" },
+        background: "rgba(255, 0, 0, var(--alpha))"
+      } as const;
+      const secondFragment = {
+        background: "rgba(255, 0, 0, var(--alpha))",
+        vars: { "--alpha": "1" }
+      } as const;
+
+      expect(cache.getFragment("background", "red", firstFragment)).toBe(
+        undefined
+      );
+
+      const className = cache.addFragment("background", "red", firstFragment);
+      expectClassName(className);
+      expect(cache.getFragment("background", "red", secondFragment)).toBe(
+        className
+      );
+      expect(cache.addFragment("background", "red", secondFragment)).toBe(
+        className
+      );
+      expect(cache.size).toBe(1);
+
+      cache.clear();
+
+      expect(cache.size).toBe(0);
+      expect(cache.hasFragment("background", "red", firstFragment)).toBe(false);
+      expect(cache.getFragment("background", "red", secondFragment)).toBe(
+        undefined
+      );
+    });
+
+    it("should treat null prototype objects as plain objects", () => {
+      const cache = createCanonicalStyleCache(debugId);
+
+      const a = Object.create(null) as Record<string, unknown>;
+      a.b = 2;
+      a.a = 1;
+
+      const b = Object.create(null) as Record<string, unknown>;
+      b.a = 1;
+      b.b = 2;
+
+      expectClassName(cache.add("obj", a));
+      expectClassName(cache.add("obj", b));
+      expect(cache.size).toBe(1);
+    });
+
+    it("should reject functions and symbols", () => {
+      const cache = createCanonicalStyleCache(debugId);
+
+      expect(() => cache.has("fn", () => undefined)).toThrow(
+        /Not supported type/
+      );
+      expect(() => cache.has("sym", Symbol("x"))).toThrow(/Not supported type/);
+    });
+
+    it("should reject class instances", () => {
+      const cache = createCanonicalStyleCache(debugId);
+
+      class User {
+        constructor(public readonly name: string) {}
+      }
+
+      expect(() => cache.has("user", new User("alice"))).toThrow(
+        /Only plain objects, Arrays, Sets, Maps, and Dates are supported/
+      );
+    });
+
+    it("should reject circular references", () => {
+      const cache = createCanonicalStyleCache(debugId);
+
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+
+      expect(() => cache.has("circular", circular)).toThrow(
+        /Circular reference is not supported/
+      );
+    });
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3439,44 +3439,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@turbo/darwin-64@npm:2.9.12":
-  version: 2.9.12
-  resolution: "@turbo/darwin-64@npm:2.9.12"
+"@turbo/darwin-64@npm:2.9.14":
+  version: 2.9.14
+  resolution: "@turbo/darwin-64@npm:2.9.14"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@turbo/darwin-arm64@npm:2.9.12":
-  version: 2.9.12
-  resolution: "@turbo/darwin-arm64@npm:2.9.12"
+"@turbo/darwin-arm64@npm:2.9.14":
+  version: 2.9.14
+  resolution: "@turbo/darwin-arm64@npm:2.9.14"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@turbo/linux-64@npm:2.9.12":
-  version: 2.9.12
-  resolution: "@turbo/linux-64@npm:2.9.12"
+"@turbo/linux-64@npm:2.9.14":
+  version: 2.9.14
+  resolution: "@turbo/linux-64@npm:2.9.14"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@turbo/linux-arm64@npm:2.9.12":
-  version: 2.9.12
-  resolution: "@turbo/linux-arm64@npm:2.9.12"
+"@turbo/linux-arm64@npm:2.9.14":
+  version: 2.9.14
+  resolution: "@turbo/linux-arm64@npm:2.9.14"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@turbo/windows-64@npm:2.9.12":
-  version: 2.9.12
-  resolution: "@turbo/windows-64@npm:2.9.12"
+"@turbo/windows-64@npm:2.9.14":
+  version: 2.9.14
+  resolution: "@turbo/windows-64@npm:2.9.14"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@turbo/windows-arm64@npm:2.9.12":
-  version: 2.9.12
-  resolution: "@turbo/windows-arm64@npm:2.9.12"
+"@turbo/windows-arm64@npm:2.9.14":
+  version: 2.9.14
+  resolution: "@turbo/windows-arm64@npm:2.9.14"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -9504,7 +9504,7 @@ __metadata:
     terser: "npm:^5.47.1"
     tsconfig-custom: "workspace:^"
     tslib: "npm:^2.8.1"
-    turbo: "npm:^2.9.12"
+    turbo: "npm:^2.9.14"
     typescript: "npm:^5.9.3"
     vite: "npm:^7.3.3"
     vite-node: "npm:^5.3.0"
@@ -12157,16 +12157,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"turbo@npm:^2.9.12":
-  version: 2.9.12
-  resolution: "turbo@npm:2.9.12"
+"turbo@npm:^2.9.14":
+  version: 2.9.14
+  resolution: "turbo@npm:2.9.14"
   dependencies:
-    "@turbo/darwin-64": "npm:2.9.12"
-    "@turbo/darwin-arm64": "npm:2.9.12"
-    "@turbo/linux-64": "npm:2.9.12"
-    "@turbo/linux-arm64": "npm:2.9.12"
-    "@turbo/windows-64": "npm:2.9.12"
-    "@turbo/windows-arm64": "npm:2.9.12"
+    "@turbo/darwin-64": "npm:2.9.14"
+    "@turbo/darwin-arm64": "npm:2.9.14"
+    "@turbo/linux-64": "npm:2.9.14"
+    "@turbo/linux-arm64": "npm:2.9.14"
+    "@turbo/windows-64": "npm:2.9.14"
+    "@turbo/windows-arm64": "npm:2.9.14"
   dependenciesMeta:
     "@turbo/darwin-64":
       optional: true
@@ -12182,7 +12182,7 @@ __metadata:
       optional: true
   bin:
     turbo: bin/turbo
-  checksum: 10/bf7601b09f85bced5fa94ea054782afc284a42a1c7736b5c6883110cdb868523dc69d4a4c6acfbd4173d5e9932379410953fdf52344baf3814698a05dd7a564c
+  checksum: 10/99ce1f10c79ec840b542cc628d44f6febc18fcff8fed08f7f966a983a71b03c7febcf3e16066667a01f9d8d7faca133ebd541c57555bd509364f669ceb46807f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2246,6 +2246,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@mincho-js/css@workspace:packages/css"
   dependencies:
+    "@emotion/hash": "npm:^0.9.2"
     "@fastify/deepmerge": "npm:^3.2.1"
     "@mincho-js/transform-to-vanilla": "workspace:^"
     "@vanilla-extract/css": "npm:^1.20.1"


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->

Implement cache key for `defineRules`.

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #316 

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSS API now returns stable, canonicalized class-name strings with automatic deduplication (order-independent); a .raw() helper still exposes merged raw CSS properties.
* **Chores**
  * Added improved hashing dependency to strengthen style identity.
  * Linting configuration broadened so TypeScript/TSX rules apply to files in nested directories.
  * Development tooling version updated for build tooling stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mincho-js/mincho/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
