### PR TITLE
 Feat: CSS - Add defineRules preset snapshot primitives 

### DIFF
--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -52,6 +52,16 @@
         "default": "./dist/cjs/compat.cjs"
       }
     },
+    "./defineRules/createDefineRulesCssRuntime": {
+      "import": {
+        "types": "./dist/esm/defineRules/createDefineRulesCssRuntime.d.ts",
+        "default": "./dist/esm/defineRules/createDefineRulesCssRuntime.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/defineRules/createDefineRulesCssRuntime.d.cts",
+        "default": "./dist/cjs/defineRules/createDefineRulesCssRuntime.cjs"
+      }
+    },
     "./rules/createRuntimeFn": {
       "import": {
         "types": "./dist/esm/rules/createRuntimeFn.d.ts",

--- a/packages/css/src/defineRules/capture.ts
+++ b/packages/css/src/defineRules/capture.ts
@@ -1,0 +1,120 @@
+import type { DefineRulesPresetMap } from "./types.js";
+
+export const DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX =
+  "__MINCHO_DEFINE_RULES_SENTINEL__:";
+
+export interface DefineRulesPresetCaptureInstance {
+  sentinelId: string;
+  filePath: string;
+  instanceIndex: number;
+  getPresetSnapshot(): DefineRulesPresetMap;
+}
+
+export interface DefineRulesPresetCaptureSession {
+  filePath: string;
+  instances: DefineRulesPresetCaptureInstance[];
+}
+
+const DEFINE_RULES_PRESET_CAPTURE_STACK = Symbol.for(
+  "@mincho-js/css/defineRulesPresetCapture"
+);
+
+type DefineRulesPresetCaptureGlobal = typeof globalThis & {
+  [DEFINE_RULES_PRESET_CAPTURE_STACK]?: DefineRulesPresetCaptureSession[];
+};
+
+function getCaptureStack(): DefineRulesPresetCaptureSession[] {
+  const captureGlobal = globalThis as DefineRulesPresetCaptureGlobal;
+  const stack = captureGlobal[DEFINE_RULES_PRESET_CAPTURE_STACK];
+
+  if (stack != null) {
+    return stack;
+  }
+
+  const nextStack: DefineRulesPresetCaptureSession[] = [];
+  captureGlobal[DEFINE_RULES_PRESET_CAPTURE_STACK] = nextStack;
+  return nextStack;
+}
+
+function clearCaptureStackIfEmpty(): void {
+  const captureGlobal = globalThis as DefineRulesPresetCaptureGlobal;
+  const stack = captureGlobal[DEFINE_RULES_PRESET_CAPTURE_STACK];
+
+  if (stack != null && stack.length === 0) {
+    delete captureGlobal[DEFINE_RULES_PRESET_CAPTURE_STACK];
+  }
+}
+
+export function beginDefineRulesPresetCapture(
+  filePath: string
+): DefineRulesPresetCaptureSession {
+  const session: DefineRulesPresetCaptureSession = {
+    filePath,
+    instances: []
+  };
+
+  getCaptureStack().push(session);
+  return session;
+}
+
+export function endDefineRulesPresetCapture():
+  | DefineRulesPresetCaptureSession
+  | undefined {
+  const captureGlobal = globalThis as DefineRulesPresetCaptureGlobal;
+  const stack = captureGlobal[DEFINE_RULES_PRESET_CAPTURE_STACK];
+  const session = stack?.pop();
+
+  clearCaptureStackIfEmpty();
+  return session;
+}
+
+export function getActiveDefineRulesPresetCapture():
+  | DefineRulesPresetCaptureSession
+  | undefined {
+  const captureGlobal = globalThis as DefineRulesPresetCaptureGlobal;
+  const stack = captureGlobal[DEFINE_RULES_PRESET_CAPTURE_STACK];
+
+  if (stack == null || stack.length === 0) {
+    return undefined;
+  }
+
+  return stack[stack.length - 1];
+}
+
+export function getDefineRulesPresetCaptureSentinelId(
+  value: unknown
+): string | undefined {
+  if (
+    typeof value !== "string" ||
+    value.startsWith(DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX) === false
+  ) {
+    return undefined;
+  }
+
+  const sentinelId = value.slice(
+    DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX.length
+  );
+  return sentinelId.length > 0 ? sentinelId : undefined;
+}
+
+export function registerDefineRulesPresetCaptureInstance(
+  sentinelValue: unknown,
+  getPresetSnapshot: () => DefineRulesPresetMap
+): DefineRulesPresetCaptureInstance | undefined {
+  const session = getActiveDefineRulesPresetCapture();
+  const sentinelId = getDefineRulesPresetCaptureSentinelId(sentinelValue);
+
+  if (session == null || sentinelId == null) {
+    return undefined;
+  }
+
+  const instance: DefineRulesPresetCaptureInstance = {
+    sentinelId,
+    filePath: session.filePath,
+    instanceIndex: session.instances.length,
+    getPresetSnapshot
+  };
+
+  session.instances.push(instance);
+  return instance;
+}

--- a/packages/css/src/defineRules/createDefineRulesCssRuntime.ts
+++ b/packages/css/src/defineRules/createDefineRulesCssRuntime.ts
@@ -1,0 +1,15 @@
+import type {
+  DefineRulesCtx,
+  DefineRulesProperties,
+  DefineRulesShortcuts
+} from "./types.js";
+import { createDefineRulesRuntime } from "./runtime.js";
+
+export const createDefineRulesCssRuntime = <
+  const Properties extends DefineRulesProperties,
+  const Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
+>(
+  config: DefineRulesCtx<Properties, Shortcuts>
+) => {
+  return createDefineRulesRuntime(config).css;
+};

--- a/packages/css/src/defineRules/index.ts
+++ b/packages/css/src/defineRules/index.ts
@@ -1,10 +1,10 @@
-import type { CSSProperties } from "@mincho-js/transform-to-vanilla";
 import { setFileScope } from "@vanilla-extract/css/fileScope";
-import { createCanonicalStyleCache } from "./utils.js";
 import { identifierName } from "../utils.js";
+import { createDefineRulesRuntime } from "./runtime.js";
+import type { DefineRulesRuntimeResult } from "./runtime.js";
 import type {
-  DefineRulesComplexCssInput,
   DefineRulesCtx,
+  DefineRulesPresetMap,
   DefineRulesProperties,
   DefineRulesShortcuts
 } from "./types.js";
@@ -13,405 +13,12 @@ import type {
 export function defineRules<
   const Properties extends DefineRulesProperties,
   const Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
->(config: DefineRulesCtx<Properties, Shortcuts>) {
-  type CssInput = DefineRulesComplexCssInput<Properties, Shortcuts>;
-  const styleCache = createCanonicalStyleCache(config.debugId);
-
-  function resolveToFragments(args: CssInput): ResolvedStyleFragment[] {
-    const fragments: ResolvedStyleFragment[] = [];
-    applyInput(config, fragments, args, []);
-    return fragments;
-  }
-
-  function cssRaw(args: CssInput): CSSProperties {
-    return flattenResolvedFragments(resolveToFragments(args));
-  }
-
-  function cssImpl(args: CssInput): string {
-    const fragments = resolveToFragments(args);
-    const emittedFragments = collectEmittedFragments(fragments);
-    const output: string[] = [];
-
-    for (const fragment of emittedFragments) {
-      const className = styleCache.addFragment(
-        fragment.inputIdentity.property,
-        fragment.inputIdentity.value,
-        fragment.style
-      );
-      output.push(className);
-    }
-    return output.sort().join(" ");
-  }
-
-  const css = Object.assign(cssImpl, { raw: cssRaw });
-  return { css };
-}
-
-// == Define Rules Impl ========================================================
-interface InputIdentity {
-  property: string;
-  value: unknown;
-}
-
-interface ResolvedStyleFragment {
-  source: {
-    key: string;
-    shortcutStack: string[];
-  };
-  inputIdentity: InputIdentity;
-  outputKeys: string[];
-  style: CSSProperties;
-}
-
-function collectEmittedFragments(
-  fragments: readonly ResolvedStyleFragment[]
-): ResolvedStyleFragment[] {
-  const occupiedKeys = new Set<string>();
-  const emittedFragments: ResolvedStyleFragment[] = [];
-
-  for (let index = fragments.length - 1; index >= 0; index -= 1) {
-    const fragment = fragments[index];
-    if (fragment == null) continue;
-
-    const emittedFragment = omitOccupiedKeys(fragment, occupiedKeys);
-    if (emittedFragment == null) {
-      continue;
-    }
-
-    emittedFragments.push(emittedFragment);
-
-    for (const key of emittedFragment.outputKeys) {
-      occupiedKeys.add(key);
-    }
-  }
-
-  return emittedFragments.reverse();
-}
-
-function omitOccupiedKeys(
-  fragment: ResolvedStyleFragment,
-  occupiedKeys: ReadonlySet<string>
-): ResolvedStyleFragment | undefined {
-  const remainingOutputKeys = fragment.outputKeys.filter(
-    (key) => !occupiedKeys.has(key)
-  );
-
-  if (remainingOutputKeys.length === 0) {
-    return undefined;
-  }
-
-  if (remainingOutputKeys.length === fragment.outputKeys.length) {
-    return fragment;
-  }
-
-  const nextStyle: Record<string, unknown> = {};
-
-  for (const key of remainingOutputKeys) {
-    nextStyle[key] = (fragment.style as Record<string, unknown>)[key];
-  }
-
-  return {
-    ...fragment,
-    outputKeys: remainingOutputKeys,
-    style: nextStyle as CSSProperties
-  };
-}
-
-function flattenResolvedFragments(
-  fragments: readonly ResolvedStyleFragment[]
-): CSSProperties {
-  const mergedStyle: CSSProperties = {};
-
-  for (const fragment of fragments) {
-    Object.assign(mergedStyle, fragment.style);
-  }
-
-  return mergedStyle;
-}
-
-function pushResolvedFragment(
-  fragmentsOut: ResolvedStyleFragment[],
-  inputIdentity: InputIdentity,
-  shortcutStack: readonly string[],
-  style: CSSProperties
-) {
-  const outputKeys = Object.keys(style);
-  if (outputKeys.length === 0) return;
-
-  fragmentsOut.push({
-    source: {
-      key: inputIdentity.property,
-      shortcutStack: [...shortcutStack]
-    },
-    inputIdentity,
-    outputKeys,
-    style
-  });
-}
-
-function applyInput<
-  Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
 >(
-  ctx: DefineRulesCtx<Properties, Shortcuts>,
-  fragmentsOut: ResolvedStyleFragment[],
-  input: unknown,
-  shortcutStack: string[]
-) {
-  if (input == null || input === false) return;
-
-  if (typeof input === "string") {
-    applyInlineShortcut(ctx, fragmentsOut, input, shortcutStack);
-    return;
-  }
-
-  if (Array.isArray(input)) {
-    applyArray(ctx, fragmentsOut, input, shortcutStack);
-    return;
-  }
-
-  if (isPlainObject(input)) {
-    applyObject(ctx, fragmentsOut, input, shortcutStack);
-    return;
-  }
-
-  throw new Error(`Unsupported css() argument: ${String(input)}`);
-}
-
-function applyInlineShortcut<
-  Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
->(
-  ctx: DefineRulesCtx<Properties, Shortcuts>,
-  fragmentsOut: ResolvedStyleFragment[],
-  shortcutName: string,
-  shortcutStack: string[]
-) {
-  if (hasOwn(ctx.shortcuts, shortcutName)) {
-    applyShortcut(ctx, fragmentsOut, shortcutName, undefined, shortcutStack);
-    return;
-  }
-  throw new Error(`Unknown fixed style: "${shortcutName}"`);
-}
-
-function applyArray<
-  Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
->(
-  ctx: DefineRulesCtx<Properties, Shortcuts>,
-  fragmentsOut: ResolvedStyleFragment[],
-  arr: readonly unknown[],
-  shortcutStack: string[]
-) {
-  for (const item of arr) {
-    applyInput(ctx, fragmentsOut, item, shortcutStack);
-  }
-}
-
-function applyObject<
-  Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
->(
-  ctx: DefineRulesCtx<Properties, Shortcuts>,
-  fragmentsOut: ResolvedStyleFragment[],
-  obj: Record<string, unknown>,
-  shortcutStack: string[]
-) {
-  for (const [k, v] of Object.entries(obj)) {
-    applyEntry(ctx, fragmentsOut, k, v, shortcutStack);
-  }
-}
-
-function applyEntry<
-  Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
->(
-  ctx: DefineRulesCtx<Properties, Shortcuts>,
-  fragmentsOut: ResolvedStyleFragment[],
-  key: string,
-  value: unknown,
-  shortcutStack: string[]
-) {
-  if (value == null) {
-    return;
-  }
-
-  if (hasOwn(ctx.shortcuts, key)) {
-    applyShortcut(ctx, fragmentsOut, key, value, shortcutStack);
-    return;
-  }
-
-  applyProperty(ctx, fragmentsOut, key, value, shortcutStack);
-}
-
-function applyProperty<
-  Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
->(
-  ctx: DefineRulesCtx<Properties, Shortcuts>,
-  fragmentsOut: ResolvedStyleFragment[],
-  prop: string,
-  value: unknown,
-  shortcutStack: string[]
-) {
-  const propertyDefinition = ctx.properties?.[prop as keyof Properties];
-
-  if (typeof propertyDefinition === "function") {
-    const result = propertyDefinition(value);
-
-    if (result == null) {
-      return;
-    }
-
-    if (isPlainObject(result)) {
-      pushResolvedFragment(
-        fragmentsOut,
-        { property: prop, value },
-        shortcutStack,
-        result as CSSProperties
-      );
-      return;
-    } else {
-      pushResolvedFragment(
-        fragmentsOut,
-        { property: prop, value },
-        shortcutStack,
-        {
-          [prop]: result
-        } as CSSProperties
-      );
-      return;
-    }
-  }
-
-  // just assign => last one wins
-  if (isPlainObject(propertyDefinition) === false) {
-    pushResolvedFragment(
-      fragmentsOut,
-      { property: prop, value },
-      shortcutStack,
-      {
-        [prop]: value
-      } as CSSProperties
-    );
-    return;
-  }
-
-  const mappedValue = propertyDefinition[value as string];
-
-  // Style object value => assign all
-  if (isPlainObject(mappedValue)) {
-    pushResolvedFragment(
-      fragmentsOut,
-      { property: prop, value },
-      shortcutStack,
-      mappedValue as CSSProperties
-    );
-    return;
-  }
-
-  // Mapped value => assign mapped value
-  pushResolvedFragment(fragmentsOut, { property: prop, value }, shortcutStack, {
-    [prop]: mappedValue ?? value
-  } as CSSProperties);
-}
-
-function applyShortcutReference<
-  Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
->(
-  ctx: DefineRulesCtx<Properties, Shortcuts>,
-  fragmentsOut: ResolvedStyleFragment[],
-  targetName: string,
-  value: unknown,
-  shortcutStack: string[]
-) {
-  if (hasOwn(ctx.shortcuts, targetName)) {
-    applyShortcut(ctx, fragmentsOut, targetName, value, shortcutStack);
-    return;
-  }
-
-  applyProperty(ctx, fragmentsOut, targetName, value, shortcutStack);
-}
-
-function applyShortcut<
-  Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
->(
-  ctx: DefineRulesCtx<Properties, Shortcuts>,
-  fragmentsOut: ResolvedStyleFragment[],
-  name: string,
-  value: unknown,
-  shortcutStack: string[]
-) {
-  if (shortcutStack.includes(name)) {
-    throw new Error(
-      `Circular shortcut reference: ${[...shortcutStack, name].join(" -> ")}`
-    );
-  }
-
-  const shortcutDefinition = ctx.shortcuts?.[name as keyof Shortcuts];
-  if (shortcutDefinition == null) return;
-
-  const nextShortcutStack = shortcutStack.concat(name);
-
-  if (typeof shortcutDefinition === "string") {
-    // single alias: pl -> paddingLeft
-    applyShortcutReference(
-      ctx,
-      fragmentsOut,
-      shortcutDefinition,
-      value,
-      nextShortcutStack
-    );
-    return;
-  }
-
-  if (Array.isArray(shortcutDefinition)) {
-    // multi alias: px -> [pl, pr]
-    for (const alias of shortcutDefinition) {
-      applyShortcutReference(
-        ctx,
-        fragmentsOut,
-        alias,
-        value,
-        nextShortcutStack
-      );
-    }
-    return;
-  }
-
-  if (typeof shortcutDefinition === "function") {
-    // fn shortcut
-    const produced = shortcutDefinition(value);
-    applyInput(ctx, fragmentsOut, produced, nextShortcutStack);
-    return;
-  }
-
-  if (isPlainObject(shortcutDefinition)) {
-    // fixed style shortcut
-    // - "inline" shortcut flag (no value) => apply
-    // - { inline: true } => apply
-    // - { inline: false } => do not apply
-    if (value === undefined || value === true) {
-      applyInput(ctx, fragmentsOut, shortcutDefinition, nextShortcutStack);
-      return;
-    }
-    if (!value) return;
-    applyInput(ctx, fragmentsOut, shortcutDefinition, nextShortcutStack);
-    return;
-  }
-
-  throw new Error(`Unsupported shortcut definition for "${name}"`);
-}
-
-// == Utils ====================================================================
-function isPlainObject(v: unknown): v is Record<string, unknown> {
-  return v != null && typeof v === "object" && !Array.isArray(v);
-}
-
-function hasOwn(obj: object | undefined, key: PropertyKey): boolean {
-  return obj != null && Object.prototype.hasOwnProperty.call(obj, key);
+  config: DefineRulesCtx<Properties, Shortcuts>
+): DefineRulesRuntimeResult<Properties, Shortcuts> {
+  const result: DefineRulesRuntimeResult<Properties, Shortcuts> =
+    createDefineRulesRuntime<Properties, Shortcuts>(config);
+  return result;
 }
 
 // == Tests ====================================================================
@@ -421,12 +28,331 @@ function hasOwn(obj: object | undefined, key: PropertyKey): boolean {
 if (import.meta.vitest) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
-  const { describe, it, expect } = import.meta.vitest;
+  const { describe, it, expect, assertType } = import.meta.vitest;
 
   const debugId = "myCSS";
   setFileScope("test");
 
+  const createDefineRulesAuthoringShapeOwner = (debugId: string) =>
+    defineRules({
+      debugId,
+      properties: {
+        color: true,
+        display: ["none", "flex"]
+      }
+    });
+
+  type DefineRulesAuthoringShapeOwner = ReturnType<
+    typeof createDefineRulesAuthoringShapeOwner
+  >;
+  type DefineRulesAuthoringShapeInput = Parameters<
+    DefineRulesAuthoringShapeOwner["css"]
+  >[0];
+
+  function expectDefineRulesAuthoringShapeBindings(
+    bindings: Pick<DefineRulesAuthoringShapeOwner, "css" | "preset">
+  ) {
+    assertType<DefineRulesAuthoringShapeOwner["css"]>(bindings.css);
+    assertType<DefineRulesPresetMap>(bindings.preset);
+    assertType<DefineRulesAuthoringShapeInput>({
+      color: "rebeccapurple",
+      display: "flex"
+    });
+
+    expect(bindings.preset).toEqual({});
+    expect(bindings.css.raw({ display: "flex" })).toEqual({
+      display: "flex"
+    });
+
+    const className = bindings.css({ display: "flex" });
+
+    expect(Object.values(bindings.preset)).toEqual([className]);
+  }
+
   describe("defineRules", () => {
+    describe.concurrent("DefineRules authoring/export shape matrix", () => {
+      it("1. owner-object form: export const presetOwner = defineRules({...})", () => {
+        const presetOwner =
+          createDefineRulesAuthoringShapeOwner("ownerObjectShape");
+
+        assertType<DefineRulesAuthoringShapeOwner>(presetOwner);
+        expectDefineRulesAuthoringShapeBindings(presetOwner);
+      });
+
+      it("2. direct destructuring form: export const { css, preset } = defineRules({...})", () => {
+        const { css, preset } = createDefineRulesAuthoringShapeOwner(
+          "directDestructuringShape"
+        );
+
+        assertType<DefineRulesAuthoringShapeOwner["css"]>(css);
+        assertType<DefineRulesPresetMap>(preset);
+        expectDefineRulesAuthoringShapeBindings({ css, preset });
+      });
+
+      it("3. aliased destructuring form: export const { css: sharedCss, preset: sharedPreset } = defineRules({...})", () => {
+        const { css: sharedCss, preset: sharedPreset } =
+          createDefineRulesAuthoringShapeOwner("aliasedDestructuringShape");
+
+        assertType<DefineRulesAuthoringShapeOwner["css"]>(sharedCss);
+        assertType<DefineRulesPresetMap>(sharedPreset);
+        expectDefineRulesAuthoringShapeBindings({
+          css: sharedCss,
+          preset: sharedPreset
+        });
+      });
+
+      it("4. owner-object member exports form: const presetOwner = defineRules({...}); export const css = presetOwner.css; export const preset = presetOwner.preset;", () => {
+        const presetOwner = createDefineRulesAuthoringShapeOwner(
+          "ownerMemberExportsShape"
+        );
+        const css = presetOwner.css;
+        const preset = presetOwner.preset;
+
+        assertType<DefineRulesAuthoringShapeOwner["css"]>(css);
+        assertType<DefineRulesPresetMap>(preset);
+        expect(preset).toBe(presetOwner.preset);
+        expectDefineRulesAuthoringShapeBindings({ css, preset });
+      });
+
+      it("5. exported owner-object destructuring form: export const presetOwner = defineRules({...}); export const { css, preset } = presetOwner;", () => {
+        const presetOwner = createDefineRulesAuthoringShapeOwner(
+          "exportedOwnerDestructuringShape"
+        );
+        const { css, preset } = presetOwner;
+
+        assertType<DefineRulesAuthoringShapeOwner["css"]>(css);
+        assertType<DefineRulesPresetMap>(preset);
+        expect(preset).toBe(presetOwner.preset);
+        expectDefineRulesAuthoringShapeBindings({ css, preset });
+      });
+
+      it("6. local destructuring export-list form: const { css, preset } = defineRules({...}); export { css, preset };", () => {
+        const { css, preset } = createDefineRulesAuthoringShapeOwner(
+          "localDestructuringExportListShape"
+        );
+
+        assertType<DefineRulesAuthoringShapeOwner["css"]>(css);
+        assertType<DefineRulesPresetMap>(preset);
+        expectDefineRulesAuthoringShapeBindings({ css, preset });
+      });
+    });
+
+    describe.concurrent("DefineRules Presets", () => {
+      it("exposes a live preset object", () => {
+        const { css, preset } = defineRules({
+          debugId: "presetIdentity",
+          properties: {
+            background: true
+          }
+        });
+
+        expect(preset).toEqual({});
+
+        const className = css({ background: "blue" });
+        const repeatedClassName = css({ background: "blue" });
+
+        expect(
+          Object.keys(preset).every(
+            (key) => key.startsWith("fragment_") === false
+          )
+        ).toBe(true);
+        expect(repeatedClassName).toBe(className);
+        expect(Object.values(preset)).toContain(className);
+        expect(
+          Object.values(preset).filter((entry) => entry === className)
+        ).toHaveLength(1);
+      });
+
+      it("exposes an empty preset object without static calls", () => {
+        const { preset } = defineRules({
+          debugId: "emptyPresetIdentity",
+          properties: {
+            background: true
+          }
+        });
+
+        expect(preset).toEqual({});
+        expect(Object.keys(preset)).toHaveLength(0);
+      });
+
+      it("Keeps preset handles live for transitive raw record composition", () => {
+        const provider = defineRules({
+          debugId: "provider",
+          properties: {
+            color: true
+          }
+        });
+        const providerColor = provider.css({ color: "red" });
+
+        const composed = defineRules({
+          debugId: "composed",
+          presets: {
+            ...provider.preset
+          },
+          properties: {
+            color: true,
+            background: true
+          }
+        });
+        const composedBackground = composed.css({ background: "blue" });
+
+        const transitive = defineRules({
+          debugId: "transitive",
+          presets: {
+            ...composed.preset
+          },
+          properties: {
+            color: true,
+            background: true,
+            display: true
+          }
+        });
+        const transitiveDisplay = transitive.css({ display: "block" });
+
+        expect(Object.values(provider.preset)).toEqual([providerColor]);
+        expect(Object.values(composed.preset)).toEqual(
+          expect.arrayContaining([providerColor, composedBackground])
+        );
+        expect(Object.values(composed.preset)).toHaveLength(2);
+        expect(Object.values(transitive.preset)).toEqual(
+          expect.arrayContaining([
+            providerColor,
+            composedBackground,
+            transitiveDisplay
+          ])
+        );
+        expect(Object.values(transitive.preset)).toHaveLength(3);
+        expect(composed.preset).not.toBe(provider.preset);
+        expect(transitive.preset).not.toBe(composed.preset);
+      });
+
+      it("Rejects malformed preset input", () => {
+        const createMalformedPresetCase = (presets: unknown) => () =>
+          defineRules({
+            presets: presets as DefineRulesPresetMap,
+            properties: {
+              color: true
+            }
+          });
+
+        const ownerPresetInput: unknown = {
+          css: true,
+          preset: {
+            colorRed: "color_red"
+          }
+        };
+        const legacySerializedPresetEnvelope: unknown = {
+          schema: "mincho.defineRulesPreset",
+          version: 2,
+          classNameByCache: {
+            colorRed: "color_red"
+          }
+        };
+
+        expect(createMalformedPresetCase(ownerPresetInput)).toThrow(
+          "Unsupported defineRules preset input"
+        );
+
+        expect(
+          createMalformedPresetCase(legacySerializedPresetEnvelope)
+        ).toThrow("Unsupported defineRules preset input");
+
+        expect(createMalformedPresetCase([])).toThrow(
+          "Unsupported defineRules preset input"
+        );
+      });
+
+      it("Reuses seeded preset class names without overwriting imported entries", () => {
+        const provider = defineRules({
+          debugId: "provider",
+          properties: {
+            background: true
+          }
+        });
+        const providerBackground = provider.css({ background: "blue" });
+        const importedPreset = {
+          ...provider.preset
+        };
+
+        const consumer = defineRules({
+          debugId: "consumer",
+          presets: importedPreset,
+          properties: {
+            background: true
+          }
+        });
+        const presetHandle = consumer.preset;
+
+        expect(presetHandle).toEqual(importedPreset);
+
+        const reusedBackground = consumer.css({ background: "blue" });
+
+        expect(reusedBackground).toBe(providerBackground);
+        expect(reusedBackground).not.toMatch(identifierName("consumer"));
+        expect(presetHandle).toEqual(importedPreset);
+        expect(Object.values(presetHandle)).toEqual([providerBackground]);
+        expect(
+          Object.values(presetHandle).filter(
+            (className) => className === reusedBackground
+          )
+        ).toHaveLength(1);
+        expect(presetHandle).toBe(consumer.preset);
+        expect(importedPreset).toEqual(provider.preset);
+      });
+
+      it("Keeps seeded preset handles isolated across defineRules instances", () => {
+        const provider = defineRules({
+          debugId: "provider",
+          properties: {
+            color: true
+          }
+        });
+        const providerColor = provider.css({ color: "red" });
+        const sharedPreset = {
+          ...provider.preset
+        };
+
+        const consumerA = defineRules({
+          debugId: "consumerA",
+          presets: sharedPreset,
+          properties: {
+            color: true,
+            background: true
+          }
+        });
+        const consumerB = defineRules({
+          debugId: "consumerB",
+          presets: sharedPreset,
+          properties: {
+            color: true,
+            background: true
+          }
+        });
+
+        expect(consumerA.css({ color: "red" })).toBe(providerColor);
+        expect(consumerB.css({ color: "red" })).toBe(providerColor);
+
+        const consumerABackground = consumerA.css({ background: "blue" });
+
+        expect(Object.values(consumerA.preset)).toEqual(
+          expect.arrayContaining([providerColor, consumerABackground])
+        );
+        expect(Object.values(consumerA.preset)).toHaveLength(2);
+        expect(Object.values(consumerB.preset)).toEqual([providerColor]);
+
+        const consumerBBackground = consumerB.css({ background: "blue" });
+
+        expect(consumerABackground).not.toBe(consumerBBackground);
+        expect(Object.values(consumerB.preset)).toEqual(
+          expect.arrayContaining([providerColor, consumerBBackground])
+        );
+        expect(Object.values(consumerB.preset)).not.toContain(
+          consumerABackground
+        );
+        expect(sharedPreset).toEqual(provider.preset);
+      });
+    });
+
     describe.concurrent("DefineRules Properties", () => {
       it("Array values for CSS properties", () => {
         const { css } = defineRules({
@@ -575,6 +501,55 @@ if (import.meta.vitest) {
         expect(
           cssResolver([{ optionalColor: "primary" }, { optionalColor: "none" }])
         ).toBe(cssResolver({ optionalColor: "primary" }));
+      });
+
+      it("createDefineRulesRuntime supports function-valued properties locally", () => {
+        const { css } = createDefineRulesRuntime({
+          properties: {
+            color(value: "brand" | "neutral") {
+              if (value === "brand") {
+                return "blue";
+              }
+
+              return "gray";
+            },
+            tone(value: "brand" | "neutral") {
+              return {
+                color: value === "brand" ? "blue" : "gray"
+              } as const;
+            },
+            display: ["none", "flex"],
+            paddingLeft: [0, 4, 8],
+            paddingRight: [0, 4, 8]
+          },
+          shortcuts: {
+            px: ["paddingLeft", "paddingRight"],
+            center(value: "none" | "flex") {
+              return {
+                display: value,
+                px: 4
+              } as const;
+            }
+          }
+        });
+
+        expect(css.raw({ color: "brand" })).toEqual({
+          color: "blue"
+        });
+        expect(css.raw({ color: "neutral" })).toEqual({
+          color: "gray"
+        });
+        expect(css.raw({ tone: "neutral" })).toEqual({
+          color: "gray"
+        });
+        expect(css.raw({ center: "flex" })).toEqual({
+          display: "flex",
+          paddingLeft: 4,
+          paddingRight: 4
+        });
+        expect(css({ center: "flex" })).toBe(
+          css({ display: "flex", paddingLeft: 4, paddingRight: 4 })
+        );
       });
 
       it("css() canonicalize className", () => {
@@ -897,6 +872,7 @@ if (import.meta.vitest) {
       });
 
       it("Circular shortcuts", () => {
+        // @ts-expect-error Type of property 'a' circularly references itself in mapped type 'ShortcutsInput<PropertiesInput<{ readonly paddingLeft: readonly [0, 4, 8]; }>, { readonly a: "b"; readonly b: readonly ["a"]; }>'.
         const { css } = defineRules({
           properties: {
             paddingLeft: [0, 4, 8]
@@ -907,7 +883,6 @@ if (import.meta.vitest) {
           }
         });
 
-        // @ts-expect-error Type of property 'a' circularly references itself in mapped type 'ShortcutsInput<PropertiesInput<{ readonly paddingLeft: readonly [0, 4, 8]; }>, { readonly a: "b"; readonly b: readonly ["a"]; }>'.
         expect(() => css.raw({ a: 4 })).toThrow(
           "Circular shortcut reference: a -> b -> a"
         );

--- a/packages/css/src/defineRules/index.ts
+++ b/packages/css/src/defineRules/index.ts
@@ -1,4 +1,6 @@
+import { addFunctionSerializer } from "@vanilla-extract/css/functionSerializer";
 import { setFileScope } from "@vanilla-extract/css/fileScope";
+import type { Serializable } from "../rules/types.js";
 import { identifierName } from "../utils.js";
 import { createDefineRulesRuntime } from "./runtime.js";
 import type { DefineRulesRuntimeResult } from "./runtime.js";
@@ -9,6 +11,12 @@ import type {
   DefineRulesShortcuts
 } from "./types.js";
 
+const DEFINE_RULES_SERIALIZED_CSS_FUNCTION_CONFIG_DIAGNOSTIC =
+  "defineRules serialized css does not support function-valued properties or shortcuts";
+const DEFINE_RULES_RUNTIME_IMPORT_PATH =
+  "@mincho-js/css/defineRules/createDefineRulesCssRuntime";
+const DEFINE_RULES_RUNTIME_IMPORT_NAME = "createDefineRulesCssRuntime";
+
 // == Define Rules =============================================================
 export function defineRules<
   const Properties extends DefineRulesProperties,
@@ -18,7 +26,58 @@ export function defineRules<
 ): DefineRulesRuntimeResult<Properties, Shortcuts> {
   const result: DefineRulesRuntimeResult<Properties, Shortcuts> =
     createDefineRulesRuntime<Properties, Shortcuts>(config);
-  return result;
+  const serializedConfig = { ...config, presets: result.preset };
+  const hasFunctionValuedConfig = hasFunctionValuedDefineRulesConfig(config);
+
+  return {
+    ...result,
+    css: addFunctionSerializer(
+      result.css,
+      createDefineRulesSerializerRecipe(
+        serializedConfig as Serializable,
+        hasFunctionValuedConfig
+      )
+    ) as DefineRulesRuntimeResult<Properties, Shortcuts>["css"]
+  };
+}
+
+function createDefineRulesSerializerRecipe(
+  serializedConfig: Serializable,
+  hasFunctionValuedConfig: boolean
+): Parameters<typeof addFunctionSerializer>[1] {
+  if (hasFunctionValuedConfig) {
+    return {
+      importPath: DEFINE_RULES_RUNTIME_IMPORT_PATH,
+      importName: DEFINE_RULES_RUNTIME_IMPORT_NAME,
+      get args(): ReadonlyArray<Serializable> {
+        throw new Error(DEFINE_RULES_SERIALIZED_CSS_FUNCTION_CONFIG_DIAGNOSTIC);
+      }
+    };
+  }
+
+  return {
+    importPath: DEFINE_RULES_RUNTIME_IMPORT_PATH,
+    importName: DEFINE_RULES_RUNTIME_IMPORT_NAME,
+    args: [serializedConfig]
+  };
+}
+
+function hasFunctionValuedDefineRulesConfig(config: {
+  properties?: object;
+  shortcuts?: object;
+}): boolean {
+  return (
+    hasFunctionValuedEntries(config.properties) ||
+    hasFunctionValuedEntries(config.shortcuts)
+  );
+}
+
+function hasFunctionValuedEntries(entries: object | undefined): boolean {
+  if (entries == null) {
+    return false;
+  }
+
+  return Object.values(entries).some((entry) => typeof entry === "function");
 }
 
 // == Tests ====================================================================
@@ -173,6 +232,118 @@ if (import.meta.vitest) {
 
         expect(preset).toEqual({});
         expect(Object.keys(preset)).toHaveLength(0);
+      });
+
+      it("exposes a live preset object through the serializer recipe", () => {
+        type DefineRulesRecipe = {
+          args?: unknown[];
+          importName?: string;
+          importPath?: string;
+        };
+
+        type DefineRulesRecipeConfig = {
+          presets?: unknown;
+        };
+
+        const { css, preset } = defineRules({
+          debugId: "serializerPresetIdentity",
+          properties: {
+            background: true
+          }
+        });
+        const recipe = (
+          css as unknown as {
+            __recipe__?: DefineRulesRecipe;
+          }
+        ).__recipe__;
+        const recipeConfig = recipe?.args?.[0];
+
+        expect(recipe?.importPath).toBe(DEFINE_RULES_RUNTIME_IMPORT_PATH);
+        expect(recipe?.importName).toBe(DEFINE_RULES_RUNTIME_IMPORT_NAME);
+        expect(recipeConfig).toEqual(expect.any(Object));
+        expect((recipeConfig as DefineRulesRecipeConfig).presets).toBe(preset);
+
+        const className = css({ background: "blue" });
+        const repeatedClassName = css({ background: "blue" });
+
+        expect(
+          Object.keys(preset).every(
+            (key) => key.startsWith("fragment_") === false
+          )
+        ).toBe(true);
+        expect(repeatedClassName).toBe(className);
+        expect(Object.values(preset)).toContain(className);
+        expect(
+          Object.values(preset).filter((entry) => entry === className)
+        ).toHaveLength(1);
+      });
+
+      it("serializes an empty preset object without static calls", () => {
+        type DefineRulesRecipe = {
+          args?: unknown[];
+        };
+
+        const { css, preset } = defineRules({
+          debugId: "emptySerializerPresetIdentity",
+          properties: {
+            background: true
+          }
+        });
+        const recipe = (
+          css as unknown as {
+            __recipe__?: DefineRulesRecipe;
+          }
+        ).__recipe__;
+        const recipeConfig = recipe?.args?.[0];
+
+        expect(recipeConfig).toEqual(expect.any(Object));
+        expect((recipeConfig as { presets?: unknown }).presets).toBe(preset);
+        expect(Object.keys(preset)).toHaveLength(0);
+      });
+
+      it("defineRules serializer rejects function-valued config with diagnostic", () => {
+        type DefineRulesRecipe = {
+          args?: unknown[];
+        };
+
+        const createRecipeArgsReader = (config: unknown) => {
+          const { css } = Reflect.apply(
+            defineRules as unknown as (...args: unknown[]) => unknown,
+            undefined,
+            [config]
+          ) as {
+            css: {
+              __recipe__?: DefineRulesRecipe;
+            };
+          };
+          const recipe = css.__recipe__;
+
+          return () => recipe?.args;
+        };
+
+        expect(
+          createRecipeArgsReader({
+            properties: {
+              color(value: string) {
+                return value;
+              }
+            }
+          })
+        ).toThrow(DEFINE_RULES_SERIALIZED_CSS_FUNCTION_CONFIG_DIAGNOSTIC);
+        expect(
+          createRecipeArgsReader({
+            properties: {
+              color: true
+            },
+            shortcuts: {
+              tone(value: "red" | "blue") {
+                return {
+                  color: value
+                } as const;
+              }
+            }
+          })
+        ).toThrow(DEFINE_RULES_SERIALIZED_CSS_FUNCTION_CONFIG_DIAGNOSTIC);
       });
 
       it("Keeps preset handles live for transitive raw record composition", () => {

--- a/packages/css/src/defineRules/index.ts
+++ b/packages/css/src/defineRules/index.ts
@@ -1,5 +1,12 @@
+import type { CSSProperties } from "@mincho-js/transform-to-vanilla";
 import { addFunctionSerializer } from "@vanilla-extract/css/functionSerializer";
 import { setFileScope } from "@vanilla-extract/css/fileScope";
+import {
+  beginDefineRulesPresetCapture,
+  DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX,
+  endDefineRulesPresetCapture,
+  getActiveDefineRulesPresetCapture
+} from "./capture.js";
 import type { Serializable } from "../rules/types.js";
 import { identifierName } from "../utils.js";
 import { createDefineRulesRuntime } from "./runtime.js";
@@ -23,9 +30,19 @@ export function defineRules<
   const Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
 >(
   config: DefineRulesCtx<Properties, Shortcuts>
+): DefineRulesRuntimeResult<Properties, Shortcuts>;
+export function defineRules<
+  const Properties extends DefineRulesProperties,
+  const Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
+>(
+  config: DefineRulesCtx<Properties, Shortcuts>,
+  ...captureSentinelArgs: [string?]
 ): DefineRulesRuntimeResult<Properties, Shortcuts> {
   const result: DefineRulesRuntimeResult<Properties, Shortcuts> =
-    createDefineRulesRuntime<Properties, Shortcuts>(config);
+    createDefineRulesRuntime<Properties, Shortcuts>(
+      config,
+      ...captureSentinelArgs
+    );
   const serializedConfig = { ...config, presets: result.preset };
   const hasFunctionValuedConfig = hasFunctionValuedDefineRulesConfig(config);
 
@@ -87,10 +104,28 @@ function hasFunctionValuedEntries(entries: object | undefined): boolean {
 if (import.meta.vitest) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
-  const { describe, it, expect, assertType } = import.meta.vitest;
+  const { describe, it, expect, afterEach, assertType } = import.meta.vitest;
 
   const debugId = "myCSS";
+  const defineRulesWithCapture = (config: unknown, captureSentinel?: string) =>
+    Reflect.apply(
+      defineRules as unknown as (...args: unknown[]) => unknown,
+      undefined,
+      [config, captureSentinel]
+    ) as {
+      css: {
+        (args: unknown): string;
+        raw(args: unknown): CSSProperties;
+      };
+      preset: DefineRulesPresetMap;
+    };
   setFileScope("test");
+
+  afterEach(() => {
+    while (getActiveDefineRulesPresetCapture() != null) {
+      endDefineRulesPresetCapture();
+    }
+  });
 
   const createDefineRulesAuthoringShapeOwner = (debugId: string) =>
     defineRules({
@@ -196,49 +231,76 @@ if (import.meta.vitest) {
       });
     });
 
+    describe("DefineRules Build Capture", () => {
+      it("binds sentinel second args to captured live preset snapshots", () => {
+        const session = beginDefineRulesPresetCapture(
+          "/virtual/provider.css.ts"
+        );
+
+        try {
+          const provider = defineRulesWithCapture(
+            {
+              debugId: "provider",
+              properties: {
+                color: true
+              }
+            },
+            `${DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX}provider`
+          );
+
+          defineRules({
+            debugId: "ignored",
+            properties: {
+              color: true
+            }
+          });
+
+          const consumer = defineRulesWithCapture(
+            {
+              debugId: "consumer",
+              properties: {
+                background: true
+              }
+            },
+            `${DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX}consumer`
+          );
+
+          const providerColor = provider.css({ color: "red" });
+          const consumerBackground = consumer.css({ background: "blue" });
+
+          expect(
+            session.instances.map((instance) => instance.sentinelId)
+          ).toEqual(["provider", "consumer"]);
+          expect(
+            session.instances.map((instance) => instance.filePath)
+          ).toEqual(["/virtual/provider.css.ts", "/virtual/provider.css.ts"]);
+          expect(
+            session.instances.map((instance) => instance.instanceIndex)
+          ).toEqual([0, 1]);
+          expect(session.instances[0]?.getPresetSnapshot()).toEqual(
+            provider.preset
+          );
+          expect(session.instances[1]?.getPresetSnapshot()).toEqual(
+            consumer.preset
+          );
+          expect(
+            Object.values(session.instances[0]?.getPresetSnapshot() ?? {})
+          ).toEqual([providerColor]);
+          expect(
+            Object.values(session.instances[1]?.getPresetSnapshot() ?? {})
+          ).toEqual([consumerBackground]);
+        } finally {
+          expect(endDefineRulesPresetCapture()).toBe(session);
+        }
+
+        expect(getActiveDefineRulesPresetCapture()).toBe(undefined);
+      });
+    });
+
     describe.concurrent("DefineRules Presets", () => {
-      it("exposes a live preset object", () => {
-        const { css, preset } = defineRules({
-          debugId: "presetIdentity",
-          properties: {
-            background: true
-          }
-        });
-
-        expect(preset).toEqual({});
-
-        const className = css({ background: "blue" });
-        const repeatedClassName = css({ background: "blue" });
-
-        expect(
-          Object.keys(preset).every(
-            (key) => key.startsWith("fragment_") === false
-          )
-        ).toBe(true);
-        expect(repeatedClassName).toBe(className);
-        expect(Object.values(preset)).toContain(className);
-        expect(
-          Object.values(preset).filter((entry) => entry === className)
-        ).toHaveLength(1);
-      });
-
-      it("exposes an empty preset object without static calls", () => {
-        const { preset } = defineRules({
-          debugId: "emptyPresetIdentity",
-          properties: {
-            background: true
-          }
-        });
-
-        expect(preset).toEqual({});
-        expect(Object.keys(preset)).toHaveLength(0);
-      });
-
       it("exposes a live preset object through the serializer recipe", () => {
         type DefineRulesRecipe = {
           args?: unknown[];
-          importName?: string;
-          importPath?: string;
         };
 
         type DefineRulesRecipeConfig = {
@@ -251,6 +313,7 @@ if (import.meta.vitest) {
             background: true
           }
         });
+
         const recipe = (
           css as unknown as {
             __recipe__?: DefineRulesRecipe;
@@ -258,8 +321,6 @@ if (import.meta.vitest) {
         ).__recipe__;
         const recipeConfig = recipe?.args?.[0];
 
-        expect(recipe?.importPath).toBe(DEFINE_RULES_RUNTIME_IMPORT_PATH);
-        expect(recipe?.importName).toBe(DEFINE_RULES_RUNTIME_IMPORT_NAME);
         expect(recipeConfig).toEqual(expect.any(Object));
         expect((recipeConfig as DefineRulesRecipeConfig).presets).toBe(preset);
 
@@ -289,6 +350,7 @@ if (import.meta.vitest) {
             background: true
           }
         });
+
         const recipe = (
           css as unknown as {
             __recipe__?: DefineRulesRecipe;
@@ -307,16 +369,12 @@ if (import.meta.vitest) {
         };
 
         const createRecipeArgsReader = (config: unknown) => {
-          const { css } = Reflect.apply(
-            defineRules as unknown as (...args: unknown[]) => unknown,
-            undefined,
-            [config]
-          ) as {
-            css: {
+          const { css } = defineRulesWithCapture(config);
+          const recipe = (
+            css as unknown as {
               __recipe__?: DefineRulesRecipe;
-            };
-          };
-          const recipe = css.__recipe__;
+            }
+          ).__recipe__;
 
           return () => recipe?.args;
         };

--- a/packages/css/src/defineRules/runtime.ts
+++ b/packages/css/src/defineRules/runtime.ts
@@ -1,0 +1,473 @@
+import type { CSSProperties } from "@mincho-js/transform-to-vanilla";
+import { createCanonicalStyleCache } from "./utils.js";
+import type {
+  DefineRulesComplexCssInput,
+  DefineRulesCtx,
+  DefineRulesPresetMap,
+  DefineRulesProperties,
+  DefineRulesShortcuts
+} from "./types.js";
+
+// == Define Rules Runtime =====================================================
+export type DefineRulesRuntimeCss<CssInput> = ((args: CssInput) => string) & {
+  raw(args: CssInput): CSSProperties;
+};
+
+export interface DefineRulesRuntimeResult<
+  Properties extends DefineRulesProperties,
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
+> {
+  css: DefineRulesRuntimeCss<DefineRulesComplexCssInput<Properties, Shortcuts>>;
+  preset: DefineRulesPresetMap;
+}
+
+export function createDefineRulesRuntime<
+  const Properties extends DefineRulesProperties,
+  const Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
+>(
+  config: DefineRulesCtx<Properties, Shortcuts>
+): DefineRulesRuntimeResult<Properties, Shortcuts> {
+  type CssInput = DefineRulesComplexCssInput<Properties, Shortcuts>;
+  const preset = normalizePresetMap(config.presets);
+  const styleCache = createCanonicalStyleCache(config.debugId);
+  styleCache.importSnapshot(preset);
+
+  function resolveToFragments(args: CssInput): ResolvedStyleFragment[] {
+    const fragments: ResolvedStyleFragment[] = [];
+    applyInput(config, fragments, args, []);
+    return fragments;
+  }
+
+  function cssRaw(args: CssInput): CSSProperties {
+    return flattenResolvedFragments(resolveToFragments(args));
+  }
+
+  function cssImpl(args: CssInput): string {
+    const fragments = resolveToFragments(args);
+    const emittedFragments = collectEmittedFragments(fragments);
+    const output: string[] = [];
+    let didAddFragment = false;
+
+    for (const fragment of emittedFragments) {
+      const hasFragment = styleCache.hasFragment(
+        fragment.inputIdentity.property,
+        fragment.inputIdentity.value,
+        fragment.style
+      );
+      const className = styleCache.addFragment(
+        fragment.inputIdentity.property,
+        fragment.inputIdentity.value,
+        fragment.style
+      );
+
+      if (hasFragment === false) {
+        didAddFragment = true;
+      }
+
+      output.push(className);
+    }
+
+    if (didAddFragment) {
+      Object.assign(preset, styleCache.exportSnapshot());
+    }
+
+    return output.sort().join(" ");
+  }
+
+  const css = Object.assign(cssImpl, {
+    raw: cssRaw
+  }) as DefineRulesRuntimeCss<CssInput>;
+  return { css, preset };
+}
+
+// == Define Rules Impl ========================================================
+interface InputIdentity {
+  property: string;
+  value: unknown;
+}
+
+interface ResolvedStyleFragment {
+  source: {
+    key: string;
+    shortcutStack: string[];
+  };
+  inputIdentity: InputIdentity;
+  outputKeys: string[];
+  style: CSSProperties;
+}
+
+function collectEmittedFragments(
+  fragments: readonly ResolvedStyleFragment[]
+): ResolvedStyleFragment[] {
+  const occupiedKeys = new Set<string>();
+  const emittedFragments: ResolvedStyleFragment[] = [];
+
+  for (let index = fragments.length - 1; index >= 0; index -= 1) {
+    const fragment = fragments[index];
+    if (fragment == null) continue;
+
+    const emittedFragment = omitOccupiedKeys(fragment, occupiedKeys);
+    if (emittedFragment == null) {
+      continue;
+    }
+
+    emittedFragments.push(emittedFragment);
+
+    for (const key of emittedFragment.outputKeys) {
+      occupiedKeys.add(key);
+    }
+  }
+
+  return emittedFragments.reverse();
+}
+
+function omitOccupiedKeys(
+  fragment: ResolvedStyleFragment,
+  occupiedKeys: ReadonlySet<string>
+): ResolvedStyleFragment | undefined {
+  const remainingOutputKeys = fragment.outputKeys.filter(
+    (key) => !occupiedKeys.has(key)
+  );
+
+  if (remainingOutputKeys.length === 0) {
+    return undefined;
+  }
+
+  if (remainingOutputKeys.length === fragment.outputKeys.length) {
+    return fragment;
+  }
+
+  const nextStyle: Record<string, unknown> = {};
+
+  for (const key of remainingOutputKeys) {
+    nextStyle[key] = (fragment.style as Record<string, unknown>)[key];
+  }
+
+  return {
+    ...fragment,
+    outputKeys: remainingOutputKeys,
+    style: nextStyle as CSSProperties
+  };
+}
+
+function flattenResolvedFragments(
+  fragments: readonly ResolvedStyleFragment[]
+): CSSProperties {
+  const mergedStyle: CSSProperties = {};
+
+  for (const fragment of fragments) {
+    Object.assign(mergedStyle, fragment.style);
+  }
+
+  return mergedStyle;
+}
+
+function pushResolvedFragment(
+  fragmentsOut: ResolvedStyleFragment[],
+  inputIdentity: InputIdentity,
+  shortcutStack: readonly string[],
+  style: CSSProperties
+) {
+  const outputKeys = Object.keys(style);
+  if (outputKeys.length === 0) return;
+
+  fragmentsOut.push({
+    source: {
+      key: inputIdentity.property,
+      shortcutStack: [...shortcutStack]
+    },
+    inputIdentity,
+    outputKeys,
+    style
+  });
+}
+
+function applyInput<
+  Properties extends DefineRulesProperties,
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
+>(
+  ctx: DefineRulesCtx<Properties, Shortcuts>,
+  fragmentsOut: ResolvedStyleFragment[],
+  input: unknown,
+  shortcutStack: string[]
+) {
+  if (input == null || input === false) return;
+
+  if (typeof input === "string") {
+    applyInlineShortcut(ctx, fragmentsOut, input, shortcutStack);
+    return;
+  }
+
+  if (Array.isArray(input)) {
+    applyArray(ctx, fragmentsOut, input, shortcutStack);
+    return;
+  }
+
+  if (isPlainObject(input)) {
+    applyObject(ctx, fragmentsOut, input, shortcutStack);
+    return;
+  }
+
+  throw new Error(`Unsupported css() argument: ${String(input)}`);
+}
+
+function applyInlineShortcut<
+  Properties extends DefineRulesProperties,
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
+>(
+  ctx: DefineRulesCtx<Properties, Shortcuts>,
+  fragmentsOut: ResolvedStyleFragment[],
+  shortcutName: string,
+  shortcutStack: string[]
+) {
+  if (hasOwn(ctx.shortcuts, shortcutName)) {
+    applyShortcut(ctx, fragmentsOut, shortcutName, undefined, shortcutStack);
+    return;
+  }
+  throw new Error(`Unknown fixed style: "${shortcutName}"`);
+}
+
+function applyArray<
+  Properties extends DefineRulesProperties,
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
+>(
+  ctx: DefineRulesCtx<Properties, Shortcuts>,
+  fragmentsOut: ResolvedStyleFragment[],
+  arr: readonly unknown[],
+  shortcutStack: string[]
+) {
+  for (const item of arr) {
+    applyInput(ctx, fragmentsOut, item, shortcutStack);
+  }
+}
+
+function applyObject<
+  Properties extends DefineRulesProperties,
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
+>(
+  ctx: DefineRulesCtx<Properties, Shortcuts>,
+  fragmentsOut: ResolvedStyleFragment[],
+  obj: Record<string, unknown>,
+  shortcutStack: string[]
+) {
+  for (const [k, v] of Object.entries(obj)) {
+    applyEntry(ctx, fragmentsOut, k, v, shortcutStack);
+  }
+}
+
+function applyEntry<
+  Properties extends DefineRulesProperties,
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
+>(
+  ctx: DefineRulesCtx<Properties, Shortcuts>,
+  fragmentsOut: ResolvedStyleFragment[],
+  key: string,
+  value: unknown,
+  shortcutStack: string[]
+) {
+  if (value == null) {
+    return;
+  }
+
+  if (hasOwn(ctx.shortcuts, key)) {
+    applyShortcut(ctx, fragmentsOut, key, value, shortcutStack);
+    return;
+  }
+
+  applyProperty(ctx, fragmentsOut, key, value, shortcutStack);
+}
+
+function applyProperty<
+  Properties extends DefineRulesProperties,
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
+>(
+  ctx: DefineRulesCtx<Properties, Shortcuts>,
+  fragmentsOut: ResolvedStyleFragment[],
+  prop: string,
+  value: unknown,
+  shortcutStack: string[]
+) {
+  const propertyDefinition = ctx.properties?.[prop as keyof Properties];
+
+  if (typeof propertyDefinition === "function") {
+    const result = propertyDefinition(value);
+
+    if (result == null) {
+      return;
+    }
+
+    if (isPlainObject(result)) {
+      pushResolvedFragment(
+        fragmentsOut,
+        { property: prop, value },
+        shortcutStack,
+        result as CSSProperties
+      );
+      return;
+    } else {
+      pushResolvedFragment(
+        fragmentsOut,
+        { property: prop, value },
+        shortcutStack,
+        {
+          [prop]: result
+        } as CSSProperties
+      );
+      return;
+    }
+  }
+
+  // just assign => last one wins
+  if (isPlainObject(propertyDefinition) === false) {
+    pushResolvedFragment(
+      fragmentsOut,
+      { property: prop, value },
+      shortcutStack,
+      {
+        [prop]: value
+      } as CSSProperties
+    );
+    return;
+  }
+
+  const mappedValue = propertyDefinition[value as string];
+
+  // Style object value => assign all
+  if (isPlainObject(mappedValue)) {
+    pushResolvedFragment(
+      fragmentsOut,
+      { property: prop, value },
+      shortcutStack,
+      mappedValue as CSSProperties
+    );
+    return;
+  }
+
+  // Mapped value => assign mapped value
+  pushResolvedFragment(fragmentsOut, { property: prop, value }, shortcutStack, {
+    [prop]: mappedValue ?? value
+  } as CSSProperties);
+}
+
+function applyShortcutReference<
+  Properties extends DefineRulesProperties,
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
+>(
+  ctx: DefineRulesCtx<Properties, Shortcuts>,
+  fragmentsOut: ResolvedStyleFragment[],
+  targetName: string,
+  value: unknown,
+  shortcutStack: string[]
+) {
+  if (hasOwn(ctx.shortcuts, targetName)) {
+    applyShortcut(ctx, fragmentsOut, targetName, value, shortcutStack);
+    return;
+  }
+
+  applyProperty(ctx, fragmentsOut, targetName, value, shortcutStack);
+}
+
+function applyShortcut<
+  Properties extends DefineRulesProperties,
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
+>(
+  ctx: DefineRulesCtx<Properties, Shortcuts>,
+  fragmentsOut: ResolvedStyleFragment[],
+  name: string,
+  value: unknown,
+  shortcutStack: string[]
+) {
+  if (shortcutStack.includes(name)) {
+    throw new Error(
+      `Circular shortcut reference: ${[...shortcutStack, name].join(" -> ")}`
+    );
+  }
+
+  const shortcutDefinition = ctx.shortcuts?.[name as keyof Shortcuts];
+  if (shortcutDefinition == null) return;
+
+  const nextShortcutStack = shortcutStack.concat(name);
+
+  if (typeof shortcutDefinition === "string") {
+    // single alias: pl -> paddingLeft
+    applyShortcutReference(
+      ctx,
+      fragmentsOut,
+      shortcutDefinition,
+      value,
+      nextShortcutStack
+    );
+    return;
+  }
+
+  if (Array.isArray(shortcutDefinition)) {
+    // multi alias: px -> [pl, pr]
+    for (const alias of shortcutDefinition) {
+      applyShortcutReference(
+        ctx,
+        fragmentsOut,
+        alias,
+        value,
+        nextShortcutStack
+      );
+    }
+    return;
+  }
+
+  if (typeof shortcutDefinition === "function") {
+    // fn shortcut
+    const produced = shortcutDefinition(value);
+    applyInput(ctx, fragmentsOut, produced, nextShortcutStack);
+    return;
+  }
+
+  if (isPlainObject(shortcutDefinition)) {
+    // fixed style shortcut
+    // - "inline" shortcut flag (no value) => apply
+    // - { inline: true } => apply
+    // - { inline: false } => do not apply
+    if (value === undefined || value === true) {
+      applyInput(ctx, fragmentsOut, shortcutDefinition, nextShortcutStack);
+      return;
+    }
+    if (!value) return;
+    applyInput(ctx, fragmentsOut, shortcutDefinition, nextShortcutStack);
+    return;
+  }
+
+  throw new Error(`Unsupported shortcut definition for "${name}"`);
+}
+
+function normalizePresetMap(presetInput: unknown): DefineRulesPresetMap {
+  if (presetInput == null) {
+    return {};
+  }
+
+  if (isDefineRulesPresetMap(presetInput)) {
+    return { ...presetInput };
+  }
+
+  throw new Error("Unsupported defineRules preset input");
+}
+
+function isDefineRulesPresetMap(value: unknown): value is DefineRulesPresetMap {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const proto = Object.getPrototypeOf(value);
+  if (proto !== Object.prototype && proto !== null) {
+    return false;
+  }
+
+  return Object.values(value).every((entry) => typeof entry === "string");
+}
+
+// == Utils ====================================================================
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v != null && typeof v === "object" && !Array.isArray(v);
+}
+
+function hasOwn(obj: object | undefined, key: PropertyKey): boolean {
+  return obj != null && Object.prototype.hasOwnProperty.call(obj, key);
+}

--- a/packages/css/src/defineRules/runtime.ts
+++ b/packages/css/src/defineRules/runtime.ts
@@ -1,4 +1,5 @@
 import type { CSSProperties } from "@mincho-js/transform-to-vanilla";
+import { registerDefineRulesPresetCaptureInstance } from "./capture.js";
 import { createCanonicalStyleCache } from "./utils.js";
 import type {
   DefineRulesComplexCssInput,
@@ -25,12 +26,19 @@ export function createDefineRulesRuntime<
   const Properties extends DefineRulesProperties,
   const Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
 >(
-  config: DefineRulesCtx<Properties, Shortcuts>
+  config: DefineRulesCtx<Properties, Shortcuts>,
+  ...captureSentinelArgs: [string?]
 ): DefineRulesRuntimeResult<Properties, Shortcuts> {
   type CssInput = DefineRulesComplexCssInput<Properties, Shortcuts>;
+  const [captureSentinel] = captureSentinelArgs;
+  // v1 build injection/capture supports only top-level local defineRules(...) callsites.
   const preset = normalizePresetMap(config.presets);
   const styleCache = createCanonicalStyleCache(config.debugId);
   styleCache.importSnapshot(preset);
+
+  registerDefineRulesPresetCaptureInstance(captureSentinel, () => ({
+    ...preset
+  }));
 
   function resolveToFragments(args: CssInput): ResolvedStyleFragment[] {
     const fragments: ResolvedStyleFragment[] = [];

--- a/packages/css/src/defineRules/types.ts
+++ b/packages/css/src/defineRules/types.ts
@@ -173,7 +173,7 @@ if (import.meta.vitest) {
     >(defineRulesCtx: DefineRulesCtx<Properties, Shortcuts>) {
       return {
         defineRulesCtx,
-        cssInput: defineRulesCtx as unknown as DefineRulesComplexCssInput<
+        _cssInput: defineRulesCtx as unknown as DefineRulesComplexCssInput<
           Properties,
           Shortcuts
         >
@@ -182,13 +182,12 @@ if (import.meta.vitest) {
 
     describe.concurrent("DefineRulesProperties Type", () => {
       it("Array values for CSS properties", () => {
-        const { defineRulesCtx, cssInput: _cssInput } =
-          createDefineRulesTypeCase({
-            properties: {
-              display: ["none", "inline", "block"],
-              paddingLeft: [0, 2, 4, 8, 16, 32, 64]
-            }
-          });
+        const { defineRulesCtx, _cssInput } = createDefineRulesTypeCase({
+          properties: {
+            display: ["none", "inline", "block"],
+            paddingLeft: [0, 2, 4, 8, 16, 32, 64]
+          }
+        });
         assertType<{
           properties?: {
             readonly display: readonly ["none", "inline", "block"];
@@ -209,15 +208,14 @@ if (import.meta.vitest) {
       });
 
       it("Object values for CSS properties", () => {
-        const { defineRulesCtx, cssInput: _cssInput } =
-          createDefineRulesTypeCase({
-            properties: {
-              color: {
-                "indigo-800": "rgb(55, 48, 163)",
-                "red-500": "rgb(239, 68, 68)"
-              }
+        const { defineRulesCtx, _cssInput } = createDefineRulesTypeCase({
+          properties: {
+            color: {
+              "indigo-800": "rgb(55, 48, 163)",
+              "red-500": "rgb(239, 68, 68)"
             }
-          });
+          }
+        });
         assertType<{
           properties?: {
             color: {
@@ -238,17 +236,16 @@ if (import.meta.vitest) {
 
       it("Object values with CSSPropertiesWithVars", () => {
         const alpha = "--alpha";
-        const { defineRulesCtx, cssInput: _cssInput } =
-          createDefineRulesTypeCase({
-            properties: {
-              background: {
-                red: {
-                  vars: { [alpha]: "1" },
-                  background: `rgba(255, 0, 0, var(${alpha}))`
-                }
+        const { defineRulesCtx, _cssInput } = createDefineRulesTypeCase({
+          properties: {
+            background: {
+              red: {
+                vars: { [alpha]: "1" },
+                background: `rgba(255, 0, 0, var(${alpha}))`
               }
             }
-          });
+          }
+        });
         assertType<{
           properties?: {
             background: {
@@ -270,13 +267,12 @@ if (import.meta.vitest) {
       });
 
       it("Boolean values for entire properties", () => {
-        const { defineRulesCtx, cssInput: _cssInput } =
-          createDefineRulesTypeCase({
-            properties: {
-              border: false,
-              margin: true
-            }
-          });
+        const { defineRulesCtx, _cssInput } = createDefineRulesTypeCase({
+          properties: {
+            border: false,
+            margin: true
+          }
+        });
         assertType<{
           properties?: {
             border: false;
@@ -295,15 +291,14 @@ if (import.meta.vitest) {
 
       it("Custom properties with CSSPropertiesWithVars", () => {
         const alpha = "--alpha";
-        const { defineRulesCtx, cssInput: _cssInput } =
-          createDefineRulesTypeCase({
-            properties: {
-              backgroundOpacity: {
-                full: { vars: { [alpha]: "1" } },
-                half: { vars: { [alpha]: "0.5" } }
-              }
+        const { defineRulesCtx, _cssInput } = createDefineRulesTypeCase({
+          properties: {
+            backgroundOpacity: {
+              full: { vars: { [alpha]: "1" } },
+              half: { vars: { [alpha]: "0.5" } }
             }
-          });
+          }
+        });
         assertType<{
           properties?: {
             backgroundOpacity: {
@@ -323,18 +318,17 @@ if (import.meta.vitest) {
       });
 
       it("Function values return CSS properties", () => {
-        const { defineRulesCtx, cssInput: _cssInput } =
-          createDefineRulesTypeCase({
-            properties: {
-              color(arg: "primary" | "secondary") {
-                if (arg === "primary") {
-                  return { color: "blue" } as const;
-                } else {
-                  return { color: "gray" } as const;
-                }
+        const { defineRulesCtx, _cssInput } = createDefineRulesTypeCase({
+          properties: {
+            color(arg: "primary" | "secondary") {
+              if (arg === "primary") {
+                return { color: "blue" } as const;
+              } else {
+                return { color: "gray" } as const;
               }
             }
-          });
+          }
+        });
         assertType<{
           properties?: {
             color: (arg: "primary" | "secondary") =>
@@ -351,25 +345,24 @@ if (import.meta.vitest) {
       });
 
       it("Function values return Style objects", () => {
-        const { defineRulesCtx, cssInput: _cssInput } =
-          createDefineRulesTypeCase({
-            properties: {
-              color(arg: "primary" | "secondary") {
-                if (arg === "primary") {
-                  return "blue";
-                } else {
-                  return "gray";
-                }
-              },
-              otherColor(arg: "primary" | "secondary") {
-                if (arg === "primary") {
-                  return { color: "red" } as const;
-                } else {
-                  return { color: "green" } as const;
-                }
+        const { defineRulesCtx, _cssInput } = createDefineRulesTypeCase({
+          properties: {
+            color(arg: "primary" | "secondary") {
+              if (arg === "primary") {
+                return "blue";
+              } else {
+                return "gray";
+              }
+            },
+            otherColor(arg: "primary" | "secondary") {
+              if (arg === "primary") {
+                return { color: "red" } as const;
+              } else {
+                return { color: "green" } as const;
               }
             }
-          });
+          }
+        });
         assertType<{
           properties?: {
             color: (arg: "primary" | "secondary") => "blue" | "gray";
@@ -387,19 +380,51 @@ if (import.meta.vitest) {
       });
     });
 
+    describe.concurrent("DefineRulesPresetMap Type", () => {
+      it("Accepts raw preset records", () => {
+        const { defineRulesCtx } = createDefineRulesTypeCase({
+          presets: {
+            colorRed: "color_red",
+            displayFlex: "display_flex"
+          },
+          properties: {
+            color: true
+          }
+        });
+
+        assertType<DefineRulesPresetMap | undefined>(defineRulesCtx.presets);
+      });
+
+      it("Rejects preset owner objects", () => {
+        const owner = {
+          css: (_args: unknown) => "className",
+          preset: {
+            colorRed: "color_red"
+          }
+        };
+
+        createDefineRulesTypeCase({
+          properties: {
+            color: true
+          },
+          // @ts-expect-error: presets accepts raw string records only.
+          presets: owner
+        });
+      });
+    });
+
     describe.concurrent("DefineRulesShortcuts Type", () => {
       it("Single property shortcut", () => {
-        const { defineRulesCtx, cssInput: _cssInput } =
-          createDefineRulesTypeCase({
-            properties: {
-              paddingLeft: [0, 4, 8],
-              paddingRight: [0, 4, 8]
-            },
-            shortcuts: {
-              pl: "paddingLeft",
-              pr: "paddingRight"
-            }
-          });
+        const { defineRulesCtx, _cssInput } = createDefineRulesTypeCase({
+          properties: {
+            paddingLeft: [0, 4, 8],
+            paddingRight: [0, 4, 8]
+          },
+          shortcuts: {
+            pl: "paddingLeft",
+            pr: "paddingRight"
+          }
+        });
         assertType<{
           properties?: {
             paddingLeft: readonly [0, 4, 8];
@@ -424,16 +449,15 @@ if (import.meta.vitest) {
       });
 
       it("Array shortcut referencing properties", () => {
-        const { defineRulesCtx, cssInput: _cssInput } =
-          createDefineRulesTypeCase({
-            properties: {
-              paddingLeft: [0, 4, 8],
-              paddingRight: [0, 4, 8, 12]
-            },
-            shortcuts: {
-              px: ["paddingLeft", "paddingRight"]
-            }
-          });
+        const { defineRulesCtx, _cssInput } = createDefineRulesTypeCase({
+          properties: {
+            paddingLeft: [0, 4, 8],
+            paddingRight: [0, 4, 8, 12]
+          },
+          shortcuts: {
+            px: ["paddingLeft", "paddingRight"]
+          }
+        });
         assertType<{
           properties?: {
             paddingLeft: readonly [0, 4, 8];
@@ -458,18 +482,17 @@ if (import.meta.vitest) {
       });
 
       it("Shortcut referencing other shortcuts", () => {
-        const { defineRulesCtx, cssInput: _cssInput } =
-          createDefineRulesTypeCase({
-            properties: {
-              paddingLeft: [0, 4, 8],
-              paddingRight: [0, 4, 8, 12]
-            },
-            shortcuts: {
-              pl: "paddingLeft",
-              pr: "paddingRight",
-              px: ["pl", "pr"]
-            }
-          });
+        const { defineRulesCtx, _cssInput } = createDefineRulesTypeCase({
+          properties: {
+            paddingLeft: [0, 4, 8],
+            paddingRight: [0, 4, 8, 12]
+          },
+          shortcuts: {
+            pl: "paddingLeft",
+            pr: "paddingRight",
+            px: ["pl", "pr"]
+          }
+        });
         assertType<{
           properties?: {
             paddingLeft: readonly [0, 4, 8];
@@ -533,15 +556,14 @@ if (import.meta.vitest) {
       });
 
       it("Fixed object shortcut", () => {
-        const { defineRulesCtx, cssInput: _cssInput } =
-          createDefineRulesTypeCase({
-            properties: {
-              display: ["none", "inline", "block"]
-            },
-            shortcuts: {
-              inline: { display: "inline" }
-            }
-          });
+        const { defineRulesCtx, _cssInput } = createDefineRulesTypeCase({
+          properties: {
+            display: ["none", "inline", "block"]
+          },
+          shortcuts: {
+            inline: { display: "inline" }
+          }
+        });
         assertType<{
           properties?: {
             display: readonly ["none", "inline", "block"];
@@ -558,23 +580,22 @@ if (import.meta.vitest) {
       });
 
       it("Function shortcut", () => {
-        const { defineRulesCtx, cssInput: _cssInput } =
-          createDefineRulesTypeCase({
-            properties: {
-              display: ["none", "inline", "block"],
-              paddingLeft: [0, 4, 8],
-              paddingRight: [0, 4, 8]
-            },
-            shortcuts: {
-              px: ["paddingLeft", "paddingRight"],
-              center(arg: "none" | "inline" | "block") {
-                return {
-                  display: arg,
-                  px: 4
-                } as const;
-              }
+        const { defineRulesCtx, _cssInput } = createDefineRulesTypeCase({
+          properties: {
+            display: ["none", "inline", "block"],
+            paddingLeft: [0, 4, 8],
+            paddingRight: [0, 4, 8]
+          },
+          shortcuts: {
+            px: ["paddingLeft", "paddingRight"],
+            center(arg: "none" | "inline" | "block") {
+              return {
+                display: arg,
+                px: 4
+              } as const;
             }
-          });
+          }
+        });
         assertType<{
           properties?: {
             display: readonly ["none", "inline", "block"];

--- a/packages/css/src/defineRules/types.ts
+++ b/packages/css/src/defineRules/types.ts
@@ -57,11 +57,14 @@ export type DefineRulesShortcuts<
   >;
 };
 
+export type DefineRulesPresetMap = Record<string, string>;
+
 export interface DefineRulesCtx<
   Properties extends DefineRulesProperties,
   Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
 > {
   debugId?: string;
+  presets?: DefineRulesPresetMap;
   properties?: Properties;
   shortcuts?: Shortcuts;
 }

--- a/packages/css/src/defineRules/utils.ts
+++ b/packages/css/src/defineRules/utils.ts
@@ -108,10 +108,11 @@ function fragmentCacheKey(
 }
 
 export function createCanonicalStyleCache(debugId?: string) {
-  let classNameCache: Record<string, string> = {};
+  let classNameCache: Record<string, string> = Object.create(null);
+  const fragmentCacheKeys = new Set<string>();
 
   function hasCacheKey(cacheKey: string): boolean {
-    return cacheKey in classNameCache;
+    return Object.prototype.hasOwnProperty.call(classNameCache, cacheKey);
   }
 
   function getCachedClassName(cacheKey: string): string | undefined {
@@ -164,11 +165,37 @@ export function createCanonicalStyleCache(debugId?: string) {
     value: unknown,
     fragment: CSSRule
   ): string {
-    return cacheClassName(fragmentCacheKey(key, value, fragment), fragment);
+    const cacheKey = fragmentCacheKey(key, value, fragment);
+    fragmentCacheKeys.add(cacheKey);
+    return cacheClassName(cacheKey, fragment);
+  }
+
+  function importSnapshot(entries: Record<string, string>): void {
+    for (const [cacheKey, className] of Object.entries(entries)) {
+      fragmentCacheKeys.add(cacheKey);
+
+      if (!hasCacheKey(cacheKey)) {
+        classNameCache[cacheKey] = className;
+      }
+    }
+  }
+
+  function exportSnapshot(): Record<string, string> {
+    const snapshot: Record<string, string> = {};
+
+    for (const cacheKey of fragmentCacheKeys) {
+      const className = classNameCache[cacheKey];
+      if (className != null) {
+        snapshot[cacheKey] = className;
+      }
+    }
+
+    return snapshot;
   }
 
   function clear(): void {
-    classNameCache = {};
+    classNameCache = Object.create(null);
+    fragmentCacheKeys.clear();
   }
 
   return {
@@ -178,6 +205,8 @@ export function createCanonicalStyleCache(debugId?: string) {
     hasFragment,
     getFragment,
     addFragment,
+    importSnapshot,
+    exportSnapshot,
     clear,
     get size() {
       return Object.keys(classNameCache).length;
@@ -413,6 +442,58 @@ if (import.meta.vitest) {
       expect(cache.getFragment("background", "red", secondFragment)).toBe(
         undefined
       );
+    });
+
+    it("should import and export tracked fragment snapshots", () => {
+      const cache = createCanonicalStyleCache(debugId);
+      const seededFragment = {
+        vars: { "--b": "2", "--a": "1" },
+        background: "rgb(0, 0, 255)"
+      } as const;
+      const reorderedFragment = {
+        background: "rgb(0, 0, 255)",
+        vars: { "--a": "1", "--b": "2" }
+      } as const;
+      const seededClassName = "seeded-background";
+      const seededSnapshot = {
+        [fragmentCacheKey("background", { b: 2, a: 1 }, seededFragment)]:
+          seededClassName
+      };
+
+      cache.importSnapshot(seededSnapshot);
+
+      expect(
+        cache.hasFragment("background", { a: 1, b: 2 }, reorderedFragment)
+      ).toBe(true);
+      expect(
+        cache.getFragment("background", { a: 1, b: 2 }, reorderedFragment)
+      ).toBe(seededClassName);
+
+      cache.add("display", "block");
+
+      expect(cache.exportSnapshot()).toEqual(seededSnapshot);
+      expect(cache.size).toBe(2);
+    });
+
+    it("should reuse seeded fragment entries without overwriting imported class names", () => {
+      const cache = createCanonicalStyleCache(debugId);
+      const seededFragment = {
+        color: "red",
+        vars: { "--shade": "500" }
+      } as const;
+      const seededClassName = "seeded-color";
+
+      cache.importSnapshot({
+        [fragmentCacheKey("color", "brand", seededFragment)]: seededClassName
+      });
+
+      expect(cache.addFragment("color", "brand", seededFragment)).toBe(
+        seededClassName
+      );
+      expect(cache.exportSnapshot()).toEqual({
+        [fragmentCacheKey("color", "brand", seededFragment)]: seededClassName
+      });
+      expect(cache.size).toBe(1);
     });
 
     it("should treat null prototype objects as plain objects", () => {

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -63,6 +63,7 @@ export type { ClassValue } from "./classname/index.js";
 export { defineRules } from "./defineRules/index.js";
 export type {
   DefineRulesCtx,
+  DefineRulesPresetMap,
   DefineRulesCssInput,
   DefineRulesComplexCssInput
 } from "./defineRules/types.js";

--- a/packages/css/vite.config.ts
+++ b/packages/css/vite.config.ts
@@ -12,6 +12,12 @@ export default (viteConfigEnv: ConfigEnv) => {
         entry: {
           index: join(packageDir, "src", "index.ts"),
           compat: join(packageDir, "src", "compat.ts"),
+          "defineRules/createDefineRulesCssRuntime": join(
+            packageDir,
+            "src",
+            "defineRules",
+            "createDefineRulesCssRuntime.ts"
+          ),
           "rules/createRuntimeFn": join(
             packageDir,
             "src",


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->
defineRules's css is now serialized runtime.

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #318 

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public entry to create standalone CSS rule runtimes.
  * Introduced preset capture and mutable preset snapshots for import/export and reuse.
  * Exposed a typed preset map for stronger preset typing.
  * Serializer now errors when attempting to serialize function-valued config.

* **Refactor**
  * `defineRules` now returns full runtime results (including presets) and uses a modular runtime with enhanced cache and preset handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mincho-js/mincho/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
