### PR TITLE
Feat: Vite/Esbuild - Use defineRules registry preset serialization

### DIFF
--- a/examples/shared-component/src/preset.css.ts
+++ b/examples/shared-component/src/preset.css.ts
@@ -1,28 +1,6 @@
-import {
-  defineRules,
-  type CSSProperties,
-  type DefineRulesPresetMap
-} from "@mincho-js/css";
+import { defineRules } from "@mincho-js/css";
 
-type SharedCssInput = Pick<
-  CSSProperties,
-  "background" | "color" | "padding" | "borderRadius" | "display"
->;
-
-type SharedCss = (args: SharedCssInput) => string;
-
-type SharedPreset = {
-  schema: "mincho.defineRulesPreset";
-  version: 3;
-  classNameByCache: DefineRulesPresetMap;
-};
-
-type SharedPresetOwner = {
-  css: SharedCss;
-  preset: SharedPreset;
-};
-
-export const { css, preset }: SharedPresetOwner = defineRules({
+export const { css, preset } = defineRules({
   debugId: "sharedPreset",
   properties: {
     background: true,

--- a/packages/babel/src/types.ts
+++ b/packages/babel/src/types.ts
@@ -1,21 +1,21 @@
 import type { NodePath, PluginPass, types as t } from "@babel/core";
 import type { Scope } from "@babel/traverse";
 
-export type PluginOptions = {
+export interface PluginOptions {
   result: [string, string];
-};
+}
 
-export type PluginState = PluginPass & {
+export interface PluginState extends PluginPass {
   opts: PluginOptions;
-};
+}
 
-export type ProgramScope = Scope & {
+export interface ProgramScope extends Scope {
   minchoData: {
     imports: Map<string, t.Identifier>;
     bindings: Array<NodePath<t.Node>>;
     nodes: Array<t.Node>;
     cssFile: string;
   };
-};
+}
 
 export type MinchoNode = ProgramScope["minchoData"]["nodes"][number];

--- a/packages/css-additional-types/codegen/index.ts
+++ b/packages/css-additional-types/codegen/index.ts
@@ -169,7 +169,7 @@ export const shorthandProperties = ${stringify(shorthanded)} as const;
 export type ShorthandProperties = DeepWriteable<typeof shorthandProperties>;
 
 export const nestedPropertiesMap: NestedPropertiesMap = ${stringifyNested};
-export type NestedPropertiesMap = ${stringifyNested};
+export interface NestedPropertiesMap ${stringifyNested}
 `;
 
 // -- Run ----------------------------------------------------------------------

--- a/packages/css-additional-types/src/index.ts
+++ b/packages/css-additional-types/src/index.ts
@@ -1073,7 +1073,7 @@ export const nestedPropertiesMap: NestedPropertiesMap = {
     Trim: "whiteSpaceTrim"
   }
 };
-export type NestedPropertiesMap = {
+export interface NestedPropertiesMap {
   msContentZoomLimit: {
     Max: "msContentZoomLimitMax";
     Min: "msContentZoomLimitMin";
@@ -1639,4 +1639,4 @@ export type NestedPropertiesMap = {
     Collapse: "whiteSpaceCollapse";
     Trim: "whiteSpaceTrim";
   };
-};
+}

--- a/packages/css/src/defineRules/registry.ts
+++ b/packages/css/src/defineRules/registry.ts
@@ -13,10 +13,10 @@ import type {
   DefineRulesShortcuts
 } from "./types.js";
 
-type NormalizedDefineRulesRegistryFileScope = {
+interface NormalizedDefineRulesRegistryFileScope {
   packageName: string;
   filePath: string;
-};
+}
 
 export interface DefineRulesRegistryInstance {
   registrationId: string;

--- a/packages/css/src/defineRules/runtime.ts
+++ b/packages/css/src/defineRules/runtime.ts
@@ -2,6 +2,7 @@ import type { CSSProperties } from "@mincho-js/transform-to-vanilla";
 import { registerDefineRulesRegistryInstance } from "./registry.js";
 import { createCanonicalStyleCache } from "./utils.js";
 import type {
+  DefineRulesCss,
   DefineRulesComplexCssInput,
   DefineRulesCtx,
   DefineRulesPresetArtifactV3,
@@ -12,16 +13,11 @@ import type {
   DefineRulesShortcuts
 } from "./types.js";
 
-// == Define Rules Runtime =====================================================
-export type DefineRulesRuntimeCss<CssInput> = ((args: CssInput) => string) & {
-  raw(args: CssInput): CSSProperties;
-};
-
 export interface DefineRulesRuntimeResult<
   Properties extends DefineRulesProperties,
   Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
 > {
-  css: DefineRulesRuntimeCss<DefineRulesComplexCssInput<Properties, Shortcuts>>;
+  css: DefineRulesCss<DefineRulesComplexCssInput<Properties, Shortcuts>>;
   preset: DefineRulesPresetArtifactV3;
 }
 
@@ -102,7 +98,7 @@ export function createDefineRulesRuntime<
 
   const css = Object.assign(cssImpl, {
     raw: cssRaw
-  }) as DefineRulesRuntimeCss<CssInput>;
+  }) as DefineRulesCss<CssInput>;
   return { css, preset: presetArtifact };
 }
 

--- a/packages/css/src/defineRules/types.ts
+++ b/packages/css/src/defineRules/types.ts
@@ -72,6 +72,11 @@ export type DefineRulesPresetInput =
 
 export type DefineRulesPresetMap = DefineRulesPresetClassNameByCache;
 
+export interface DefineRulesCss<CssInput> {
+  (args: CssInput): string;
+  raw(args: CssInput): CSSProperties;
+}
+
 export interface DefineRulesCtx<
   Properties extends DefineRulesProperties,
   Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -63,7 +63,11 @@ export type { ClassValue } from "./classname/index.js";
 export { defineRules } from "./defineRules/index.js";
 export type {
   DefineRulesCtx,
+  DefineRulesProperties,
+  DefineRulesShortcuts,
+  DefineRulesPresetArtifactV3,
   DefineRulesPresetMap,
+  DefineRulesCss,
   DefineRulesCssInput,
   DefineRulesComplexCssInput
 } from "./defineRules/types.js";

--- a/packages/css/src/rules/types.ts
+++ b/packages/css/src/rules/types.ts
@@ -189,14 +189,15 @@ export interface RecipeClassNames<Variants extends VariantGroups> {
   variants: VariantsClassNames<Variants>;
 }
 
-export type RuntimeFn<
+export interface RuntimeFn<
   Variants extends VariantGroups,
   Props extends ComplexPropDefinitions<PropTarget | undefined>
-> = ((options?: ResolveComplex<VariantSelection<Variants>>) => string) & {
+> {
+  (options?: ResolveComplex<VariantSelection<Variants>>): string;
   props: (options: Resolve<PropDefinitionOutput<Props>>) => CSSRule;
   variants: () => (keyof Variants)[];
   classNames: RecipeClassNames<Variants>;
-};
+}
 
 export type RulesVariants<
   RuleFn extends RuntimeFn<

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -1,6 +1,5 @@
 import * as fs from "node:fs";
 import { dirname, join } from "node:path";
-import { processVanillaFile } from "@vanilla-extract/integration";
 import { vanillaExtractPlugin } from "@vanilla-extract/esbuild-plugin";
 import { type Plugin as EsbuildPlugin } from "esbuild";
 import {
@@ -15,10 +14,6 @@ const integrationHelpers = {
   compile,
   processDefineRulesPresetRegistryFile,
   runDefineRulesPresetRegistryStep
-};
-
-const vanillaExtractIntegrationHelpers = {
-  processVanillaFile
 };
 
 interface MinchoEsbuildPluginOptions {
@@ -163,14 +158,11 @@ if (import.meta.vitest) {
   // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
   const { afterEach, beforeAll, describe, expect, it, vi } = import.meta.vitest;
 
-  const DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX =
-    "__MINCHO_DEFINE_RULES_SENTINEL__:";
-  const DEFINE_RULES_PRESET_BACKFILL_MISMATCH_ERROR =
-    "defineRules preset backfill mismatch";
-  const DEFINE_RULES_FUNCTION_CONFIG_DIAGNOSTIC =
-    "defineRules serialized css does not support function-valued properties or shortcuts";
+  const DEFINE_RULES_PRESET_SCHEMA = "mincho.defineRulesPreset";
   type DefineRulesPresetSerializationCase = {
     caseId: string;
+    expectedEvaluation: "serialized" | "not-serialized";
+    expectedRegistryInstances: number;
     expectedSourceSnippets: readonly string[];
     relativePath: string;
   };
@@ -180,25 +172,26 @@ if (import.meta.vitest) {
       fixturePath: string;
     };
 
+  type DefineRulesPresetRegistryResult = Awaited<
+    ReturnType<typeof processDefineRulesPresetRegistryFile>
+  >;
+
   type DefineRulesPresetSerializationPaths = {
     consumer: string;
-    multipleInstances: string;
   };
 
   type DefineRulesPresetSerializationManifest = {
     DEFINE_RULES_PRESET_SERIALIZATION_PATHS: DefineRulesPresetSerializationPaths;
-    DEFINE_RULES_PRESET_SERIALIZATION_SUPPORTED_MATRIX_CASES: readonly DefineRulesPresetSerializationCase[];
-    DEFINE_RULES_PRESET_SERIALIZATION_UNSUPPORTED_MATRIX_CASES: readonly DefineRulesPresetSerializationCase[];
+    DEFINE_RULES_PRESET_SERIALIZATION_REGISTRY_MATRIX_CASES: readonly DefineRulesPresetSerializationCase[];
     createDefineRulesPresetSerializationFixturePath: (
       relativePath: string
     ) => string;
   };
 
   let consumerFixturePath: string;
-  let multipleInstancesFixturePath: string;
-  let supportedFixtureMatrixCases: DefineRulesPresetSerializationFixtureCase[] =
+  let registryFixtureMatrixCases: DefineRulesPresetSerializationFixtureCase[] =
     [];
-  let unsupportedFixtureMatrixCases: DefineRulesPresetSerializationFixtureCase[] =
+  let serializedRegistryFixtureCases: DefineRulesPresetSerializationFixtureCase[] =
     [];
 
   function getDefineRulesPresetSerializationManifestUrl(): string {
@@ -229,26 +222,34 @@ if (import.meta.vitest) {
   ): void {
     const {
       DEFINE_RULES_PRESET_SERIALIZATION_PATHS,
-      DEFINE_RULES_PRESET_SERIALIZATION_SUPPORTED_MATRIX_CASES,
-      DEFINE_RULES_PRESET_SERIALIZATION_UNSUPPORTED_MATRIX_CASES,
+      DEFINE_RULES_PRESET_SERIALIZATION_REGISTRY_MATRIX_CASES,
       createDefineRulesPresetSerializationFixturePath
     } = manifest;
 
-    multipleInstancesFixturePath =
-      createDefineRulesPresetSerializationFixturePath(
-        DEFINE_RULES_PRESET_SERIALIZATION_PATHS.multipleInstances
-      );
     consumerFixturePath = createDefineRulesPresetSerializationFixturePath(
       DEFINE_RULES_PRESET_SERIALIZATION_PATHS.consumer
     );
-    supportedFixtureMatrixCases = createFixtureMatrixCases(
-      DEFINE_RULES_PRESET_SERIALIZATION_SUPPORTED_MATRIX_CASES,
+    registryFixtureMatrixCases = createFixtureMatrixCases(
+      DEFINE_RULES_PRESET_SERIALIZATION_REGISTRY_MATRIX_CASES,
       createDefineRulesPresetSerializationFixturePath
     );
-    unsupportedFixtureMatrixCases = createFixtureMatrixCases(
-      DEFINE_RULES_PRESET_SERIALIZATION_UNSUPPORTED_MATRIX_CASES,
-      createDefineRulesPresetSerializationFixturePath
+    serializedRegistryFixtureCases = registryFixtureMatrixCases.filter(
+      (fixtureCase) => fixtureCase.expectedEvaluation === "serialized"
     );
+  }
+
+  function getRegistryFixtureCase(
+    caseId: string
+  ): DefineRulesPresetSerializationFixtureCase {
+    const fixtureCase = registryFixtureMatrixCases.find(
+      (candidate) => candidate.caseId === caseId
+    );
+
+    if (fixtureCase == null) {
+      throw new Error(`Missing registry fixture case ${caseId}`);
+    }
+
+    return fixtureCase;
   }
 
   beforeAll(async () => {
@@ -273,26 +274,50 @@ if (import.meta.vitest) {
     };
   }
 
+  type ScriptLoadResult = {
+    pluginData: {
+      mainFilePath: string;
+    };
+  };
+
+  type ResolvedExtractedCssResult = {
+    namespace: string;
+    path: string;
+    pluginData: {
+      path: string;
+      mainFilePath: string;
+    };
+  };
+
+  type ExtractedCssLoadResult = {
+    contents: string;
+    loader: string;
+    resolveDir: string;
+  };
+
   type LoadCallback = (args: MockLoadArgs) => Promise<unknown>;
   type ResolveCallback = (args: MockResolveArgs) => Promise<unknown>;
   type TestEsbuildApi = Parameters<typeof compile>[0]["esbuild"];
 
   function createBuildHarness({
     absWorkingDir = "/workspace",
-    esbuild
+    esbuild,
+    minify = false
   }: {
     absWorkingDir?: string;
     esbuild?: TestEsbuildApi;
+    minify?: boolean;
   } = {}) {
     let extractedCssResolveCallback: ResolveCallback | undefined;
     let extractedCssLoadCallback: LoadCallback | undefined;
     let scriptLoadCallback: LoadCallback | undefined;
+    let endCallback: (() => void) | undefined;
 
     const build = {
       esbuild: esbuild ?? {},
       initialOptions: {
         absWorkingDir,
-        minify: false
+        minify
       },
       onResolve(_options: { filter: RegExp }, callback: ResolveCallback): void {
         extractedCssResolveCallback = callback;
@@ -308,12 +333,17 @@ if (import.meta.vitest) {
 
         scriptLoadCallback = callback;
       },
-      onEnd(): void {}
+      onEnd(callback: () => void): void {
+        endCallback = callback;
+      }
     } as unknown as Parameters<EsbuildPlugin["setup"]>[0];
 
     minchoEsbuildPlugin().setup(build);
 
     return {
+      endBuild() {
+        endCallback?.();
+      },
       async loadScript(args: MockLoadArgs) {
         if (scriptLoadCallback == null) {
           throw new Error("Missing script onLoad callback");
@@ -338,89 +368,6 @@ if (import.meta.vitest) {
     };
   }
 
-  function createSentinelBuildSource(sentinelId: string): string {
-    return `
-      import { defineRules } from "@mincho-js/css";
-
-      export const preset = defineRules(
-        {
-          properties: {
-            color: true,
-            display: true
-          }
-        },
-        "${DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX}${sentinelId}"
-      );
-    `;
-  }
-
-  function createBackfilledBuildSource(): string {
-    return `
-      import { defineRules } from "@mincho-js/css";
-
-      export const preset = defineRules({
-        presets: {
-          "shared": "shared_class"
-        },
-        properties: {
-          color: true,
-          display: true
-        }
-      });
-    `;
-  }
-
-  function createLivePresetBuildSource(): string {
-    return `
-      import { defineRules } from "@mincho-js/css";
-
-      export const { css } = defineRules({ properties: { background: true } });
-      export const fillBlue = css({ background: "blue" });
-    `;
-  }
-
-  function createLivePresetSmokeEntrySource(): string {
-    return `
-      import { css, defineRules } from "@mincho-js/css";
-
-      const presetOwner = defineRules({
-        debugId: "esbuild-build-smoke",
-        properties: {
-          background: true
-        }
-      });
-      export const fillBlue = css(
-        presetOwner.css.raw({ background: "blue" })
-      );
-    `;
-  }
-
-  async function createLivePresetSmokeFixture(prefix: string) {
-    const cacheRoot = join(process.cwd(), "packages/esbuild/.cache");
-    await fs.promises.mkdir(cacheRoot, { recursive: true });
-    const root = await fs.promises.mkdtemp(join(cacheRoot, prefix));
-    const srcRoot = join(root, "src");
-    const entryPath = join(srcRoot, "entry.ts");
-    await fs.promises.mkdir(srcRoot, { recursive: true });
-    await fs.promises.writeFile(entryPath, createLivePresetSmokeEntrySource());
-
-    return {
-      entryPath,
-      root
-    };
-  }
-
-  function extractFillBlueClassName(source: string): string {
-    const match = source.match(/fillBlue\s*=\s*["']([^"']+)["']/);
-    if (match?.[1] == null) {
-      throw new Error(
-        "Expected build output to include a fillBlue class literal"
-      );
-    }
-
-    return match[1];
-  }
-
   function readFixtureSource(filePath: string): string {
     return fs.readFileSync(filePath, "utf8");
   }
@@ -435,251 +382,309 @@ if (import.meta.vitest) {
     );
   }
 
-  function injectDefineRulesPresetSentinels(
-    source: string,
-    sentinelIds: readonly string[]
-  ): string {
-    let nextSource = source;
-    let searchIndex = 0;
-
-    for (const sentinelId of sentinelIds) {
-      const callStart = nextSource.indexOf("defineRules(", searchIndex);
-      if (callStart === -1) {
-        throw new Error(
-          "Failed to locate a fixture defineRules call for sentinel injection"
-        );
-      }
-
-      const openParenIndex = nextSource.indexOf("(", callStart);
-      if (openParenIndex === -1) {
-        throw new Error("Failed to locate a fixture defineRules config object");
-      }
-
-      let depth = 0;
-      let closingParenIndex = -1;
-      let activeQuote: '"' | "'" | "`" | undefined;
-      let escaped = false;
-      for (let index = openParenIndex; index < nextSource.length; index += 1) {
-        const character = nextSource[index];
-        if (character == null) {
-          continue;
-        }
-
-        if (activeQuote != null) {
-          if (escaped) {
-            escaped = false;
-            continue;
-          }
-
-          if (character === "\\") {
-            escaped = true;
-            continue;
-          }
-
-          if (character === activeQuote) {
-            activeQuote = undefined;
-          }
-
-          continue;
-        }
-
-        if (character === '"' || character === "'" || character === "`") {
-          activeQuote = character;
-          continue;
-        }
-
-        if (character === "(") {
-          depth += 1;
-          continue;
-        }
-
-        if (character !== ")") {
-          continue;
-        }
-
-        depth -= 1;
-        if (depth === 0) {
-          closingParenIndex = index;
-          break;
-        }
-      }
-
-      if (closingParenIndex === -1) {
-        throw new Error(
-          "Failed to locate the closing parenthesis for a fixture defineRules call"
-        );
-      }
-
-      nextSource = `${nextSource.slice(0, closingParenIndex)}, "${DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX}${sentinelId}"${nextSource.slice(closingParenIndex)}`;
-      searchIndex =
-        closingParenIndex +
-        DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX.length +
-        sentinelId.length +
-        6;
-    }
-
-    return nextSource;
-  }
-
-  function createFixtureBuildSource(
-    filePath: string,
-    ...sentinelIds: string[]
-  ): string {
-    return injectDefineRulesPresetSentinels(
-      readFixtureSource(filePath),
-      sentinelIds
-    );
-  }
-
-  function createPresetCaptureSession(
-    filePath: string,
-    sentinelId: string,
-    presetMap: Record<string, string>
-  ) {
+  function createEmptyRegistrySession(): DefineRulesPresetRegistryResult["registrySession"] {
     return {
-      filePath,
-      instances: [
-        {
-          sentinelId,
-          filePath,
-          instanceIndex: 0,
-          getPresetSnapshot: () => presetMap
-        }
-      ]
+      instances: [],
+      nextRegistrationIndex: 0,
+      nextRegistrationIndexByFileScope: {}
     };
   }
 
-  function findMatchingObjectBrace(
-    source: string,
-    openBraceIndex: number
-  ): number {
-    if (source[openBraceIndex] !== "{") {
-      throw new Error("Expected an object literal opening brace");
-    }
-
-    let depth = 0;
-    let activeQuote: '"' | "'" | "`" | undefined;
-    let escaped = false;
-
-    for (let index = openBraceIndex; index < source.length; index += 1) {
-      const character = source[index];
-      if (character == null) {
-        continue;
-      }
-
-      if (activeQuote != null) {
-        if (escaped) {
-          escaped = false;
-          continue;
-        }
-
-        if (character === "\\") {
-          escaped = true;
-          continue;
-        }
-
-        if (character === activeQuote) {
-          activeQuote = undefined;
-        }
-
-        continue;
-      }
-
-      if (character === '"' || character === "'" || character === "`") {
-        activeQuote = character;
-        continue;
-      }
-
-      if (character === "{") {
-        depth += 1;
-        continue;
-      }
-
-      if (character !== "}") {
-        continue;
-      }
-
-      depth -= 1;
-      if (depth === 0) {
-        return index;
-      }
-    }
-
-    throw new Error("Failed to locate the closing brace for an object literal");
-  }
-
-  function extractObjectLiteralPropertyValuesFromBuildSource(
-    source: string,
-    propertyName: string
-  ): string[] {
-    const propertyPattern = new RegExp(
-      `(?:^|[,\\{])\\s*(?:"${propertyName}"|'${propertyName}'|${propertyName})\\s*:`,
-      "g"
-    );
-    const objectLiterals: string[] = [];
-
-    while (propertyPattern.exec(source) != null) {
-      const openBraceIndex = source.indexOf("{", propertyPattern.lastIndex);
-      if (openBraceIndex === -1) {
-        throw new Error(
-          `Failed to locate object literal value for ${propertyName}`
-        );
-      }
-
-      if (
-        source.slice(propertyPattern.lastIndex, openBraceIndex).trim() !== ""
-      ) {
-        continue;
-      }
-
-      const closeBraceIndex = findMatchingObjectBrace(source, openBraceIndex);
-      objectLiterals.push(source.slice(openBraceIndex, closeBraceIndex + 1));
-      propertyPattern.lastIndex = closeBraceIndex + 1;
-    }
-
-    return objectLiterals;
-  }
-
-  function parseStringMapLiteral(
-    objectLiteral: string
-  ): Record<string, string> {
-    try {
-      return JSON.parse(objectLiteral) as Record<string, string>;
-    } catch {
-      const presetMap: Record<string, string> = {};
-
-      for (const entryMatch of objectLiteral.matchAll(
-        /(?:"([^"]+)"|'([^']+)'|([A-Za-z_$][\w$-]*))\s*:\s*(?:"([^"]*)"|'([^']*)')/g
-      )) {
-        const key = entryMatch[1] ?? entryMatch[2] ?? entryMatch[3];
-        const value = entryMatch[4] ?? entryMatch[5];
-        if (key != null && value != null) {
-          presetMap[key] = value;
-        }
-      }
-
-      if (
-        Object.keys(presetMap).length === 0 &&
-        objectLiteral.trim() !== "{}"
-      ) {
-        throw new Error("Failed to parse serialized preset map entries");
-      }
-
-      return presetMap;
-    }
-  }
-
-  function extractPresetMapsFromBuildSource(
+  function createRegistryResult(
     source: string
-  ): Array<Record<string, string>> {
-    return extractObjectLiteralPropertyValuesFromBuildSource(
+  ): DefineRulesPresetRegistryResult {
+    return {
       source,
-      "presets"
-    ).map(parseStringMapLiteral);
+      registrySession: createEmptyRegistrySession()
+    };
+  }
+
+  function createV3PresetBuildSource(className: string): string {
+    return `
+      export const preset = {
+        schema: "${DEFINE_RULES_PRESET_SCHEMA}",
+        version: 3,
+        classNameByCache: {
+          shared: "${className}"
+        }
+      };
+      export const shared = "${className}";
+    `;
+  }
+
+  function expectSourceToContainV3PresetArtifact(source: string): void {
+    expect(source).toMatch(
+      new RegExp(
+        `["']?schema["']?\\s*:\\s*["']${escapeRegExp(DEFINE_RULES_PRESET_SCHEMA)}["']`
+      )
+    );
+    expect(source).toMatch(/["']?version["']?\s*:\s*3/);
+    expect(source).toMatch(/["']?classNameByCache["']?\s*:\s*\{/);
+  }
+
+  function countV3PresetArtifacts(source: string): number {
+    return Array.from(
+      source.matchAll(
+        /["']?schema["']?\s*:\s*["']mincho\.defineRulesPreset["']/g
+      )
+    ).length;
+  }
+
+  function expectSourceToContainPopulatedClassNameByCache(
+    source: string
+  ): void {
+    expect(source).toMatch(
+      /["']?classNameByCache["']?\s*:\s*\{[\s\S]*["'][^"']+["']/
+    );
+  }
+
+  function expectSourceToContainClassNameByCacheValue(
+    source: string,
+    className: string
+  ): void {
+    expectSourceToContainV3PresetArtifact(source);
+    expect(source).toMatch(
+      new RegExp(
+        `["']?classNameByCache["']?\\s*:\\s*\\{[\\s\\S]*["']${escapeRegExp(className)}["']`
+      )
+    );
+  }
+
+  function expectSourceToOmitLegacyCaptureMarker(source: string): void {
+    expect(source).not.toMatch(/__MINCHO_DEFINE_RULES_[A-Z]+__:?/);
+  }
+
+  function createLivePresetBuildSource(): string {
+    return `
+      import { defineRules } from "@mincho-js/css";
+
+      export const { css, preset } = defineRules({ properties: { background: true } });
+      export const fillBlue = css({ background: "blue" });
+    `;
+  }
+
+  function createLivePresetSmokeEntrySource(): string {
+    return `
+      import { css as vanillaCss, defineRules } from "@mincho-js/css";
+
+      export const { css: presetCss, preset } = defineRules({
+        debugId: "esbuild-build-smoke",
+        properties: {
+          background: true
+        }
+      });
+      export const fillBlue = vanillaCss([
+        presetCss({ background: "blue" })
+      ]);
+    `;
+  }
+
+  function getEsbuildTestCacheRoot(): string {
+    const cwd = process.cwd();
+    const packagePathSuffix = join("packages", "esbuild");
+
+    return cwd.endsWith(packagePathSuffix)
+      ? join(cwd, ".cache")
+      : join(cwd, packagePathSuffix, ".cache");
+  }
+
+  async function createLivePresetSmokeFixture(prefix: string) {
+    const cacheRoot = getEsbuildTestCacheRoot();
+    await fs.promises.mkdir(cacheRoot, { recursive: true });
+    const root = await fs.promises.mkdtemp(join(cacheRoot, prefix));
+    const srcRoot = join(root, "src");
+    const entryPath = join(srcRoot, "entry.ts");
+    await fs.promises.mkdir(srcRoot, { recursive: true });
+    await fs.promises.writeFile(entryPath, createLivePresetSmokeEntrySource());
+
+    return {
+      entryPath,
+      root
+    };
+  }
+
+  function createRealRegistryBuildEntrySource(
+    fixtureCase: DefineRulesPresetSerializationFixtureCase,
+    _fixtureSource: string
+  ): string {
+    if (fixtureCase.caseId === "registry-helper-wrapped-executed") {
+      return `
+        import { css, defineRules } from "@mincho-js/css";
+        function createPresetOwner() {
+          return defineRules({ properties: { color: true, display: true } });
+        }
+        const presetOwner = createPresetOwner();
+        export const { css: presetCss, preset } = presetOwner;
+        export const shared = presetCss({ color: "rebeccapurple", display: "flex" });
+        export const __registryBuildMarker = css([shared]);
+        export const __registryBuildPresetArtifact = JSON.stringify(preset);
+      `;
+    }
+
+    if (fixtureCase.caseId === "registry-iife-executed") {
+      return `
+        import { css, defineRules } from "@mincho-js/css";
+        const presetOwner = (() => defineRules({ properties: { color: true, display: true } }))();
+        export const { css: presetCss, preset } = presetOwner;
+        export const shared = presetCss({ color: "rebeccapurple", display: "flex" });
+        export const __registryBuildMarker = css([shared]);
+        export const __registryBuildPresetArtifact = JSON.stringify(preset);
+      `;
+    }
+
+    if (fixtureCase.caseId === "registry-nested-function-executed") {
+      return `
+        import { css, defineRules } from "@mincho-js/css";
+        function createPresetOwner() {
+          return defineRules({ properties: { color: true, display: true } });
+        }
+        const presetOwner = createPresetOwner();
+        export const { css: presetCss, preset } = presetOwner;
+        export const shared = presetCss({ color: "rebeccapurple", display: "flex" });
+        export const __registryBuildMarker = css([shared]);
+        export const __registryBuildPresetArtifact = JSON.stringify(preset);
+      `;
+    }
+
+    if (fixtureCase.caseId === "registry-multiple-instances") {
+      return `
+        import { css, defineRules } from "@mincho-js/css";
+        const primaryPresetOwner = defineRules({ properties: { color: true, display: true } });
+        const secondaryPresetOwner = defineRules({ properties: { padding: true, margin: true } });
+        export const { css: primaryCss, preset: primaryPreset } = primaryPresetOwner;
+        export const secondaryPreset = secondaryPresetOwner.preset;
+        export const shared = primaryCss({ color: "rebeccapurple", display: "flex" });
+        export const secondaryShared = secondaryPresetOwner.css({ padding: 17, margin: 7 });
+        export const __registryBuildMarker = css([shared, secondaryShared]);
+        export const __registryBuildPresetArtifacts = [
+          JSON.stringify(primaryPreset),
+          JSON.stringify(secondaryPreset)
+        ];
+      `;
+    }
+
+    if (fixtureCase.caseId === "registry-imported-helper-executed") {
+      return `
+        import { css } from "@mincho-js/css";
+        import { createPresetOwner } from "./helper";
+        const presetOwner = createPresetOwner();
+        export const { css: presetCss, preset } = presetOwner;
+        export const shared = presetCss({ color: "rebeccapurple", display: "flex" });
+        export const __registryBuildMarker = css([shared]);
+        export const __registryBuildPresetArtifact = JSON.stringify(preset);
+      `;
+    }
+
+    return _fixtureSource;
+  }
+
+  async function createRealEsbuildRegistryFixture(
+    fixtureCase: DefineRulesPresetSerializationFixtureCase
+  ) {
+    const cacheRoot = getEsbuildTestCacheRoot();
+    await fs.promises.mkdir(cacheRoot, { recursive: true });
+    const root = await fs.promises.mkdtemp(
+      join(cacheRoot, `${fixtureCase.caseId}-`)
+    );
+    const srcRoot = join(root, "src");
+    await fs.promises.cp(dirname(fixtureCase.fixturePath), srcRoot, {
+      recursive: true
+    });
+    const fixtureSource = await fs.promises.readFile(
+      join(srcRoot, "index.css.ts"),
+      "utf8"
+    );
+    const entrySource = createRealRegistryBuildEntrySource(
+      fixtureCase,
+      fixtureSource
+    );
+    const entryPath = join(srcRoot, "entry.ts");
+    await fs.promises.writeFile(entryPath, entrySource);
+
+    return {
+      entryPath,
+      root
+    };
+  }
+
+  async function buildRealEsbuildRegistryFixture(
+    fixtureCase: DefineRulesPresetSerializationFixtureCase
+  ) {
+    const realEsbuild = await import("esbuild");
+    const { entryPath, root } =
+      await createRealEsbuildRegistryFixture(fixtureCase);
+
+    const fixtureSource = await fs.promises.readFile(
+      join(root, "src/index.css.ts"),
+      "utf8"
+    );
+    const babelTransformSpy = vi
+      .spyOn(integrationHelpers, "babelTransform")
+      .mockResolvedValue({
+        code: 'import "extracted_registry.css.ts";\nexport const __registryBuildMarker = "entry";',
+        result: ["extracted_registry.css.ts", fixtureSource]
+      });
+    const registrySources: string[] = [];
+    const processRegistryFile =
+      integrationHelpers.processDefineRulesPresetRegistryFile;
+    integrationHelpers.processDefineRulesPresetRegistryFile = async (
+      options
+    ) => {
+      const result = await processRegistryFile(options);
+      registrySources.push(result.source);
+      return result;
+    };
+
+    try {
+      const result = await realEsbuild.build({
+        absWorkingDir: root,
+        bundle: true,
+        entryPoints: [entryPath],
+        external: ["@mincho-js/css"],
+        format: "esm",
+        logLevel: "silent",
+        minify: false,
+        outdir: join(root, "dist"),
+        plugins: minchoEsbuildPlugins(),
+        write: false
+      });
+      const jsOutput = result.outputFiles.find((outputFile) =>
+        outputFile.path.endsWith(".js")
+      );
+      const cssOutput = result.outputFiles.find((outputFile) =>
+        outputFile.path.endsWith(".css")
+      );
+
+      if (jsOutput == null) {
+        throw new Error("Expected esbuild registry build to emit a JS file");
+      }
+
+      return {
+        css: cssOutput?.text ?? "",
+        js: jsOutput.text,
+        registrySource: registrySources.join("\n")
+      };
+    } finally {
+      integrationHelpers.processDefineRulesPresetRegistryFile =
+        processRegistryFile;
+      babelTransformSpy.mockRestore();
+      await fs.promises.rm(root, { force: true, recursive: true });
+    }
   }
 
   function escapeRegExp(value: string): string {
     return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+
+  function extractFillBlueClassName(source: string): string {
+    const match = source.match(/fillBlue\s*=\s*["']([^"']+)["']/);
+    if (match?.[1] == null) {
+      throw new Error(
+        "Expected build output to include a fillBlue class literal"
+      );
+    }
+
+    return match[1];
   }
 
   function extractExportedVariableInitFromBuildSource(
@@ -734,6 +739,19 @@ if (import.meta.vitest) {
     return stringLiteralMatch[1] ?? stringLiteralMatch[2]!;
   }
 
+  function splitClassNames(className: string): string[] {
+    return className.split(/\s+/).filter(Boolean);
+  }
+
+  function expectCssSourceToContainClassNames(
+    source: string,
+    className: string
+  ): void {
+    for (const fragmentClassName of splitClassNames(className)) {
+      expect(source).toContain(`.${fragmentClassName}`);
+    }
+  }
+
   function hasCssCallWithStringProperty(
     source: string,
     propertyName: string,
@@ -759,6 +777,31 @@ if (import.meta.vitest) {
     };
   }
 
+  async function loadExtractedCssFromEntry(
+    harness: ReturnType<typeof createBuildHarness>,
+    entryPath = "/workspace/src/app.ts",
+    extractedPath = "extracted_rules.css.ts"
+  ) {
+    const scriptLoadResult = (await harness.loadScript({
+      path: entryPath
+    })) as ScriptLoadResult;
+    const resolveResult = (await harness.resolveExtractedCss({
+      path: extractedPath,
+      importer: entryPath,
+      pluginData: scriptLoadResult.pluginData
+    })) as ResolvedExtractedCssResult;
+    const loadResult = (await harness.loadExtractedCss({
+      path: resolveResult.path,
+      pluginData: resolveResult.pluginData
+    })) as ExtractedCssLoadResult;
+
+    return {
+      loadResult,
+      resolveResult,
+      scriptLoadResult
+    };
+  }
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -775,7 +818,7 @@ if (import.meta.vitest) {
       ).toBe('"blue_class"');
     });
 
-    it("builds a real esbuild fixture with defineRules preset backfill", async () => {
+    it("builds a real esbuild fixture and emits defineRules preset registry artifact", async () => {
       const realEsbuild = await import("esbuild");
       const { entryPath, root } = await createLivePresetSmokeFixture(
         "define-rules-esbuild-smoke-"
@@ -808,24 +851,97 @@ if (import.meta.vitest) {
         }
 
         const fillBlueClassName = extractFillBlueClassName(jsOutput.text);
-        expect(jsOutput.text).not.toMatch(
-          new RegExp(
-            `${escapeRegExp(DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX)}[^"']+`
-          )
-        );
+        expectSourceToOmitLegacyCaptureMarker(jsOutput.text);
         expect(jsOutput.text).not.toContain('background: "blue"');
-        expect(cssOutput.text).toContain(`.${fillBlueClassName}`);
+        expectCssSourceToContainClassNames(cssOutput.text, fillBlueClassName);
         expect(cssOutput.text).toContain("background: blue;");
+
+        vi.spyOn(integrationHelpers, "babelTransform").mockResolvedValue({
+          code: 'import "extracted_rules.css.ts";\nexport { css, preset, fillBlue };',
+          result: ["extracted_rules.css.ts", createLivePresetBuildSource()]
+        });
+        const harness = createBuildHarness({
+          absWorkingDir: process.cwd(),
+          esbuild: realEsbuild
+        });
+        const { loadResult } = await loadExtractedCssFromEntry(
+          harness,
+          join(process.cwd(), "packages/esbuild/src/registry-entry.ts")
+        );
+        const registryClassName = extractExportedStringValueFromBuildSource(
+          loadResult.contents,
+          "fillBlue"
+        );
+
+        expectSourceToContainClassNameByCacheValue(
+          loadResult.contents,
+          registryClassName
+        );
+        expectSourceToContainPopulatedClassNameByCache(loadResult.contents);
+        expectSourceToOmitLegacyCaptureMarker(loadResult.contents);
       } finally {
         await fs.promises.rm(root, { force: true, recursive: true });
       }
     });
 
-    it("serializes live preset output with the class literal emitted for static css calls", async () => {
+    it("real esbuild registry builds helper-wrapped, IIFE, nested, multiple instances, and imported helper fixtures", async () => {
+      const realBuildCaseIds = [
+        "registry-helper-wrapped-executed",
+        "registry-iife-executed",
+        "registry-nested-function-executed",
+        "registry-multiple-instances",
+        "registry-imported-helper-executed"
+      ];
+
+      for (const caseId of realBuildCaseIds) {
+        const fixtureCase = serializedRegistryFixtureCases.find(
+          (candidate) => candidate.caseId === caseId
+        );
+        if (fixtureCase == null) {
+          throw new Error(`Missing registry fixture case ${caseId}`);
+        }
+
+        const { js, registrySource } =
+          await buildRealEsbuildRegistryFixture(fixtureCase);
+
+        expect(registrySource).not.toBe("");
+        expectSourceToContainV3PresetArtifact(registrySource);
+        expectSourceToContainPopulatedClassNameByCache(registrySource);
+        expectSourceToOmitLegacyCaptureMarker(registrySource);
+        expectSourceToOmitLegacyCaptureMarker(js);
+        if (fixtureCase.expectedRegistryInstances > 1) {
+          const artifactCount = Array.from(
+            registrySource.matchAll(
+              /["']?schema["']?\s*:\s*["']mincho\.defineRulesPreset["']/g
+            )
+          ).length;
+          expect(artifactCount).toBeGreaterThanOrEqual(
+            fixtureCase.expectedRegistryInstances
+          );
+        }
+      }
+    });
+
+    it("real esbuild function-valued config build skips registry artifacts", async () => {
+      const fixtureCase = getRegistryFixtureCase(
+        "registry-function-config-invalid"
+      );
+      const { js, registrySource } =
+        await buildRealEsbuildRegistryFixture(fixtureCase);
+
+      expect(registrySource).not.toBe("");
+      expect(countV3PresetArtifacts(registrySource)).toBe(0);
+      expect(countV3PresetArtifacts(js)).toBe(0);
+      expect(registrySource).toContain("rebeccapurple");
+      expectSourceToOmitLegacyCaptureMarker(registrySource);
+      expectSourceToOmitLegacyCaptureMarker(js);
+    });
+
+    it("serializes live preset output through the esbuild registry path", async () => {
       const livePresetFixtureSource = createLivePresetBuildSource();
       expectSourceToContainSnippet(
         livePresetFixtureSource,
-        "export const { css } = defineRules({ properties: { background: true } });"
+        "export const { css, preset } = defineRules({ properties: { background: true } });"
       );
       expectSourceToContainSnippet(
         livePresetFixtureSource,
@@ -839,14 +955,76 @@ if (import.meta.vitest) {
       );
 
       vi.spyOn(integrationHelpers, "babelTransform").mockResolvedValue({
-        code: 'import "extracted_rules.css.ts";\nexport { css, fillBlue };',
+        code: 'import "extracted_rules.css.ts";\nexport { css, preset, fillBlue };',
         result: ["extracted_rules.css.ts", livePresetFixtureSource]
       });
-      const registryQueueSpy = vi.spyOn(
+      const registrySpy = vi.spyOn(
         integrationHelpers,
-        "runDefineRulesPresetRegistryStep"
+        "processDefineRulesPresetRegistryFile"
       );
-      const registryFileSpy = vi.spyOn(
+
+      const harness = createBuildHarness({
+        absWorkingDir: process.cwd(),
+        esbuild: realEsbuild
+      });
+      const { loadResult, resolveResult } = await loadExtractedCssFromEntry(
+        harness,
+        entryPath
+      );
+      const fillBlueInit = extractExportedVariableInitFromBuildSource(
+        loadResult.contents,
+        "fillBlue"
+      );
+      const fillBlueClassName = extractExportedStringValueFromBuildSource(
+        loadResult.contents,
+        "fillBlue"
+      );
+
+      expect(registrySpy).toHaveBeenCalledWith({
+        source: expect.any(String),
+        filePath: resolveResult.path,
+        outputCss: undefined,
+        identOption: "debug"
+      });
+      expect(registrySpy).toHaveBeenCalledTimes(1);
+      expect(loadResult.loader).toBe("js");
+      expect(loadResult.resolveDir).toBe(dirname(resolveResult.path));
+      expect(fillBlueInit).toMatch(/^(?:"[^"]+"|'[^']+')$/);
+      expect(fillBlueClassName.split(/\s+/)).toHaveLength(1);
+      expect(
+        hasCssCallWithStringProperty(loadResult.contents, "background", "blue")
+      ).toBe(false);
+      expectSourceToContainClassNameByCacheValue(
+        loadResult.contents,
+        fillBlueClassName
+      );
+      expectSourceToOmitLegacyCaptureMarker(loadResult.contents);
+    });
+
+    it("defineRules exported css skips function-valued registry artifacts", async () => {
+      const functionValuedConfigBuildSource = `
+        import { defineRules } from "@mincho-js/css";
+
+        const functionConfig = defineRules({
+          properties: {
+            color(value: "brand" | "neutral") {
+              return value === "brand" ? "blue" : "gray";
+            }
+          }
+        });
+        export const raw = functionConfig.css.raw({ color: "brand" });
+      `;
+      const realEsbuild = await import("esbuild");
+      const entryPath = join(
+        process.cwd(),
+        "packages/esbuild/src/function-valued-config-entry.ts"
+      );
+
+      vi.spyOn(integrationHelpers, "babelTransform").mockResolvedValue({
+        code: 'import "extracted_rules.css.ts";\nexport { raw };',
+        result: ["extracted_rules.css.ts", functionValuedConfigBuildSource]
+      });
+      const registrySpy = vi.spyOn(
         integrationHelpers,
         "processDefineRulesPresetRegistryFile"
       );
@@ -857,142 +1035,26 @@ if (import.meta.vitest) {
       });
       const scriptLoadResult = (await harness.loadScript({
         path: entryPath
-      })) as {
-        pluginData: {
-          mainFilePath: string;
-        };
-      };
+      })) as ScriptLoadResult;
       const resolveResult = (await harness.resolveExtractedCss({
         path: "extracted_rules.css.ts",
         importer: entryPath,
         pluginData: scriptLoadResult.pluginData
-      })) as {
-        path: string;
-        pluginData: {
-          path: string;
-          mainFilePath: string;
-        };
-      };
+      })) as ResolvedExtractedCssResult;
+
       const loadResult = (await harness.loadExtractedCss({
         path: resolveResult.path,
         pluginData: resolveResult.pluginData
-      })) as {
-        contents: string;
-        loader: string;
-        resolveDir: string;
-      };
-      const fillBlueInit = extractExportedVariableInitFromBuildSource(
-        loadResult.contents,
-        "fillBlue"
-      );
-      const fillBlueClassName = extractExportedStringValueFromBuildSource(
-        loadResult.contents,
-        "fillBlue"
-      );
-      const serializedPresetMaps = extractPresetMapsFromBuildSource(
-        loadResult.contents
-      );
-      const [serializedPresetMap] = serializedPresetMaps;
+      })) as ExtractedCssLoadResult;
 
-      expect(registryQueueSpy).toHaveBeenCalledTimes(1);
-      expect(registryFileSpy).toHaveBeenCalledWith({
-        source: expect.any(String),
-        filePath: resolveResult.path,
-        outputCss: undefined,
-        identOption: "debug"
-      });
+      expect(registrySpy).toHaveBeenCalledTimes(1);
       expect(loadResult.loader).toBe("js");
-      expect(loadResult.resolveDir).toBe(dirname(resolveResult.path));
-      expect(fillBlueInit).toMatch(/^(?:"[^"]+"|'[^']+')$/);
-      expect(fillBlueClassName.split(/\s+/)).toHaveLength(1);
-      expect(
-        hasCssCallWithStringProperty(loadResult.contents, "background", "blue")
-      ).toBe(false);
-      expect(serializedPresetMaps).toHaveLength(1);
-      if (serializedPresetMap == null) {
-        throw new Error("Expected serialized css to include a preset map");
-      }
-
-      expect(
-        Object.keys(serializedPresetMap).every(
-          (key) => key.startsWith("fragment_") === false
-        )
-      ).toBe(true);
-      expect(Object.values(serializedPresetMap)).toContain(fillBlueClassName);
-      expect(loadResult.contents).toContain("presets");
-      expect(loadResult.contents).not.toContain(
-        DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX
-      );
+      expect(countV3PresetArtifacts(loadResult.contents)).toBe(0);
+      expect(loadResult.contents).toContain("blue");
+      expectSourceToOmitLegacyCaptureMarker(loadResult.contents);
     });
 
-    it("defineRules exported css rejects function-valued config", async () => {
-      const functionValuedConfigBuildSource = `
-        import { defineRules } from "@mincho-js/css";
-
-        export const { css } = defineRules({
-          properties: {
-            color(value: "brand" | "neutral") {
-              return value === "brand" ? "blue" : "gray";
-            }
-          }
-        });
-      `;
-      const realEsbuild = await import("esbuild");
-      const entryPath = join(
-        process.cwd(),
-        "packages/esbuild/src/function-valued-config-entry.ts"
-      );
-
-      vi.spyOn(integrationHelpers, "babelTransform").mockResolvedValue({
-        code: 'import "extracted_rules.css.ts";\nexport { css };',
-        result: ["extracted_rules.css.ts", functionValuedConfigBuildSource]
-      });
-      const harness = createBuildHarness({
-        absWorkingDir: process.cwd(),
-        esbuild: realEsbuild
-      });
-      const scriptLoadResult = (await harness.loadScript({
-        path: entryPath
-      })) as {
-        pluginData: {
-          mainFilePath: string;
-        };
-      };
-      const resolveResult = (await harness.resolveExtractedCss({
-        path: "extracted_rules.css.ts",
-        importer: entryPath,
-        pluginData: scriptLoadResult.pluginData
-      })) as {
-        path: string;
-        pluginData: {
-          path: string;
-          mainFilePath: string;
-        };
-      };
-
-      await expect(
-        harness.loadExtractedCss({
-          path: resolveResult.path,
-          pluginData: resolveResult.pluginData
-        })
-      ).rejects.toThrow(DEFINE_RULES_FUNCTION_CONFIG_DIAGNOSTIC);
-    });
-
-    it.skip("routes extracted css through shared preset backfill without breaking the namespace flow", async () => {
-      const captureSession = {
-        filePath: "/workspace/src/extracted_rules.css.ts",
-        instances: [
-          {
-            sentinelId: "provider",
-            filePath: "/workspace/src/extracted_rules.css.ts",
-            instanceIndex: 0,
-            getPresetSnapshot: () => ({
-              shared: "shared_class"
-            })
-          }
-        ]
-      };
-
+    it("routes extracted css through the shared preset registry wrapper without breaking the namespace flow", async () => {
       vi.spyOn(integrationHelpers, "babelTransform").mockResolvedValue({
         code: "export const app = {};",
         result: ["extracted_rules.css.ts", "resolver contents"]
@@ -1000,54 +1062,19 @@ if (import.meta.vitest) {
       vi.spyOn(integrationHelpers, "compile").mockResolvedValue({
         source: "compiled source"
       } as Awaited<ReturnType<typeof compile>>);
-      const captureSpy = vi
-        .spyOn(integrationHelpers, "captureDefineRulesPresetSession")
-        .mockImplementation(
-          async (_filePath: string, evaluate: () => Promise<string>) => ({
-            result: await evaluate(),
-            captureSession
-          })
+      const registryStepSpy = vi.spyOn(
+        integrationHelpers,
+        "runDefineRulesPresetRegistryStep"
+      );
+      const registrySpy = vi
+        .spyOn(integrationHelpers, "processDefineRulesPresetRegistryFile")
+        .mockResolvedValue(
+          createRegistryResult(createV3PresetBuildSource("shared_class"))
         );
-      const backfillSpy = vi
-        .spyOn(integrationHelpers, "backfillDefineRulesPresetArtifacts")
-        .mockReturnValue([
-          {
-            filePath: "/workspace/src/extracted_rules.css.ts",
-            source: createBackfilledBuildSource()
-          }
-        ]);
-      const processVanillaFileSpy = vi
-        .spyOn(vanillaExtractIntegrationHelpers, "processVanillaFile")
-        .mockResolvedValue(createSentinelBuildSource("provider"));
 
       const harness = createBuildHarness();
-      const scriptLoadResult = (await harness.loadScript({
-        path: "/workspace/src/app.ts"
-      })) as {
-        pluginData: {
-          mainFilePath: string;
-        };
-      };
-      const resolveResult = (await harness.resolveExtractedCss({
-        path: "extracted_rules.css.ts",
-        importer: "/workspace/src/app.ts",
-        pluginData: scriptLoadResult.pluginData
-      })) as {
-        namespace: string;
-        path: string;
-        pluginData: {
-          path: string;
-          mainFilePath: string;
-        };
-      };
-      const loadResult = (await harness.loadExtractedCss({
-        path: resolveResult.path,
-        pluginData: resolveResult.pluginData
-      })) as {
-        contents: string;
-        loader: string;
-        resolveDir: string;
-      };
+      const { loadResult, resolveResult } =
+        await loadExtractedCssFromEntry(harness);
 
       expect(resolveResult).toEqual({
         namespace: "extracted-css",
@@ -1057,72 +1084,24 @@ if (import.meta.vitest) {
           mainFilePath: "/workspace/src/app.ts"
         }
       });
-      expect(captureSpy).toHaveBeenCalledWith(
-        "/workspace/src/extracted_rules.css.ts",
-        expect.any(Function)
-      );
-      expect(processVanillaFileSpy).toHaveBeenCalledWith({
+      expect(registryStepSpy).toHaveBeenCalledWith(expect.any(Function));
+      expect(registryStepSpy).toHaveBeenCalledTimes(1);
+      expect(registrySpy).toHaveBeenCalledWith({
         source: "compiled source",
         filePath: "/workspace/src/extracted_rules.css.ts",
         outputCss: undefined,
         identOption: "debug"
       });
-      expect(backfillSpy).toHaveBeenCalledWith(
-        [
-          {
-            filePath: "/workspace/src/extracted_rules.css.ts",
-            source: expect.stringContaining(
-              `${DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX}provider`
-            )
-          }
-        ],
-        captureSession
-      );
       expect(loadResult.loader).toBe("js");
       expect(loadResult.resolveDir).toBe("/workspace/src");
-      expect(loadResult.contents).toContain("presets");
-      expect(extractPresetMapsFromBuildSource(loadResult.contents)).toEqual([
-        {
-          shared: "shared_class"
-        }
-      ]);
-      expect(loadResult.contents).not.toContain(
-        DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX
+      expectSourceToContainClassNameByCacheValue(
+        loadResult.contents,
+        "shared_class"
       );
+      expectSourceToOmitLegacyCaptureMarker(loadResult.contents);
     });
 
-    it.skip("backfills isolated raw preset maps from the multiple-instance fixture", async () => {
-      const fixtureBuildSource = injectDefineRulesPresetSentinels(
-        readFixtureSource(multipleInstancesFixturePath),
-        ["primary", "secondary"]
-      );
-
-      expect(fixtureBuildSource).toContain(
-        "export const preset = sharedPreset;"
-      );
-      expect(fixtureBuildSource).toContain("export const css = sharedCss;");
-      const captureSession = {
-        filePath: "/workspace/src/extracted_rules.css.ts",
-        instances: [
-          {
-            sentinelId: "primary",
-            filePath: "/workspace/src/extracted_rules.css.ts",
-            instanceIndex: 0,
-            getPresetSnapshot: () => ({
-              shared: "shared_class"
-            })
-          },
-          {
-            sentinelId: "secondary",
-            filePath: "/workspace/src/extracted_rules.css.ts",
-            instanceIndex: 1,
-            getPresetSnapshot: () => ({
-              secondary: "secondary_class"
-            })
-          }
-        ]
-      };
-
+    it("passes short identifiers to the registry wrapper when esbuild minifies", async () => {
       vi.spyOn(integrationHelpers, "babelTransform").mockResolvedValue({
         code: "export const app = {};",
         result: ["extracted_rules.css.ts", "resolver contents"]
@@ -1130,265 +1109,130 @@ if (import.meta.vitest) {
       vi.spyOn(integrationHelpers, "compile").mockResolvedValue({
         source: "compiled source"
       } as Awaited<ReturnType<typeof compile>>);
-      vi.spyOn(
-        integrationHelpers,
-        "captureDefineRulesPresetSession"
-      ).mockImplementation(
-        async (_filePath: string, evaluate: () => Promise<string>) => ({
-          result: await evaluate(),
-          captureSession
-        })
-      );
-      const backfillSpy = vi.spyOn(
-        integrationHelpers,
-        "backfillDefineRulesPresetArtifacts"
-      );
-      vi.spyOn(
-        vanillaExtractIntegrationHelpers,
-        "processVanillaFile"
-      ).mockResolvedValue(fixtureBuildSource);
+      const registrySpy = vi
+        .spyOn(integrationHelpers, "processDefineRulesPresetRegistryFile")
+        .mockResolvedValue(
+          createRegistryResult(createV3PresetBuildSource("short_class"))
+        );
 
-      const harness = createBuildHarness();
+      const harness = createBuildHarness({ minify: true });
+      await loadExtractedCssFromEntry(harness);
+
+      expect(registrySpy).toHaveBeenCalledWith({
+        source: "compiled source",
+        filePath: "/workspace/src/extracted_rules.css.ts",
+        outputCss: undefined,
+        identOption: "short"
+      });
+    });
+
+    it("serializes supported fixture matrix cases through the esbuild extracted-css registry path", async () => {
+      for (const fixtureCase of serializedRegistryFixtureCases) {
+        if (fixtureCase.caseId === "registry-imported-helper-executed") {
+          continue;
+        }
+
+        vi.restoreAllMocks();
+
+        const fixtureSource = readFixtureSource(fixtureCase.fixturePath);
+        for (const expectedSourceSnippet of fixtureCase.expectedSourceSnippets) {
+          expectSourceToContainSnippet(fixtureSource, expectedSourceSnippet);
+        }
+
+        vi.spyOn(integrationHelpers, "babelTransform").mockResolvedValue({
+          code: 'import "extracted_rules.css.ts";\nexport { css, preset, shared };',
+          result: ["extracted_rules.css.ts", "resolver contents"]
+        });
+        const compileFixtureSource = integrationHelpers.compile;
+        vi.spyOn(integrationHelpers, "compile").mockImplementation(
+          (options: Parameters<typeof compile>[0]) =>
+            compileFixtureSource({
+              ...options,
+              contents: fixtureSource
+            })
+        );
+        const registrySpy = vi.spyOn(
+          integrationHelpers,
+          "processDefineRulesPresetRegistryFile"
+        );
+
+        const realEsbuild = await import("esbuild");
+        const harness = createBuildHarness({
+          absWorkingDir: process.cwd(),
+          esbuild: realEsbuild
+        });
+        const { loadResult, resolveResult } = await loadExtractedCssFromEntry(
+          harness,
+          join(process.cwd(), "packages/esbuild/src/app.ts")
+        );
+
+        expect(registrySpy).toHaveBeenCalledWith({
+          source: expect.any(String),
+          filePath: resolveResult.path,
+          outputCss: undefined,
+          identOption: "debug"
+        });
+        expect(registrySpy).toHaveBeenCalledTimes(1);
+        expect(loadResult.loader).toBe("js");
+        expect(loadResult.resolveDir).toBe(dirname(resolveResult.path));
+        expectSourceToContainV3PresetArtifact(loadResult.contents);
+        expectSourceToContainPopulatedClassNameByCache(loadResult.contents);
+        expectSourceToOmitLegacyCaptureMarker(loadResult.contents);
+      }
+    });
+
+    it("skips function-valued config fixture registry artifacts through the esbuild registry path", async () => {
+      const fixtureCase = getRegistryFixtureCase(
+        "registry-function-config-invalid"
+      );
+      const fixtureSource = readFixtureSource(fixtureCase.fixturePath);
+      for (const expectedSourceSnippet of fixtureCase.expectedSourceSnippets) {
+        expectSourceToContainSnippet(fixtureSource, expectedSourceSnippet);
+      }
+
+      vi.spyOn(integrationHelpers, "babelTransform").mockResolvedValue({
+        code: 'import "extracted_rules.css.ts";\nexport { raw };',
+        result: ["extracted_rules.css.ts", "resolver contents"]
+      });
+      const compileFixtureSource = integrationHelpers.compile;
+      vi.spyOn(integrationHelpers, "compile").mockImplementation(
+        (options: Parameters<typeof compile>[0]) =>
+          compileFixtureSource({
+            ...options,
+            filePath: fixtureCase.fixturePath,
+            originalPath: fixtureCase.fixturePath,
+            contents: fixtureSource
+          })
+      );
+      const registrySpy = vi.spyOn(
+        integrationHelpers,
+        "processDefineRulesPresetRegistryFile"
+      );
+
+      const realEsbuild = await import("esbuild");
+      const harness = createBuildHarness({
+        absWorkingDir: process.cwd(),
+        esbuild: realEsbuild
+      });
       const scriptLoadResult = (await harness.loadScript({
-        path: "/workspace/src/app.ts"
-      })) as {
-        pluginData: {
-          mainFilePath: string;
-        };
-      };
+        path: join(process.cwd(), "packages/esbuild/src/app.ts")
+      })) as ScriptLoadResult;
       const resolveResult = (await harness.resolveExtractedCss({
         path: "extracted_rules.css.ts",
-        importer: "/workspace/src/app.ts",
+        importer: join(process.cwd(), "packages/esbuild/src/app.ts"),
         pluginData: scriptLoadResult.pluginData
-      })) as {
-        path: string;
-        pluginData: {
-          path: string;
-          mainFilePath: string;
-        };
-      };
+      })) as ResolvedExtractedCssResult;
       const loadResult = (await harness.loadExtractedCss({
         path: resolveResult.path,
         pluginData: resolveResult.pluginData
-      })) as {
-        contents: string;
-        loader: string;
-        resolveDir: string;
-      };
+      })) as ExtractedCssLoadResult;
 
-      expect(backfillSpy).toHaveBeenCalledWith(
-        [
-          {
-            filePath: "/workspace/src/extracted_rules.css.ts",
-            source: expect.stringContaining(
-              `${DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX}primary`
-            )
-          }
-        ],
-        captureSession
-      );
+      expect(registrySpy).toHaveBeenCalledTimes(1);
       expect(loadResult.loader).toBe("js");
-      expect(loadResult.resolveDir).toBe("/workspace/src");
-      expect(loadResult.contents).toContain("presets");
-      expect(loadResult.contents).not.toContain(
-        DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX
-      );
-      expect(loadResult.contents).toContain(
-        "export const preset = sharedPreset;"
-      );
-      expect(loadResult.contents).toContain("export const css = sharedCss;");
-      expect(extractPresetMapsFromBuildSource(loadResult.contents)).toEqual([
-        {
-          shared: "shared_class"
-        },
-        {
-          secondary: "secondary_class"
-        }
-      ]);
-    });
-
-    it.skip("backfills supported fixture matrix cases through the esbuild extracted-css matrix path", async () => {
-      for (const fixtureCase of supportedFixtureMatrixCases) {
-        vi.restoreAllMocks();
-
-        const fixtureSource = readFixtureSource(fixtureCase.fixturePath);
-        for (const expectedSourceSnippet of fixtureCase.expectedSourceSnippets) {
-          expectSourceToContainSnippet(fixtureSource, expectedSourceSnippet);
-        }
-
-        const buildSource = createFixtureBuildSource(
-          fixtureCase.fixturePath,
-          fixtureCase.caseId
-        );
-        const presetMap = {
-          [fixtureCase.caseId]: `${fixtureCase.caseId}_class`
-        };
-        let captureSession:
-          | ReturnType<typeof createPresetCaptureSession>
-          | undefined;
-
-        vi.spyOn(integrationHelpers, "babelTransform").mockResolvedValue({
-          code: "export const app = {};",
-          result: ["extracted_rules.css.ts", "resolver contents"]
-        });
-        vi.spyOn(integrationHelpers, "compile").mockResolvedValue({
-          source: "compiled source"
-        } as Awaited<ReturnType<typeof compile>>);
-        vi.spyOn(
-          integrationHelpers,
-          "captureDefineRulesPresetSession"
-        ).mockImplementation(
-          async (filePath: string, evaluate: () => Promise<string>) => {
-            captureSession = createPresetCaptureSession(
-              filePath,
-              fixtureCase.caseId,
-              presetMap
-            );
-
-            return {
-              result: await evaluate(),
-              captureSession
-            };
-          }
-        );
-        const backfillSpy = vi.spyOn(
-          integrationHelpers,
-          "backfillDefineRulesPresetArtifacts"
-        );
-        vi.spyOn(
-          vanillaExtractIntegrationHelpers,
-          "processVanillaFile"
-        ).mockResolvedValue(buildSource);
-
-        const harness = createBuildHarness();
-        const scriptLoadResult = (await harness.loadScript({
-          path: "/workspace/src/app.ts"
-        })) as {
-          pluginData: {
-            mainFilePath: string;
-          };
-        };
-        const resolveResult = (await harness.resolveExtractedCss({
-          path: "extracted_rules.css.ts",
-          importer: "/workspace/src/app.ts",
-          pluginData: scriptLoadResult.pluginData
-        })) as {
-          path: string;
-          pluginData: {
-            path: string;
-            mainFilePath: string;
-          };
-        };
-        const loadResult = (await harness.loadExtractedCss({
-          path: resolveResult.path,
-          pluginData: resolveResult.pluginData
-        })) as {
-          contents: string;
-          loader: string;
-          resolveDir: string;
-        };
-
-        expect(backfillSpy).toHaveBeenCalledWith(
-          [
-            {
-              filePath: "/workspace/src/extracted_rules.css.ts",
-              source: expect.stringContaining(
-                `${DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX}${fixtureCase.caseId}`
-              )
-            }
-          ],
-          captureSession
-        );
-        expect(backfillSpy).toHaveBeenCalledTimes(1);
-        expect(loadResult.loader).toBe("js");
-        expect(loadResult.resolveDir).toBe("/workspace/src");
-
-        for (const expectedSourceSnippet of fixtureCase.expectedSourceSnippets) {
-          expectSourceToContainSnippet(
-            loadResult.contents,
-            expectedSourceSnippet
-          );
-        }
-
-        expect(extractPresetMapsFromBuildSource(loadResult.contents)).toEqual([
-          presetMap
-        ]);
-        expect(loadResult.contents).toContain("presets");
-        expect(loadResult.contents).not.toContain(
-          DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX
-        );
-      }
-    });
-
-    it.skip("keeps the locked mismatch boundary for unsupported fixture matrix cases through the esbuild extracted-css path", async () => {
-      for (const fixtureCase of unsupportedFixtureMatrixCases) {
-        vi.restoreAllMocks();
-
-        const fixtureSource = readFixtureSource(fixtureCase.fixturePath);
-        for (const expectedSourceSnippet of fixtureCase.expectedSourceSnippets) {
-          expectSourceToContainSnippet(fixtureSource, expectedSourceSnippet);
-        }
-
-        const buildSource = createFixtureBuildSource(
-          fixtureCase.fixturePath,
-          fixtureCase.caseId
-        );
-
-        vi.spyOn(integrationHelpers, "babelTransform").mockResolvedValue({
-          code: "export const app = {};",
-          result: ["extracted_rules.css.ts", "resolver contents"]
-        });
-        vi.spyOn(integrationHelpers, "compile").mockResolvedValue({
-          source: "compiled source"
-        } as Awaited<ReturnType<typeof compile>>);
-        vi.spyOn(
-          integrationHelpers,
-          "captureDefineRulesPresetSession"
-        ).mockImplementation(
-          async (filePath: string, evaluate: () => Promise<string>) => ({
-            result: await evaluate(),
-            captureSession: createPresetCaptureSession(
-              filePath,
-              fixtureCase.caseId,
-              {
-                [fixtureCase.caseId]: `${fixtureCase.caseId}_class`
-              }
-            )
-          })
-        );
-        vi.spyOn(
-          vanillaExtractIntegrationHelpers,
-          "processVanillaFile"
-        ).mockResolvedValue(buildSource);
-
-        const harness = createBuildHarness();
-        const scriptLoadResult = (await harness.loadScript({
-          path: "/workspace/src/app.ts"
-        })) as {
-          pluginData: {
-            mainFilePath: string;
-          };
-        };
-        const resolveResult = (await harness.resolveExtractedCss({
-          path: "extracted_rules.css.ts",
-          importer: "/workspace/src/app.ts",
-          pluginData: scriptLoadResult.pluginData
-        })) as {
-          path: string;
-          pluginData: {
-            path: string;
-            mainFilePath: string;
-          };
-        };
-
-        await expect(
-          harness.loadExtractedCss({
-            path: resolveResult.path,
-            pluginData: resolveResult.pluginData
-          })
-        ).rejects.toThrow(DEFINE_RULES_PRESET_BACKFILL_MISMATCH_ERROR);
-      }
-    });
+      expect(countV3PresetArtifacts(loadResult.contents)).toBe(0);
+      expect(loadResult.contents).toContain("rebeccapurple");
+      expectSourceToOmitLegacyCaptureMarker(loadResult.contents);
+    }, 20000);
 
     it("keeps root css alias reuse paired with the explicit css asset import when no local extraction is needed", async () => {
       const consumerFixtureSource = readFixtureSource(
@@ -1440,29 +1284,19 @@ if (import.meta.vitest) {
       vi.spyOn(integrationHelpers, "compile").mockResolvedValue({
         source: "compiled source"
       } as Awaited<ReturnType<typeof compile>>);
-      const registryFileSpy = vi
+      const registrySpy = vi
         .spyOn(integrationHelpers, "processDefineRulesPresetRegistryFile")
         .mockRejectedValue(new ReferenceError("window is not defined"));
 
       const harness = createBuildHarness();
       const scriptLoadResult = (await harness.loadScript({
         path: "/workspace/src/app.ts"
-      })) as {
-        pluginData: {
-          mainFilePath: string;
-        };
-      };
+      })) as ScriptLoadResult;
       const resolveResult = (await harness.resolveExtractedCss({
         path: "extracted_rules.css.ts",
         importer: "/workspace/src/app.ts",
         pluginData: scriptLoadResult.pluginData
-      })) as {
-        path: string;
-        pluginData: {
-          path: string;
-          mainFilePath: string;
-        };
-      };
+      })) as ResolvedExtractedCssResult;
       const loadResult = (await harness.loadExtractedCss({
         path: resolveResult.path,
         pluginData: resolveResult.pluginData
@@ -1473,7 +1307,7 @@ if (import.meta.vitest) {
         }>;
       };
 
-      expect(registryFileSpy).toHaveBeenCalledWith({
+      expect(registrySpy).toHaveBeenCalledWith({
         source: "compiled source",
         filePath: "/workspace/src/extracted_rules.css.ts",
         outputCss: undefined,
@@ -1490,14 +1324,45 @@ if (import.meta.vitest) {
       });
     });
 
-    it.skip("defineRules preset capture sessions are queued so concurrent esbuild loads cannot overlap shared preset sessions", async () => {
+    it("cleans extracted-css resolvers on build end", async () => {
+      vi.spyOn(integrationHelpers, "babelTransform").mockResolvedValue({
+        code: 'import "extracted_rules.css.ts";\nexport const app = {};',
+        result: ["extracted_rules.css.ts", "resolver contents"]
+      });
+
+      const harness = createBuildHarness();
+      const scriptLoadResult = (await harness.loadScript({
+        path: "/workspace/src/app.ts"
+      })) as ScriptLoadResult;
+      const resolveBeforeEnd = await harness.resolveExtractedCss({
+        path: "extracted_rules.css.ts",
+        importer: "/workspace/src/app.ts",
+        pluginData: scriptLoadResult.pluginData
+      });
+
+      harness.endBuild();
+
+      const resolveAfterEnd = await harness.resolveExtractedCss({
+        path: "extracted_rules.css.ts",
+        importer: "/workspace/src/app.ts",
+        pluginData: scriptLoadResult.pluginData
+      });
+
+      expect(resolveBeforeEnd).toEqual({
+        namespace: "extracted-css",
+        path: "/workspace/src/extracted_rules.css.ts",
+        pluginData: {
+          path: "extracted_rules.css.ts",
+          mainFilePath: "/workspace/src/app.ts"
+        }
+      });
+      expect(resolveAfterEnd).toBeUndefined();
+    });
+
+    it("defineRules preset registry steps are queued so concurrent esbuild loads cannot overlap shared registry sessions", async () => {
       const firstDeferred = createDeferred<string>();
       const secondDeferred = createDeferred<string>();
       const processOrder: string[] = [];
-      const captureSessions = new Map<
-        string,
-        ReturnType<typeof createPresetCaptureSession>
-      >();
 
       vi.spyOn(integrationHelpers, "babelTransform")
         .mockResolvedValueOnce({
@@ -1514,103 +1379,52 @@ if (import.meta.vitest) {
             source: `compiled source:${options.filePath}`
           }) as Awaited<ReturnType<typeof compile>>
       );
-      vi.spyOn(
-        integrationHelpers,
-        "captureDefineRulesPresetSession"
-      ).mockImplementation(
-        async (filePath: string, evaluate: () => Promise<string>) => {
-          const result = await evaluate();
-          const sentinelId = filePath.endsWith("extracted_a.css.ts")
-            ? "provider-a"
-            : "provider-b";
-          const captureSession = createPresetCaptureSession(
-            filePath,
-            sentinelId,
-            {
-              [sentinelId]: `${sentinelId}_class`
+      const registrySpy = vi
+        .spyOn(integrationHelpers, "processDefineRulesPresetRegistryFile")
+        .mockImplementation(
+          async (
+            options: Parameters<typeof processDefineRulesPresetRegistryFile>[0]
+          ) => {
+            processOrder.push(`start:${options.filePath}`);
+
+            if (options.filePath.endsWith("extracted_a.css.ts")) {
+              const result = await firstDeferred.promise;
+              processOrder.push(`end:${options.filePath}`);
+              return createRegistryResult(result);
             }
-          );
-          captureSessions.set(filePath, captureSession);
 
-          return {
-            result,
-            captureSession
-          };
-        }
-      );
-      const backfillSpy = vi.spyOn(
-        integrationHelpers,
-        "backfillDefineRulesPresetArtifacts"
-      );
-      vi.spyOn(
-        vanillaExtractIntegrationHelpers,
-        "processVanillaFile"
-      ).mockImplementation(
-        async ({ filePath }: Parameters<typeof processVanillaFile>[0]) => {
-          processOrder.push(`start:${filePath}`);
-
-          if (filePath.endsWith("extracted_a.css.ts")) {
-            const result = await firstDeferred.promise;
-            processOrder.push(`end:${filePath}`);
-            return result;
+            const result = await secondDeferred.promise;
+            processOrder.push(`end:${options.filePath}`);
+            return createRegistryResult(result);
           }
-
-          const result = await secondDeferred.promise;
-          processOrder.push(`end:${filePath}`);
-          return result;
-        }
-      );
+        );
 
       const harness = createBuildHarness();
       const scriptLoadResultA = (await harness.loadScript({
         path: "/workspace/src/app-a.ts"
-      })) as {
-        pluginData: {
-          mainFilePath: string;
-        };
-      };
+      })) as ScriptLoadResult;
       const scriptLoadResultB = (await harness.loadScript({
         path: "/workspace/src/app-b.ts"
-      })) as {
-        pluginData: {
-          mainFilePath: string;
-        };
-      };
+      })) as ScriptLoadResult;
       const resolveResultA = (await harness.resolveExtractedCss({
         path: "extracted_a.css.ts",
         importer: "/workspace/src/app-a.ts",
         pluginData: scriptLoadResultA.pluginData
-      })) as {
-        path: string;
-        pluginData: {
-          path: string;
-          mainFilePath: string;
-        };
-      };
+      })) as ResolvedExtractedCssResult;
       const resolveResultB = (await harness.resolveExtractedCss({
         path: "extracted_b.css.ts",
         importer: "/workspace/src/app-b.ts",
         pluginData: scriptLoadResultB.pluginData
-      })) as {
-        path: string;
-        pluginData: {
-          path: string;
-          mainFilePath: string;
-        };
-      };
+      })) as ResolvedExtractedCssResult;
 
       const firstLoadPromise = harness.loadExtractedCss({
         path: resolveResultA.path,
         pluginData: resolveResultA.pluginData
-      }) as Promise<{
-        contents: string;
-      }>;
+      }) as Promise<ExtractedCssLoadResult>;
       const secondLoadPromise = harness.loadExtractedCss({
         path: resolveResultB.path,
         pluginData: resolveResultB.pluginData
-      }) as Promise<{
-        contents: string;
-      }>;
+      }) as Promise<ExtractedCssLoadResult>;
 
       await vi.waitFor(() => {
         expect(processOrder).toEqual([
@@ -1618,7 +1432,7 @@ if (import.meta.vitest) {
         ]);
       });
 
-      firstDeferred.resolve(createSentinelBuildSource("provider-a"));
+      firstDeferred.resolve(createV3PresetBuildSource("provider-a_class"));
       const firstLoadResult = await firstLoadPromise;
 
       await vi.waitFor(() => {
@@ -1629,7 +1443,7 @@ if (import.meta.vitest) {
         ]);
       });
 
-      secondDeferred.resolve(createSentinelBuildSource("provider-b"));
+      secondDeferred.resolve(createV3PresetBuildSource("provider-b_class"));
       const secondLoadResult = await secondLoadPromise;
 
       expect(processOrder).toEqual([
@@ -1638,40 +1452,26 @@ if (import.meta.vitest) {
         "start:/workspace/src/extracted_b.css.ts",
         "end:/workspace/src/extracted_b.css.ts"
       ]);
-      expect(backfillSpy).toHaveBeenNthCalledWith(
-        1,
-        [
-          {
-            filePath: "/workspace/src/extracted_a.css.ts",
-            source: expect.stringContaining("provider-a")
-          }
-        ],
-        captureSessions.get("/workspace/src/extracted_a.css.ts")
+      expect(registrySpy).toHaveBeenNthCalledWith(1, {
+        source: "compiled source:/workspace/src/extracted_a.css.ts",
+        filePath: "/workspace/src/extracted_a.css.ts",
+        outputCss: undefined,
+        identOption: "debug"
+      });
+      expect(registrySpy).toHaveBeenNthCalledWith(2, {
+        source: "compiled source:/workspace/src/extracted_b.css.ts",
+        filePath: "/workspace/src/extracted_b.css.ts",
+        outputCss: undefined,
+        identOption: "debug"
+      });
+      expectSourceToContainClassNameByCacheValue(
+        firstLoadResult.contents,
+        "provider-a_class"
       );
-      expect(backfillSpy).toHaveBeenNthCalledWith(
-        2,
-        [
-          {
-            filePath: "/workspace/src/extracted_b.css.ts",
-            source: expect.stringContaining("provider-b")
-          }
-        ],
-        captureSessions.get("/workspace/src/extracted_b.css.ts")
+      expectSourceToContainClassNameByCacheValue(
+        secondLoadResult.contents,
+        "provider-b_class"
       );
-      expect(
-        extractPresetMapsFromBuildSource(firstLoadResult.contents)
-      ).toEqual([
-        {
-          "provider-a": "provider-a_class"
-        }
-      ]);
-      expect(
-        extractPresetMapsFromBuildSource(secondLoadResult.contents)
-      ).toEqual([
-        {
-          "provider-b": "provider-b_class"
-        }
-      ]);
       expect(firstLoadResult.contents).not.toContain("provider-b_class");
       expect(secondLoadResult.contents).not.toContain("provider-a_class");
     });

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -5,10 +5,10 @@ import {
   processDefineRulesPresetRegistryFile,
   runDefineRulesPresetRegistryStep
 } from "@mincho-js/integration";
-import { processVanillaFile } from "@vanilla-extract/integration";
 import { normalizePath } from "@rollup/pluginutils";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import * as fs from "node:fs";
+import { fileURLToPath } from "node:url";
 
 interface Module {
   lastHMRTimestamp?: number;
@@ -179,6 +179,7 @@ export function minchoVitePlugin(_options?: {
         extractedCssFileFilter(id)
       ) {
         try {
+          resolverCache.delete(moduleInfo.originalPath);
           const { source, watchFiles } = await compile({
             filePath: moduleInfo.filePath,
             cwd: config.root,
@@ -200,7 +201,7 @@ export function minchoVitePlugin(_options?: {
             }
           }
 
-          const processVanillaFileOptions = {
+          const contents = await processDefineRulesPresetViteFile({
             source,
             filePath: moduleInfo.filePath,
             identOption: config.mode === "production" ? "short" : "debug",
@@ -224,18 +225,7 @@ export function minchoVitePlugin(_options?: {
 
               return `import "${id}";`;
             }
-          } satisfies Parameters<typeof processVanillaFile>[0];
-
-          const contents =
-            config.command === "build"
-              ? await runDefineRulesPresetRegistryStep(async () => {
-                  const { source } = await processDefineRulesPresetRegistryFile(
-                    processVanillaFileOptions
-                  );
-
-                  return source;
-                })
-              : await processVanillaFile(processVanillaFileOptions);
+          });
 
           return contents;
         } catch (error) {
@@ -307,6 +297,21 @@ export function minchoVitePlugin(_options?: {
   } as PluginOption;
 }
 
+let collectDefineRulesPresetViteRegistrySource:
+  | ((source: string) => void)
+  | undefined;
+
+async function processDefineRulesPresetViteFile(
+  options: Parameters<typeof processDefineRulesPresetRegistryFile>[0]
+): Promise<string> {
+  const { source } = await runDefineRulesPresetRegistryStep(() =>
+    processDefineRulesPresetRegistryFile(options)
+  );
+  collectDefineRulesPresetViteRegistrySource?.(source);
+
+  return source;
+}
+
 function customNormalize(path: string) {
   return path.startsWith("/") ? path.slice(1) : path;
 }
@@ -320,16 +325,13 @@ if (import.meta.vitest) {
   // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
   const { afterEach, beforeAll, describe, expect, it, vi } = import.meta.vitest;
 
-  const DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX =
-    "__MINCHO_DEFINE_RULES_SENTINEL__:";
-  const DEFINE_RULES_PRESET_BACKFILL_MISMATCH_ERROR =
-    "defineRules preset backfill mismatch";
-  const DEFINE_RULES_FUNCTION_CONFIG_DIAGNOSTIC =
-    "defineRules serialized css does not support function-valued properties or shortcuts";
+  const DEFINE_RULES_PRESET_SCHEMA = "mincho.defineRulesPreset";
   const explicitProviderSidecarImport =
     'import "@mincho-js-proof/define-rules-preset/shared-component.css";';
   type DefineRulesPresetSerializationCase = {
     caseId: string;
+    expectedEvaluation: "serialized" | "not-serialized";
+    expectedRegistryInstances: number;
     expectedSourceSnippets: readonly string[];
     relativePath: string;
   };
@@ -338,6 +340,10 @@ if (import.meta.vitest) {
     DefineRulesPresetSerializationCase & {
       fixturePath: string;
     };
+
+  type DefineRulesPresetRegistryResult = Awaited<
+    ReturnType<typeof processDefineRulesPresetRegistryFile>
+  >;
 
   type DefineRulesPresetSerializationPaths = {
     providerDistModule: string;
@@ -349,8 +355,7 @@ if (import.meta.vitest) {
 
   type DefineRulesPresetSerializationManifest = {
     DEFINE_RULES_PRESET_SERIALIZATION_PATHS: DefineRulesPresetSerializationPaths;
-    DEFINE_RULES_PRESET_SERIALIZATION_SUPPORTED_MATRIX_CASES: readonly DefineRulesPresetSerializationCase[];
-    DEFINE_RULES_PRESET_SERIALIZATION_UNSUPPORTED_MATRIX_CASES: readonly DefineRulesPresetSerializationCase[];
+    DEFINE_RULES_PRESET_SERIALIZATION_REGISTRY_MATRIX_CASES: readonly DefineRulesPresetSerializationCase[];
     createDefineRulesPresetSerializationFixturePath: (
       relativePath: string
     ) => string;
@@ -359,9 +364,9 @@ if (import.meta.vitest) {
   let providerDistModulePath: string;
   let providerRootFixturePath: string;
   let providerSidecarCssPath: string;
-  let supportedFixtureMatrixCases: DefineRulesPresetSerializationFixtureCase[] =
+  let registryFixtureMatrixCases: DefineRulesPresetSerializationFixtureCase[] =
     [];
-  let unsupportedFixtureMatrixCases: DefineRulesPresetSerializationFixtureCase[] =
+  let serializedRegistryFixtureCases: DefineRulesPresetSerializationFixtureCase[] =
     [];
   let viteConsumerEntryPath: string;
   let viteConsumerRootPath: string;
@@ -371,6 +376,10 @@ if (import.meta.vitest) {
       "../../integration/src/__fixtures__/defineRules-preset-serialization/manifest.ts",
       import.meta.url
     ).href;
+  }
+
+  function createViteFixtureCacheRoot(): string {
+    return join(fileURLToPath(new URL("..", import.meta.url)), ".cache");
   }
 
   async function loadDefineRulesPresetSerializationManifest(): Promise<DefineRulesPresetSerializationManifest> {
@@ -394,8 +403,7 @@ if (import.meta.vitest) {
   ): void {
     const {
       DEFINE_RULES_PRESET_SERIALIZATION_PATHS,
-      DEFINE_RULES_PRESET_SERIALIZATION_SUPPORTED_MATRIX_CASES,
-      DEFINE_RULES_PRESET_SERIALIZATION_UNSUPPORTED_MATRIX_CASES,
+      DEFINE_RULES_PRESET_SERIALIZATION_REGISTRY_MATRIX_CASES,
       createDefineRulesPresetSerializationFixturePath
     } = manifest;
 
@@ -414,14 +422,27 @@ if (import.meta.vitest) {
     providerSidecarCssPath = createDefineRulesPresetSerializationFixturePath(
       DEFINE_RULES_PRESET_SERIALIZATION_PATHS.providerSidecarCss
     );
-    supportedFixtureMatrixCases = createFixtureMatrixCases(
-      DEFINE_RULES_PRESET_SERIALIZATION_SUPPORTED_MATRIX_CASES,
+    registryFixtureMatrixCases = createFixtureMatrixCases(
+      DEFINE_RULES_PRESET_SERIALIZATION_REGISTRY_MATRIX_CASES,
       createDefineRulesPresetSerializationFixturePath
     );
-    unsupportedFixtureMatrixCases = createFixtureMatrixCases(
-      DEFINE_RULES_PRESET_SERIALIZATION_UNSUPPORTED_MATRIX_CASES,
-      createDefineRulesPresetSerializationFixturePath
+    serializedRegistryFixtureCases = registryFixtureMatrixCases.filter(
+      (fixtureCase) => fixtureCase.expectedEvaluation === "serialized"
     );
+  }
+
+  function getRegistryFixtureCase(
+    caseId: string
+  ): DefineRulesPresetSerializationFixtureCase {
+    const fixtureCase = registryFixtureMatrixCases.find(
+      (candidate) => candidate.caseId === caseId
+    );
+
+    if (fixtureCase == null) {
+      throw new Error(`Missing registry fixture case ${caseId}`);
+    }
+
+    return fixtureCase;
   }
 
   beforeAll(async () => {
@@ -444,111 +465,96 @@ if (import.meta.vitest) {
     );
   }
 
-  function injectDefineRulesPresetSentinel(
-    source: string,
-    sentinelId: string
-  ): string {
-    const callStart = source.indexOf("defineRules(");
-    if (callStart === -1) {
-      throw new Error(
-        "Failed to locate a fixture defineRules call for sentinel injection"
-      );
-    }
-
-    const openParenIndex = source.indexOf("(", callStart);
-    if (openParenIndex === -1) {
-      throw new Error(
-        "Failed to locate the opening parenthesis for a fixture defineRules call"
-      );
-    }
-
-    let depth = 0;
-    let closingParenIndex = -1;
-    let activeQuote: '"' | "'" | "`" | undefined;
-    let escaped = false;
-
-    for (let index = openParenIndex; index < source.length; index += 1) {
-      const character = source[index];
-      if (character == null) {
-        continue;
-      }
-
-      if (activeQuote != null) {
-        if (escaped) {
-          escaped = false;
-          continue;
-        }
-
-        if (character === "\\") {
-          escaped = true;
-          continue;
-        }
-
-        if (character === activeQuote) {
-          activeQuote = undefined;
-        }
-
-        continue;
-      }
-
-      if (character === '"' || character === "'" || character === "`") {
-        activeQuote = character;
-        continue;
-      }
-
-      if (character === "(") {
-        depth += 1;
-        continue;
-      }
-
-      if (character !== ")") {
-        continue;
-      }
-
-      depth -= 1;
-      if (depth === 0) {
-        closingParenIndex = index;
-        break;
-      }
-    }
-
-    if (closingParenIndex === -1) {
-      throw new Error(
-        "Failed to locate the closing parenthesis for a fixture defineRules call"
-      );
-    }
-
-    return `${source.slice(0, closingParenIndex)}, "${DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX}${sentinelId}"${source.slice(closingParenIndex)}`;
+  function createEmptyRegistrySession(): DefineRulesPresetRegistryResult["registrySession"] {
+    return {
+      instances: [],
+      nextRegistrationIndex: 0,
+      nextRegistrationIndexByFileScope: {}
+    };
   }
 
-  function createFixtureBuildSource(
-    filePath: string,
-    sentinelId: string
-  ): string {
-    return injectDefineRulesPresetSentinel(
-      readFixtureSource(filePath),
-      sentinelId
+  function createRegistryResult(
+    source: string
+  ): DefineRulesPresetRegistryResult {
+    return {
+      source,
+      registrySession: createEmptyRegistrySession()
+    };
+  }
+
+  function createV3PresetBuildSource(className: string): string {
+    return `
+      export const preset = {
+        schema: "${DEFINE_RULES_PRESET_SCHEMA}",
+        version: 3,
+        classNameByCache: {
+          shared: "${className}"
+        }
+      };
+      export const shared = "${className}";
+    `;
+  }
+
+  function expectSourceToContainV3PresetArtifact(source: string): void {
+    expect(source).toMatch(
+      new RegExp(
+        `["']?schema["']?\\s*:\\s*["']${escapeRegExp(DEFINE_RULES_PRESET_SCHEMA)}["']`
+      )
     );
+    expect(source).toMatch(/["']?version["']?\s*:\s*3/);
+    expect(source).toMatch(/["']?classNameByCache["']?\s*:\s*\{/);
+  }
+
+  function countV3PresetArtifacts(source: string): number {
+    return Array.from(
+      source.matchAll(
+        /["']?schema["']?\s*:\s*["']mincho\.defineRulesPreset["']/g
+      )
+    ).length;
+  }
+
+  function expectSourceToContainPopulatedClassNameByCache(
+    source: string
+  ): void {
+    expect(source).toMatch(
+      /["']?classNameByCache["']?\s*:\s*\{[\s\S]*["'][^"']+["']\s*:/
+    );
+  }
+
+  function expectSourceToContainClassNameByCacheValue(
+    source: string,
+    className: string
+  ): void {
+    expectSourceToContainV3PresetArtifact(source);
+    expect(source).toMatch(
+      new RegExp(
+        `["']?classNameByCache["']?\\s*:\\s*\\{[\\s\\S]*["']${escapeRegExp(className)}["']`
+      )
+    );
+  }
+
+  function expectSourceToOmitLegacyCaptureMarker(source: string): void {
+    expect(source).not.toMatch(/__MINCHO_DEFINE_RULES_[A-Z]+__:?/);
   }
 
   function createLivePresetSmokeEntrySource(): string {
     return `
-      import { css, defineRules } from "@mincho-js/css";
+      import { css as vanillaCss, defineRules } from "@mincho-js/css";
 
-      const presetOwner = defineRules({
+      export const { css: presetCss, preset } = defineRules({
         debugId: "vite-build-smoke",
         properties: {
           background: true
         }
       });
-      export const fillBlue = css(
-        presetOwner.css.raw({ background: "blue" })
-      );
+      export const fillBlue = vanillaCss([
+        presetCss({ background: "blue" })
+      ]);
     `;
   }
 
   async function createLivePresetSmokeFixture(prefix: string) {
-    const cacheRoot = join(process.cwd(), "packages/vite/.cache");
+    const cacheRoot = createViteFixtureCacheRoot();
     await fs.promises.mkdir(cacheRoot, { recursive: true });
     const root = await fs.promises.mkdtemp(join(cacheRoot, prefix));
     const srcRoot = join(root, "src");
@@ -562,33 +568,212 @@ if (import.meta.vitest) {
     };
   }
 
-  function extractFillBlueClassName(source: string): string {
-    const match = source.match(/fillBlue\s*=\s*["']([^"']+)["']/);
+  function createRealRegistryBuildEntrySource(
+    fixtureCase: DefineRulesPresetSerializationFixtureCase,
+    _fixtureSource: string
+  ): string {
+    if (fixtureCase.caseId === "registry-helper-wrapped-executed") {
+      return `
+        import { css, defineRules } from "@mincho-js/css";
+        function createPresetOwner() {
+          return defineRules({ properties: { color: true, display: true } });
+        }
+        const presetOwner = createPresetOwner();
+        export const { css: presetCss, preset } = presetOwner;
+        export const shared = presetCss({ color: "rebeccapurple", display: "flex" });
+        export const __registryBuildMarker = css([shared]);
+        export const __registryBuildPresetArtifact = JSON.stringify(preset);
+      `;
+    }
+
+    if (fixtureCase.caseId === "registry-iife-executed") {
+      return `
+        import { css, defineRules } from "@mincho-js/css";
+        const presetOwner = (() => defineRules({ properties: { color: true, display: true } }))();
+        export const { css: presetCss, preset } = presetOwner;
+        export const shared = presetCss({ color: "rebeccapurple", display: "flex" });
+        export const __registryBuildMarker = css([shared]);
+        export const __registryBuildPresetArtifact = JSON.stringify(preset);
+      `;
+    }
+
+    if (fixtureCase.caseId === "registry-nested-function-executed") {
+      return `
+        import { css, defineRules } from "@mincho-js/css";
+        function createPresetOwner() {
+          return defineRules({ properties: { color: true, display: true } });
+        }
+        const presetOwner = createPresetOwner();
+        export const { css: presetCss, preset } = presetOwner;
+        export const shared = presetCss({ color: "rebeccapurple", display: "flex" });
+        export const __registryBuildMarker = css([shared]);
+        export const __registryBuildPresetArtifact = JSON.stringify(preset);
+      `;
+    }
+
+    if (fixtureCase.caseId === "registry-multiple-instances") {
+      return `
+        import { css, defineRules } from "@mincho-js/css";
+        const primaryPresetOwner = defineRules({ properties: { color: true, display: true } });
+        const secondaryPresetOwner = defineRules({ properties: { padding: true, margin: true } });
+        export const { css: primaryCss, preset: primaryPreset } = primaryPresetOwner;
+        export const secondaryPreset = secondaryPresetOwner.preset;
+        export const shared = primaryCss({ color: "rebeccapurple", display: "flex" });
+        export const secondaryShared = secondaryPresetOwner.css({ padding: 17, margin: 7 });
+        export const __registryBuildMarker = css([shared, secondaryShared]);
+        export const __registryBuildPresetArtifacts = [
+          JSON.stringify(primaryPreset),
+          JSON.stringify(secondaryPreset)
+        ];
+      `;
+    }
+
+    if (fixtureCase.caseId === "registry-imported-helper-executed") {
+      return `
+        import { css } from "@mincho-js/css";
+        import { createPresetOwner } from "./helper";
+        const presetOwner = createPresetOwner();
+        export const { css: presetCss, preset } = presetOwner;
+        export const shared = presetCss({ color: "rebeccapurple", display: "flex" });
+        export const __registryBuildMarker = css([shared]);
+        export const __registryBuildPresetArtifact = JSON.stringify(preset);
+      `;
+    }
+
+    return _fixtureSource;
+  }
+
+  async function createRealViteRegistryFixture(
+    fixtureCase: DefineRulesPresetSerializationFixtureCase
+  ) {
+    const cacheRoot = createViteFixtureCacheRoot();
+    await fs.promises.mkdir(cacheRoot, { recursive: true });
+    const root = await fs.promises.mkdtemp(
+      join(cacheRoot, `${fixtureCase.caseId}-`)
+    );
+    const srcRoot = join(root, "src");
+    await fs.promises.cp(dirname(fixtureCase.fixturePath), srcRoot, {
+      recursive: true
+    });
+    const fixtureSource = await fs.promises.readFile(
+      join(srcRoot, "index.css.ts"),
+      "utf8"
+    );
+    const entrySource = createRealRegistryBuildEntrySource(
+      fixtureCase,
+      fixtureSource
+    );
+    const entryPath = join(srcRoot, "entry.ts");
+    await fs.promises.writeFile(entryPath, entrySource);
+
+    return {
+      entryPath,
+      root
+    };
+  }
+
+  async function buildRealViteRegistryFixture(
+    fixtureCase: DefineRulesPresetSerializationFixtureCase
+  ) {
+    const { build } = await import("vite");
+    const { entryPath, root } =
+      await createRealViteRegistryFixture(fixtureCase);
+
+    const fixtureSource = await fs.promises.readFile(
+      join(root, "src/index.css.ts"),
+      "utf8"
+    );
+    const integrationModule = await import("@mincho-js/integration");
+    const babelTransformSpy = vi
+      .spyOn(integrationModule, "babelTransform")
+      .mockResolvedValue({
+        code: 'import "extracted_registry.css.ts";\nexport const __registryBuildMarker = "entry";',
+        result: ["extracted_registry.css.ts", fixtureSource]
+      });
+    const registrySources: string[] = [];
+    collectDefineRulesPresetViteRegistrySource = (source) => {
+      registrySources.push(source);
+    };
+
+    try {
+      const buildResult = await build({
+        root,
+        configFile: false,
+        logLevel: "silent",
+        plugins: [minchoVitePlugin() as never],
+        build: {
+          cssMinify: false,
+          emptyOutDir: false,
+          lib: {
+            entry: entryPath,
+            fileName: "index",
+            formats: ["es"]
+          },
+          minify: false,
+          write: false
+        },
+        resolve: {
+          preserveSymlinks: true
+        }
+      });
+      type ViteRegistryOutput =
+        | { code: string; fileName: string; type: "chunk" }
+        | { fileName: string; source: string | Uint8Array; type: "asset" };
+      const rollupOutputs = Array.isArray(buildResult)
+        ? buildResult
+        : [buildResult];
+      const outputFiles = rollupOutputs.flatMap((rollupOutput) => {
+        const possibleRollupOutput = rollupOutput as { output?: unknown };
+        if (!Array.isArray(possibleRollupOutput.output)) {
+          throw new Error(
+            "Expected Vite registry build to return Rollup output"
+          );
+        }
+
+        return possibleRollupOutput.output as ViteRegistryOutput[];
+      });
+      const jsOutput = outputFiles.find(
+        (output) =>
+          output.type === "chunk" && /\.(?:mjs|js)$/.test(output.fileName)
+      );
+      const cssOutput = outputFiles.find(
+        (output) => output.type === "asset" && output.fileName.endsWith(".css")
+      );
+
+      if (jsOutput?.type !== "chunk") {
+        throw new Error("Expected Vite registry build to emit an ES chunk");
+      }
+
+      return {
+        css: cssOutput?.type === "asset" ? String(cssOutput.source) : "",
+        js: jsOutput.code,
+        registrySource: registrySources.join("\n")
+      };
+    } finally {
+      collectDefineRulesPresetViteRegistrySource = undefined;
+      babelTransformSpy.mockRestore();
+      await fs.promises.rm(root, { force: true, recursive: true });
+    }
+  }
+
+  function extractAssignedStringValueFromBuildSource(
+    source: string,
+    assignmentName: string
+  ): string {
+    const match = source.match(
+      new RegExp(`${escapeRegExp(assignmentName)}\\s*=\\s*["']([^"']+)["']`)
+    );
     if (match?.[1] == null) {
       throw new Error(
-        "Expected build output to include a fillBlue class literal"
+        `Expected build output to include a ${assignmentName} string literal`
       );
     }
 
     return match[1];
   }
 
-  function createPresetCaptureSession(
-    filePath: string,
-    sentinelId: string,
-    presetMap: Record<string, string>
-  ) {
-    return {
-      filePath,
-      instances: [
-        {
-          sentinelId,
-          filePath,
-          instanceIndex: 0,
-          getPresetSnapshot: () => presetMap
-        }
-      ]
-    };
+  function extractFillBlueClassName(source: string): string {
+    return extractAssignedStringValueFromBuildSource(source, "fillBlue");
   }
 
   function createDeferred<Value>() {
@@ -702,59 +887,6 @@ if (import.meta.vitest) {
     };
   }
 
-  function createSentinelBuildSource(sentinelId: string): string {
-    return `
-      import { defineRules } from "@mincho-js/css";
-
-      export const preset = defineRules(
-        {
-          properties: {
-            color: true,
-            display: true
-          }
-        },
-        "${DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX}${sentinelId}"
-      );
-    `;
-  }
-
-  function extractPresetMapFromBuildSource(
-    source: string
-  ): Record<string, string> {
-    const presetMapMatch = source.match(
-      /["']?presets["']?\s*:\s*(\{[\s\S]*?\})(?=\s*[,}])/
-    );
-
-    if (presetMapMatch?.[1] == null) {
-      throw new Error(
-        "Failed to locate a raw preset map in the rewritten build output"
-      );
-    }
-
-    const presetMap: Record<string, string> = {};
-
-    for (const presetEntryMatch of presetMapMatch[1].matchAll(
-      /(?:(["'])([^"']+)\1|([A-Za-z_$][\w$]*))\s*:\s*(["'])(.*?)\4/g
-    )) {
-      const key = presetEntryMatch[2] ?? presetEntryMatch[3];
-      const value = presetEntryMatch[5];
-
-      if (key == null || value == null) {
-        continue;
-      }
-
-      presetMap[key] = value;
-    }
-
-    if (Object.keys(presetMap).length === 0) {
-      throw new Error(
-        "Failed to parse a serialized preset map from rewritten build output"
-      );
-    }
-
-    return presetMap;
-  }
-
   function escapeRegExp(value: string): string {
     return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   }
@@ -849,17 +981,11 @@ if (import.meta.vitest) {
   });
 
   describe("minchoVitePlugin", () => {
-    it.skip("defineRules preset capture sessions are queued in Vite builds", async () => {
+    it("defineRules preset registry steps are queued in Vite extracted transforms", async () => {
       const integrationModule = await import("@mincho-js/integration");
-      const vanillaExtractIntegration =
-        await import("@vanilla-extract/integration");
       const firstDeferred = createDeferred<string>();
       const secondDeferred = createDeferred<string>();
       const processOrder: string[] = [];
-      const captureSessions = new Map<
-        string,
-        ReturnType<typeof createPresetCaptureSession>
-      >();
 
       vi.spyOn(integrationModule, "babelTransform")
         .mockResolvedValueOnce({
@@ -877,52 +1003,25 @@ if (import.meta.vitest) {
             watchFiles: []
           }) as Awaited<ReturnType<typeof compile>>
       );
-      vi.spyOn(
-        integrationModule,
-        "captureDefineRulesPresetSession"
-      ).mockImplementation(
-        async (filePath: string, evaluate: () => Promise<string>) => {
-          const result = await evaluate();
-          const sentinelId = filePath.endsWith("extracted_a.css.ts")
-            ? "provider-a"
-            : "provider-b";
-          const captureSession = createPresetCaptureSession(
-            filePath,
-            sentinelId,
-            {
-              [sentinelId]: `${sentinelId}_class`
+      const registrySpy = vi
+        .spyOn(integrationModule, "processDefineRulesPresetRegistryFile")
+        .mockImplementation(
+          async (
+            options: Parameters<typeof processDefineRulesPresetRegistryFile>[0]
+          ) => {
+            processOrder.push(`start:${options.filePath}`);
+
+            if (options.filePath.endsWith("extracted_a.css.ts")) {
+              const result = await firstDeferred.promise;
+              processOrder.push(`end:${options.filePath}`);
+              return createRegistryResult(result);
             }
-          );
-          captureSessions.set(filePath, captureSession);
 
-          return {
-            result,
-            captureSession
-          };
-        }
-      );
-      const backfillSpy = vi.spyOn(
-        integrationModule,
-        "backfillDefineRulesPresetArtifacts"
-      );
-      vi.spyOn(
-        vanillaExtractIntegration,
-        "processVanillaFile"
-      ).mockImplementation(
-        async ({ filePath }: Parameters<typeof processVanillaFile>[0]) => {
-          processOrder.push(`start:${filePath}`);
-
-          if (filePath.endsWith("extracted_a.css.ts")) {
-            const result = await firstDeferred.promise;
-            processOrder.push(`end:${filePath}`);
-            return result;
+            const result = await secondDeferred.promise;
+            processOrder.push(`end:${options.filePath}`);
+            return createRegistryResult(result);
           }
-
-          const result = await secondDeferred.promise;
-          processOrder.push(`end:${filePath}`);
-          return result;
-        }
-      );
+        );
 
       const harness = await createViteHarness();
       const firstFixture = await createExtractedCssFixture(harness);
@@ -940,7 +1039,7 @@ if (import.meta.vitest) {
         expect(processOrder).toEqual([`start:${firstFixture.extractedId}`]);
       });
 
-      firstDeferred.resolve(createSentinelBuildSource("provider-a"));
+      firstDeferred.resolve(createV3PresetBuildSource("provider-a_class"));
       const firstTransformResult = await firstTransformPromise;
       assertString(
         firstTransformResult,
@@ -955,7 +1054,7 @@ if (import.meta.vitest) {
         ]);
       });
 
-      secondDeferred.resolve(createSentinelBuildSource("provider-b"));
+      secondDeferred.resolve(createV3PresetBuildSource("provider-b_class"));
       const secondTransformResult = await secondTransformPromise;
       assertString(
         secondTransformResult,
@@ -968,43 +1067,38 @@ if (import.meta.vitest) {
         `start:${secondFixture.extractedId}`,
         `end:${secondFixture.extractedId}`
       ]);
-      expect(backfillSpy).toHaveBeenNthCalledWith(
+      expect(registrySpy).toHaveBeenNthCalledWith(
         1,
-        [
-          {
-            filePath: firstFixture.extractedId,
-            source: expect.stringContaining("provider-a")
-          }
-        ],
-        captureSessions.get(firstFixture.extractedId)
+        expect.objectContaining({
+          filePath: firstFixture.extractedId,
+          identOption: "short",
+          source: `compiled source:${firstFixture.extractedId}`,
+          serializeVirtualCssPath: expect.any(Function)
+        })
       );
-      expect(backfillSpy).toHaveBeenNthCalledWith(
+      expect(registrySpy).toHaveBeenNthCalledWith(
         2,
-        [
-          {
-            filePath: secondFixture.extractedId,
-            source: expect.stringContaining("provider-b")
-          }
-        ],
-        captureSessions.get(secondFixture.extractedId)
+        expect.objectContaining({
+          filePath: secondFixture.extractedId,
+          identOption: "short",
+          source: `compiled source:${secondFixture.extractedId}`,
+          serializeVirtualCssPath: expect.any(Function)
+        })
       );
-      expect(extractPresetMapFromBuildSource(firstTransformResult)).toEqual({
-        "provider-a": "provider-a_class"
-      });
-      expect(extractPresetMapFromBuildSource(secondTransformResult)).toEqual({
-        "provider-b": "provider-b_class"
-      });
+      expectSourceToContainClassNameByCacheValue(
+        firstTransformResult,
+        "provider-a_class"
+      );
+      expectSourceToContainClassNameByCacheValue(
+        secondTransformResult,
+        "provider-b_class"
+      );
       expect(firstTransformResult).not.toContain("provider-b_class");
       expect(secondTransformResult).not.toContain("provider-a_class");
     });
 
-    it.skip("backfills build output preset maps and strips sentinel args", async () => {
+    it("uses registry wrapper source for build output preset artifacts", async () => {
       const integrationModule = await import("@mincho-js/integration");
-      const vanillaExtractIntegration =
-        await import("@vanilla-extract/integration");
-      let captureSession:
-        | ReturnType<typeof createPresetCaptureSession>
-        | undefined;
 
       vi.spyOn(integrationModule, "babelTransform").mockResolvedValue({
         code: 'import "extracted_rules.css.ts";\nexport { css, shared };',
@@ -1014,34 +1108,11 @@ if (import.meta.vitest) {
         source: "compiled source",
         watchFiles: []
       } as Awaited<ReturnType<typeof compile>>);
-      vi.spyOn(
-        integrationModule,
-        "captureDefineRulesPresetSession"
-      ).mockImplementation(
-        async (filePath: string, evaluate: () => Promise<string>) => {
-          const nextCaptureSession = createPresetCaptureSession(
-            filePath,
-            "provider",
-            {
-              shared: "shared_class"
-            }
-          );
-          captureSession = nextCaptureSession;
-
-          return {
-            result: await evaluate(),
-            captureSession: nextCaptureSession
-          };
-        }
-      );
-      const backfillSpy = vi.spyOn(
-        integrationModule,
-        "backfillDefineRulesPresetArtifacts"
-      );
-      vi.spyOn(
-        vanillaExtractIntegration,
-        "processVanillaFile"
-      ).mockResolvedValue(createSentinelBuildSource("provider"));
+      const registrySpy = vi
+        .spyOn(integrationModule, "processDefineRulesPresetRegistryFile")
+        .mockResolvedValue(
+          createRegistryResult(createV3PresetBuildSource("shared_class"))
+        );
 
       const harness = await createViteHarness();
       const { extractedId, extractedSource } =
@@ -1054,32 +1125,24 @@ if (import.meta.vitest) {
         transformedExtractedCss,
         "Expected extracted css transform to return source text"
       );
-      if (captureSession == null) {
-        throw new Error("Expected defineRules preset capture session");
-      }
 
-      expect(backfillSpy).toHaveBeenCalledWith(
-        [
-          {
-            filePath: extractedId,
-            source: expect.stringContaining(
-              `${DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX}provider`
-            )
-          }
-        ],
-        captureSession
+      expect(registrySpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filePath: extractedId,
+          identOption: "short",
+          source: "compiled source",
+          serializeVirtualCssPath: expect.any(Function)
+        })
       );
-      expect(backfillSpy).toHaveBeenCalledTimes(1);
-      expect(extractPresetMapFromBuildSource(transformedExtractedCss)).toEqual({
-        shared: "shared_class"
-      });
-      expect(transformedExtractedCss).toContain("presets");
-      expect(transformedExtractedCss).not.toContain(
-        DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX
+      expect(registrySpy).toHaveBeenCalledTimes(1);
+      expectSourceToContainClassNameByCacheValue(
+        transformedExtractedCss,
+        "shared_class"
       );
+      expectSourceToOmitLegacyCaptureMarker(transformedExtractedCss);
     });
 
-    it("builds a real Vite fixture with defineRules preset backfill", async () => {
+    it("builds a real Vite fixture with defineRules preset registry artifact", async () => {
       const { build } = await import("vite");
       const { entryPath, root } = await createLivePresetSmokeFixture(
         "define-rules-vite-smoke-"
@@ -1142,19 +1205,68 @@ if (import.meta.vitest) {
         }
 
         const fillBlueClassName = extractFillBlueClassName(jsOutput.code);
-        expect(jsOutput.code).toContain("presets");
-        expect(jsOutput.code).not.toMatch(
-          new RegExp(
-            `${escapeRegExp(DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX)}[^"']+`
-          )
-        );
+        expectSourceToContainV3PresetArtifact(jsOutput.code);
+        expectSourceToOmitLegacyCaptureMarker(jsOutput.code);
         expect(jsOutput.code).not.toContain('background: "blue"');
         expect(cssOutput.source).toContain(`.${fillBlueClassName}`);
         expect(cssOutput.source).toContain("background: blue;");
       } finally {
         await fs.promises.rm(root, { force: true, recursive: true });
       }
-    });
+    }, 20000);
+
+    it("real Vite registry builds helper-wrapped, IIFE, nested, multiple instances, and imported helper fixtures", async () => {
+      const realBuildCaseIds = [
+        "registry-helper-wrapped-executed",
+        "registry-iife-executed",
+        "registry-nested-function-executed",
+        "registry-multiple-instances",
+        "registry-imported-helper-executed"
+      ];
+
+      for (const caseId of realBuildCaseIds) {
+        const fixtureCase = serializedRegistryFixtureCases.find(
+          (candidate) => candidate.caseId === caseId
+        );
+        if (fixtureCase == null) {
+          throw new Error(`Missing registry fixture case ${caseId}`);
+        }
+
+        const { js, registrySource } =
+          await buildRealViteRegistryFixture(fixtureCase);
+
+        expect(registrySource).not.toBe("");
+        expectSourceToContainV3PresetArtifact(registrySource);
+        expectSourceToContainPopulatedClassNameByCache(registrySource);
+        expectSourceToOmitLegacyCaptureMarker(registrySource);
+        expectSourceToOmitLegacyCaptureMarker(js);
+        if (fixtureCase.expectedRegistryInstances > 1) {
+          const artifactCount = Array.from(
+            registrySource.matchAll(
+              /["']?schema["']?\s*:\s*["']mincho\.defineRulesPreset["']/g
+            )
+          ).length;
+          expect(artifactCount).toBeGreaterThanOrEqual(
+            fixtureCase.expectedRegistryInstances
+          );
+        }
+      }
+    }, 20000);
+
+    it("real Vite function-valued config build skips registry artifacts", async () => {
+      const fixtureCase = getRegistryFixtureCase(
+        "registry-function-config-invalid"
+      );
+      const { js, registrySource } =
+        await buildRealViteRegistryFixture(fixtureCase);
+
+      expect(registrySource).not.toBe("");
+      expect(countV3PresetArtifacts(registrySource)).toBe(0);
+      expect(countV3PresetArtifacts(js)).toBe(0);
+      expect(registrySource).toContain("rebeccapurple");
+      expectSourceToOmitLegacyCaptureMarker(registrySource);
+      expectSourceToOmitLegacyCaptureMarker(js);
+    }, 20000);
 
     it("serializes live preset output through the Vite build artifact path", async () => {
       const integrationModule = await import("@mincho-js/integration");
@@ -1178,7 +1290,7 @@ if (import.meta.vitest) {
       vi.spyOn(integrationModule, "compile").mockImplementation(
         compileLivePresetFixture
       );
-      const registryFileSpy = vi.spyOn(
+      const registrySpy = vi.spyOn(
         integrationModule,
         "processDefineRulesPresetRegistryFile"
       );
@@ -1204,20 +1316,11 @@ if (import.meta.vitest) {
           transformedExtractedCss,
           "fillBlue"
         );
-      const serializedPresetMap = extractPresetMapFromBuildSource(
-        transformedExtractedCss
+      expect(registrySpy).toHaveBeenCalledTimes(1);
+      expectSourceToContainClassNameByCacheValue(
+        transformedExtractedCss,
+        fillBlueClassName
       );
-      const serializedFillBlueEntry = Object.entries(serializedPresetMap).find(
-        ([key, value]) =>
-          key.startsWith("fragment_") === false && value === fillBlueClassName
-      );
-
-      expect(registryFileSpy).toHaveBeenCalledWith({
-        source: expect.any(String),
-        filePath: extractedId,
-        identOption: "short",
-        serializeVirtualCssPath: expect.any(Function)
-      });
       expect(fillBlueClassName.split(/\s+/)).toHaveLength(1);
       expect(fillBlueInitializer).not.toMatch(/\bcss\s*\(/);
       expect(
@@ -1227,25 +1330,26 @@ if (import.meta.vitest) {
           "blue"
         )
       ).toBe(false);
-      expect(serializedFillBlueEntry).toBeDefined();
+      expectSourceToOmitLegacyCaptureMarker(transformedExtractedCss);
     });
 
-    it("defineRules exported css rejects function-valued config", async () => {
+    it("defineRules exported css skips function-valued config registry artifacts", async () => {
       const integrationModule = await import("@mincho-js/integration");
       const functionValuedConfigBuildSource = `
         import { defineRules } from "@mincho-js/css";
 
-        export const { css } = defineRules({
+        const functionConfig = defineRules({
           properties: {
             color(value: "brand" | "neutral") {
               return value === "brand" ? "blue" : "gray";
             }
           }
         });
+        export const raw = functionConfig.css.raw({ color: "brand" });
       `;
 
       vi.spyOn(integrationModule, "babelTransform").mockResolvedValue({
-        code: 'import "extracted_rules.css.ts";\nexport { css };',
+        code: 'import "extracted_rules.css.ts";\nexport { raw };',
         result: ["extracted_rules.css.ts", "resolver contents"]
       });
       const compileFixtureSource: typeof compile = integrationModule.compile;
@@ -1256,57 +1360,72 @@ if (import.meta.vitest) {
             contents: functionValuedConfigBuildSource
           })
       );
+      const registrySpy = vi.spyOn(
+        integrationModule,
+        "processDefineRulesPresetRegistryFile"
+      );
+
       const harness = await createViteHarness();
       const { extractedId, extractedSource } =
         await createExtractedCssFixture(harness);
 
-      await expect(
-        harness.transform(extractedId, extractedSource)
-      ).rejects.toThrow(DEFINE_RULES_FUNCTION_CONFIG_DIAGNOSTIC);
+      const transformedExtractedCss = await harness.transform(
+        extractedId,
+        extractedSource
+      );
+      assertString(
+        transformedExtractedCss,
+        "Expected function-valued config transform to return source text"
+      );
+
+      expect(registrySpy).toHaveBeenCalledTimes(1);
+      expect(countV3PresetArtifacts(transformedExtractedCss)).toBe(0);
+      expect(transformedExtractedCss).toContain("blue");
+      expectSourceToOmitLegacyCaptureMarker(transformedExtractedCss);
     });
 
-    it.skip("bubbles the locked mismatch error from build-time preset backfill", async () => {
+    it("bubbles registry validation errors from build-time preset serialization", async () => {
       const integrationModule = await import("@mincho-js/integration");
-      const vanillaExtractIntegration =
-        await import("@vanilla-extract/integration");
       const consoleErrorSpy = vi
         .spyOn(console, "error")
         .mockImplementation(() => {});
-      const captureSession = {
-        filePath: "/virtual/extracted_rules.css.ts",
-        instances: [
-          {
-            sentinelId: "provider",
-            filePath: "/virtual/extracted_rules.css.ts",
-            instanceIndex: 0,
-            getPresetSnapshot: () => ({
-              shared: "shared_class"
-            })
+      const invalidShortcutBuildSource = `
+        import { defineRules } from "@mincho-js/css";
+
+        const invalid = defineRules({
+          properties: {
+            color: true
+          },
+          shortcuts: {
+            tone: [
+              { color: "red" },
+              {
+                dynamic(value: string) {
+                  return { color: value };
+                }
+              }
+            ]
           }
-        ]
-      };
+        });
+        export const raw = invalid.css.raw({ color: "red" });
+      `;
 
       vi.spyOn(integrationModule, "babelTransform").mockResolvedValue({
-        code: 'import "extracted_rules.css.ts";\nexport { css, shared };',
+        code: 'import "extracted_rules.css.ts";\nexport { raw };',
         result: ["extracted_rules.css.ts", "resolver contents"]
       });
-      vi.spyOn(integrationModule, "compile").mockResolvedValue({
-        source: "compiled source",
-        watchFiles: []
-      } as Awaited<ReturnType<typeof compile>>);
-      vi.spyOn(
-        integrationModule,
-        "captureDefineRulesPresetSession"
-      ).mockImplementation(
-        async (_filePath: string, evaluate: () => Promise<string>) => ({
-          result: await evaluate(),
-          captureSession
-        })
+      const compileFixtureSource: typeof compile = integrationModule.compile;
+      vi.spyOn(integrationModule, "compile").mockImplementation(
+        (options: Parameters<typeof compileFixtureSource>[0]) =>
+          compileFixtureSource({
+            ...options,
+            contents: invalidShortcutBuildSource
+          })
       );
-      vi.spyOn(
-        vanillaExtractIntegration,
-        "processVanillaFile"
-      ).mockResolvedValue(createSentinelBuildSource("other"));
+      const registrySpy = vi.spyOn(
+        integrationModule,
+        "processDefineRulesPresetRegistryFile"
+      );
 
       const harness = await createViteHarness();
       const { extractedId, extractedSource } =
@@ -1314,12 +1433,13 @@ if (import.meta.vitest) {
 
       await expect(
         harness.transform(extractedId, extractedSource)
-      ).rejects.toThrow(DEFINE_RULES_PRESET_BACKFILL_MISMATCH_ERROR);
+      ).rejects.toThrow("config.shortcuts.tone[1].dynamic");
+      expect(registrySpy).toHaveBeenCalledTimes(1);
       expect(consoleErrorSpy).not.toHaveBeenCalled();
     });
 
-    it.skip("backfills supported fixture matrix cases through the Vite extracted-css matrix path", async () => {
-      for (const fixtureCase of supportedFixtureMatrixCases) {
+    it("serializes supported fixture matrix cases through the Vite extracted-css registry path", async () => {
+      for (const fixtureCase of serializedRegistryFixtureCases) {
         vi.restoreAllMocks();
 
         const fixtureSource = readFixtureSource(fixtureCase.fixturePath);
@@ -1327,53 +1447,25 @@ if (import.meta.vitest) {
           expectSourceToContainSnippet(fixtureSource, expectedSourceSnippet);
         }
 
-        const buildSource = createFixtureBuildSource(
-          fixtureCase.fixturePath,
-          fixtureCase.caseId
-        );
-        const presetMap = {
-          [fixtureCase.caseId]: `${fixtureCase.caseId}_class`
-        };
         const integrationModule = await import("@mincho-js/integration");
-        const vanillaExtractIntegration =
-          await import("@vanilla-extract/integration");
-        let captureSession:
-          | ReturnType<typeof createPresetCaptureSession>
-          | undefined;
-
         vi.spyOn(integrationModule, "babelTransform").mockResolvedValue({
-          code: 'import "extracted_rules.css.ts";\nexport { css, preset };',
+          code: 'import "extracted_rules.css.ts";\nexport { css, preset, shared };',
           result: ["extracted_rules.css.ts", "resolver contents"]
         });
-        vi.spyOn(integrationModule, "compile").mockResolvedValue({
-          source: "compiled source",
-          watchFiles: []
-        } as Awaited<ReturnType<typeof compile>>);
-        vi.spyOn(
-          integrationModule,
-          "captureDefineRulesPresetSession"
-        ).mockImplementation(
-          async (filePath: string, evaluate: () => Promise<string>) => {
-            captureSession = createPresetCaptureSession(
-              filePath,
-              fixtureCase.caseId,
-              presetMap
-            );
-
-            return {
-              result: await evaluate(),
-              captureSession
-            };
-          }
+        const compileFixtureSource: typeof compile = integrationModule.compile;
+        vi.spyOn(integrationModule, "compile").mockImplementation(
+          (options: Parameters<typeof compileFixtureSource>[0]) =>
+            compileFixtureSource({
+              ...options,
+              filePath: fixtureCase.fixturePath,
+              originalPath: fixtureCase.fixturePath,
+              contents: fixtureSource
+            })
         );
-        const backfillSpy = vi.spyOn(
+        const registrySpy = vi.spyOn(
           integrationModule,
-          "backfillDefineRulesPresetArtifacts"
+          "processDefineRulesPresetRegistryFile"
         );
-        vi.spyOn(
-          vanillaExtractIntegration,
-          "processVanillaFile"
-        ).mockResolvedValue(buildSource);
 
         const harness = await createViteHarness();
         const { extractedId, extractedSource } =
@@ -1387,94 +1479,66 @@ if (import.meta.vitest) {
           "Expected extracted css transform to return source text"
         );
 
-        expect(backfillSpy).toHaveBeenCalledWith(
-          [
-            {
-              filePath: extractedId,
-              source: expect.stringContaining(
-                `${DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX}${fixtureCase.caseId}`
-              )
-            }
-          ],
-          captureSession
-        );
-        expect(backfillSpy).toHaveBeenCalledTimes(1);
-
-        for (const expectedSourceSnippet of fixtureCase.expectedSourceSnippets) {
-          expectSourceToContainSnippet(
-            transformedExtractedCss,
-            expectedSourceSnippet
-          );
-        }
-
-        expect(
-          extractPresetMapFromBuildSource(transformedExtractedCss)
-        ).toEqual(presetMap);
-        expect(transformedExtractedCss).toContain("presets");
-        expect(transformedExtractedCss).not.toContain(
-          DEFINE_RULES_PRESET_CAPTURE_SENTINEL_PREFIX
-        );
-      }
-    });
-
-    it.skip("keeps the locked mismatch boundary for unsupported fixture matrix cases through the Vite extracted-css path", async () => {
-      for (const fixtureCase of unsupportedFixtureMatrixCases) {
-        vi.restoreAllMocks();
-
-        const fixtureSource = readFixtureSource(fixtureCase.fixturePath);
-        for (const expectedSourceSnippet of fixtureCase.expectedSourceSnippets) {
-          expectSourceToContainSnippet(fixtureSource, expectedSourceSnippet);
-        }
-
-        const buildSource = createFixtureBuildSource(
-          fixtureCase.fixturePath,
-          fixtureCase.caseId
-        );
-        const integrationModule = await import("@mincho-js/integration");
-        const vanillaExtractIntegration =
-          await import("@vanilla-extract/integration");
-        const consoleErrorSpy = vi
-          .spyOn(console, "error")
-          .mockImplementation(() => {});
-
-        vi.spyOn(integrationModule, "babelTransform").mockResolvedValue({
-          code: 'import "extracted_rules.css.ts";\nexport { css, preset };',
-          result: ["extracted_rules.css.ts", "resolver contents"]
-        });
-        vi.spyOn(integrationModule, "compile").mockResolvedValue({
-          source: "compiled source",
-          watchFiles: []
-        } as Awaited<ReturnType<typeof compile>>);
-        vi.spyOn(
-          integrationModule,
-          "captureDefineRulesPresetSession"
-        ).mockImplementation(
-          async (filePath: string, evaluate: () => Promise<string>) => ({
-            result: await evaluate(),
-            captureSession: createPresetCaptureSession(
-              filePath,
-              fixtureCase.caseId,
-              {
-                [fixtureCase.caseId]: `${fixtureCase.caseId}_class`
-              }
-            )
+        expect(registrySpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            filePath: extractedId,
+            identOption: "short",
+            serializeVirtualCssPath: expect.any(Function)
           })
         );
-        vi.spyOn(
-          vanillaExtractIntegration,
-          "processVanillaFile"
-        ).mockResolvedValue(buildSource);
-
-        const harness = await createViteHarness();
-        const { extractedId, extractedSource } =
-          await createExtractedCssFixture(harness);
-
-        await expect(
-          harness.transform(extractedId, extractedSource)
-        ).rejects.toThrow(DEFINE_RULES_PRESET_BACKFILL_MISMATCH_ERROR);
-        expect(consoleErrorSpy).not.toHaveBeenCalled();
+        expect(registrySpy).toHaveBeenCalledTimes(1);
+        expectSourceToContainV3PresetArtifact(transformedExtractedCss);
+        expectSourceToContainPopulatedClassNameByCache(transformedExtractedCss);
+        expectSourceToOmitLegacyCaptureMarker(transformedExtractedCss);
       }
     });
+
+    it("keeps function-valued config fixture artifact-free through the Vite registry path", async () => {
+      const fixtureCase = getRegistryFixtureCase(
+        "registry-function-config-invalid"
+      );
+      const fixtureSource = readFixtureSource(fixtureCase.fixturePath);
+      for (const expectedSourceSnippet of fixtureCase.expectedSourceSnippets) {
+        expectSourceToContainSnippet(fixtureSource, expectedSourceSnippet);
+      }
+
+      const integrationModule = await import("@mincho-js/integration");
+      vi.spyOn(integrationModule, "babelTransform").mockResolvedValue({
+        code: 'import "extracted_rules.css.ts";\nexport { raw };',
+        result: ["extracted_rules.css.ts", "resolver contents"]
+      });
+      const compileFixtureSource: typeof compile = integrationModule.compile;
+      vi.spyOn(integrationModule, "compile").mockImplementation(
+        (options: Parameters<typeof compileFixtureSource>[0]) =>
+          compileFixtureSource({
+            ...options,
+            filePath: fixtureCase.fixturePath,
+            originalPath: fixtureCase.fixturePath,
+            contents: fixtureSource
+          })
+      );
+      const registrySpy = vi.spyOn(
+        integrationModule,
+        "processDefineRulesPresetRegistryFile"
+      );
+
+      const harness = await createViteHarness();
+      const { extractedId, extractedSource } =
+        await createExtractedCssFixture(harness);
+      const transformedExtractedCss = await harness.transform(
+        extractedId,
+        extractedSource
+      );
+      assertString(
+        transformedExtractedCss,
+        "Expected function-valued fixture transform to return source text"
+      );
+
+      expect(registrySpy).toHaveBeenCalledTimes(1);
+      expect(countV3PresetArtifacts(transformedExtractedCss)).toBe(0);
+      expect(transformedExtractedCss).toContain("rebeccapurple");
+      expectSourceToOmitLegacyCaptureMarker(transformedExtractedCss);
+    }, 20000);
 
     it("keeps root css alias reuse paired with the explicit css asset import when no local extraction is needed", async () => {
       const harness = await createViteHarness();
@@ -1563,11 +1627,164 @@ if (import.meta.vitest) {
       expect(missingSidecarSource).not.toContain(providerSharedClassName);
     });
 
+    it("drops stale registry artifacts during repeated HMR-style transforms", async () => {
+      const integrationModule = await import("@mincho-js/integration");
+      const createStaleRegistrySource = (includeRemovedOwner: boolean) => {
+        const removedOwnerSource = includeRemovedOwner
+          ? `
+              const removedOwner = defineRules({
+                debugId: "vite-removed-stale",
+                properties: {
+                  padding: true
+                }
+              });
+              export const removedClass = removedOwner.css({ padding: 12 });
+              export const removedPreset = removedOwner.preset;
+            `
+          : "";
+
+        return `
+          import { defineRules } from "@mincho-js/css";
+
+          const currentOwner = defineRules({
+            debugId: "vite-current-stale",
+            properties: {
+              color: true
+            }
+          });
+          ${removedOwnerSource}
+          export const currentClass = currentOwner.css({ color: "navy" });
+          export const currentPreset = currentOwner.preset;
+        `;
+      };
+      const firstRegistrySource = createStaleRegistrySource(true);
+      const secondRegistrySource = createStaleRegistrySource(false);
+
+      vi.spyOn(integrationModule, "babelTransform").mockResolvedValue({
+        code: 'import "extracted_stale.css.ts";\nexport { currentClass };',
+        result: ["extracted_stale.css.ts", "resolver contents"]
+      });
+      const registrySpy = vi.spyOn(
+        integrationModule,
+        "processDefineRulesPresetRegistryFile"
+      );
+
+      const harness = await createViteHarness({
+        configOverrides: {
+          command: "serve",
+          mode: "development"
+        }
+      });
+      const { extractedId, extractedSource } =
+        await createExtractedCssFixture(harness);
+      expect(extractedSource).toBe("resolver contents");
+      const firstTransform = await harness.transform(
+        extractedId,
+        firstRegistrySource
+      );
+      assertString(
+        firstTransform,
+        "Expected first repeated transform to return source text"
+      );
+      const firstVirtualImportMatch = firstTransform.match(
+        /import\s+"([^"]+\.vanilla\.css)";/
+      );
+      if (firstVirtualImportMatch?.[1] == null) {
+        throw new Error(
+          "Expected first repeated transform to import virtual CSS"
+        );
+      }
+      const resolvedVirtualId = harness.resolveId(firstVirtualImportMatch[1]);
+      assertString(
+        resolvedVirtualId,
+        "Expected repeated transform virtual CSS id to resolve"
+      );
+      const currentClassName = extractVariableStringValueFromBuildSource(
+        firstTransform,
+        "currentClass"
+      );
+      const removedClassName = extractVariableStringValueFromBuildSource(
+        firstTransform,
+        "removedClass"
+      );
+      expect(removedClassName).not.toBe(currentClassName);
+      const firstVirtualCss = await harness.load(resolvedVirtualId);
+      assertString(
+        firstVirtualCss,
+        "Expected first repeated transform virtual CSS to load"
+      );
+
+      expect(registrySpy).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          filePath: extractedId,
+          identOption: "debug",
+          serializeVirtualCssPath: expect.any(Function)
+        })
+      );
+      expect(countV3PresetArtifacts(firstTransform)).toBe(2);
+      expectSourceToContainClassNameByCacheValue(
+        firstTransform,
+        currentClassName
+      );
+      expectSourceToContainClassNameByCacheValue(
+        firstTransform,
+        removedClassName
+      );
+      expectCssSourceToContainClassNames(firstVirtualCss, currentClassName);
+      expectCssSourceToContainClassNames(firstVirtualCss, removedClassName);
+      expectSourceToOmitLegacyCaptureMarker(firstTransform);
+
+      const secondTransform = await harness.transform(
+        extractedId,
+        secondRegistrySource
+      );
+      assertString(
+        secondTransform,
+        "Expected second repeated transform to return source text"
+      );
+      const secondCurrentClassName = extractVariableStringValueFromBuildSource(
+        secondTransform,
+        "currentClass"
+      );
+      const secondVirtualCss = await harness.load(resolvedVirtualId);
+      assertString(
+        secondVirtualCss,
+        "Expected second repeated transform virtual CSS to load"
+      );
+
+      expect(registrySpy).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          filePath: extractedId,
+          identOption: "debug",
+          serializeVirtualCssPath: expect.any(Function)
+        })
+      );
+      expect(countV3PresetArtifacts(secondTransform)).toBe(1);
+      expectSourceToContainClassNameByCacheValue(
+        secondTransform,
+        secondCurrentClassName
+      );
+      expect(secondTransform).not.toContain(removedClassName);
+      expect(secondTransform).not.toContain("removedClass");
+      expect(secondTransform).not.toContain("removedPreset");
+      expectCssSourceToContainClassNames(
+        secondVirtualCss,
+        secondCurrentClassName
+      );
+      for (const removedFragmentClassName of splitClassNames(
+        removedClassName
+      )) {
+        expect(secondVirtualCss).not.toContain(`.${removedFragmentClassName}`);
+      }
+      expectSourceToOmitLegacyCaptureMarker(secondTransform);
+      expect(registrySpy).toHaveBeenCalledTimes(2);
+    });
+
     it("defineRules presets survive cross-module HMR without stale preset duplication", async () => {
       const { defineRules } = await import("@mincho-js/css");
       const integrationModule = await import("@mincho-js/integration");
-      const vanillaExtractIntegration =
-        await import("@vanilla-extract/integration");
       const fileScopeModule = await import("@vanilla-extract/css/fileScope");
 
       fileScopeModule.setFileScope("hmr-provider.css.ts");
@@ -1637,13 +1854,13 @@ if (import.meta.vitest) {
           }) as Awaited<ReturnType<typeof compile>>
       );
       vi.spyOn(
-        vanillaExtractIntegration,
-        "processVanillaFile"
+        integrationModule,
+        "processDefineRulesPresetRegistryFile"
       ).mockImplementation(
         async ({
           source,
           serializeVirtualCssPath
-        }: Parameters<typeof processVanillaFile>[0]) => {
+        }: Parameters<typeof processDefineRulesPresetRegistryFile>[0]) => {
           const providerVersion = providerVersions[providerVersionIndex];
           if (providerVersion == null) {
             throw new Error(
@@ -1662,7 +1879,7 @@ if (import.meta.vitest) {
               )
             })) ?? "";
 
-          return `${virtualImport}\n${source}`;
+          return createRegistryResult(`${virtualImport}\n${source}`);
         }
       );
 
@@ -1743,7 +1960,9 @@ if (import.meta.vitest) {
         color: "mediumseagreen",
         display: "flex"
       });
-      const seededEntryCount = Object.keys(providerV2.preset).length;
+      const providerClassNameByCache = providerV2.preset.classNameByCache;
+      const consumerClassNameByCache = consumer.preset.classNameByCache;
+      const seededEntryCount = Object.keys(providerClassNameByCache).length;
       const staleOnlyClassNames = splitClassNames(
         staleProviderClassName
       ).filter(
@@ -1752,20 +1971,22 @@ if (import.meta.vitest) {
       );
 
       expect(reusedUpdatedClassName).toBe(updatedProviderClassName);
-      expect(Object.keys(consumer.preset)).toHaveLength(seededEntryCount);
-      expect(consumer.preset).toEqual(
-        expect.objectContaining(providerV2.preset)
+      expect(Object.keys(consumerClassNameByCache)).toHaveLength(
+        seededEntryCount
+      );
+      expect(consumerClassNameByCache).toEqual(
+        expect.objectContaining(providerClassNameByCache)
       );
       for (const staleClassName of staleOnlyClassNames) {
-        expect(Object.values(consumer.preset)).not.toContain(staleClassName);
+        expect(Object.values(consumerClassNameByCache)).not.toContain(
+          staleClassName
+        );
       }
       fileScopeModule.endFileScope();
     });
 
     it("keeps dev virtual css caching and HMR bookkeeping on the local path", async () => {
       const integrationModule = await import("@mincho-js/integration");
-      const vanillaExtractIntegration =
-        await import("@vanilla-extract/integration");
       const cssSource = ".shared { color: rebeccapurple; }";
       const virtualCssId = "src/extracted_rules.css.ts.vanilla.css";
       const expectedModuleId = normalizePath(
@@ -1776,14 +1997,6 @@ if (import.meta.vitest) {
       };
       const getModuleById = vi.fn(() => hmrModule);
       const invalidateModule = vi.fn();
-      const registryQueueSpy = vi.spyOn(
-        integrationModule,
-        "runDefineRulesPresetRegistryStep"
-      );
-      const registryFileSpy = vi.spyOn(
-        integrationModule,
-        "processDefineRulesPresetRegistryFile"
-      );
 
       vi.spyOn(integrationModule, "babelTransform").mockResolvedValue({
         code: 'import "extracted_rules.css.ts";\nexport { css, shared };',
@@ -1793,24 +2006,23 @@ if (import.meta.vitest) {
         source: "compiled source",
         watchFiles: []
       } as Awaited<ReturnType<typeof compile>>);
-      vi.spyOn(
-        vanillaExtractIntegration,
-        "processVanillaFile"
-      ).mockImplementation(
-        async ({
-          serializeVirtualCssPath
-        }: Parameters<typeof processVanillaFile>[0]) => {
-          return (
-            (await serializeVirtualCssPath?.({
-              fileName: "src/extracted_rules.css.ts",
-              fileScope: {
-                filePath: "src/extracted_rules.css.ts"
-              },
-              source: cssSource
-            })) ?? ""
-          );
-        }
-      );
+      const registrySpy = vi
+        .spyOn(integrationModule, "processDefineRulesPresetRegistryFile")
+        .mockImplementation(
+          async ({
+            serializeVirtualCssPath
+          }: Parameters<typeof processDefineRulesPresetRegistryFile>[0]) => {
+            return createRegistryResult(
+              (await serializeVirtualCssPath?.({
+                fileName: "src/extracted_rules.css.ts",
+                fileScope: {
+                  filePath: "src/extracted_rules.css.ts"
+                },
+                source: cssSource
+              })) ?? ""
+            );
+          }
+        );
 
       const harness = await createViteHarness({
         configOverrides: {
@@ -1850,8 +2062,15 @@ if (import.meta.vitest) {
       expect(getModuleById).toHaveBeenCalledWith(expectedModuleId);
       expect(invalidateModule).toHaveBeenCalledWith(hmrModule);
       expect(hmrModule.lastHMRTimestamp).toBe(123);
-      expect(registryQueueSpy).not.toHaveBeenCalled();
-      expect(registryFileSpy).not.toHaveBeenCalled();
+      expect(registrySpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filePath: extractedId,
+          identOption: "debug",
+          source: "compiled source",
+          serializeVirtualCssPath: expect.any(Function)
+        })
+      );
+      expect(registrySpy).toHaveBeenCalledTimes(1);
     });
   });
 }


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->
This PR applies registry-based `defineRules` preset serialization to the Vite and Esbuild adapters and updates the shared example to consume the v3 preset artifact type.

- Update `@mincho-js/vite` to serialize `defineRules` preset artifacts from registry session data.
- Update `@mincho-js/esbuild` to use the same registry-based serialization contract.
- Align bundler-specific smoke coverage with the v3 preset artifact shape.
- Update the shared-component example preset typing for the v3 artifact contract.

After the CSS core and integration packages expose the registry/v3 contract, the bundler adapters need to consume that same contract so real Vite and Esbuild builds emit the same artifact shape as the integration fixture matrix.
The example update provides consumer-facing coverage for the new preset artifact type.

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #327
- #319 
- #315 


<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded and strengthened tests for CSS extraction, registry artifacts, HMR, and concurrent build scenarios.

* **Refactor**
  * Plugins now route extracted CSS through a unified registry flow; legacy capture markers and integration paths removed.
  * Improved build/transform cleanup, resolver/cache handling, and deterministic end-of-build behavior.

* **Examples / Types**
  * Minor signature and type-declaration adjustments and a small example update for preset exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
