### PR TITLE
Feat: CSS - Expose cx from defineRules result

### DIFF
--- a/examples/shared-component/src/index.ts
+++ b/examples/shared-component/src/index.ts
@@ -1,2 +1,2 @@
-export { css, preset } from "./preset.css.js";
+export { cx, css, preset } from "./preset.css.js";
 export { SharedExampleCard } from "./SharedExampleCard.js";

--- a/examples/shared-component/src/preset.css.ts
+++ b/examples/shared-component/src/preset.css.ts
@@ -1,6 +1,6 @@
 import { defineRules } from "@mincho-js/css";
 
-export const { css, preset } = defineRules({
+export const { cx, css, preset } = defineRules({
   debugId: "sharedPreset",
   properties: {
     background: true,
@@ -11,10 +11,13 @@ export const { css, preset } = defineRules({
   }
 });
 
-export const sharedCardClassName = css({
-  background: "rebeccapurple",
-  color: "white",
-  padding: 16,
-  borderRadius: 12,
-  display: "block"
-});
+export const sharedCardClassName = cx(
+  css({
+    background: "rebeccapurple",
+    color: "white",
+    padding: 16,
+    borderRadius: 12,
+    display: "block"
+  }),
+  "shared-card"
+);

--- a/packages/css/README.md
+++ b/packages/css/README.md
@@ -195,6 +195,31 @@ export function MyButton() {
 }
 ```
 
+### defineRules()
+
+The `defineRules()` function creates a scoped authoring API and returns `css`, `cx`, and `preset` together. The returned `cx` is the existing root `cx` from `@mincho-js/css`, so it has the same class-composition behavior as importing `cx` directly.
+
+```typescript
+import { defineRules } from "@mincho-js/css";
+
+const { css, cx } = defineRules({
+  properties: {
+    color: true,
+    padding: true
+  }
+});
+
+export const className = cx(
+  css({
+    color: "white",
+    padding: 12
+  }),
+  "external"
+);
+```
+
+Duplicate classes and conflicting utility-like classes are preserved in input order. No tailwind-merge-style conflict resolution, dedupe, or sorting is performed.
+
 ## Features
 
 Some features are already implemented in Vanilla Extract, but we're assuming a first-time reader.

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -62,6 +62,16 @@
         "default": "./dist/cjs/defineRules/createDefineRulesCssRuntime.cjs"
       }
     },
+    "./defineRules/createDefineRulesCxRuntime": {
+      "import": {
+        "types": "./dist/esm/defineRules/createDefineRulesCxRuntime.d.ts",
+        "default": "./dist/esm/defineRules/createDefineRulesCxRuntime.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/defineRules/createDefineRulesCxRuntime.d.cts",
+        "default": "./dist/cjs/defineRules/createDefineRulesCxRuntime.cjs"
+      }
+    },
     "./defineRules/registry": {
       "import": {
         "types": "./dist/esm/defineRules/registry.d.ts",

--- a/packages/css/src/classname/index.ts
+++ b/packages/css/src/classname/index.ts
@@ -1,3 +1,3 @@
 export { cx } from "./cx.js";
 
-export type { ClassValue } from "./types.js";
+export type { ClassValue, Cx } from "./types.js";

--- a/packages/css/src/classname/types.ts
+++ b/packages/css/src/classname/types.ts
@@ -73,6 +73,23 @@ export type ClassMultipleResult<T extends ClassMultipleInput> = {
   [K in keyof T]: string;
 };
 
+export interface CxWith<Input extends ClassValue> {
+  (...className: Input[]): string;
+  multiple<ClassNameMap extends Record<string, Input>>(
+    classNameMap: ClassNameMap
+  ): { [K in keyof ClassNameMap]: string };
+}
+
+export interface Cx {
+  (...inputs: ClassValue[]): string;
+  multiple<ClassNameMap extends Record<string, ClassValue>>(
+    map: ClassNameMap
+  ): { [K in keyof ClassNameMap]: string };
+  with<const Input extends ClassValue>(
+    callback?: (params: Input) => ClassValue
+  ): CxWith<Input>;
+}
+
 // == Tests ====================================================================
 // Ignore errors when compiling to CommonJS.
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/css/src/defineRules/createDefineRulesCxRuntime.ts
+++ b/packages/css/src/defineRules/createDefineRulesCxRuntime.ts
@@ -1,0 +1,3 @@
+import { cx } from "../classname/cx.js";
+
+export const createDefineRulesCxRuntime = () => cx;

--- a/packages/css/src/defineRules/index.ts
+++ b/packages/css/src/defineRules/index.ts
@@ -8,6 +8,7 @@ import {
 import type { Serializable } from "../rules/types.js";
 import { identifierName } from "../utils.js";
 import { createDefineRulesRuntime } from "./runtime.js";
+import { cx } from "../classname/cx.js";
 import type { DefineRulesRuntimeResult } from "./runtime.js";
 import type {
   DefineRulesCtx,
@@ -22,6 +23,9 @@ const DEFINE_RULES_SERIALIZED_CSS_FUNCTION_CONFIG_DIAGNOSTIC =
 const DEFINE_RULES_RUNTIME_IMPORT_PATH =
   "@mincho-js/css/defineRules/createDefineRulesCssRuntime";
 const DEFINE_RULES_RUNTIME_IMPORT_NAME = "createDefineRulesCssRuntime";
+const DEFINE_RULES_CX_RUNTIME_IMPORT_PATH =
+  "@mincho-js/css/defineRules/createDefineRulesCxRuntime";
+const DEFINE_RULES_CX_RUNTIME_IMPORT_NAME = "createDefineRulesCxRuntime";
 
 // == Define Rules =============================================================
 export function defineRules<
@@ -40,6 +44,7 @@ export function defineRules<
 
   return {
     ...result,
+    cx: addDefineRulesCxSerializer(result.cx),
     css: addFunctionSerializer(
       result.css,
       createDefineRulesSerializerRecipe(
@@ -48,6 +53,20 @@ export function defineRules<
       )
     ) as DefineRulesRuntimeResult<Properties, Shortcuts>["css"]
   };
+}
+
+function addDefineRulesCxSerializer<CxFunction extends object>(
+  cx: CxFunction
+): CxFunction {
+  if (Reflect.has(cx, "__recipe__")) {
+    return cx;
+  }
+
+  return addFunctionSerializer(cx, {
+    importPath: DEFINE_RULES_CX_RUNTIME_IMPORT_PATH,
+    importName: DEFINE_RULES_CX_RUNTIME_IMPORT_NAME,
+    args: []
+  });
 }
 
 function createDefineRulesSerializerRecipe(
@@ -134,30 +153,40 @@ if (import.meta.vitest) {
   type DefineRulesAuthoringShapeOwner = ReturnType<
     typeof createDefineRulesAuthoringShapeOwner
   >;
+  type DefineRulesAuthoringShapeBindings = Pick<
+    DefineRulesAuthoringShapeOwner,
+    "css" | "cx" | "preset"
+  >;
   type DefineRulesAuthoringShapeInput = Parameters<
     DefineRulesAuthoringShapeOwner["css"]
   >[0];
 
   function expectDefineRulesAuthoringShapeBindings(
-    bindings: Pick<DefineRulesAuthoringShapeOwner, "css" | "preset">
+    bindings: DefineRulesAuthoringShapeBindings
   ) {
     assertType<DefineRulesAuthoringShapeOwner["css"]>(bindings.css);
+    assertType<DefineRulesAuthoringShapeOwner["cx"]>(bindings.cx);
     assertType<DefineRulesPresetArtifactV3>(bindings.preset);
     assertType<DefineRulesAuthoringShapeInput>({
       color: "rebeccapurple",
       display: "flex"
     });
 
+    expect(bindings.cx).toBe(cx);
+    expect(bindings.cx.multiple).toBe(cx.multiple);
+    expect(bindings.cx.with).toBe(cx.with);
+
     expect(bindings.preset).toEqual({
       schema: "mincho.defineRulesPreset",
       version: 3,
-      classNameByCache: {}
+      classNameByCache: expect.any(Object)
     });
+    const className = bindings.css({ display: "flex" });
+
+    expect(bindings.cx(className, "external")).toBe(`${className} external`);
     expect(bindings.css.raw({ display: "flex" })).toEqual({
       display: "flex"
     });
-
-    const className = bindings.css({ display: "flex" });
 
     expect(Object.values(bindings.preset.classNameByCache)).toEqual([
       className
@@ -169,66 +198,84 @@ if (import.meta.vitest) {
       it("1. owner-object form: export const presetOwner = defineRules({...})", () => {
         const presetOwner =
           createDefineRulesAuthoringShapeOwner("ownerObjectShape");
+        const className = presetOwner.css({ display: "flex" });
 
         assertType<DefineRulesAuthoringShapeOwner>(presetOwner);
+        expect(presetOwner.cx(className, "external")).toBe(
+          `${className} external`
+        );
         expectDefineRulesAuthoringShapeBindings(presetOwner);
       });
 
-      it("2. direct destructuring form: export const { css, preset } = defineRules({...})", () => {
-        const { css, preset } = createDefineRulesAuthoringShapeOwner(
+      it("2. direct destructuring form: export const { css, cx, preset } = defineRules({...})", () => {
+        const { css, cx, preset } = createDefineRulesAuthoringShapeOwner(
           "directDestructuringShape"
         );
+        const className = css({ display: "flex" });
 
         assertType<DefineRulesAuthoringShapeOwner["css"]>(css);
+        assertType<DefineRulesAuthoringShapeOwner["cx"]>(cx);
         assertType<DefineRulesPresetArtifactV3>(preset);
-        expectDefineRulesAuthoringShapeBindings({ css, preset });
+        expect(cx(className, "external")).toBe(`${className} external`);
+        expectDefineRulesAuthoringShapeBindings({ css, cx, preset });
       });
 
-      it("3. aliased destructuring form: export const { css: sharedCss, preset: sharedPreset } = defineRules({...})", () => {
-        const { css: sharedCss, preset: sharedPreset } =
-          createDefineRulesAuthoringShapeOwner("aliasedDestructuringShape");
+      it("3. aliased destructuring form: export const { css: sharedCss, cx: compose, preset: sharedPreset } = defineRules({...})", () => {
+        const {
+          css: sharedCss,
+          cx: compose,
+          preset: sharedPreset
+        } = createDefineRulesAuthoringShapeOwner("aliasedDestructuringShape");
+        const className = sharedCss({ display: "flex" });
 
         assertType<DefineRulesAuthoringShapeOwner["css"]>(sharedCss);
+        assertType<DefineRulesAuthoringShapeOwner["cx"]>(compose);
         assertType<DefineRulesPresetArtifactV3>(sharedPreset);
+        expect(compose(className, "external")).toBe(`${className} external`);
         expectDefineRulesAuthoringShapeBindings({
           css: sharedCss,
+          cx: compose,
           preset: sharedPreset
         });
       });
 
-      it("4. owner-object member exports form: const presetOwner = defineRules({...}); export const css = presetOwner.css; export const preset = presetOwner.preset;", () => {
+      it("4. owner-object member exports form: const presetOwner = defineRules({...}); export const css = presetOwner.css; export const cx = presetOwner.cx; export const preset = presetOwner.preset;", () => {
         const presetOwner = createDefineRulesAuthoringShapeOwner(
           "ownerMemberExportsShape"
         );
         const css = presetOwner.css;
+        const compose = presetOwner.cx;
         const preset = presetOwner.preset;
 
         assertType<DefineRulesAuthoringShapeOwner["css"]>(css);
+        assertType<DefineRulesAuthoringShapeOwner["cx"]>(compose);
         assertType<DefineRulesPresetArtifactV3>(preset);
         expect(preset).toBe(presetOwner.preset);
-        expectDefineRulesAuthoringShapeBindings({ css, preset });
+        expectDefineRulesAuthoringShapeBindings({ css, cx: compose, preset });
       });
 
-      it("5. exported owner-object destructuring form: export const presetOwner = defineRules({...}); export const { css, preset } = presetOwner;", () => {
+      it("5. exported owner-object destructuring form: export const presetOwner = defineRules({...}); export const { css, cx, preset } = presetOwner;", () => {
         const presetOwner = createDefineRulesAuthoringShapeOwner(
           "exportedOwnerDestructuringShape"
         );
-        const { css, preset } = presetOwner;
+        const { css, cx: compose, preset } = presetOwner;
 
         assertType<DefineRulesAuthoringShapeOwner["css"]>(css);
+        assertType<DefineRulesAuthoringShapeOwner["cx"]>(compose);
         assertType<DefineRulesPresetArtifactV3>(preset);
         expect(preset).toBe(presetOwner.preset);
-        expectDefineRulesAuthoringShapeBindings({ css, preset });
+        expectDefineRulesAuthoringShapeBindings({ css, cx: compose, preset });
       });
 
-      it("6. local destructuring export-list form: const { css, preset } = defineRules({...}); export { css, preset };", () => {
-        const { css, preset } = createDefineRulesAuthoringShapeOwner(
+      it("6. local destructuring export-list form: const { css, cx, preset } = defineRules({...}); export { css, cx, preset };", () => {
+        const { css, cx, preset } = createDefineRulesAuthoringShapeOwner(
           "localDestructuringExportListShape"
         );
 
         assertType<DefineRulesAuthoringShapeOwner["css"]>(css);
+        assertType<DefineRulesAuthoringShapeOwner["cx"]>(cx);
         assertType<DefineRulesPresetArtifactV3>(preset);
-        expectDefineRulesAuthoringShapeBindings({ css, preset });
+        expectDefineRulesAuthoringShapeBindings({ css, cx, preset });
       });
 
       it("7. public defineRules signature accepts only config", () => {
@@ -238,6 +285,53 @@ if (import.meta.vitest) {
         };
 
         expect(assertRemovedPrivateArgument).toEqual(expect.any(Function));
+      });
+    });
+
+    describe.concurrent("DefineRules cx", () => {
+      it("preserves duplicate classes and input order", () => {
+        const owner = createDefineRulesAuthoringShapeOwner("cxNoMerge");
+
+        expect(owner.cx("a", "a")).toBe("a a");
+        expect(owner.cx("px-2", "px-4")).toBe("px-2 px-4");
+      });
+
+      it("filters falsy values like root cx", () => {
+        const owner = createDefineRulesAuthoringShapeOwner("cxFalsyFilter");
+
+        expect(owner.cx("a", false, undefined, null, "b")).toBe(
+          cx("a", false, undefined, null, "b")
+        );
+      });
+
+      it("matches root cx.multiple() output", () => {
+        const owner = createDefineRulesAuthoringShapeOwner("cxMultiple");
+        const result = owner.cx.multiple({ base: "a", active: ["a", "b"] });
+
+        expect(result).toEqual({ base: "a", active: "a b" });
+        expect(result).toEqual(cx.multiple({ base: "a", active: ["a", "b"] }));
+      });
+
+      it("supports typed constraints and runtime composition", () => {
+        type LayoutClass = "flex" | "grid" | "block";
+
+        const owner = createDefineRulesAuthoringShapeOwner("cxWith");
+        const constrained = owner.cx.with<LayoutClass>();
+
+        assertType<(...classNames: LayoutClass[]) => string>(constrained);
+        expect(constrained("flex", "grid")).toBe("flex grid");
+
+        const composed = owner.cx.with<{
+          base: string;
+          active?: string;
+        }>(({ base, active }) => [base, active && `active-${active}`]);
+
+        assertType<(params: { base: string; active?: string }) => string>(
+          composed
+        );
+        expect(composed({ base: "btn", active: "primary" })).toBe(
+          "btn active-primary"
+        );
       });
     });
 

--- a/packages/css/src/defineRules/runtime.ts
+++ b/packages/css/src/defineRules/runtime.ts
@@ -1,4 +1,6 @@
 import type { CSSProperties } from "@mincho-js/transform-to-vanilla";
+import { cx } from "../classname/cx.js";
+import type { Cx } from "../classname/index.js";
 import { registerDefineRulesRegistryInstance } from "./registry.js";
 import { createCanonicalStyleCache } from "./utils.js";
 import type {
@@ -18,6 +20,7 @@ export interface DefineRulesRuntimeResult<
   Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
 > {
   css: DefineRulesCss<DefineRulesComplexCssInput<Properties, Shortcuts>>;
+  cx: Cx;
   preset: DefineRulesPresetArtifactV3;
 }
 
@@ -99,7 +102,7 @@ export function createDefineRulesRuntime<
   const css = Object.assign(cssImpl, {
     raw: cssRaw
   }) as DefineRulesCss<CssInput>;
-  return { css, preset: presetArtifact };
+  return { css, cx, preset: presetArtifact };
 }
 
 // == Define Rules Impl ========================================================

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -59,7 +59,7 @@ export type {
   ResolveTheme
 } from "./theme/types.js";
 export { cx } from "./classname/index.js";
-export type { ClassValue } from "./classname/index.js";
+export type { ClassValue, Cx } from "./classname/index.js";
 export { defineRules } from "./defineRules/index.js";
 export type {
   DefineRulesCtx,

--- a/packages/css/vite.config.ts
+++ b/packages/css/vite.config.ts
@@ -18,6 +18,12 @@ export default (viteConfigEnv: ConfigEnv) => {
             "defineRules",
             "createDefineRulesCssRuntime.ts"
           ),
+          "defineRules/createDefineRulesCxRuntime": join(
+            packageDir,
+            "src",
+            "defineRules",
+            "createDefineRulesCxRuntime.ts"
+          ),
           "defineRules/registry": join(
             packageDir,
             "src",

--- a/packages/integration/src/defineRulesPreset.ts
+++ b/packages/integration/src/defineRulesPreset.ts
@@ -400,6 +400,52 @@ if (import.meta.vitest) {
     expect(normalizedSource).toContain("classNameByCache:{");
   }
 
+  function expectSerializedPresetArtifactsToOmitCx(
+    source: string,
+    registrySession: DefineRulesRegistrySession
+  ): void {
+    const normalizedSource = normalizeSource(source);
+    const artifactMatches = Array.from(
+      normalizedSource.matchAll(/\{schema:["']mincho\.defineRulesPreset["']/g)
+    );
+
+    expect(artifactMatches).toHaveLength(registrySession.instances.length);
+    for (const artifactMatch of artifactMatches) {
+      let depth = 0;
+      let artifactEndIndex = artifactMatch.index;
+      for (
+        let index = artifactMatch.index;
+        index < normalizedSource.length;
+        index += 1
+      ) {
+        const character = normalizedSource[index];
+        if (character === "{") {
+          depth += 1;
+        }
+        if (character === "}") {
+          depth -= 1;
+          if (depth === 0) {
+            artifactEndIndex = index + 1;
+            break;
+          }
+        }
+      }
+      const artifactSource = normalizedSource.slice(
+        artifactMatch.index,
+        artifactEndIndex
+      );
+
+      expect(artifactSource).toContain("version:3");
+      expect(artifactSource).toContain("classNameByCache:{");
+      expect(artifactSource).not.toContain("cx:");
+      expect(artifactSource).not.toContain('"cx":');
+      expect(artifactSource).not.toContain("'cx':");
+    }
+    for (const instance of registrySession.instances) {
+      expect(Object.hasOwn(instance.presetArtifact, "cx")).toBe(false);
+    }
+  }
+
   function countV3PresetArtifacts(source: string): number {
     return Array.from(
       normalizeSource(source).matchAll(
@@ -685,6 +731,75 @@ if (import.meta.vitest) {
 
       expect(functionConfigResult.registrySession.instances).toHaveLength(0);
 
+      expect(getActiveDefineRulesRegistrySession()).toBe(undefined);
+    });
+
+    it("serializes owner-object defineRules css calls composed with returned cx", async () => {
+      const { source, registrySession, emittedCss } =
+        await processRegistryFixture(
+          `
+          import { defineRules } from "@mincho-js/css";
+
+          const owner = defineRules({
+            debugId: "owner-returned-cx",
+            properties: {
+              color: true
+            }
+          });
+          export const ownerClassName = owner.cx(owner.css({ color: "hotpink" }), "owner-external");
+          export const ownerPreset = owner.preset;
+        `,
+          "owner-returned-cx"
+        );
+      const [ownerInstance] = registrySession.instances;
+      const ownerClassNames = getRegistryInstanceClassNames(ownerInstance);
+
+      expect(registrySession.instances).toHaveLength(1);
+      expectSourceToContainV3PresetArtifact(source);
+      expectSerializedPresetArtifactsToOmitCx(source, registrySession);
+      expectRegistryInstancesToHaveClassNameByCache(registrySession);
+      expect(ownerClassNames).toHaveLength(1);
+      expect(source).toContain(
+        `ownerClassName = '${ownerClassNames[0]} owner-external'`
+      );
+      expect(source).toContain("owner-external");
+      expect(source).toContain(ownerClassNames[0]!);
+      expect(emittedCss).toMatch(/color:\s*hotpink/);
+      expect(getActiveDefineRulesRegistrySession()).toBe(undefined);
+    });
+
+    it("serializes destructured defineRules css calls composed with returned cx", async () => {
+      const { source, registrySession, emittedCss } =
+        await processRegistryFixture(
+          `
+          import { defineRules } from "@mincho-js/css";
+
+          const { css, cx, preset } = defineRules({
+            debugId: "destructured-returned-cx",
+            properties: {
+              display: true
+            }
+          });
+          export const destructuredClassName = cx(css({ display: "flex" }), "destructured-external");
+          export const destructuredPreset = preset;
+        `,
+          "destructured-returned-cx"
+        );
+      const [destructuredInstance] = registrySession.instances;
+      const destructuredClassNames =
+        getRegistryInstanceClassNames(destructuredInstance);
+
+      expect(registrySession.instances).toHaveLength(1);
+      expectSourceToContainV3PresetArtifact(source);
+      expectSerializedPresetArtifactsToOmitCx(source, registrySession);
+      expectRegistryInstancesToHaveClassNameByCache(registrySession);
+      expect(destructuredClassNames).toHaveLength(1);
+      expect(source).toContain(
+        `destructuredClassName = '${destructuredClassNames[0]} destructured-external'`
+      );
+      expect(source).toContain("destructured-external");
+      expect(source).toContain(destructuredClassNames[0]!);
+      expect(emittedCss).toMatch(/display:\s*flex/);
       expect(getActiveDefineRulesRegistrySession()).toBe(undefined);
     });
 


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->
Export `cx` from defineRules


## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #334

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `cx` function now exported from `defineRules()`, enabling composition of generated CSS classes with static class names.

* **Documentation**
  * Updated documentation with examples and guidance for using `cx` with `defineRules()`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
