### PR TITLE
Feat: CSS - Add defineRules condition metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup
         uses: ./.github/actions/node-setup
@@ -41,9 +43,6 @@ jobs:
 
       - name: Check package consistency
         run: yarn constraints
-
-      - name: Check package audit
-        run: yarn npm audit --all
 
       - name: Project Reference Check
         run: yarn sync:check

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,26 @@
+name: Dependency Audit
+
+on:
+  schedule:
+    # Cron format: minute hour day-of-month month day-of-week (UTC).
+    # every Saturday at 01:00 UTC.
+    - cron: "0 1 * * 6"
+  workflow_dispatch: {}
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup
+        uses: ./.github/actions/node-setup
+
+      - name: Check package audit
+        run: yarn npm audit --all

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -20,12 +20,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - name: Setup
         uses: ./.github/actions/node-setup
         with:
           strict: false
+
       - name: Build site
         run: yarn workspace mincho-docs build
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -106,6 +106,7 @@
     "build": "yarn g:build",
     "build:watch": "yarn g:build-watch",
     "test": "yarn g:test",
+    "bench": "yarn run -T vitest bench",
     "test:watch": "yarn g:test-watch",
     "lint": "yarn g:lint",
     "fix": "yarn g:fix",

--- a/packages/css/src/defineRules/conditions.ts
+++ b/packages/css/src/defineRules/conditions.ts
@@ -1,0 +1,208 @@
+export type DefineRulesConditionObject = {
+  "@layer"?: string;
+  "@supports"?: string;
+  "@media"?: string;
+  "@container"?: string;
+  selector?: string;
+};
+
+export interface NormalizedCondition {
+  layer: string | null;
+  supports: string | null;
+  media: string | null;
+  container: string | null;
+  selector: string;
+}
+
+export type DefineRulesCondition = string | DefineRulesConditionObject;
+
+export type DefineRulesConditions = Record<string, DefineRulesCondition>;
+export type ConditionAliasValue = string | DefineRulesConditionObject;
+export type ConditionAliasMap = Record<`_${string}`, ConditionAliasValue>;
+
+export type DefineRulesConditionAliasKey<
+  Conditions extends DefineRulesConditions
+> = `_${Extract<keyof Conditions, string>}`;
+
+const CONDITION_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9]*$/;
+const MEDIA_PREFIX_PATTERN = /^@media\s+/;
+const ALLOWED_CONDITION_KEYS = new Set([
+  "@layer",
+  "@supports",
+  "@media",
+  "@container",
+  "selector"
+]);
+const RESERVED_CONDITION_ALIASES = new Set([
+  "_hover",
+  "__before",
+  "_media",
+  "_supports",
+  "_container",
+  "_layer",
+  "_selector",
+  "_base"
+]);
+
+export function normalizeDefineRulesConditions(
+  conditions: DefineRulesConditions | undefined
+): ConditionAliasMap {
+  if (conditions == null) {
+    return {};
+  }
+
+  const normalized: ConditionAliasMap = {};
+
+  for (const [name, value] of Object.entries(conditions)) {
+    validateDefineRulesConditionName(name);
+    normalized[`_${name}`] = normalizeDefineRulesConditionValue(value, name);
+  }
+
+  return normalized;
+}
+
+export function validateDefineRulesConditionName(name: string): void {
+  const alias = `_${name}`;
+
+  if (!CONDITION_NAME_PATTERN.test(name)) {
+    throw new Error(
+      `Invalid defineRules condition name "${name}". Condition names must match ${CONDITION_NAME_PATTERN}.`
+    );
+  }
+
+  if (RESERVED_CONDITION_ALIASES.has(alias)) {
+    throw new Error(`Reserved defineRules condition alias "${alias}".`);
+  }
+}
+
+export function normalizeDefineRulesConditionValue(
+  value: DefineRulesCondition,
+  name = "<condition>"
+): ConditionAliasValue {
+  if (typeof value === "string") {
+    return normalizeMediaQuery(value);
+  }
+
+  if (!isPlainRecordObject(value)) {
+    throw new Error(`Unsupported defineRules condition value for "${name}".`);
+  }
+
+  const condition: DefineRulesConditionObject = {};
+
+  for (const [key, entry] of Object.entries(value)) {
+    if (!ALLOWED_CONDITION_KEYS.has(key)) {
+      throw new Error(
+        `Unsupported defineRules condition key "${key}" for "${name}".`
+      );
+    }
+
+    if (typeof entry !== "string") {
+      throw new Error(
+        `Unsupported defineRules condition value at "${name}.${key}".`
+      );
+    }
+
+    condition[key as keyof DefineRulesConditionObject] =
+      key === "@media" ? normalizeMediaQuery(entry) : entry;
+  }
+
+  return condition;
+}
+
+function normalizeMediaQuery(query: string): string {
+  return query.replace(MEDIA_PREFIX_PATTERN, "");
+}
+
+function isPlainRecordObject(value: unknown): value is Record<string, unknown> {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+// == Tests ====================================================================
+// Ignore errors when compiling to CommonJS.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+  const { describe, it, expect } = import.meta.vitest;
+
+  describe.concurrent("defineRules conditions", () => {
+    it("normalizes base, string, prefixed string, and object condition configs", () => {
+      expect(
+        normalizeDefineRulesConditions({
+          mobile: {},
+          tablet: "screen and (min-width: 768px)",
+          desktop: "@media screen and (min-width: 1024px)",
+          grid: {
+            "@supports": "(display: grid)",
+            "@media": "@media screen and (min-width: 1280px)"
+          }
+        })
+      ).toEqual({
+        _mobile: {},
+        _tablet: "screen and (min-width: 768px)",
+        _desktop: "screen and (min-width: 1024px)",
+        _grid: {
+          "@supports": "(display: grid)",
+          "@media": "screen and (min-width: 1280px)"
+        }
+      });
+    });
+
+    it("canonicalizes string and object media condition configs", () => {
+      expect(
+        normalizeDefineRulesConditionValue(
+          "@media screen and (min-width: 768px)",
+          "tablet"
+        )
+      ).toBe("screen and (min-width: 768px)");
+      expect(
+        normalizeDefineRulesConditionValue(
+          {
+            "@media": "@media screen and (min-width: 768px)"
+          },
+          "tablet"
+        )
+      ).toEqual({
+        "@media": "screen and (min-width: 768px)"
+      });
+    });
+
+    it("rejects invalid bare condition names", () => {
+      expect(() => validateDefineRulesConditionName("_mobile")).toThrow(
+        'Invalid defineRules condition name "_mobile"'
+      );
+      expect(() => validateDefineRulesConditionName("@mobile")).toThrow(
+        'Invalid defineRules condition name "@mobile"'
+      );
+    });
+
+    it("rejects reserved aliases", () => {
+      expect(() => validateDefineRulesConditionName("hover")).toThrow(
+        'Reserved defineRules condition alias "_hover"'
+      );
+      expect(() => validateDefineRulesConditionName("media")).toThrow(
+        'Reserved defineRules condition alias "_media"'
+      );
+      expect(() => validateDefineRulesConditionName("base")).toThrow(
+        'Reserved defineRules condition alias "_base"'
+      );
+    });
+
+    it("rejects invalid condition object keys", () => {
+      expect(() =>
+        normalizeDefineRulesConditionValue(
+          {
+            unknown: "value"
+          } as never,
+          "mobile"
+        )
+      ).toThrow('Unsupported defineRules condition key "unknown"');
+    });
+  });
+}

--- a/packages/css/src/defineRules/createDefineRulesCssRuntime.ts
+++ b/packages/css/src/defineRules/createDefineRulesCssRuntime.ts
@@ -1,7 +1,7 @@
 import type {
   DefineRulesConditions,
-  DefineRulesCtx,
   DefineRulesEmptyConditions,
+  DefineRulesCtx,
   DefineRulesProperties,
   DefineRulesShortcuts
 } from "./types.js";

--- a/packages/css/src/defineRules/createDefineRulesCssRuntime.ts
+++ b/packages/css/src/defineRules/createDefineRulesCssRuntime.ts
@@ -1,5 +1,7 @@
 import type {
+  DefineRulesConditions,
   DefineRulesCtx,
+  DefineRulesEmptyConditions,
   DefineRulesProperties,
   DefineRulesShortcuts
 } from "./types.js";
@@ -7,9 +9,14 @@ import { createDefineRulesRuntime } from "./runtime.js";
 
 export const createDefineRulesCssRuntime = <
   const Properties extends DefineRulesProperties,
-  const Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
+  const Shortcuts extends DefineRulesShortcuts<
+    Properties,
+    Shortcuts,
+    Conditions
+  >,
+  const Conditions extends DefineRulesConditions = DefineRulesEmptyConditions
 >(
-  config: DefineRulesCtx<Properties, Shortcuts>
+  config: DefineRulesCtx<Properties, Shortcuts, Conditions>
 ) => {
   return createDefineRulesRuntime(config, {
     preservePresetReference: true

--- a/packages/css/src/defineRules/createDefineRulesCxRuntime.ts
+++ b/packages/css/src/defineRules/createDefineRulesCxRuntime.ts
@@ -1,3 +1,24 @@
-import { cx } from "../classname/cx.js";
+import type {
+  DefineRulesConditions,
+  DefineRulesEmptyConditions,
+  DefineRulesCtx,
+  DefineRulesProperties,
+  DefineRulesShortcuts
+} from "./types.js";
+import { createDefineRulesRuntime } from "./runtime.js";
 
-export const createDefineRulesCxRuntime = () => cx;
+export const createDefineRulesCxRuntime = <
+  const Properties extends DefineRulesProperties,
+  const Shortcuts extends DefineRulesShortcuts<
+    Properties,
+    Shortcuts,
+    Conditions
+  >,
+  const Conditions extends DefineRulesConditions = DefineRulesEmptyConditions
+>(
+  config: DefineRulesCtx<Properties, Shortcuts, Conditions>
+) => {
+  return createDefineRulesRuntime(config, {
+    preservePresetReference: true
+  }).cx;
+};

--- a/packages/css/src/defineRules/index.ts
+++ b/packages/css/src/defineRules/index.ts
@@ -10,18 +10,21 @@ import { identifierName } from "../utils.js";
 import { createDefineRulesRuntime } from "./runtime.js";
 import { cx } from "../classname/cx.js";
 import type { DefineRulesRuntimeResult } from "./runtime.js";
+import {
+  normalizeDefineRulesConditions,
+  normalizeDefineRulesConditionValue
+} from "./conditions.js";
 import type {
   DefineRulesCtx,
+  DefineRulesPresetArtifactV4,
   DefineRulesConditions,
   DefineRulesEmptyConditions,
-  DefineRulesPresetArtifactV3,
-  DefineRulesPresetInput,
   DefineRulesProperties,
   DefineRulesShortcuts
 } from "./types.js";
 
 const DEFINE_RULES_SERIALIZED_CSS_FUNCTION_CONFIG_DIAGNOSTIC =
-  "defineRules serialized css does not support function-valued properties or shortcuts";
+  "defineRules serialized css does not support function-valued conditions, properties, or shortcuts";
 const DEFINE_RULES_RUNTIME_IMPORT_PATH =
   "@mincho-js/css/defineRules/createDefineRulesCssRuntime";
 const DEFINE_RULES_RUNTIME_IMPORT_NAME = "createDefineRulesCssRuntime";
@@ -51,11 +54,17 @@ export function defineRules<
 
   return {
     ...result,
-    cx: addDefineRulesCxSerializer(result.cx),
+    cx: addDefineRulesCxSerializer(
+      result.cx,
+      createDefineRulesCxSerializerRecipe(
+        serializedConfig as unknown as Serializable,
+        functionValuedConfigPath
+      )
+    ),
     css: addFunctionSerializer(
       result.css,
       createDefineRulesSerializerRecipe(
-        serializedConfig as Serializable,
+        serializedConfig as unknown as Serializable,
         functionValuedConfigPath
       )
     ) as DefineRulesRuntimeResult<Properties, Shortcuts, Conditions>["css"]
@@ -63,17 +72,37 @@ export function defineRules<
 }
 
 function addDefineRulesCxSerializer<CxFunction extends object>(
-  cx: CxFunction
+  cx: CxFunction,
+  recipe: Parameters<typeof addFunctionSerializer>[1]
 ): CxFunction {
   if (Reflect.has(cx, "__recipe__")) {
     return cx;
   }
 
-  return addFunctionSerializer(cx, {
+  return addFunctionSerializer(cx, recipe);
+}
+
+function createDefineRulesCxSerializerRecipe(
+  serializedConfig: Serializable,
+  functionValuedConfigPath: string | undefined
+): Parameters<typeof addFunctionSerializer>[1] {
+  if (functionValuedConfigPath != null) {
+    return {
+      importPath: DEFINE_RULES_CX_RUNTIME_IMPORT_PATH,
+      importName: DEFINE_RULES_CX_RUNTIME_IMPORT_NAME,
+      get args(): ReadonlyArray<Serializable> {
+        throw new Error(
+          createFunctionValuedConfigDiagnostic(functionValuedConfigPath)
+        );
+      }
+    };
+  }
+
+  return {
     importPath: DEFINE_RULES_CX_RUNTIME_IMPORT_PATH,
     importName: DEFINE_RULES_CX_RUNTIME_IMPORT_NAME,
-    args: []
-  });
+    args: [serializedConfig]
+  };
 }
 
 function createDefineRulesSerializerRecipe(
@@ -104,30 +133,65 @@ function createFunctionValuedConfigDiagnostic(configPath: string): string {
 }
 
 function getFunctionValuedDefineRulesConfigPath(config: {
+  conditions?: object;
   properties?: object;
   shortcuts?: object;
 }): string | undefined {
   return (
+    getFunctionValuedEntriesPath(config.conditions, "config.conditions") ??
     getFunctionValuedEntriesPath(config.properties, "config.properties") ??
     getFunctionValuedEntriesPath(config.shortcuts, "config.shortcuts")
   );
 }
 
 function getFunctionValuedEntriesPath(
-  entries: object | undefined,
-  path: string
+  entry: unknown,
+  path: string,
+  seenEntries: WeakSet<object> = new WeakSet()
 ): string | undefined {
-  if (entries == null) {
+  if (typeof entry === "function") {
+    return path;
+  }
+
+  if (entry == null || typeof entry !== "object") {
     return undefined;
   }
 
-  for (const [key, entry] of Object.entries(entries)) {
-    if (typeof entry === "function") {
-      return `${path}.${key}`;
+  if (seenEntries.has(entry)) {
+    return undefined;
+  }
+  seenEntries.add(entry);
+
+  if (Array.isArray(entry)) {
+    for (let index = 0; index < entry.length; index += 1) {
+      const nestedPath = getFunctionValuedEntriesPath(
+        entry[index],
+        `${path}[${index}]`,
+        seenEntries
+      );
+      if (nestedPath != null) return nestedPath;
     }
+    return undefined;
+  }
+
+  for (const [key, value] of Object.entries(entry)) {
+    const nestedPath = getFunctionValuedEntriesPath(
+      value,
+      `${path}${formatConfigPathSegment(key)}`,
+      seenEntries
+    );
+    if (nestedPath != null) return nestedPath;
   }
 
   return undefined;
+}
+
+function formatConfigPathSegment(key: string): string {
+  if (/^[A-Za-z_$][\w$]*$/.test(key)) {
+    return `.${key}`;
+  }
+
+  return `[${JSON.stringify(key)}]`;
 }
 
 // == Tests ====================================================================
@@ -173,21 +237,25 @@ if (import.meta.vitest) {
   ) {
     assertType<DefineRulesAuthoringShapeOwner["css"]>(bindings.css);
     assertType<DefineRulesAuthoringShapeOwner["cx"]>(bindings.cx);
-    assertType<DefineRulesPresetArtifactV3>(bindings.preset);
+    assertType<DefineRulesPresetArtifactV4>(bindings.preset);
     assertType<DefineRulesAuthoringShapeInput>({
       color: "rebeccapurple",
       display: "flex"
     });
 
-    expect(bindings.cx).toBe(cx);
-    expect(bindings.cx.multiple).toBe(cx.multiple);
-    expect(bindings.cx.with).toBe(cx.with);
-
     expect(bindings.preset).toEqual({
       schema: "mincho.defineRulesPreset",
-      version: 3,
-      classNameByCache: expect.any(Object)
+      version: 4,
+      classNameByCache: expect.any(Object),
+      writeKeyByCacheKey: expect.any(Object),
+      conditionById: expect.any(Object),
+      propertyById: expect.any(Object),
+      writeKeyById: expect.any(Object)
     });
+    expect(bindings.cx).not.toBe(cx);
+    expect(bindings.cx("external external", "external")).toBe(
+      cx("external external", "external")
+    );
     const className = bindings.css({ display: "flex" });
 
     expect(bindings.cx(className, "external")).toBe(`${className} external`);
@@ -222,7 +290,7 @@ if (import.meta.vitest) {
 
         assertType<DefineRulesAuthoringShapeOwner["css"]>(css);
         assertType<DefineRulesAuthoringShapeOwner["cx"]>(cx);
-        assertType<DefineRulesPresetArtifactV3>(preset);
+        assertType<DefineRulesPresetArtifactV4>(preset);
         expect(cx(className, "external")).toBe(`${className} external`);
         expectDefineRulesAuthoringShapeBindings({ css, cx, preset });
       });
@@ -237,7 +305,7 @@ if (import.meta.vitest) {
 
         assertType<DefineRulesAuthoringShapeOwner["css"]>(sharedCss);
         assertType<DefineRulesAuthoringShapeOwner["cx"]>(compose);
-        assertType<DefineRulesPresetArtifactV3>(sharedPreset);
+        assertType<DefineRulesPresetArtifactV4>(sharedPreset);
         expect(compose(className, "external")).toBe(`${className} external`);
         expectDefineRulesAuthoringShapeBindings({
           css: sharedCss,
@@ -256,7 +324,7 @@ if (import.meta.vitest) {
 
         assertType<DefineRulesAuthoringShapeOwner["css"]>(css);
         assertType<DefineRulesAuthoringShapeOwner["cx"]>(compose);
-        assertType<DefineRulesPresetArtifactV3>(preset);
+        assertType<DefineRulesPresetArtifactV4>(preset);
         expect(preset).toBe(presetOwner.preset);
         expectDefineRulesAuthoringShapeBindings({ css, cx: compose, preset });
       });
@@ -269,7 +337,7 @@ if (import.meta.vitest) {
 
         assertType<DefineRulesAuthoringShapeOwner["css"]>(css);
         assertType<DefineRulesAuthoringShapeOwner["cx"]>(compose);
-        assertType<DefineRulesPresetArtifactV3>(preset);
+        assertType<DefineRulesPresetArtifactV4>(preset);
         expect(preset).toBe(presetOwner.preset);
         expectDefineRulesAuthoringShapeBindings({ css, cx: compose, preset });
       });
@@ -281,7 +349,7 @@ if (import.meta.vitest) {
 
         assertType<DefineRulesAuthoringShapeOwner["css"]>(css);
         assertType<DefineRulesAuthoringShapeOwner["cx"]>(cx);
-        assertType<DefineRulesPresetArtifactV3>(preset);
+        assertType<DefineRulesPresetArtifactV4>(preset);
         expectDefineRulesAuthoringShapeBindings({ css, cx, preset });
       });
 
@@ -295,12 +363,283 @@ if (import.meta.vitest) {
       });
     });
 
-    describe.concurrent("DefineRules cx", () => {
-      it("preserves duplicate classes and input order", () => {
-        const owner = createDefineRulesAuthoringShapeOwner("cxNoMerge");
+    describe.concurrent("DefineRules Conditions", () => {
+      const createConditionConfigCase =
+        (conditions: DefineRulesConditions) => () =>
+          createDefineRulesRuntime({
+            conditions,
+            properties: {
+              color: true
+            }
+          });
 
-        expect(owner.cx("a", "a")).toBe("a a");
-        expect(owner.cx("px-2", "px-4")).toBe("px-2 px-4");
+      it("validates configured condition aliases without runtime condition emission", () => {
+        const { css } = defineRules({
+          conditions: {
+            mobile: {},
+            tablet: "@media screen and (min-width: 768px)",
+            desktop: {
+              "@media": "screen and (min-width: 1024px)"
+            },
+            supportsGrid: {
+              "@supports": "(display: grid)"
+            }
+          },
+          properties: {
+            color: true,
+            display: ["none", "flex"]
+          }
+        });
+
+        expect(
+          css.raw({
+            color: "red",
+            display: "flex"
+          })
+        ).toEqual({
+          color: "red",
+          display: "flex"
+        });
+      });
+
+      it("returns nested raw rules and condition metadata for configured aliases", () => {
+        const { css, preset } = defineRules({
+          debugId: "conditionalRuntime",
+          conditions: {
+            tablet: "@media screen and (min-width: 768px)",
+            supportsGrid: {
+              "@supports": "(display: grid)",
+              selector: "&[data-grid]"
+            },
+            containerLayer: {
+              "@layer": "components",
+              "@container": "(min-width: 32rem)"
+            }
+          },
+          properties: {
+            color: true,
+            display: true,
+            fontSize: true
+          }
+        });
+
+        const input = {
+          color: {
+            base: "red",
+            _tablet: "blue"
+          },
+          _tablet: {
+            display: "flex"
+          },
+          _supportsGrid: {
+            fontSize: 16
+          },
+          _containerLayer: {
+            color: "green"
+          }
+        } as const;
+
+        const className = css(input);
+
+        expect(css.raw(input)).toEqual({
+          color: "red",
+          "@media": {
+            "screen and (min-width: 768px)": {
+              color: "blue",
+              display: "flex"
+            }
+          },
+          "@supports": {
+            "(display: grid)": {
+              selectors: {
+                "&[data-grid]": {
+                  fontSize: 16
+                }
+              }
+            }
+          },
+          "@layer": {
+            components: {
+              "@container": {
+                "(min-width: 32rem)": {
+                  color: "green"
+                }
+              }
+            }
+          }
+        });
+        expect(className.split(" ")).toHaveLength(5);
+        expect(Object.values(preset.conditionById)).toEqual(
+          expect.arrayContaining([
+            {
+              layer: null,
+              supports: null,
+              media: "screen and (min-width: 768px)",
+              container: null,
+              selector: "&"
+            },
+            {
+              layer: null,
+              supports: "(display: grid)",
+              media: null,
+              container: null,
+              selector: "&[data-grid]"
+            },
+            {
+              layer: "components",
+              supports: null,
+              media: null,
+              container: "(min-width: 32rem)",
+              selector: "&"
+            }
+          ])
+        );
+        expect(Object.values(preset.propertyById)).toEqual(
+          expect.arrayContaining(["color", "display", "fontSize"])
+        );
+      });
+
+      it("normalizes empty object conditions to the transform base alias value", () => {
+        expect(
+          normalizeDefineRulesConditions({
+            mobile: {}
+          })
+        ).toEqual({
+          _mobile: {}
+        });
+      });
+
+      it("canonicalizes string and object media condition configs", () => {
+        expect(
+          normalizeDefineRulesConditionValue(
+            "@media screen and (min-width: 768px)",
+            "tablet"
+          )
+        ).toBe("screen and (min-width: 768px)");
+        expect(
+          normalizeDefineRulesConditionValue(
+            {
+              "@media": "@media screen and (min-width: 768px)"
+            },
+            "tablet"
+          )
+        ).toEqual({
+          "@media": "screen and (min-width: 768px)"
+        });
+      });
+
+      it("throws clear runtime diagnostics for invalid and reserved condition names", () => {
+        expect(createConditionConfigCase({ hover: {} })).toThrow(
+          'Reserved defineRules condition alias "_hover"'
+        );
+        expect(createConditionConfigCase({ media: {} })).toThrow(
+          'Reserved defineRules condition alias "_media"'
+        );
+        expect(createConditionConfigCase({ _mobile: {} })).toThrow(
+          'Invalid defineRules condition name "_mobile"'
+        );
+        expect(createConditionConfigCase({ "@mobile": {} })).toThrow(
+          'Invalid defineRules condition name "@mobile"'
+        );
+      });
+
+      it("throws clear runtime diagnostics for invalid condition object keys", () => {
+        expect(
+          createConditionConfigCase({
+            mobile: {
+              unknown: "x"
+            } as never
+          })
+        ).toThrow('Unsupported defineRules condition key "unknown"');
+      });
+    });
+
+    describe.concurrent("DefineRules cx", () => {
+      it("keeps only the later known class for the same condition and property", () => {
+        const { css, cx: scopedCx } = defineRules({
+          debugId: "cxSameConditionProperty",
+          conditions: {
+            desktop: {
+              "@media": "screen and (min-width: 1024px)"
+            }
+          },
+          properties: {
+            color: true
+          }
+        });
+        const desktopPrimary = css({ _desktop: { color: "primary" } });
+        const desktopInverse = css({ _desktop: { color: "inverse" } });
+
+        expect(scopedCx(desktopPrimary, desktopInverse)).toBe(desktopInverse);
+      });
+
+      it("keeps known classes for different conditions", () => {
+        const { css, cx: scopedCx } = defineRules({
+          debugId: "cxDifferentConditions",
+          conditions: {
+            mobile: {},
+            desktop: {
+              "@media": "screen and (min-width: 1024px)"
+            }
+          },
+          properties: {
+            color: true
+          }
+        });
+        const mobileMuted = css({ _mobile: { color: "muted" } });
+        const desktopInverse = css({ _desktop: { color: "inverse" } });
+
+        expect(scopedCx(mobileMuted, desktopInverse)).toBe(
+          `${mobileMuted} ${desktopInverse}`
+        );
+      });
+
+      it("preserves unknown duplicate strings in order around known classes", () => {
+        const owner = defineRules({
+          debugId: "cxUnknownDuplicateOrder",
+          properties: {
+            color: true
+          }
+        });
+        const colorRed = owner.css({ color: "red" });
+
+        expect(owner.cx("external external", colorRed, "external")).toBe(
+          `external external ${colorRed} external`
+        );
+      });
+
+      it("keeps unknown-only output compatible while returning a scoped cx", () => {
+        const owner = createDefineRulesAuthoringShapeOwner("cxScopedIdentity");
+
+        expect(owner.cx).not.toBe(cx);
+        expect(owner.cx("external", ["external"], { active: true })).toBe(
+          cx("external", ["external"], { active: true })
+        );
+      });
+
+      it("uses hydrated write-key metadata to merge known atomic classes", () => {
+        const provider = defineRules({
+          debugId: "cxProvider",
+          properties: {
+            color: true,
+            background: true
+          }
+        });
+        const providerColor = provider.css({ color: "red" });
+        const providerBackground = provider.css({ background: "blue" });
+        const consumer = defineRules({
+          debugId: "cxConsumer",
+          presets: provider.preset,
+          properties: {
+            color: true,
+            background: true
+          }
+        });
+
+        expect(consumer.cx(providerColor, providerColor)).toBe(providerColor);
+        expect(
+          consumer.cx(providerColor, providerBackground, providerColor)
+        ).toBe(`${providerBackground} ${providerColor}`);
       });
 
       it("filters falsy values like root cx", () => {
@@ -311,12 +650,69 @@ if (import.meta.vitest) {
         );
       });
 
-      it("matches root cx.multiple() output", () => {
+      it("merges known atomic classes in cx.multiple()", () => {
         const owner = createDefineRulesAuthoringShapeOwner("cxMultiple");
-        const result = owner.cx.multiple({ base: "a", active: ["a", "b"] });
+        const displayNone = owner.css({ display: "none" });
+        const displayFlex = owner.css({ display: "flex" });
+        const result = owner.cx.multiple({
+          base: displayNone,
+          active: [displayNone, displayFlex]
+        });
 
-        expect(result).toEqual({ base: "a", active: "a b" });
-        expect(result).toEqual(cx.multiple({ base: "a", active: ["a", "b"] }));
+        expect(result).toEqual({ base: displayNone, active: displayFlex });
+      });
+
+      it("merges known atomic classes through cx.with() and with().multiple()", () => {
+        const owner = createDefineRulesAuthoringShapeOwner("cxWithKnownMerge");
+        const displayNone = owner.css({ display: "none" });
+        const displayFlex = owner.css({ display: "flex" });
+        const composed = owner.cx.with<{
+          base: string;
+          override?: string;
+        }>(({ base, override }) => [base, override]);
+
+        expect(composed({ base: displayNone, override: displayFlex })).toBe(
+          displayFlex
+        );
+        expect(
+          composed.multiple({
+            inactive: { base: displayNone },
+            active: { base: displayNone, override: displayFlex }
+          })
+        ).toEqual({ inactive: displayNone, active: displayFlex });
+      });
+
+      it("preserves repeated full cx inputs while using the private full-result cache", () => {
+        const owner = defineRules({
+          debugId: "cxRepeatedFullInput",
+          properties: {
+            background: true,
+            color: true
+          }
+        });
+        const colorRed = owner.css({ color: "red" });
+        const colorBlue = owner.css({ color: "blue" });
+        const backgroundBlue = owner.css({ background: "blue" });
+        const expected = `external external ${backgroundBlue} ${colorBlue} external`;
+
+        expect(
+          owner.cx(
+            "external external",
+            colorRed,
+            backgroundBlue,
+            colorBlue,
+            "external"
+          )
+        ).toBe(expected);
+        expect(
+          owner.cx(
+            "external external",
+            colorRed,
+            backgroundBlue,
+            colorBlue,
+            "external"
+          )
+        ).toBe(expected);
       });
 
       it("supports typed constraints and runtime composition", () => {
@@ -343,7 +739,7 @@ if (import.meta.vitest) {
     });
 
     describe("DefineRules Registry", () => {
-      it("registers live v3 preset artifacts with deferred snapshots", () => {
+      it("registers live v4 preset artifacts with deferred snapshots", () => {
         const session = beginDefineRulesRegistrySession();
 
         try {
@@ -386,13 +782,13 @@ if (import.meta.vitest) {
           expect(session.instances[1]?.presetArtifact).toBe(middle.preset);
           expect(session.instances[2]?.presetArtifact).toBe(consumer.preset);
           expect(session.instances[0]?.getPresetSnapshot()).toEqual(
-            provider.preset.classNameByCache
+            provider.preset
           );
           expect(session.instances[1]?.getPresetSnapshot()).toEqual(
-            middle.preset.classNameByCache
+            middle.preset
           );
           expect(session.instances[2]?.getPresetSnapshot()).toEqual(
-            consumer.preset.classNameByCache
+            consumer.preset
           );
           expect(Object.values(provider.preset.classNameByCache)).toEqual([
             providerColor
@@ -409,45 +805,41 @@ if (import.meta.vitest) {
 
         expect(getActiveDefineRulesRegistrySession()).toBe(undefined);
       });
-
-      it("does not register function-valued configs into registry sessions", () => {
-        type DefineRulesRecipe = {
-          args?: unknown[];
-        };
-        const session = beginDefineRulesRegistrySession();
-
-        try {
-          const { css } = defineRules({
-            debugId: "functionConfigNotRegistered",
-            properties: {
-              color(value: string) {
-                return value;
-              }
-            }
-          });
-          const recipe = (
-            css as unknown as {
-              __recipe__?: DefineRulesRecipe;
-            }
-          ).__recipe__;
-
-          expect(css.raw({ color: "red" })).toEqual({
-            color: "red"
-          });
-          expect(() => recipe?.args).toThrow(
-            DEFINE_RULES_SERIALIZED_CSS_FUNCTION_CONFIG_DIAGNOSTIC
-          );
-          expect(session.instances).toEqual([]);
-        } finally {
-          expect(endDefineRulesRegistrySession()).toBe(session);
-        }
-
-        expect(getActiveDefineRulesRegistrySession()).toBe(undefined);
-      });
     });
 
     describe.concurrent("DefineRules Presets", () => {
-      it("exposes a live preset object through the serializer recipe", () => {
+      const createEmptyPresetArtifact = (): DefineRulesPresetArtifactV4 => ({
+        schema: "mincho.defineRulesPreset",
+        version: 4,
+        classNameByCache: {},
+        writeKeyByCacheKey: {},
+        conditionById: {},
+        propertyById: {},
+        writeKeyById: {}
+      });
+
+      const clonePresetArtifact = (
+        preset: DefineRulesPresetArtifactV4
+      ): DefineRulesPresetArtifactV4 => ({
+        schema: "mincho.defineRulesPreset",
+        version: 4,
+        classNameByCache: { ...preset.classNameByCache },
+        writeKeyByCacheKey: { ...preset.writeKeyByCacheKey },
+        conditionById: Object.fromEntries(
+          Object.entries(preset.conditionById).map(
+            ([conditionId, condition]) => [conditionId, { ...condition }]
+          )
+        ),
+        propertyById: { ...preset.propertyById },
+        writeKeyById: Object.fromEntries(
+          Object.entries(preset.writeKeyById).map(([writeKeyId, writeKey]) => [
+            writeKeyId,
+            { ...writeKey }
+          ])
+        )
+      });
+
+      it("exposes a live v4 preset object through the serializer recipe", () => {
         type DefineRulesRecipe = {
           args?: unknown[];
         };
@@ -472,25 +864,34 @@ if (import.meta.vitest) {
 
         expect(recipeConfig).toEqual(expect.any(Object));
         expect((recipeConfig as DefineRulesRecipeConfig).presets).toBe(preset);
+        expect(Object.keys(preset)).toEqual([
+          "schema",
+          "version",
+          "classNameByCache",
+          "writeKeyByCacheKey",
+          "conditionById",
+          "propertyById",
+          "writeKeyById"
+        ]);
+        expect(preset).not.toHaveProperty("registeredSegments");
+        expect(preset).not.toHaveProperty("segmentCache");
+        expect(preset).not.toHaveProperty("fullResultCache");
+        expect(preset).not.toHaveProperty("cx");
+        expect(preset).not.toHaveProperty("atomicClassByClassName");
 
         const className = css({ background: "blue" });
         const repeatedClassName = css({ background: "blue" });
 
-        expect(
-          Object.keys(preset.classNameByCache).every(
-            (key) => key.startsWith("fragment_") === false
-          )
-        ).toBe(true);
         expect(repeatedClassName).toBe(className);
         expect(Object.values(preset.classNameByCache)).toContain(className);
-        expect(
-          Object.values(preset.classNameByCache).filter(
-            (entry) => entry === className
-          )
-        ).toHaveLength(1);
+        expect(Object.values(preset.classNameByCache)).toHaveLength(1);
+        expect(Object.keys(preset.writeKeyByCacheKey)).toEqual(
+          Object.keys(preset.classNameByCache)
+        );
+        expect(JSON.stringify(preset).split(className)).toHaveLength(2);
       });
 
-      it("serializes an empty preset object without static calls", () => {
+      it("serializes an empty v4 preset object without static calls", () => {
         type DefineRulesRecipe = {
           args?: unknown[];
         };
@@ -511,17 +912,13 @@ if (import.meta.vitest) {
 
         expect(recipeConfig).toEqual(expect.any(Object));
         expect((recipeConfig as { presets?: unknown }).presets).toBe(preset);
-        expect(Object.keys(preset.classNameByCache)).toHaveLength(0);
+        expect(preset).toEqual(createEmptyPresetArtifact());
       });
 
-      it("keeps serialized runtime preset handles live for later static css calls", async () => {
+      it("keeps serialized runtime v4 preset handles live for later static css calls", async () => {
         const { createDefineRulesCssRuntime } =
           await import("./createDefineRulesCssRuntime.js");
-        const preset: DefineRulesPresetArtifactV3 = {
-          schema: "mincho.defineRulesPreset",
-          version: 3,
-          classNameByCache: {}
-        };
+        const preset = createEmptyPresetArtifact();
         const css = createDefineRulesCssRuntime({
           debugId: "serializedRuntimePresetHandle",
           properties: {
@@ -533,6 +930,9 @@ if (import.meta.vitest) {
         const className = css({ background: "blue" });
 
         expect(Object.values(preset.classNameByCache)).toEqual([className]);
+        expect(Object.keys(preset.writeKeyByCacheKey)).toEqual(
+          Object.keys(preset.classNameByCache)
+        );
         expect(css({ background: "blue" })).toBe(className);
       });
 
@@ -551,6 +951,14 @@ if (import.meta.vitest) {
 
           return () => recipe?.args;
         };
+        const createSerializerArgsReader = (config: unknown) => {
+          const recipe = createDefineRulesSerializerRecipe(
+            {} as Serializable,
+            getFunctionValuedDefineRulesConfigPath(config as never)
+          );
+
+          return () => recipe.args;
+        };
 
         expect(
           createRecipeArgsReader({
@@ -560,7 +968,28 @@ if (import.meta.vitest) {
               }
             }
           })
-        ).toThrow(DEFINE_RULES_SERIALIZED_CSS_FUNCTION_CONFIG_DIAGNOSTIC);
+        ).toThrow(
+          createFunctionValuedConfigDiagnostic("config.properties.color")
+        );
+        expect(
+          createRecipeArgsReader({
+            properties: {
+              palette: {
+                brand: {
+                  tone(value: string) {
+                    return {
+                      color: value
+                    } as const;
+                  }
+                }
+              }
+            }
+          })
+        ).toThrow(
+          createFunctionValuedConfigDiagnostic(
+            "config.properties.palette.brand.tone"
+          )
+        );
         expect(
           createRecipeArgsReader({
             properties: {
@@ -574,85 +1003,94 @@ if (import.meta.vitest) {
               }
             }
           })
-        ).toThrow(DEFINE_RULES_SERIALIZED_CSS_FUNCTION_CONFIG_DIAGNOSTIC);
-      });
+        ).toThrow(
+          createFunctionValuedConfigDiagnostic("config.shortcuts.tone")
+        );
+        expect(
+          createRecipeArgsReader({
+            properties: {
+              color: true
+            },
+            shortcuts: {
+              layout: [
+                "color",
+                {
+                  tone(value: "red" | "blue") {
+                    return {
+                      color: value
+                    } as const;
+                  }
+                }
+              ]
+            }
+          })
+        ).toThrow(
+          createFunctionValuedConfigDiagnostic(
+            "config.shortcuts.layout[1].tone"
+          )
+        );
+        expect(
+          createSerializerArgsReader({
+            conditions: {
+              dynamic: {
+                selector(value: string) {
+                  return value;
+                }
+              }
+            }
+          })
+        ).toThrow(
+          createFunctionValuedConfigDiagnostic(
+            "config.conditions.dynamic.selector"
+          )
+        );
 
-      it("Keeps preset handles live for transitive raw record composition", () => {
-        const provider = defineRules({
-          debugId: "provider",
-          properties: {
-            color: true
-          }
-        });
-        const providerColor = provider.css({ color: "red" });
-
-        const composed = defineRules({
-          debugId: "composed",
-          presets: {
-            ...provider.preset.classNameByCache
-          },
-          properties: {
-            color: true,
-            background: true
-          }
-        });
-        const composedBackground = composed.css({ background: "blue" });
-
-        const transitive = defineRules({
-          debugId: "transitive",
-          presets: {
-            ...composed.preset.classNameByCache
-          },
-          properties: {
-            color: true,
-            background: true,
-            display: true
-          }
-        });
-        const transitiveDisplay = transitive.css({ display: "block" });
-
-        expect(Object.values(provider.preset.classNameByCache)).toEqual([
-          providerColor
+        expect(
+          createRecipeArgsReader({
+            conditions: {
+              mobile: {},
+              tablet: "screen and (min-width: 768px)",
+              desktop: {
+                "@media": "@media screen and (min-width: 1024px)",
+                selector: "&[data-desktop]"
+              }
+            },
+            properties: {
+              color: true
+            },
+            shortcuts: {
+              badge: {
+                color: "red"
+              }
+            }
+          })()
+        ).toEqual([
+          expect.objectContaining({
+            conditions: {
+              mobile: {},
+              tablet: "screen and (min-width: 768px)",
+              desktop: {
+                "@media": "@media screen and (min-width: 1024px)",
+                selector: "&[data-desktop]"
+              }
+            }
+          })
         ]);
-        expect(Object.values(composed.preset.classNameByCache)).toEqual(
-          expect.arrayContaining([providerColor, composedBackground])
-        );
-        expect(Object.values(composed.preset.classNameByCache)).toHaveLength(2);
-        expect(Object.values(transitive.preset.classNameByCache)).toEqual(
-          expect.arrayContaining([
-            providerColor,
-            composedBackground,
-            transitiveDisplay
-          ])
-        );
-        expect(Object.values(transitive.preset.classNameByCache)).toHaveLength(
-          3
-        );
-        expect(composed.preset).not.toBe(provider.preset);
-        expect(transitive.preset).not.toBe(composed.preset);
       });
 
-      it("Imports v3 preset artifacts by copying classNameByCache", () => {
+      it("imports v4 preset artifacts by remapping metadata and copying class cache", () => {
         const provider = defineRules({
-          debugId: "v3Provider",
+          debugId: "v4Provider",
           properties: {
             color: true
           }
         });
         const providerColor = provider.css({ color: "red" });
-        const artifact: DefineRulesPresetArtifactV3 = {
-          schema: "mincho.defineRulesPreset",
-          version: 3,
-          classNameByCache: {
-            ...provider.preset.classNameByCache
-          }
-        };
-        const artifactSnapshot = {
-          ...artifact.classNameByCache
-        };
+        const artifact = clonePresetArtifact(provider.preset);
+        const artifactSnapshot = clonePresetArtifact(artifact);
 
         const consumer = defineRules({
-          debugId: "v3Consumer",
+          debugId: "v4Consumer",
           presets: artifact,
           properties: {
             color: true,
@@ -660,7 +1098,9 @@ if (import.meta.vitest) {
           }
         });
 
-        expect(consumer.preset.classNameByCache).toEqual(artifactSnapshot);
+        expect(consumer.preset.classNameByCache).toEqual(
+          artifactSnapshot.classNameByCache
+        );
         expect(consumer.preset.classNameByCache).not.toBe(
           artifact.classNameByCache
         );
@@ -672,10 +1112,10 @@ if (import.meta.vitest) {
           expect.arrayContaining([providerColor, consumerBackground])
         );
         expect(Object.values(consumer.preset.classNameByCache)).toHaveLength(2);
-        expect(artifact.classNameByCache).toEqual(artifactSnapshot);
+        expect(artifact).toEqual(artifactSnapshot);
       });
 
-      it("Merges recursive preset input arrays without mutating imports", () => {
+      it("merges recursive v4 preset input arrays without mutating imports", () => {
         const colorProvider = defineRules({
           debugId: "arrayColorProvider",
           properties: {
@@ -690,16 +1130,8 @@ if (import.meta.vitest) {
         });
         const colorClassName = colorProvider.css({ color: "red" });
         const displayClassName = displayProvider.css({ display: "flex" });
-        const displayArtifact: DefineRulesPresetArtifactV3 = {
-          schema: "mincho.defineRulesPreset",
-          version: 3,
-          classNameByCache: {
-            ...displayProvider.preset.classNameByCache
-          }
-        };
-        const displayArtifactSnapshot = {
-          ...displayArtifact.classNameByCache
-        };
+        const displayArtifact = clonePresetArtifact(displayProvider.preset);
+        const displayArtifactSnapshot = clonePresetArtifact(displayArtifact);
 
         const consumer = defineRules({
           debugId: "arrayConsumer",
@@ -727,68 +1159,10 @@ if (import.meta.vitest) {
         expect(Object.values(colorProvider.preset.classNameByCache)).toEqual([
           colorClassName
         ]);
-        expect(displayArtifact.classNameByCache).toEqual(
-          displayArtifactSnapshot
-        );
+        expect(displayArtifact).toEqual(displayArtifactSnapshot);
       });
 
-      it("Rejects malformed preset input", () => {
-        const createMalformedPresetCase = (presets: unknown) => () =>
-          defineRules({
-            presets: presets as DefineRulesPresetInput,
-            properties: {
-              color: true
-            }
-          });
-
-        const ownerPresetInput: unknown = {
-          css: true,
-          preset: {
-            colorRed: "color_red"
-          }
-        };
-        const legacyPresetCacheKey = ["className", "ByCache"].join("");
-        const legacySerializedPresetEnvelope: unknown = {
-          schema: "mincho.defineRulesPreset",
-          version: Number("2"),
-          [legacyPresetCacheKey]: {
-            colorRed: "color_red"
-          }
-        };
-        const invalidArtifact: unknown = {
-          schema: "mincho.defineRulesPreset",
-          version: 3,
-          classNameByCache: {
-            colorRed: 1
-          }
-        };
-
-        expect(createMalformedPresetCase(ownerPresetInput)).toThrow(
-          "Unsupported defineRules preset input at config.presets"
-        );
-
-        expect(
-          createMalformedPresetCase(legacySerializedPresetEnvelope)
-        ).toThrow("Unsupported defineRules preset input at config.presets");
-
-        expect(createMalformedPresetCase(new Map())).toThrow(
-          "Unsupported defineRules preset input at config.presets"
-        );
-
-        expect(createMalformedPresetCase(invalidArtifact)).toThrow(
-          "Unsupported defineRules preset input at " +
-            "config.presets.classNameByCache"
-        );
-
-        expect(
-          createMalformedPresetCase([
-            { colorRed: "color_red" },
-            ownerPresetInput
-          ])
-        ).toThrow("Unsupported defineRules preset input at config.presets[1]");
-      });
-
-      it("Reuses seeded preset class names without overwriting imported entries", () => {
+      it("reuses imported v4 preset class names without overwriting entries", () => {
         const provider = defineRules({
           debugId: "provider",
           properties: {
@@ -796,9 +1170,8 @@ if (import.meta.vitest) {
           }
         });
         const providerBackground = provider.css({ background: "blue" });
-        const importedPreset = {
-          ...provider.preset.classNameByCache
-        };
+        const importedPreset = clonePresetArtifact(provider.preset);
+        const importedSnapshot = clonePresetArtifact(importedPreset);
 
         const consumer = defineRules({
           debugId: "consumer",
@@ -809,13 +1182,13 @@ if (import.meta.vitest) {
         });
         const presetHandle = consumer.preset.classNameByCache;
 
-        expect(presetHandle).toEqual(importedPreset);
+        expect(presetHandle).toEqual(importedSnapshot.classNameByCache);
 
         const reusedBackground = consumer.css({ background: "blue" });
 
         expect(reusedBackground).toBe(providerBackground);
         expect(reusedBackground).not.toMatch(identifierName("consumer"));
-        expect(presetHandle).toEqual(importedPreset);
+        expect(presetHandle).toEqual(importedSnapshot.classNameByCache);
         expect(Object.values(presetHandle)).toEqual([providerBackground]);
         expect(
           Object.values(presetHandle).filter(
@@ -823,10 +1196,10 @@ if (import.meta.vitest) {
           )
         ).toHaveLength(1);
         expect(presetHandle).toBe(consumer.preset.classNameByCache);
-        expect(importedPreset).toEqual(provider.preset.classNameByCache);
+        expect(importedPreset).toEqual(importedSnapshot);
       });
 
-      it("Keeps seeded preset handles isolated across defineRules instances", () => {
+      it("keeps imported v4 preset handles isolated across defineRules instances", () => {
         const provider = defineRules({
           debugId: "provider",
           properties: {
@@ -834,9 +1207,8 @@ if (import.meta.vitest) {
           }
         });
         const providerColor = provider.css({ color: "red" });
-        const sharedPreset = {
-          ...provider.preset.classNameByCache
-        };
+        const sharedPreset = clonePresetArtifact(provider.preset);
+        const sharedSnapshot = clonePresetArtifact(sharedPreset);
 
         const consumerA = defineRules({
           debugId: "consumerA",
@@ -879,7 +1251,7 @@ if (import.meta.vitest) {
         expect(Object.values(consumerB.preset.classNameByCache)).not.toContain(
           consumerABackground
         );
-        expect(sharedPreset).toEqual(provider.preset.classNameByCache);
+        expect(sharedPreset).toEqual(sharedSnapshot);
       });
     });
 
@@ -1082,7 +1454,7 @@ if (import.meta.vitest) {
         );
       });
 
-      it("css() canonicalize className", () => {
+      it("css() reuses atomic class names while preserving source order", () => {
         const { css } = defineRules({
           debugId,
           properties: {
@@ -1099,11 +1471,49 @@ if (import.meta.vitest) {
 
         expect(colorRed).toBe(css({ color: "red" }));
         expect(backgroundBlue).toBe(css({ background: "blue" }));
-        expect(combined).toBe(css({ color: "red", background: "blue" }));
-        expect(reversedCombined).toBe(combined);
+        expect(combined).toBe(`${colorRed} ${backgroundBlue}`);
+        expect(reversedCombined).toBe(`${backgroundBlue} ${colorRed}`);
       });
 
-      it("css() dedupes equivalent whole fragments when object key order differs", () => {
+      it("preserves surviving class source order instead of lexicographic order", () => {
+        const { css } = defineRules({
+          debugId: "sourceOrderRuntime",
+          properties: {
+            alignItems: true,
+            background: true,
+            borderColor: true,
+            color: true,
+            opacity: true,
+            zIndex: true
+          }
+        });
+        const candidates = [
+          { color: "red" },
+          { background: "blue" },
+          { borderColor: "green" },
+          { alignItems: "center" },
+          { opacity: 0.5 },
+          { zIndex: 1 }
+        ] as const;
+        const entries = candidates.map((input) => ({
+          input,
+          className: css(input)
+        }));
+        const [lexicographicFirst, sourceFirst] = [...entries].sort((a, b) =>
+          a.className.localeCompare(b.className)
+        );
+
+        expect(sourceFirst).toBeDefined();
+        expect(lexicographicFirst).toBeDefined();
+        if (sourceFirst == null || lexicographicFirst == null) return;
+        expect(sourceFirst.className > lexicographicFirst.className).toBe(true);
+
+        expect(css([sourceFirst.input, lexicographicFirst.input])).toBe(
+          `${sourceFirst.className} ${lexicographicFirst.className}`
+        );
+      });
+
+      it("css() reuses equivalent atomic fragments when object key order differs", () => {
         const alpha = "--alpha";
         const { css } = defineRules({
           properties: {
@@ -1125,8 +1535,15 @@ if (import.meta.vitest) {
           }
         });
 
-        expect(css({ background: { red: 255, blue: 255 } })).toBe(
-          css({ background: { blue: 255, red: 255 } })
+        const redFirstClassNames = css({
+          background: { red: 255, blue: 255 }
+        }).split(" ");
+        const blueFirstClassNames = css({
+          background: { blue: 255, red: 255 }
+        }).split(" ");
+
+        expect(new Set(redFirstClassNames)).toEqual(
+          new Set(blueFirstClassNames)
         );
       });
 
@@ -1176,9 +1593,10 @@ if (import.meta.vitest) {
           { background: "blue" }
         ]).split(" ");
 
-        expect(fullRed).toHaveLength(1);
+        expect(fullRed).toHaveLength(2);
         expect(prunedAfterFull).toHaveLength(2);
-        expect(prunedAfterFull[0]).not.toBe(fullRed[0]);
+        expect(prunedAfterFull[0]).toBe(fullRed[0]);
+        expect(prunedAfterFull[1]).not.toBe(fullRed[1]);
 
         const cssPrunedFirst = createCss();
         const prunedBeforeFull = cssPrunedFirst([
@@ -1190,8 +1608,9 @@ if (import.meta.vitest) {
         );
 
         expect(prunedBeforeFull).toHaveLength(2);
-        expect(fullAfterPruned).toHaveLength(1);
-        expect(fullAfterPruned[0]).not.toBe(prunedBeforeFull[0]);
+        expect(fullAfterPruned).toHaveLength(2);
+        expect(fullAfterPruned[0]).toBe(prunedBeforeFull[0]);
+        expect(fullAfterPruned[1]).not.toBe(prunedBeforeFull[1]);
       });
     });
 
@@ -1399,6 +1818,82 @@ if (import.meta.vitest) {
           })
         );
         expect(css({ center: "inline" }).split(" ")).toHaveLength(3);
+      });
+
+      it("resolves shortcut conflicts by transformed property within each condition", () => {
+        const { css } = defineRules({
+          conditions: {
+            tablet: "@media screen and (min-width: 768px)"
+          },
+          properties: {
+            padding: true,
+            paddingLeft: true,
+            paddingRight: true
+          },
+          shortcuts: {
+            px(value: 4 | 8) {
+              return {
+                padding: {
+                  Left: value,
+                  Right: value
+                }
+              } as const;
+            }
+          }
+        });
+
+        expect(
+          css.raw({
+            px: {
+              _tablet: 4
+            },
+            paddingLeft: {
+              _tablet: 8
+            }
+          })
+        ).toEqual({
+          "@media": {
+            "screen and (min-width: 768px)": {
+              paddingRight: 4,
+              paddingLeft: 8
+            }
+          }
+        });
+        expect(
+          css({
+            px: {
+              _tablet: 4
+            },
+            paddingLeft: {
+              _tablet: 8
+            }
+          })
+        ).toBe(
+          css({
+            paddingRight: {
+              _tablet: 4
+            },
+            paddingLeft: {
+              _tablet: 8
+            }
+          })
+        );
+        expect(
+          css.raw({
+            px: 4,
+            paddingLeft: {
+              _tablet: 8
+            }
+          })
+        ).toEqual({
+          paddingLeft: 4,
+          paddingRight: 4,
+          "@media": {
+            "screen and (min-width: 768px)": {
+              paddingLeft: 8
+            }
+          }
+        });
       });
 
       it("Circular shortcuts", () => {

--- a/packages/css/src/defineRules/index.ts
+++ b/packages/css/src/defineRules/index.ts
@@ -12,6 +12,8 @@ import { cx } from "../classname/cx.js";
 import type { DefineRulesRuntimeResult } from "./runtime.js";
 import type {
   DefineRulesCtx,
+  DefineRulesConditions,
+  DefineRulesEmptyConditions,
   DefineRulesPresetArtifactV3,
   DefineRulesPresetInput,
   DefineRulesProperties,
@@ -30,14 +32,19 @@ const DEFINE_RULES_CX_RUNTIME_IMPORT_NAME = "createDefineRulesCxRuntime";
 // == Define Rules =============================================================
 export function defineRules<
   const Properties extends DefineRulesProperties,
-  const Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
+  const Shortcuts extends DefineRulesShortcuts<
+    Properties,
+    Shortcuts,
+    Conditions
+  >,
+  const Conditions extends DefineRulesConditions = DefineRulesEmptyConditions
 >(
-  config: DefineRulesCtx<Properties, Shortcuts>
-): DefineRulesRuntimeResult<Properties, Shortcuts> {
+  config: DefineRulesCtx<Properties, Shortcuts, Conditions>
+): DefineRulesRuntimeResult<Properties, Shortcuts, Conditions> {
   const functionValuedConfigPath =
     getFunctionValuedDefineRulesConfigPath(config);
-  const result: DefineRulesRuntimeResult<Properties, Shortcuts> =
-    createDefineRulesRuntime<Properties, Shortcuts>(config, {
+  const result: DefineRulesRuntimeResult<Properties, Shortcuts, Conditions> =
+    createDefineRulesRuntime<Properties, Shortcuts, Conditions>(config, {
       registerPreset: functionValuedConfigPath == null
     });
   const serializedConfig = { ...config, presets: result.preset };
@@ -51,7 +58,7 @@ export function defineRules<
         serializedConfig as Serializable,
         functionValuedConfigPath
       )
-    ) as DefineRulesRuntimeResult<Properties, Shortcuts>["css"]
+    ) as DefineRulesRuntimeResult<Properties, Shortcuts, Conditions>["css"]
   };
 }
 

--- a/packages/css/src/defineRules/metadata.bench.ts
+++ b/packages/css/src/defineRules/metadata.bench.ts
@@ -1,0 +1,112 @@
+import {
+  endFileScope,
+  hasFileScope,
+  setFileScope
+} from "@vanilla-extract/css/fileScope";
+import { afterAll, bench, describe } from "vitest";
+import type { ClassValue } from "../classname/index.js";
+import { defineRules } from "./index.js";
+
+type Props = { className: string };
+
+setFileScope("metadata.bench.ts", "@mincho-js/css");
+
+const runtime = defineRules({
+  debugId: "cxCacheBench",
+  properties: {
+    color: true,
+    backgroundColor: true,
+    display: true,
+    padding: true
+  }
+});
+
+const registeredClassLists = [
+  runtime.css({ color: "red", backgroundColor: "blue", display: "block" }),
+  runtime.css({ color: "blue", backgroundColor: "white", display: "flex" }),
+  runtime.css({ color: "red", padding: 8, display: "flex" })
+] as const;
+const colorRed = runtime.css({ color: "red" });
+const colorBlue = runtime.css({ color: "blue" });
+const displayFlex = runtime.css({ display: "flex" });
+const paddingSmall = runtime.css({ padding: 4 });
+const paddingLarge = runtime.css({ padding: 8 });
+const fullResultInput: ClassValue[] = [
+  registeredClassLists[0],
+  [registeredClassLists[1], { [displayFlex]: true }],
+  [paddingSmall, [paddingLarge]]
+];
+const repeatedExternalProps = Array.from(
+  { length: 5 },
+  (_, index): Props => ({
+    className: `external-prop-${index} ${colorRed} ${colorBlue} ${displayFlex}`
+  })
+);
+let cacheEvictionBatch = 0;
+let uniqueExternalBatch = 0;
+
+function evictFullResultCache(): void {
+  const batch = cacheEvictionBatch;
+  cacheEvictionBatch += 1;
+
+  for (let index = 0; index < 4; index += 1) {
+    runtime.cx(`full-result-evict-${batch}-${index}`);
+  }
+}
+
+function cxFullResultInput(): string {
+  return runtime.cx(...fullResultInput);
+}
+
+for (const classList of registeredClassLists) {
+  runtime.cx(classList);
+}
+for (const props of repeatedExternalProps) {
+  runtime.cx(props.className);
+}
+cxFullResultInput();
+
+afterAll(() => {
+  while (hasFileScope()) {
+    endFileScope();
+  }
+});
+
+describe("defineRules scoped cx cache fast paths", () => {
+  bench(
+    "registeredSegments hit and epoch merge for 3 known class lists",
+    () => {
+      evictFullResultCache();
+
+      for (const classList of registeredClassLists) {
+        runtime.cx(classList);
+      }
+    }
+  );
+
+  bench("bounded segment LRU hit for repeated external props.className", () => {
+    evictFullResultCache();
+
+    for (const props of repeatedExternalProps) {
+      runtime.cx(props.className);
+    }
+  });
+
+  bench("bounded segment LRU miss for 1000 unique external strings", () => {
+    const batch = uniqueExternalBatch;
+    uniqueExternalBatch += 1;
+
+    for (let index = 0; index < 1000; index += 1) {
+      runtime.cx(
+        `external-miss-${batch}-${index} ${colorRed} ${colorBlue} unknown-${index}`
+      );
+    }
+  });
+
+  bench(
+    "full-result cache hit for repeated identical flattened input size 4",
+    () => {
+      cxFullResultInput();
+    }
+  );
+});

--- a/packages/css/src/defineRules/metadata.ts
+++ b/packages/css/src/defineRules/metadata.ts
@@ -1,0 +1,750 @@
+import type { NormalizedCondition } from "./conditions.js";
+import type {
+  DefineRulesPresetArtifactV4,
+  DefineRulesPresetCompiledEntry,
+  DefineRulesPresetCompiledKnownEntry,
+  DefineRulesPresetCompiledSegment,
+  DefineRulesPresetCompiledUnknownEntry
+} from "./types.js";
+
+export type ConditionId = number;
+export type PropertyId = number;
+export type WriteKeyId = number;
+
+export type CompiledKnownEntry = DefineRulesPresetCompiledKnownEntry & {
+  writeKeyId: WriteKeyId;
+};
+export type CompiledUnknownEntry = DefineRulesPresetCompiledUnknownEntry;
+export type CompiledEntry =
+  | (DefineRulesPresetCompiledEntry & { kind: "known"; writeKeyId: WriteKeyId })
+  | CompiledUnknownEntry;
+export interface CompiledSegment extends DefineRulesPresetCompiledSegment {
+  entries: CompiledEntry[];
+}
+
+export interface EngineMetadataOptions {
+  segmentCacheSize?: number;
+  fullResultCacheSize?: number;
+  initialEpochCapacity?: number;
+  initialEpoch?: number;
+}
+
+export interface EngineMetadata {
+  internCondition(condition: NormalizedCondition): ConditionId;
+  internProperty(property: string): PropertyId;
+  internWriteKey(conditionId: ConditionId, propertyId: PropertyId): WriteKeyId;
+  registerAtomicClass(className: string, writeKeyId: WriteKeyId): void;
+  registerAtomicCacheEntry(
+    cacheKey: string,
+    className: string,
+    writeKeyId: WriteKeyId
+  ): void;
+  hydrateAtomicClassesFromArtifact(
+    artifact: Pick<
+      DefineRulesPresetArtifactV4,
+      "classNameByCache" | "writeKeyByCacheKey"
+    >
+  ): void;
+  registerSegment(input: string, compiledSegment: CompiledSegment): void;
+  getCompiledSegment(input: string): CompiledSegment;
+  compileSegment(input: string): CompiledSegment;
+  mergeCompiledSegments(segments: readonly CompiledSegment[]): string;
+  mergeClassList(input: string): string;
+  getCachedFullResult(input: string): string | undefined;
+  setCachedFullResult(input: string, result: string): void;
+  clearRuntimeCaches(): void;
+  exportArtifact(): DefineRulesPresetArtifactV4;
+  getWriteKeyIdForClassName(className: string): WriteKeyId | undefined;
+  readonly segmentCacheSize: number;
+  readonly fullResultCacheSize: number;
+  readonly registeredSegmentSize: number;
+}
+
+const DEFAULT_SEGMENT_CACHE_SIZE = 2048;
+const DEFAULT_FULL_RESULT_CACHE_SIZE = 4;
+const MAX_EPOCH = 0xffffffff;
+
+class BoundedLru<K, V> {
+  private readonly entries = new Map<K, V>();
+  private readonly maxSize: number;
+
+  constructor(maxSize: number) {
+    this.maxSize = Math.max(0, maxSize);
+  }
+
+  get(key: K): V | undefined {
+    const value = this.entries.get(key);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    this.entries.delete(key);
+    this.entries.set(key, value);
+    return value;
+  }
+
+  set(key: K, value: V): void {
+    if (this.maxSize === 0) {
+      return;
+    }
+
+    this.entries.delete(key);
+    this.entries.set(key, value);
+
+    while (this.entries.size > this.maxSize) {
+      const oldest = this.entries.keys().next();
+
+      if (oldest.done) {
+        return;
+      }
+
+      this.entries.delete(oldest.value);
+    }
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  delete(key: K): void {
+    this.entries.delete(key);
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+}
+
+export function createEngineMetadata(
+  options: EngineMetadataOptions = {}
+): EngineMetadata {
+  const conditionIdByKey = new Map<string, ConditionId>();
+  const propertyIdByKey = new Map<string, PropertyId>();
+  const writeKeyIdByKey = new Map<string, WriteKeyId>();
+  const classNameByCache: Record<string, string> = {};
+  const writeKeyByCacheKey: Record<string, number> = {};
+  const conditionById: Record<number, NormalizedCondition> = {};
+  const propertyById: Record<number, string> = {};
+  const writeKeyById: Record<
+    number,
+    { conditionId: number; propertyId: number }
+  > = {};
+  const writeKeyIdByClassName = new Map<string, WriteKeyId>();
+  const registeredSegments = new Map<string, CompiledSegment>();
+  const segmentCache = new BoundedLru<string, CompiledSegment>(
+    options.segmentCacheSize ?? DEFAULT_SEGMENT_CACHE_SIZE
+  );
+  const fullResultCache = new BoundedLru<string, string>(
+    options.fullResultCacheSize ?? DEFAULT_FULL_RESULT_CACHE_SIZE
+  );
+  let seenEpoch = new Uint32Array(options.initialEpochCapacity ?? 16);
+  let currentEpoch = options.initialEpoch ?? 0;
+
+  function internCondition(condition: NormalizedCondition): ConditionId {
+    const key = conditionCacheKey(condition);
+    const existing = conditionIdByKey.get(key);
+
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const conditionId = conditionIdByKey.size;
+    conditionIdByKey.set(key, conditionId);
+    conditionById[conditionId] = { ...condition };
+    return conditionId;
+  }
+
+  function internProperty(property: string): PropertyId {
+    const existing = propertyIdByKey.get(property);
+
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const propertyId = propertyIdByKey.size;
+    propertyIdByKey.set(property, propertyId);
+    propertyById[propertyId] = property;
+    return propertyId;
+  }
+
+  function internWriteKey(
+    conditionId: ConditionId,
+    propertyId: PropertyId
+  ): WriteKeyId {
+    const key = `${conditionId}:${propertyId}`;
+    const existing = writeKeyIdByKey.get(key);
+
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const writeKeyId = writeKeyIdByKey.size;
+    writeKeyIdByKey.set(key, writeKeyId);
+    writeKeyById[writeKeyId] = { conditionId, propertyId };
+    return writeKeyId;
+  }
+
+  function registerAtomicClass(
+    className: string,
+    writeKeyId: WriteKeyId
+  ): void {
+    writeKeyIdByClassName.set(className, writeKeyId);
+    clearRuntimeCaches();
+  }
+
+  function registerAtomicCacheEntry(
+    cacheKey: string,
+    className: string,
+    writeKeyId: WriteKeyId
+  ): void {
+    classNameByCache[cacheKey] = className;
+    writeKeyByCacheKey[cacheKey] = writeKeyId;
+    registerAtomicClass(className, writeKeyId);
+  }
+
+  function hydrateAtomicClassesFromArtifact(
+    artifact: Pick<
+      DefineRulesPresetArtifactV4,
+      "classNameByCache" | "writeKeyByCacheKey"
+    >
+  ): void {
+    for (const [cacheKey, className] of Object.entries(
+      artifact.classNameByCache
+    )) {
+      const writeKeyId = artifact.writeKeyByCacheKey[cacheKey];
+
+      if (typeof writeKeyId === "number") {
+        registerAtomicClass(className, writeKeyId);
+      }
+    }
+  }
+
+  function registerSegment(
+    input: string,
+    compiledSegment: CompiledSegment
+  ): void {
+    registeredSegments.set(input, compiledSegment);
+    fullResultCache.delete(input);
+  }
+
+  function getCompiledSegment(input: string): CompiledSegment {
+    const registeredSegment = registeredSegments.get(input);
+
+    if (registeredSegment !== undefined) {
+      return registeredSegment;
+    }
+
+    const cachedSegment = segmentCache.get(input);
+
+    if (cachedSegment !== undefined) {
+      return cachedSegment;
+    }
+
+    const compiledSegment = compileSegment(input);
+    segmentCache.set(input, compiledSegment);
+    return compiledSegment;
+  }
+
+  function compileSegment(input: string): CompiledSegment {
+    const entries: CompiledEntry[] = [];
+    const trimmed = input.trim();
+
+    if (trimmed.length === 0) {
+      return { entries, hasKnownAtomicClass: false };
+    }
+
+    let hasKnownAtomicClass = false;
+
+    for (const className of trimmed.split(/\s+/)) {
+      const writeKeyId = writeKeyIdByClassName.get(className);
+
+      if (writeKeyId === undefined) {
+        entries.push({ kind: "unknown", className });
+        continue;
+      }
+
+      hasKnownAtomicClass = true;
+      entries.push({ kind: "known", className, writeKeyId });
+    }
+
+    return { entries, hasKnownAtomicClass };
+  }
+
+  function mergeCompiledSegments(segments: readonly CompiledSegment[]): string {
+    const epoch = nextEpoch();
+    const keptEntries: CompiledEntry[] = [];
+
+    for (
+      let segmentIndex = segments.length - 1;
+      segmentIndex >= 0;
+      segmentIndex -= 1
+    ) {
+      const segment = segments[segmentIndex];
+
+      if (segment == null) {
+        continue;
+      }
+
+      for (
+        let entryIndex = segment.entries.length - 1;
+        entryIndex >= 0;
+        entryIndex -= 1
+      ) {
+        const entry = segment.entries[entryIndex];
+
+        if (entry == null) {
+          continue;
+        }
+
+        if (entry.kind === "unknown") {
+          keptEntries.push(entry);
+          continue;
+        }
+
+        ensureSeenEpochCapacity(entry.writeKeyId);
+
+        if (seenEpoch[entry.writeKeyId] === epoch) {
+          continue;
+        }
+
+        seenEpoch[entry.writeKeyId] = epoch;
+        keptEntries.push(entry);
+      }
+    }
+
+    return keptEntries
+      .reverse()
+      .map((entry) => entry.className)
+      .join(" ");
+  }
+
+  function mergeClassList(input: string): string {
+    const cachedResult = fullResultCache.get(input);
+
+    if (cachedResult !== undefined) {
+      return cachedResult;
+    }
+
+    const result = mergeCompiledSegments([getCompiledSegment(input)]);
+    fullResultCache.set(input, result);
+    return result;
+  }
+
+  function getCachedFullResult(input: string): string | undefined {
+    return fullResultCache.get(input);
+  }
+
+  function setCachedFullResult(input: string, result: string): void {
+    fullResultCache.set(input, result);
+  }
+
+  function clearRuntimeCaches(): void {
+    segmentCache.clear();
+    fullResultCache.clear();
+  }
+
+  function exportArtifact(): DefineRulesPresetArtifactV4 {
+    return {
+      schema: "mincho.defineRulesPreset",
+      version: 4,
+      classNameByCache: { ...classNameByCache },
+      writeKeyByCacheKey: { ...writeKeyByCacheKey },
+      conditionById: cloneConditionById(conditionById),
+      propertyById: { ...propertyById },
+      writeKeyById: cloneWriteKeyById(writeKeyById)
+    };
+  }
+
+  function getWriteKeyIdForClassName(
+    className: string
+  ): WriteKeyId | undefined {
+    return writeKeyIdByClassName.get(className);
+  }
+
+  function nextEpoch(): number {
+    currentEpoch += 1;
+
+    if (currentEpoch >= MAX_EPOCH) {
+      seenEpoch.fill(0);
+      currentEpoch = 1;
+    }
+
+    return currentEpoch;
+  }
+
+  function ensureSeenEpochCapacity(writeKeyId: WriteKeyId): void {
+    if (writeKeyId < seenEpoch.length) {
+      return;
+    }
+
+    let nextLength = Math.max(1, seenEpoch.length);
+
+    while (writeKeyId >= nextLength) {
+      nextLength *= 2;
+    }
+
+    const nextSeenEpoch = new Uint32Array(nextLength);
+    nextSeenEpoch.set(seenEpoch);
+    seenEpoch = nextSeenEpoch;
+  }
+
+  return {
+    internCondition,
+    internProperty,
+    internWriteKey,
+    registerAtomicClass,
+    registerAtomicCacheEntry,
+    hydrateAtomicClassesFromArtifact,
+    registerSegment,
+    getCompiledSegment,
+    compileSegment,
+    mergeCompiledSegments,
+    mergeClassList,
+    getCachedFullResult,
+    setCachedFullResult,
+    clearRuntimeCaches,
+    exportArtifact,
+    getWriteKeyIdForClassName,
+    get segmentCacheSize() {
+      return segmentCache.size;
+    },
+    get fullResultCacheSize() {
+      return fullResultCache.size;
+    },
+    get registeredSegmentSize() {
+      return registeredSegments.size;
+    }
+  };
+}
+
+function conditionCacheKey(condition: NormalizedCondition): string {
+  return JSON.stringify([
+    condition.layer,
+    condition.supports,
+    condition.media,
+    condition.container,
+    condition.selector
+  ]);
+}
+
+function cloneConditionById(
+  conditionById: Record<number, NormalizedCondition>
+): Record<number, NormalizedCondition> {
+  const clone: Record<number, NormalizedCondition> = {};
+
+  for (const [conditionId, condition] of Object.entries(conditionById)) {
+    clone[Number(conditionId)] = { ...condition };
+  }
+
+  return clone;
+}
+
+function cloneWriteKeyById(
+  writeKeyById: Record<number, { conditionId: number; propertyId: number }>
+): Record<number, { conditionId: number; propertyId: number }> {
+  const clone: Record<number, { conditionId: number; propertyId: number }> = {};
+
+  for (const [writeKeyId, writeKey] of Object.entries(writeKeyById)) {
+    clone[Number(writeKeyId)] = { ...writeKey };
+  }
+
+  return clone;
+}
+
+// == Tests ====================================================================
+// Ignore errors when compiling to CommonJS.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+  const { describe, it, expect, assertType } = import.meta.vitest;
+
+  function baseCondition(
+    overrides: Partial<NormalizedCondition> = {}
+  ): NormalizedCondition {
+    return {
+      layer: null,
+      supports: null,
+      media: null,
+      container: null,
+      selector: "&",
+      ...overrides
+    };
+  }
+
+  function registerAtomicPair(
+    metadata: EngineMetadata,
+    property: string,
+    firstClassName: string,
+    secondClassName: string
+  ) {
+    const conditionId = metadata.internCondition(baseCondition());
+    const propertyId = metadata.internProperty(property);
+    const writeKeyId = metadata.internWriteKey(conditionId, propertyId);
+
+    metadata.registerAtomicCacheEntry(
+      `${property}:first`,
+      firstClassName,
+      writeKeyId
+    );
+    metadata.registerAtomicCacheEntry(
+      `${property}:second`,
+      secondClassName,
+      writeKeyId
+    );
+
+    return writeKeyId;
+  }
+
+  describe("createEngineMetadata", () => {
+    it("interns identical normalized condition tuples to the same condition ID", () => {
+      const metadata = createEngineMetadata();
+      const firstId = metadata.internCondition(
+        baseCondition({ media: "screen and (min-width: 768px)" })
+      );
+      const secondId = metadata.internCondition(
+        baseCondition({ media: "screen and (min-width: 768px)" })
+      );
+      const differentId = metadata.internCondition(
+        baseCondition({ media: "screen and (min-width: 1024px)" })
+      );
+
+      expect(secondId).toBe(firstId);
+      expect(differentId).not.toBe(firstId);
+    });
+
+    it("interns write keys by condition and transformed property only", () => {
+      const metadata = createEngineMetadata();
+      const conditionId = metadata.internCondition(baseCondition());
+      const propertyId = metadata.internProperty("paddingLeft");
+      const firstWriteKeyId = metadata.internWriteKey(conditionId, propertyId);
+      const secondWriteKeyId = metadata.internWriteKey(conditionId, propertyId);
+
+      metadata.registerAtomicCacheEntry(
+        "paddingLeft:4",
+        "pl_4",
+        firstWriteKeyId
+      );
+      metadata.registerAtomicCacheEntry(
+        "paddingLeft:8",
+        "pl_8",
+        secondWriteKeyId
+      );
+
+      expect(secondWriteKeyId).toBe(firstWriteKeyId);
+      expect(metadata.exportArtifact().writeKeyByCacheKey).toEqual({
+        "paddingLeft:4": firstWriteKeyId,
+        "paddingLeft:8": firstWriteKeyId
+      });
+    });
+
+    it("compiles unknown entries unchanged and known entries from hydrated runtime lookup", () => {
+      const source = createEngineMetadata();
+      const writeKeyId = registerAtomicPair(
+        source,
+        "color",
+        "color_red",
+        "color_blue"
+      );
+      const runtime = createEngineMetadata();
+
+      runtime.hydrateAtomicClassesFromArtifact(source.exportArtifact());
+
+      expect(runtime.compileSegment("external color_red external")).toEqual({
+        entries: [
+          { kind: "unknown", className: "external" },
+          { kind: "known", className: "color_red", writeKeyId },
+          { kind: "unknown", className: "external" }
+        ],
+        hasKnownAtomicClass: true
+      });
+    });
+
+    it("merges using hydrated runtime state after dropping preset artifact maps", () => {
+      const source = createEngineMetadata();
+      registerAtomicPair(source, "color", "color_red", "color_blue");
+      const artifact = source.exportArtifact();
+      const runtime = createEngineMetadata();
+
+      runtime.hydrateAtomicClassesFromArtifact(artifact);
+      artifact.classNameByCache = {};
+      artifact.writeKeyByCacheKey = {};
+      artifact.conditionById = {};
+      artifact.propertyById = {};
+      artifact.writeKeyById = {};
+
+      expect(
+        runtime.mergeClassList("before color_red middle color_blue after")
+      ).toBe("before middle color_blue after");
+    });
+
+    it("checks registered segments before the bounded segment LRU", () => {
+      const metadata = createEngineMetadata();
+      const input = "same-instance";
+      const cachedSegment = metadata.getCompiledSegment(input);
+      const registeredSegment: CompiledSegment = {
+        entries: [
+          { kind: "known", className: input, writeKeyId: 12 as WriteKeyId }
+        ],
+        hasKnownAtomicClass: true
+      };
+
+      metadata.registerSegment(input, registeredSegment);
+
+      expect(cachedSegment).toEqual({
+        entries: [{ kind: "unknown", className: input }],
+        hasKnownAtomicClass: false
+      });
+      expect(metadata.getCompiledSegment(input)).toBe(registeredSegment);
+    });
+
+    it("invalidates only the matching full-result cache entry when registering a segment", () => {
+      const metadata = createEngineMetadata();
+      const input = "same-instance";
+      const otherInput = "other-instance";
+      const registeredSegment: CompiledSegment = {
+        entries: [{ kind: "unknown", className: "registered-instance" }],
+        hasKnownAtomicClass: false
+      };
+
+      expect(metadata.mergeClassList(input)).toBe(input);
+      expect(metadata.mergeClassList(otherInput)).toBe(otherInput);
+      expect(metadata.segmentCacheSize).toBe(2);
+      expect(metadata.fullResultCacheSize).toBe(2);
+
+      metadata.registerSegment(input, registeredSegment);
+
+      expect(metadata.segmentCacheSize).toBe(2);
+      expect(metadata.fullResultCacheSize).toBe(1);
+      expect(metadata.getCachedFullResult(input)).toBe(undefined);
+      expect(metadata.getCachedFullResult(otherInput)).toBe(otherInput);
+      expect(metadata.mergeClassList(input)).toBe("registered-instance");
+    });
+
+    it("evicts the oldest external segment after 2048 unique segment cache entries", () => {
+      const metadata = createEngineMetadata();
+      const originalSegment = metadata.getCompiledSegment("evict-me");
+
+      for (let index = 0; index < DEFAULT_SEGMENT_CACHE_SIZE; index += 1) {
+        metadata.getCompiledSegment(`external-${index}`);
+      }
+
+      expect(metadata.segmentCacheSize).toBe(DEFAULT_SEGMENT_CACHE_SIZE);
+      expect(metadata.getCompiledSegment("evict-me")).not.toBe(originalSegment);
+    });
+
+    it("caches full merge results and evicts them after four newer flattened inputs", () => {
+      const metadata = createEngineMetadata();
+
+      expect(metadata.getCachedFullResult("repeat")).toBe(undefined);
+      expect(metadata.mergeClassList("repeat")).toBe("repeat");
+      expect(metadata.mergeClassList("repeat")).toBe("repeat");
+      expect(metadata.getCachedFullResult("repeat")).toBe("repeat");
+
+      for (let index = 0; index < DEFAULT_FULL_RESULT_CACHE_SIZE; index += 1) {
+        metadata.mergeClassList(`flattened-${index}`);
+      }
+
+      expect(metadata.fullResultCacheSize).toBe(DEFAULT_FULL_RESULT_CACHE_SIZE);
+      expect(metadata.getCachedFullResult("repeat")).toBe(undefined);
+    });
+
+    it("clears stale segment and full-result caches when atomics are registered or hydrated", () => {
+      const metadata = createEngineMetadata();
+      const conditionId = metadata.internCondition(baseCondition());
+      const propertyId = metadata.internProperty("color");
+      const writeKeyId = metadata.internWriteKey(conditionId, propertyId);
+
+      expect(metadata.mergeClassList("color_red color_blue")).toBe(
+        "color_red color_blue"
+      );
+      expect(metadata.segmentCacheSize).toBeGreaterThan(0);
+      expect(metadata.fullResultCacheSize).toBeGreaterThan(0);
+
+      metadata.registerAtomicClass("color_red", writeKeyId);
+
+      expect(metadata.segmentCacheSize).toBe(0);
+      expect(metadata.fullResultCacheSize).toBe(0);
+
+      metadata.registerAtomicClass("color_blue", writeKeyId);
+
+      expect(metadata.mergeClassList("color_red color_blue")).toBe(
+        "color_blue"
+      );
+
+      const source = createEngineMetadata();
+      registerAtomicPair(source, "display", "display_block", "display_flex");
+      const hydrated = createEngineMetadata();
+
+      hydrated.mergeClassList("display_block display_flex");
+      expect(hydrated.segmentCacheSize).toBeGreaterThan(0);
+      expect(hydrated.fullResultCacheSize).toBeGreaterThan(0);
+
+      hydrated.hydrateAtomicClassesFromArtifact(source.exportArtifact());
+
+      expect(hydrated.segmentCacheSize).toBe(0);
+      expect(hydrated.fullResultCacheSize).toBe(0);
+      expect(hydrated.mergeClassList("display_block display_flex")).toBe(
+        "display_flex"
+      );
+    });
+
+    it("serializes only artifact-safe V4 metadata keys", () => {
+      const metadata = createEngineMetadata();
+      registerAtomicPair(metadata, "color", "color_red", "color_blue");
+
+      metadata.registerSegment("color_red", {
+        entries: [{ kind: "unknown", className: "color_red" }],
+        hasKnownAtomicClass: false
+      });
+      metadata.mergeClassList("color_red");
+
+      const artifact = metadata.exportArtifact();
+      const serializedArtifact = JSON.stringify(artifact);
+
+      expect(Object.keys(artifact)).toEqual([
+        "schema",
+        "version",
+        "classNameByCache",
+        "writeKeyByCacheKey",
+        "conditionById",
+        "propertyById",
+        "writeKeyById"
+      ]);
+      expect(serializedArtifact).not.toContain("registeredSegments");
+      expect(serializedArtifact).not.toContain("segmentCache");
+      expect(serializedArtifact).not.toContain("fullResultCache");
+    });
+
+    it("grows epoch arrays and resets the epoch counter before overflow reuse", () => {
+      const metadata = createEngineMetadata({
+        initialEpoch: MAX_EPOCH - 1,
+        initialEpochCapacity: 1
+      });
+      const segment: CompiledSegment = {
+        entries: [
+          { kind: "known", className: "old", writeKeyId: 4096 },
+          { kind: "known", className: "new", writeKeyId: 4096 }
+        ],
+        hasKnownAtomicClass: true
+      };
+
+      expect(metadata.mergeCompiledSegments([segment])).toBe("new");
+      expect(metadata.mergeCompiledSegments([segment])).toBe("new");
+    });
+
+    it("exposes artifact-safe compiled segment types without private runtime interfaces", () => {
+      const segment: DefineRulesPresetCompiledSegment = {
+        entries: [
+          { kind: "unknown", className: "external" },
+          { kind: "known", className: "color_red", writeKeyId: 0 }
+        ],
+        hasKnownAtomicClass: true
+      };
+
+      assertType<DefineRulesPresetCompiledSegment>(segment);
+    });
+  });
+}

--- a/packages/css/src/defineRules/registry.ts
+++ b/packages/css/src/defineRules/registry.ts
@@ -6,8 +6,12 @@ import {
   setFileScope
 } from "@vanilla-extract/css/fileScope";
 import type {
-  DefineRulesPresetArtifactV3,
-  DefineRulesPresetMap
+  DefineRulesConditions,
+  DefineRulesEmptyConditions,
+  DefineRulesCtx,
+  DefineRulesPresetArtifactV4,
+  DefineRulesProperties,
+  DefineRulesShortcuts
 } from "./types.js";
 
 interface NormalizedDefineRulesRegistryFileScope {
@@ -20,8 +24,8 @@ export interface DefineRulesRegistryInstance {
   fileScope: NormalizedDefineRulesRegistryFileScope;
   registrationIndex: number;
   config: unknown;
-  presetArtifact: DefineRulesPresetArtifactV3;
-  getPresetSnapshot(): DefineRulesPresetMap;
+  presetArtifact: DefineRulesPresetArtifactV4;
+  getPresetSnapshot(): DefineRulesPresetArtifactV4;
 }
 
 export interface DefineRulesRegistrySession {
@@ -104,10 +108,18 @@ export function normalizeDefineRulesRegistryFileScope(
   };
 }
 
-export function registerDefineRulesRegistryInstance(metadata: {
-  config: unknown;
-  presetArtifact: DefineRulesPresetArtifactV3;
-  getPresetSnapshot(): DefineRulesPresetMap;
+export function registerDefineRulesRegistryInstance<
+  const Properties extends DefineRulesProperties,
+  const Shortcuts extends DefineRulesShortcuts<
+    Properties,
+    Shortcuts,
+    Conditions
+  >,
+  const Conditions extends DefineRulesConditions = DefineRulesEmptyConditions
+>(metadata: {
+  config: DefineRulesCtx<Properties, Shortcuts, Conditions>;
+  presetArtifact: DefineRulesPresetArtifactV4;
+  getPresetSnapshot(): DefineRulesPresetArtifactV4;
 }): DefineRulesRegistryInstance | undefined {
   const session = getActiveDefineRulesRegistrySession();
 
@@ -150,13 +162,41 @@ if (import.meta.vitest) {
   // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
   const { describe, it, expect, afterEach } = import.meta.vitest;
 
-  const createRegistryMetadata = (preset: DefineRulesPresetMap = {}) => {
-    const presetArtifact: DefineRulesPresetArtifactV3 = {
-      schema: "mincho.defineRulesPreset",
-      version: 3,
-      classNameByCache: preset
-    };
+  const createRegistryPresetArtifact = (): DefineRulesPresetArtifactV4 => ({
+    schema: "mincho.defineRulesPreset",
+    version: 4,
+    classNameByCache: {},
+    writeKeyByCacheKey: {},
+    conditionById: {},
+    propertyById: {},
+    writeKeyById: {}
+  });
 
+  const cloneRegistryPresetArtifact = (
+    artifact: DefineRulesPresetArtifactV4
+  ): DefineRulesPresetArtifactV4 => ({
+    schema: "mincho.defineRulesPreset",
+    version: 4,
+    classNameByCache: { ...artifact.classNameByCache },
+    writeKeyByCacheKey: { ...artifact.writeKeyByCacheKey },
+    conditionById: Object.fromEntries(
+      Object.entries(artifact.conditionById).map(([conditionId, condition]) => [
+        conditionId,
+        { ...condition }
+      ])
+    ),
+    propertyById: { ...artifact.propertyById },
+    writeKeyById: Object.fromEntries(
+      Object.entries(artifact.writeKeyById).map(([writeKeyId, writeKey]) => [
+        writeKeyId,
+        { ...writeKey }
+      ])
+    )
+  });
+
+  const createRegistryMetadata = (
+    presetArtifact: DefineRulesPresetArtifactV4 = createRegistryPresetArtifact()
+  ) => {
     return {
       config: {
         debugId: "registry",
@@ -165,9 +205,7 @@ if (import.meta.vitest) {
         }
       } as const,
       presetArtifact,
-      getPresetSnapshot: () => ({
-        ...preset
-      })
+      getPresetSnapshot: () => cloneRegistryPresetArtifact(presetArtifact)
     };
   };
 
@@ -359,14 +397,12 @@ if (import.meta.vitest) {
     it("stores live preset artifact references and defers snapshot reads", () => {
       const session = beginDefineRulesRegistrySession();
       setFileScope("live.css.ts", "pkg");
-      const preset: DefineRulesPresetMap = {};
+      const preset = createRegistryPresetArtifact();
       let snapshotReadCount = 0;
       const metadata = createRegistryMetadata(preset);
       const getPresetSnapshot = () => {
         snapshotReadCount += 1;
-        return {
-          ...preset
-        };
+        return cloneRegistryPresetArtifact(preset);
       };
 
       const instance = registerDefineRulesRegistryInstance({
@@ -374,16 +410,46 @@ if (import.meta.vitest) {
         getPresetSnapshot
       });
 
-      preset.colorRed = "color_red";
+      preset.classNameByCache.colorRed = "color_red";
+      preset.writeKeyByCacheKey.colorRed = 0;
+      preset.conditionById[0] = {
+        layer: null,
+        supports: null,
+        media: null,
+        container: null,
+        selector: "&"
+      };
+      preset.propertyById[0] = "color";
+      preset.writeKeyById[0] = {
+        conditionId: 0,
+        propertyId: 0
+      };
 
       expect(instance?.presetArtifact).toBe(metadata.presetArtifact);
       expect(instance?.config).toBe(metadata.config);
       expect(snapshotReadCount).toBe(0);
-      expect(instance?.getPresetSnapshot()).toEqual({
-        colorRed: "color_red"
-      });
+      expect(instance?.getPresetSnapshot()).toEqual(preset);
       expect(snapshotReadCount).toBe(1);
       expect(session.instances[0]).toBe(instance);
+    });
+
+    it("stores v4 preset artifact metadata", () => {
+      beginDefineRulesRegistrySession();
+      setFileScope("v4.css.ts", "pkg");
+
+      const instance = registerDefineRulesRegistryInstance(
+        createRegistryMetadata()
+      );
+
+      expect(instance?.presetArtifact).toEqual({
+        schema: "mincho.defineRulesPreset",
+        version: 4,
+        classNameByCache: {},
+        writeKeyByCacheKey: {},
+        conditionById: {},
+        propertyById: {},
+        writeKeyById: {}
+      });
     });
   });
 }

--- a/packages/css/src/defineRules/registry.ts
+++ b/packages/css/src/defineRules/registry.ts
@@ -6,11 +6,8 @@ import {
   setFileScope
 } from "@vanilla-extract/css/fileScope";
 import type {
-  DefineRulesCtx,
   DefineRulesPresetArtifactV3,
-  DefineRulesPresetMap,
-  DefineRulesProperties,
-  DefineRulesShortcuts
+  DefineRulesPresetMap
 } from "./types.js";
 
 interface NormalizedDefineRulesRegistryFileScope {
@@ -107,11 +104,8 @@ export function normalizeDefineRulesRegistryFileScope(
   };
 }
 
-export function registerDefineRulesRegistryInstance<
-  const Properties extends DefineRulesProperties,
-  const Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
->(metadata: {
-  config: DefineRulesCtx<Properties, Shortcuts>;
+export function registerDefineRulesRegistryInstance(metadata: {
+  config: unknown;
   presetArtifact: DefineRulesPresetArtifactV3;
   getPresetSnapshot(): DefineRulesPresetMap;
 }): DefineRulesRegistryInstance | undefined {

--- a/packages/css/src/defineRules/runtime.ts
+++ b/packages/css/src/defineRules/runtime.ts
@@ -1,21 +1,50 @@
-import type { CSSProperties } from "@mincho-js/transform-to-vanilla";
-import { cx } from "../classname/cx.js";
+import { collectStyleDeclarations } from "@mincho-js/transform-to-vanilla";
+import type {
+  ConditionAliasMap,
+  CSSRule,
+  NormalizedCondition
+} from "@mincho-js/transform-to-vanilla";
+import {
+  endFileScope,
+  hasFileScope,
+  setFileScope
+} from "@vanilla-extract/css/fileScope";
+import { cx as rootCx } from "../classname/cx.js";
+import type {
+  ClassMultipleInput,
+  ClassMultipleResult,
+  ClassValue
+} from "../classname/types.js";
 import type { Cx } from "../classname/index.js";
 import { registerDefineRulesRegistryInstance } from "./registry.js";
+import { normalizeDefineRulesConditions } from "./conditions.js";
 import { createCanonicalStyleCache } from "./utils.js";
+import { createEngineMetadata } from "./metadata.js";
+import type { EngineMetadata } from "./metadata.js";
 import type {
   DefineRulesCss,
   DefineRulesComplexCssInput,
   DefineRulesCtx,
   DefineRulesConditions,
   DefineRulesEmptyConditions,
-  DefineRulesPresetArtifactV3,
-  DefineRulesPresetClassNameByCache,
+  DefineRulesPresetArtifactV4,
   DefineRulesPresetInput,
-  DefineRulesPresetMap,
   DefineRulesProperties,
   DefineRulesShortcuts
 } from "./types.js";
+
+const CONDITION_AT_RULES = [
+  ["layer", "@layer"],
+  ["supports", "@supports"],
+  ["media", "@media"],
+  ["container", "@container"]
+] as const satisfies readonly (readonly [
+  Exclude<keyof NormalizedCondition, "selector">,
+  string
+])[];
+
+// == Define Rules Runtime =====================================================
+type DefineRulesRuntimeCx = Cx;
 
 export interface DefineRulesRuntimeResult<
   Properties extends DefineRulesProperties,
@@ -25,8 +54,8 @@ export interface DefineRulesRuntimeResult<
   css: DefineRulesCss<
     DefineRulesComplexCssInput<Properties, Shortcuts, Conditions>
   >;
-  cx: Cx;
-  preset: DefineRulesPresetArtifactV3;
+  cx: DefineRulesRuntimeCx;
+  preset: DefineRulesPresetArtifactV4;
 }
 
 export interface DefineRulesRuntimeOptions {
@@ -47,72 +76,144 @@ export function createDefineRulesRuntime<
   options: DefineRulesRuntimeOptions = {}
 ): DefineRulesRuntimeResult<Properties, Shortcuts, Conditions> {
   type CssInput = DefineRulesComplexCssInput<Properties, Shortcuts, Conditions>;
-  const presetArtifact = createDefineRulesPresetArtifact(
-    config.presets,
-    options?.preservePresetReference === true
+  const normalizedConditions = normalizeDefineRulesConditions(
+    config.conditions
   );
   const styleCache = createCanonicalStyleCache(config.debugId);
-  styleCache.importSnapshot(presetArtifact.classNameByCache);
+  const metadata = createEngineMetadata();
+  const presetArtifact = createDefineRulesPresetArtifact(
+    config.presets,
+    options?.preservePresetReference === true,
+    styleCache,
+    metadata
+  );
 
   if (options.registerPreset !== false) {
     registerDefineRulesRegistryInstance({
       config,
       presetArtifact,
-      getPresetSnapshot: () => ({
-        ...presetArtifact.classNameByCache
-      })
+      getPresetSnapshot: () => clonePresetArtifact(presetArtifact)
     });
   }
 
   function resolveToFragments(args: CssInput): ResolvedStyleFragment[] {
     const fragments: ResolvedStyleFragment[] = [];
-    applyInput(config as RuntimeDefineRulesCtx, fragments, args, []);
+    applyInput(config, fragments, args, []);
     return fragments;
   }
 
-  function cssRaw(args: CssInput): CSSProperties {
-    return flattenResolvedFragments(resolveToFragments(args));
+  function cssRaw(args: CssInput): CSSRule {
+    return flattenAtomicWrites(
+      collectEmittedAtomicWrites(
+        collectAtomicWrites(resolveToFragments(args), normalizedConditions)
+      )
+    );
   }
 
   function cssImpl(args: CssInput): string {
-    const fragments = resolveToFragments(args);
-    const emittedFragments = collectEmittedFragments(fragments);
-    const output: string[] = [];
-    let didAddFragment = false;
+    const atomicWrites = collectEmittedAtomicWrites(
+      collectAtomicWrites(resolveToFragments(args), normalizedConditions)
+    );
+    const entries = [] as Array<{
+      kind: "known";
+      className: string;
+      writeKeyId: number;
+    }>;
+    let didAddAtomicCacheEntry = false;
 
-    for (const fragment of emittedFragments) {
+    for (const atomicWrite of atomicWrites) {
       const hasFragment = styleCache.hasFragment(
-        fragment.inputIdentity.property,
-        fragment.inputIdentity.value,
-        fragment.style
+        atomicWrite.property,
+        atomicWrite.value,
+        atomicWrite.style
       );
       const className = styleCache.addFragment(
-        fragment.inputIdentity.property,
-        fragment.inputIdentity.value,
-        fragment.style
+        atomicWrite.property,
+        atomicWrite.value,
+        atomicWrite.style
       );
+      const writeKeyId = internAtomicWriteKey(metadata, atomicWrite);
 
       if (hasFragment === false) {
-        didAddFragment = true;
+        registerAtomicWriteMetadata(
+          metadata,
+          styleCache,
+          className,
+          writeKeyId
+        );
+        didAddAtomicCacheEntry = true;
       }
 
-      output.push(className);
+      entries.push({ kind: "known", className, writeKeyId });
     }
 
-    if (didAddFragment) {
-      Object.assign(
-        presetArtifact.classNameByCache,
-        styleCache.exportSnapshot()
-      );
+    const className = entries.map((entry) => entry.className).join(" ");
+    metadata.registerSegment(className, {
+      entries,
+      hasKnownAtomicClass: entries.length > 0
+    });
+
+    if (didAddAtomicCacheEntry) {
+      syncPresetArtifact(presetArtifact, metadata.exportArtifact());
     }
 
-    return output.sort().join(" ");
+    return className;
   }
 
   const css = Object.assign(cssImpl, {
     raw: cssRaw
   }) as DefineRulesCss<CssInput>;
+  const cx = createDefineRulesCx(metadata);
   return { css, cx, preset: presetArtifact };
+}
+
+function createDefineRulesCx(metadata: EngineMetadata): DefineRulesRuntimeCx {
+  const cxImpl = ((...inputs: ClassValue[]) => {
+    const className = rootCx(...inputs);
+    return metadata.mergeClassList(className);
+  }) as (...inputs: ClassValue[]) => string;
+
+  function cxMultiple<T extends ClassMultipleInput>(
+    map: T
+  ): ClassMultipleResult<T> {
+    const result = {} as ClassMultipleResult<T>;
+
+    for (const key in map) {
+      result[key] = cxImpl(map[key]);
+    }
+
+    return result;
+  }
+
+  function cxWith<const T extends ClassValue>(
+    callback?: (params: T) => ClassValue
+  ) {
+    const cxFunction = callback ?? ((className: T) => className);
+
+    function cxWithImpl(...className: T[]) {
+      const result = className.map((cn) => cxFunction(cn));
+      return cxImpl(...result);
+    }
+
+    function cxWithMultiple<ClassNameMap extends ClassMultipleInput<T>>(
+      classNameMap: ClassNameMap
+    ): ClassMultipleResult<ClassNameMap> {
+      type TransformedClassNameMap = Record<keyof ClassNameMap, ClassValue>;
+      const transformedClassNameMap: TransformedClassNameMap =
+        {} as TransformedClassNameMap;
+      for (const key in classNameMap) {
+        transformedClassNameMap[key] = cxFunction(classNameMap[key]);
+      }
+      return cxMultiple(transformedClassNameMap);
+    }
+
+    return Object.assign(cxWithImpl, { multiple: cxWithMultiple });
+  }
+
+  return Object.assign(cxImpl, {
+    multiple: cxMultiple,
+    with: cxWith
+  }) as DefineRulesRuntimeCx;
 }
 
 // == Define Rules Impl ========================================================
@@ -121,95 +222,159 @@ interface InputIdentity {
   value: unknown;
 }
 
-interface RuntimeDefineRulesCtx {
-  properties?: Record<string, unknown>;
-  shortcuts?: Record<string, unknown>;
-}
-
 interface ResolvedStyleFragment {
   source: {
     key: string;
     shortcutStack: string[];
   };
   inputIdentity: InputIdentity;
-  outputKeys: string[];
-  style: CSSProperties;
+  style: CSSRule;
 }
 
-function collectEmittedFragments(
-  fragments: readonly ResolvedStyleFragment[]
-): ResolvedStyleFragment[] {
-  const occupiedKeys = new Set<string>();
-  const emittedFragments: ResolvedStyleFragment[] = [];
+interface AtomicWrite {
+  condition: NormalizedCondition;
+  property: string;
+  value: unknown;
+  style: CSSRule;
+  writeKey: string;
+}
 
-  for (let index = fragments.length - 1; index >= 0; index -= 1) {
-    const fragment = fragments[index];
-    if (fragment == null) continue;
+function collectAtomicWrites(
+  fragments: readonly ResolvedStyleFragment[],
+  conditions: ConditionAliasMap
+): AtomicWrite[] {
+  const atomicWrites: AtomicWrite[] = [];
 
-    const emittedFragment = omitOccupiedKeys(fragment, occupiedKeys);
-    if (emittedFragment == null) {
+  for (const fragment of fragments) {
+    const declarations = collectStyleDeclarations(fragment.style, {
+      conditions
+    });
+
+    for (const declaration of declarations) {
+      atomicWrites.push({
+        condition: declaration.condition,
+        property: declaration.property,
+        value: declaration.value,
+        style: styleForDeclarationCondition(
+          declaration.condition,
+          declaration.property,
+          declaration.value
+        ),
+        writeKey: atomicWriteKey(declaration.condition, declaration.property)
+      });
+    }
+  }
+
+  return atomicWrites;
+}
+
+function collectEmittedAtomicWrites(
+  atomicWrites: readonly AtomicWrite[]
+): AtomicWrite[] {
+  const occupiedWriteKeys = new Set<string>();
+  const emittedWrites: AtomicWrite[] = [];
+
+  for (let index = atomicWrites.length - 1; index >= 0; index -= 1) {
+    const atomicWrite = atomicWrites[index];
+
+    if (atomicWrite == null || occupiedWriteKeys.has(atomicWrite.writeKey)) {
       continue;
     }
 
-    emittedFragments.push(emittedFragment);
-
-    for (const key of emittedFragment.outputKeys) {
-      occupiedKeys.add(key);
-    }
+    occupiedWriteKeys.add(atomicWrite.writeKey);
+    emittedWrites.push(atomicWrite);
   }
 
-  return emittedFragments.reverse();
+  return emittedWrites.reverse();
 }
 
-function omitOccupiedKeys(
-  fragment: ResolvedStyleFragment,
-  occupiedKeys: ReadonlySet<string>
-): ResolvedStyleFragment | undefined {
-  const remainingOutputKeys = fragment.outputKeys.filter(
-    (key) => !occupiedKeys.has(key)
-  );
+function flattenAtomicWrites(atomicWrites: readonly AtomicWrite[]): CSSRule {
+  const mergedStyle: CSSRule = {};
 
-  if (remainingOutputKeys.length === 0) {
-    return undefined;
-  }
-
-  if (remainingOutputKeys.length === fragment.outputKeys.length) {
-    return fragment;
-  }
-
-  const nextStyle: Record<string, unknown> = {};
-
-  for (const key of remainingOutputKeys) {
-    nextStyle[key] = (fragment.style as Record<string, unknown>)[key];
-  }
-
-  return {
-    ...fragment,
-    outputKeys: remainingOutputKeys,
-    style: nextStyle as CSSProperties
-  };
-}
-
-function flattenResolvedFragments(
-  fragments: readonly ResolvedStyleFragment[]
-): CSSProperties {
-  const mergedStyle: CSSProperties = {};
-
-  for (const fragment of fragments) {
-    Object.assign(mergedStyle, fragment.style);
+  for (const atomicWrite of atomicWrites) {
+    mergeStyleInto(
+      mergedStyle as unknown as Record<string, unknown>,
+      atomicWrite.style as unknown as Record<string, unknown>
+    );
   }
 
   return mergedStyle;
+}
+
+function styleForDeclarationCondition(
+  condition: NormalizedCondition,
+  property: string,
+  value: unknown
+): CSSRule {
+  let style = {
+    [property.startsWith("--") ? "vars" : property]: property.startsWith("--")
+      ? { [property]: value }
+      : value
+  } as CSSRule;
+
+  if (condition.selector !== "&") {
+    style = {
+      selectors: {
+        [condition.selector]: style
+      }
+    } as CSSRule;
+  }
+
+  for (let index = CONDITION_AT_RULES.length - 1; index >= 0; index -= 1) {
+    const entry = CONDITION_AT_RULES[index];
+    if (entry == null) continue;
+
+    const [conditionKey, atRule] = entry;
+    const conditionValue = condition[conditionKey];
+    if (conditionValue == null) continue;
+
+    style = {
+      [atRule]: {
+        [conditionValue]: style
+      }
+    } as unknown as CSSRule;
+  }
+
+  return style;
+}
+
+function atomicWriteKey(
+  condition: NormalizedCondition,
+  property: string
+): string {
+  return JSON.stringify([
+    condition.layer,
+    condition.supports,
+    condition.media,
+    condition.container,
+    condition.selector,
+    property
+  ]);
+}
+
+function mergeStyleInto(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>
+): void {
+  for (const [key, value] of Object.entries(source)) {
+    const previous = target[key];
+
+    if (isPlainObject(previous) && isPlainObject(value)) {
+      mergeStyleInto(previous, value);
+      continue;
+    }
+
+    target[key] = value;
+  }
 }
 
 function pushResolvedFragment(
   fragmentsOut: ResolvedStyleFragment[],
   inputIdentity: InputIdentity,
   shortcutStack: readonly string[],
-  style: CSSProperties
+  style: CSSRule
 ) {
-  const outputKeys = Object.keys(style);
-  if (outputKeys.length === 0) return;
+  if (Object.keys(style).length === 0) return;
 
   fragmentsOut.push({
     source: {
@@ -217,13 +382,16 @@ function pushResolvedFragment(
       shortcutStack: [...shortcutStack]
     },
     inputIdentity,
-    outputKeys,
     style
   });
 }
 
-function applyInput(
-  ctx: RuntimeDefineRulesCtx,
+function applyInput<
+  Properties extends DefineRulesProperties,
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts, Conditions>,
+  Conditions extends DefineRulesConditions
+>(
+  ctx: DefineRulesCtx<Properties, Shortcuts, Conditions>,
   fragmentsOut: ResolvedStyleFragment[],
   input: unknown,
   shortcutStack: string[]
@@ -248,8 +416,12 @@ function applyInput(
   throw new Error(`Unsupported css() argument: ${String(input)}`);
 }
 
-function applyInlineShortcut(
-  ctx: RuntimeDefineRulesCtx,
+function applyInlineShortcut<
+  Properties extends DefineRulesProperties,
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts, Conditions>,
+  Conditions extends DefineRulesConditions
+>(
+  ctx: DefineRulesCtx<Properties, Shortcuts, Conditions>,
   fragmentsOut: ResolvedStyleFragment[],
   shortcutName: string,
   shortcutStack: string[]
@@ -261,8 +433,12 @@ function applyInlineShortcut(
   throw new Error(`Unknown fixed style: "${shortcutName}"`);
 }
 
-function applyArray(
-  ctx: RuntimeDefineRulesCtx,
+function applyArray<
+  Properties extends DefineRulesProperties,
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts, Conditions>,
+  Conditions extends DefineRulesConditions
+>(
+  ctx: DefineRulesCtx<Properties, Shortcuts, Conditions>,
   fragmentsOut: ResolvedStyleFragment[],
   arr: readonly unknown[],
   shortcutStack: string[]
@@ -272,8 +448,12 @@ function applyArray(
   }
 }
 
-function applyObject(
-  ctx: RuntimeDefineRulesCtx,
+function applyObject<
+  Properties extends DefineRulesProperties,
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts, Conditions>,
+  Conditions extends DefineRulesConditions
+>(
+  ctx: DefineRulesCtx<Properties, Shortcuts, Conditions>,
   fragmentsOut: ResolvedStyleFragment[],
   obj: Record<string, unknown>,
   shortcutStack: string[]
@@ -283,8 +463,12 @@ function applyObject(
   }
 }
 
-function applyEntry(
-  ctx: RuntimeDefineRulesCtx,
+function applyEntry<
+  Properties extends DefineRulesProperties,
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts, Conditions>,
+  Conditions extends DefineRulesConditions
+>(
+  ctx: DefineRulesCtx<Properties, Shortcuts, Conditions>,
   fragmentsOut: ResolvedStyleFragment[],
   key: string,
   value: unknown,
@@ -293,7 +477,6 @@ function applyEntry(
   if (value == null) {
     return;
   }
-
   if (hasOwn(ctx.shortcuts, key)) {
     applyShortcut(ctx, fragmentsOut, key, value, shortcutStack);
     return;
@@ -302,14 +485,18 @@ function applyEntry(
   applyProperty(ctx, fragmentsOut, key, value, shortcutStack);
 }
 
-function applyProperty(
-  ctx: RuntimeDefineRulesCtx,
+function applyProperty<
+  Properties extends DefineRulesProperties,
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts, Conditions>,
+  Conditions extends DefineRulesConditions
+>(
+  ctx: DefineRulesCtx<Properties, Shortcuts, Conditions>,
   fragmentsOut: ResolvedStyleFragment[],
   prop: string,
   value: unknown,
   shortcutStack: string[]
 ) {
-  const propertyDefinition = ctx.properties?.[prop];
+  const propertyDefinition = ctx.properties?.[prop as keyof Properties];
 
   if (typeof propertyDefinition === "function") {
     const result = propertyDefinition(value);
@@ -323,7 +510,7 @@ function applyProperty(
         fragmentsOut,
         { property: prop, value },
         shortcutStack,
-        result as CSSProperties
+        result as CSSRule
       );
       return;
     } else {
@@ -333,7 +520,7 @@ function applyProperty(
         shortcutStack,
         {
           [prop]: result
-        } as CSSProperties
+        } as CSSRule
       );
       return;
     }
@@ -347,7 +534,7 @@ function applyProperty(
       shortcutStack,
       {
         [prop]: value
-      } as CSSProperties
+      } as CSSRule
     );
     return;
   }
@@ -360,7 +547,7 @@ function applyProperty(
       fragmentsOut,
       { property: prop, value },
       shortcutStack,
-      mappedValue as CSSProperties
+      mappedValue as CSSRule
     );
     return;
   }
@@ -368,11 +555,15 @@ function applyProperty(
   // Mapped value => assign mapped value
   pushResolvedFragment(fragmentsOut, { property: prop, value }, shortcutStack, {
     [prop]: mappedValue ?? value
-  } as CSSProperties);
+  } as CSSRule);
 }
 
-function applyShortcutReference(
-  ctx: RuntimeDefineRulesCtx,
+function applyShortcutReference<
+  Properties extends DefineRulesProperties,
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts, Conditions>,
+  Conditions extends DefineRulesConditions
+>(
+  ctx: DefineRulesCtx<Properties, Shortcuts, Conditions>,
   fragmentsOut: ResolvedStyleFragment[],
   targetName: string,
   value: unknown,
@@ -386,8 +577,12 @@ function applyShortcutReference(
   applyProperty(ctx, fragmentsOut, targetName, value, shortcutStack);
 }
 
-function applyShortcut(
-  ctx: RuntimeDefineRulesCtx,
+function applyShortcut<
+  Properties extends DefineRulesProperties,
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts, Conditions>,
+  Conditions extends DefineRulesConditions
+>(
+  ctx: DefineRulesCtx<Properties, Shortcuts, Conditions>,
   fragmentsOut: ResolvedStyleFragment[],
   name: string,
   value: unknown,
@@ -399,7 +594,7 @@ function applyShortcut(
     );
   }
 
-  const shortcutDefinition = ctx.shortcuts?.[name];
+  const shortcutDefinition = ctx.shortcuts?.[name as keyof Shortcuts];
   if (shortcutDefinition == null) return;
 
   const nextShortcutStack = shortcutStack.concat(name);
@@ -456,95 +651,241 @@ function applyShortcut(
 
 function createDefineRulesPresetArtifact(
   presetInput: DefineRulesPresetInput | undefined,
-  preserveReference: boolean
-): DefineRulesPresetArtifactV3 {
-  if (preserveReference && isDefineRulesPresetArtifactV3(presetInput)) {
-    return presetInput;
+  preserveReference: boolean,
+  styleCache: ReturnType<typeof createCanonicalStyleCache>,
+  metadata: EngineMetadata
+): DefineRulesPresetArtifactV4 {
+  const presetArtifact =
+    preserveReference && isDefineRulesPresetArtifactV4(presetInput)
+      ? presetInput
+      : metadata.exportArtifact();
+
+  importPresetInput(presetInput, styleCache, metadata);
+  syncPresetArtifact(presetArtifact, metadata.exportArtifact());
+
+  return presetArtifact;
+}
+
+function importPresetInput(
+  presetInput: DefineRulesPresetInput | undefined,
+  styleCache: ReturnType<typeof createCanonicalStyleCache>,
+  metadata: EngineMetadata
+): void {
+  if (presetInput == null) {
+    return;
   }
 
+  if (Array.isArray(presetInput)) {
+    for (const item of presetInput) {
+      importPresetInput(item, styleCache, metadata);
+    }
+    return;
+  }
+
+  if (!isDefineRulesPresetArtifactV4(presetInput)) {
+    throwUnsupportedPresetInput();
+  }
+
+  importV4PresetArtifact(presetInput, styleCache, metadata);
+}
+
+function isDefineRulesPresetArtifactV4(
+  value: unknown
+): value is DefineRulesPresetArtifactV4 {
+  return (
+    isPlainRecordObject(value) &&
+    value.schema === "mincho.defineRulesPreset" &&
+    value.version === 4 &&
+    isStringRecord(value.classNameByCache) &&
+    isNumberRecord(value.writeKeyByCacheKey) &&
+    isPlainRecordObject(value.conditionById) &&
+    Object.values(value.conditionById).every(isNormalizedCondition) &&
+    isStringRecord(value.propertyById) &&
+    isPlainRecordObject(value.writeKeyById) &&
+    Object.values(value.writeKeyById).every(isPresetWriteKey)
+  );
+}
+
+function importV4PresetArtifact(
+  artifact: DefineRulesPresetArtifactV4,
+  styleCache: ReturnType<typeof createCanonicalStyleCache>,
+  metadata: EngineMetadata
+): void {
+  const conditionIdMap: Record<number, number> = {};
+  const propertyIdMap: Record<number, number> = {};
+  const writeKeyIdMap: Record<number, number> = {};
+
+  for (const [artifactConditionId, condition] of Object.entries(
+    artifact.conditionById
+  )) {
+    conditionIdMap[Number(artifactConditionId)] =
+      metadata.internCondition(condition);
+  }
+
+  for (const [artifactPropertyId, property] of Object.entries(
+    artifact.propertyById
+  )) {
+    propertyIdMap[Number(artifactPropertyId)] =
+      metadata.internProperty(property);
+  }
+
+  for (const [artifactWriteKeyId, writeKey] of Object.entries(
+    artifact.writeKeyById
+  )) {
+    const conditionId = conditionIdMap[writeKey.conditionId];
+    const propertyId = propertyIdMap[writeKey.propertyId];
+    if (conditionId === undefined || propertyId === undefined) {
+      throwUnsupportedPresetInput();
+    }
+    writeKeyIdMap[Number(artifactWriteKeyId)] = metadata.internWriteKey(
+      conditionId,
+      propertyId
+    );
+  }
+
+  styleCache.importSnapshot(artifact.classNameByCache);
+
+  for (const [cacheKey, artifactWriteKeyId] of Object.entries(
+    artifact.writeKeyByCacheKey
+  )) {
+    const className = artifact.classNameByCache[cacheKey];
+    const writeKeyId = writeKeyIdMap[artifactWriteKeyId];
+
+    if (className === undefined || writeKeyId === undefined) {
+      throwUnsupportedPresetInput();
+    }
+
+    metadata.registerAtomicCacheEntry(cacheKey, className, writeKeyId);
+  }
+}
+
+function internAtomicWriteKey(
+  metadata: EngineMetadata,
+  atomicWrite: AtomicWrite
+): number {
+  const conditionId = metadata.internCondition(atomicWrite.condition);
+  const propertyId = metadata.internProperty(atomicWrite.property);
+  return metadata.internWriteKey(conditionId, propertyId);
+}
+
+function registerAtomicWriteMetadata(
+  metadata: EngineMetadata,
+  styleCache: ReturnType<typeof createCanonicalStyleCache>,
+  className: string,
+  writeKeyId: number
+): void {
+  const cacheKey = findCacheKeyForClassName(styleCache, className);
+  metadata.registerAtomicCacheEntry(cacheKey, className, writeKeyId);
+}
+
+function findCacheKeyForClassName(
+  styleCache: ReturnType<typeof createCanonicalStyleCache>,
+  className: string
+): string {
+  for (const [cacheKey, cachedClassName] of Object.entries(
+    styleCache.exportSnapshot()
+  )) {
+    if (cachedClassName === className) {
+      return cacheKey;
+    }
+  }
+
+  throw new Error(`Unable to resolve defineRules cache key for ${className}`);
+}
+
+function clonePresetArtifact(
+  artifact: DefineRulesPresetArtifactV4
+): DefineRulesPresetArtifactV4 {
   return {
     schema: "mincho.defineRulesPreset",
-    version: 3,
-    classNameByCache: normalizePresetMap(presetInput, preserveReference)
+    version: 4,
+    classNameByCache: { ...artifact.classNameByCache },
+    writeKeyByCacheKey: { ...artifact.writeKeyByCacheKey },
+    conditionById: cloneConditionById(artifact.conditionById),
+    propertyById: { ...artifact.propertyById },
+    writeKeyById: cloneWriteKeyById(artifact.writeKeyById)
   };
 }
 
-function normalizePresetMap(
-  presetInput: DefineRulesPresetInput | undefined,
-  preserveReference: boolean
-): DefineRulesPresetMap {
-  if (presetInput == null) {
-    return {};
+function cloneConditionById(
+  conditionById: DefineRulesPresetArtifactV4["conditionById"]
+): DefineRulesPresetArtifactV4["conditionById"] {
+  const clone: DefineRulesPresetArtifactV4["conditionById"] = {};
+
+  for (const [conditionId, condition] of Object.entries(conditionById)) {
+    clone[Number(conditionId)] = { ...condition };
   }
 
-  return normalizePresetInput(presetInput, preserveReference, "config.presets");
+  return clone;
 }
 
-function normalizePresetInput(
-  presetInput: unknown,
-  preserveReference: boolean,
-  path: string
-): DefineRulesPresetMap {
-  if (Array.isArray(presetInput)) {
-    const mergedPreset: DefineRulesPresetMap = {};
+function cloneWriteKeyById(
+  writeKeyById: DefineRulesPresetArtifactV4["writeKeyById"]
+): DefineRulesPresetArtifactV4["writeKeyById"] {
+  const clone: DefineRulesPresetArtifactV4["writeKeyById"] = {};
 
-    for (const [index, item] of presetInput.entries()) {
-      Object.assign(
-        mergedPreset,
-        normalizePresetInput(item, false, `${path}[${index}]`)
-      );
-    }
-
-    return mergedPreset;
+  for (const [writeKeyId, writeKey] of Object.entries(writeKeyById)) {
+    clone[Number(writeKeyId)] = { ...writeKey };
   }
 
-  if (isDefineRulesPresetArtifactV3(presetInput)) {
-    return preserveReference
-      ? presetInput.classNameByCache
-      : { ...presetInput.classNameByCache };
-  }
-
-  if (isDefineRulesPresetArtifactEnvelope(presetInput)) {
-    if (presetInput.version === 3) {
-      throwUnsupportedPresetInput(`${path}.classNameByCache`);
-    }
-
-    throwUnsupportedPresetInput(path);
-  }
-
-  if (isDefineRulesPresetClassNameByCache(presetInput)) {
-    return preserveReference ? presetInput : { ...presetInput };
-  }
-
-  throwUnsupportedPresetInput(path);
+  return clone;
 }
 
-function isDefineRulesPresetArtifactV3(
-  value: unknown
-): value is DefineRulesPresetArtifactV3 {
-  return (
-    isDefineRulesPresetArtifactEnvelope(value) &&
-    value.version === 3 &&
-    isDefineRulesPresetClassNameByCache(value.classNameByCache)
-  );
+function syncPresetArtifact(
+  target: DefineRulesPresetArtifactV4,
+  source: DefineRulesPresetArtifactV4
+): void {
+  target.schema = source.schema;
+  target.version = source.version;
+  replaceRecord(target.classNameByCache, source.classNameByCache);
+  replaceRecord(target.writeKeyByCacheKey, source.writeKeyByCacheKey);
+  replaceRecord(target.conditionById, source.conditionById);
+  replaceRecord(target.propertyById, source.propertyById);
+  replaceRecord(target.writeKeyById, source.writeKeyById);
 }
 
-function isDefineRulesPresetArtifactEnvelope(value: unknown): value is {
-  schema: "mincho.defineRulesPreset";
-  version?: unknown;
-  classNameByCache?: unknown;
-} {
-  return (
-    isPlainRecordObject(value) && value.schema === "mincho.defineRulesPreset"
-  );
+function replaceRecord<T>(
+  target: Record<string, T>,
+  source: Record<string, T>
+) {
+  for (const key of Object.keys(target)) {
+    delete target[key];
+  }
+  Object.assign(target, source);
 }
 
-function isDefineRulesPresetClassNameByCache(
-  value: unknown
-): value is DefineRulesPresetClassNameByCache {
+function isStringRecord(value: unknown): value is Record<string, string> {
   return (
     isPlainRecordObject(value) &&
     Object.values(value).every((entry) => typeof entry === "string")
+  );
+}
+
+function isNumberRecord(value: unknown): value is Record<string, number> {
+  return (
+    isPlainRecordObject(value) &&
+    Object.values(value).every((entry) => typeof entry === "number")
+  );
+}
+
+function isPresetWriteKey(
+  value: unknown
+): value is DefineRulesPresetArtifactV4["writeKeyById"][number] {
+  return (
+    isPlainRecordObject(value) &&
+    typeof value.conditionId === "number" &&
+    typeof value.propertyId === "number"
+  );
+}
+
+function isNormalizedCondition(value: unknown): value is NormalizedCondition {
+  return (
+    isPlainRecordObject(value) &&
+    typeof value.selector === "string" &&
+    (value.layer === null || typeof value.layer === "string") &&
+    (value.supports === null || typeof value.supports === "string") &&
+    (value.media === null || typeof value.media === "string") &&
+    (value.container === null || typeof value.container === "string")
   );
 }
 
@@ -557,8 +898,145 @@ function isPlainRecordObject(value: unknown): value is Record<string, unknown> {
   return proto === Object.prototype || proto === null;
 }
 
-function throwUnsupportedPresetInput(path: string): never {
-  throw new Error(`Unsupported defineRules preset input at ${path}`);
+function throwUnsupportedPresetInput(): never {
+  throw new Error(
+    "Unsupported defineRules preset input at config.presets; expected version 4"
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+  const { describe, it, expect, afterEach } = import.meta.vitest;
+
+  afterEach(() => {
+    while (hasFileScope()) {
+      endFileScope();
+    }
+  });
+
+  function cloneRuntimePresetArtifact(
+    artifact: DefineRulesPresetArtifactV4
+  ): DefineRulesPresetArtifactV4 {
+    return clonePresetArtifact(artifact);
+  }
+
+  describe("defineRules runtime presets", () => {
+    it("exports v4 artifacts with metadata maps and no runtime-only state", () => {
+      setFileScope("runtime-v4.css.ts", "pkg");
+      const runtime = createDefineRulesRuntime({
+        debugId: "runtimeV4Artifact",
+        properties: {
+          color: true
+        }
+      });
+      const className = runtime.css({ color: "red" });
+      const artifact = runtime.preset;
+
+      expect(Object.keys(artifact)).toEqual([
+        "schema",
+        "version",
+        "classNameByCache",
+        "writeKeyByCacheKey",
+        "conditionById",
+        "propertyById",
+        "writeKeyById"
+      ]);
+      expect(artifact).not.toHaveProperty("registeredSegments");
+      expect(artifact).not.toHaveProperty("segmentCache");
+      expect(artifact).not.toHaveProperty("fullResultCache");
+      expect(artifact).not.toHaveProperty("cx");
+      expect(artifact).not.toHaveProperty("atomicClassByClassName");
+      expect(artifact.version).toBe(4);
+      expect(Object.values(artifact.classNameByCache)).toEqual([className]);
+      expect(Object.keys(artifact.writeKeyByCacheKey)).toEqual(
+        Object.keys(artifact.classNameByCache)
+      );
+      expect(
+        JSON.stringify({
+          writeKeyByCacheKey: artifact.writeKeyByCacheKey,
+          conditionById: artifact.conditionById,
+          propertyById: artifact.propertyById,
+          writeKeyById: artifact.writeKeyById
+        })
+      ).not.toContain(className);
+    });
+
+    it("remaps colliding artifact-local IDs from imported v4 presets", () => {
+      setFileScope("runtime-remap.css.ts", "pkg");
+      const colorProvider = createDefineRulesRuntime({
+        debugId: "colorProvider",
+        properties: {
+          color: true
+        }
+      });
+      const backgroundProvider = createDefineRulesRuntime({
+        debugId: "backgroundProvider",
+        properties: {
+          background: true
+        }
+      });
+      const colorClassName = colorProvider.css({ color: "red" });
+      const backgroundClassName = backgroundProvider.css({
+        background: "blue"
+      });
+      const colorPreset = cloneRuntimePresetArtifact(colorProvider.preset);
+      const backgroundPreset = cloneRuntimePresetArtifact(
+        backgroundProvider.preset
+      );
+
+      expect(Object.keys(colorPreset.writeKeyById)).toEqual(["0"]);
+      expect(Object.keys(backgroundPreset.writeKeyById)).toEqual(["0"]);
+
+      const consumer = createDefineRulesRuntime({
+        debugId: "remapConsumer",
+        presets: [colorPreset, backgroundPreset],
+        properties: {
+          color: true,
+          background: true
+        }
+      });
+
+      expect(consumer.css({ color: "red" })).toBe(colorClassName);
+      expect(consumer.css({ background: "blue" })).toBe(backgroundClassName);
+
+      const importedCacheKeys = Object.keys(consumer.preset.writeKeyByCacheKey);
+      const colorCacheKey = Object.keys(colorPreset.classNameByCache)[0];
+      const backgroundCacheKey = Object.keys(
+        backgroundPreset.classNameByCache
+      )[0];
+      const colorWriteKeyId =
+        consumer.preset.writeKeyByCacheKey[colorCacheKey as string];
+      const backgroundWriteKeyId =
+        consumer.preset.writeKeyByCacheKey[backgroundCacheKey as string];
+
+      expect(importedCacheKeys).toEqual(
+        expect.arrayContaining([colorCacheKey, backgroundCacheKey])
+      );
+      expect(colorWriteKeyId).not.toBe(backgroundWriteKeyId);
+      expect(
+        consumer.preset.propertyById[
+          consumer.preset.writeKeyById[colorWriteKeyId].propertyId
+        ]
+      ).toBe("color");
+      expect(
+        consumer.preset.propertyById[
+          consumer.preset.writeKeyById[backgroundWriteKeyId].propertyId
+        ]
+      ).toBe("background");
+
+      consumer.preset.classNameByCache = {};
+      consumer.preset.writeKeyByCacheKey = {};
+      consumer.preset.conditionById = {};
+      consumer.preset.propertyById = {};
+      consumer.preset.writeKeyById = {};
+      expect(
+        consumer.cx(colorClassName, backgroundClassName, colorClassName)
+      ).toBe(`${backgroundClassName} ${colorClassName}`);
+    });
+  });
 }
 
 // == Utils ====================================================================

--- a/packages/css/src/defineRules/runtime.ts
+++ b/packages/css/src/defineRules/runtime.ts
@@ -7,6 +7,8 @@ import type {
   DefineRulesCss,
   DefineRulesComplexCssInput,
   DefineRulesCtx,
+  DefineRulesConditions,
+  DefineRulesEmptyConditions,
   DefineRulesPresetArtifactV3,
   DefineRulesPresetClassNameByCache,
   DefineRulesPresetInput,
@@ -17,9 +19,12 @@ import type {
 
 export interface DefineRulesRuntimeResult<
   Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts, Conditions>,
+  Conditions extends DefineRulesConditions = DefineRulesEmptyConditions
 > {
-  css: DefineRulesCss<DefineRulesComplexCssInput<Properties, Shortcuts>>;
+  css: DefineRulesCss<
+    DefineRulesComplexCssInput<Properties, Shortcuts, Conditions>
+  >;
   cx: Cx;
   preset: DefineRulesPresetArtifactV3;
 }
@@ -31,12 +36,17 @@ export interface DefineRulesRuntimeOptions {
 
 export function createDefineRulesRuntime<
   const Properties extends DefineRulesProperties,
-  const Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
+  const Shortcuts extends DefineRulesShortcuts<
+    Properties,
+    Shortcuts,
+    Conditions
+  >,
+  const Conditions extends DefineRulesConditions = DefineRulesEmptyConditions
 >(
-  config: DefineRulesCtx<Properties, Shortcuts>,
+  config: DefineRulesCtx<Properties, Shortcuts, Conditions>,
   options: DefineRulesRuntimeOptions = {}
-): DefineRulesRuntimeResult<Properties, Shortcuts> {
-  type CssInput = DefineRulesComplexCssInput<Properties, Shortcuts>;
+): DefineRulesRuntimeResult<Properties, Shortcuts, Conditions> {
+  type CssInput = DefineRulesComplexCssInput<Properties, Shortcuts, Conditions>;
   const presetArtifact = createDefineRulesPresetArtifact(
     config.presets,
     options?.preservePresetReference === true
@@ -56,7 +66,7 @@ export function createDefineRulesRuntime<
 
   function resolveToFragments(args: CssInput): ResolvedStyleFragment[] {
     const fragments: ResolvedStyleFragment[] = [];
-    applyInput(config, fragments, args, []);
+    applyInput(config as RuntimeDefineRulesCtx, fragments, args, []);
     return fragments;
   }
 
@@ -109,6 +119,11 @@ export function createDefineRulesRuntime<
 interface InputIdentity {
   property: string;
   value: unknown;
+}
+
+interface RuntimeDefineRulesCtx {
+  properties?: Record<string, unknown>;
+  shortcuts?: Record<string, unknown>;
 }
 
 interface ResolvedStyleFragment {
@@ -207,11 +222,8 @@ function pushResolvedFragment(
   });
 }
 
-function applyInput<
-  Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
->(
-  ctx: DefineRulesCtx<Properties, Shortcuts>,
+function applyInput(
+  ctx: RuntimeDefineRulesCtx,
   fragmentsOut: ResolvedStyleFragment[],
   input: unknown,
   shortcutStack: string[]
@@ -236,11 +248,8 @@ function applyInput<
   throw new Error(`Unsupported css() argument: ${String(input)}`);
 }
 
-function applyInlineShortcut<
-  Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
->(
-  ctx: DefineRulesCtx<Properties, Shortcuts>,
+function applyInlineShortcut(
+  ctx: RuntimeDefineRulesCtx,
   fragmentsOut: ResolvedStyleFragment[],
   shortcutName: string,
   shortcutStack: string[]
@@ -252,11 +261,8 @@ function applyInlineShortcut<
   throw new Error(`Unknown fixed style: "${shortcutName}"`);
 }
 
-function applyArray<
-  Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
->(
-  ctx: DefineRulesCtx<Properties, Shortcuts>,
+function applyArray(
+  ctx: RuntimeDefineRulesCtx,
   fragmentsOut: ResolvedStyleFragment[],
   arr: readonly unknown[],
   shortcutStack: string[]
@@ -266,11 +272,8 @@ function applyArray<
   }
 }
 
-function applyObject<
-  Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
->(
-  ctx: DefineRulesCtx<Properties, Shortcuts>,
+function applyObject(
+  ctx: RuntimeDefineRulesCtx,
   fragmentsOut: ResolvedStyleFragment[],
   obj: Record<string, unknown>,
   shortcutStack: string[]
@@ -280,11 +283,8 @@ function applyObject<
   }
 }
 
-function applyEntry<
-  Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
->(
-  ctx: DefineRulesCtx<Properties, Shortcuts>,
+function applyEntry(
+  ctx: RuntimeDefineRulesCtx,
   fragmentsOut: ResolvedStyleFragment[],
   key: string,
   value: unknown,
@@ -302,17 +302,14 @@ function applyEntry<
   applyProperty(ctx, fragmentsOut, key, value, shortcutStack);
 }
 
-function applyProperty<
-  Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
->(
-  ctx: DefineRulesCtx<Properties, Shortcuts>,
+function applyProperty(
+  ctx: RuntimeDefineRulesCtx,
   fragmentsOut: ResolvedStyleFragment[],
   prop: string,
   value: unknown,
   shortcutStack: string[]
 ) {
-  const propertyDefinition = ctx.properties?.[prop as keyof Properties];
+  const propertyDefinition = ctx.properties?.[prop];
 
   if (typeof propertyDefinition === "function") {
     const result = propertyDefinition(value);
@@ -374,11 +371,8 @@ function applyProperty<
   } as CSSProperties);
 }
 
-function applyShortcutReference<
-  Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
->(
-  ctx: DefineRulesCtx<Properties, Shortcuts>,
+function applyShortcutReference(
+  ctx: RuntimeDefineRulesCtx,
   fragmentsOut: ResolvedStyleFragment[],
   targetName: string,
   value: unknown,
@@ -392,11 +386,8 @@ function applyShortcutReference<
   applyProperty(ctx, fragmentsOut, targetName, value, shortcutStack);
 }
 
-function applyShortcut<
-  Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
->(
-  ctx: DefineRulesCtx<Properties, Shortcuts>,
+function applyShortcut(
+  ctx: RuntimeDefineRulesCtx,
   fragmentsOut: ResolvedStyleFragment[],
   name: string,
   value: unknown,
@@ -408,7 +399,7 @@ function applyShortcut<
     );
   }
 
-  const shortcutDefinition = ctx.shortcuts?.[name as keyof Shortcuts];
+  const shortcutDefinition = ctx.shortcuts?.[name];
   if (shortcutDefinition == null) return;
 
   const nextShortcutStack = shortcutStack.concat(name);

--- a/packages/css/src/defineRules/runtime.ts
+++ b/packages/css/src/defineRules/runtime.ts
@@ -16,6 +16,7 @@ import type {
   ClassValue
 } from "../classname/types.js";
 import type { Cx } from "../classname/index.js";
+import { isUnSafeObjectKey } from "../utils.js";
 import { registerDefineRulesRegistryInstance } from "./registry.js";
 import { normalizeDefineRulesConditions } from "./conditions.js";
 import { createCanonicalStyleCache } from "./utils.js";
@@ -357,6 +358,10 @@ function mergeStyleInto(
   source: Record<string, unknown>
 ): void {
   for (const [key, value] of Object.entries(source)) {
+    if (isUnSafeObjectKey(key)) {
+      continue;
+    }
+
     const previous = target[key];
 
     if (isPlainObject(previous) && isPlainObject(value)) {
@@ -924,6 +929,43 @@ if (import.meta.vitest) {
   }
 
   describe("defineRules runtime presets", () => {
+    it("skips unsafe object keys while merging style fragments", () => {
+      const objectPrototype = Object.prototype as Record<string, unknown>;
+      const source: Record<string, unknown> = { color: "red" };
+      const target: Record<string, unknown> = {};
+
+      Object.defineProperty(source, "__proto__", {
+        value: { minchoPrototypePolluted: true },
+        enumerable: true
+      });
+      Object.defineProperty(source, "constructor", {
+        value: { minchoPrototypePolluted: true },
+        enumerable: true
+      });
+      Object.defineProperty(source, "prototype", {
+        value: { minchoPrototypePolluted: true },
+        enumerable: true
+      });
+
+      try {
+        mergeStyleInto(target, source);
+
+        expect(target).toEqual({ color: "red" });
+        expect(Object.prototype.hasOwnProperty.call(target, "__proto__")).toBe(
+          false
+        );
+        expect(
+          Object.prototype.hasOwnProperty.call(target, "constructor")
+        ).toBe(false);
+        expect(Object.prototype.hasOwnProperty.call(target, "prototype")).toBe(
+          false
+        );
+        expect(objectPrototype.minchoPrototypePolluted).toBe(undefined);
+      } finally {
+        delete objectPrototype.minchoPrototypePolluted;
+      }
+    });
+
     it("exports v4 artifacts with metadata maps and no runtime-only state", () => {
       setFileScope("runtime-v4.css.ts", "pkg");
       const runtime = createDefineRulesRuntime({

--- a/packages/css/src/defineRules/types.ts
+++ b/packages/css/src/defineRules/types.ts
@@ -1,8 +1,20 @@
 import type {
   NonNullableString,
   CSSProperties,
+  CSSRule,
   CSSPropertiesWithVars
 } from "@mincho-js/transform-to-vanilla";
+import type {
+  DefineRulesConditionAliasKey,
+  DefineRulesConditions,
+  NormalizedCondition
+} from "./conditions.js";
+export type DefineRulesEmptyConditions = Record<never, never>;
+export type {
+  DefineRulesCondition,
+  DefineRulesConditionAliasKey,
+  DefineRulesConditions
+} from "./conditions.js";
 
 type CSSPropertiesKeys = keyof CSSProperties;
 
@@ -37,25 +49,50 @@ export type DefineRulesProperties =
 
 type ShortcutValue<
   Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>,
-  ShortcutsKey extends keyof Shortcuts
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts, Conditions>,
+  ShortcutsKey extends keyof Shortcuts,
+  Conditions extends DefineRulesConditions = DefineRulesEmptyConditions
 > =
   | keyof Properties
   | Exclude<keyof Shortcuts, ShortcutsKey>
   | ReadonlyArray<keyof Properties | Exclude<keyof Shortcuts, ShortcutsKey>>
-  | DefineRulesCssInput<Properties, Shortcuts>
-  | DefineRulesValueResolver<DefineRulesCssInput<Properties, Shortcuts>>;
+  | DefineRulesNestedCssInput<Properties, Shortcuts, Conditions>
+  | DefineRulesValueResolver<
+      DefineRulesNestedCssInput<Properties, Shortcuts, Conditions>
+    >;
 
 export type DefineRulesShortcuts<
   Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts, Conditions>,
+  Conditions extends DefineRulesConditions = DefineRulesEmptyConditions
 > = {
   [ShortcutsKey in keyof Shortcuts]: ShortcutValue<
     Properties,
     Shortcuts,
-    ShortcutsKey
+    ShortcutsKey,
+    Conditions
   >;
 };
+
+export interface DefineRulesPresetCompiledKnownEntry {
+  kind: "known";
+  className: string;
+  writeKeyId: number;
+}
+
+export interface DefineRulesPresetCompiledUnknownEntry {
+  kind: "unknown";
+  className: string;
+}
+
+export type DefineRulesPresetCompiledEntry =
+  | DefineRulesPresetCompiledKnownEntry
+  | DefineRulesPresetCompiledUnknownEntry;
+
+export interface DefineRulesPresetCompiledSegment {
+  entries: DefineRulesPresetCompiledEntry[];
+  hasKnownAtomicClass: boolean;
+}
 
 export type DefineRulesPresetClassNameByCache = Record<string, string>;
 
@@ -65,8 +102,24 @@ export type DefineRulesPresetArtifactV3 = {
   classNameByCache: DefineRulesPresetClassNameByCache;
 };
 
+export interface DefineRulesPresetWriteKey {
+  conditionId: number;
+  propertyId: number;
+}
+
+export type DefineRulesPresetArtifactV4 = {
+  schema: "mincho.defineRulesPreset";
+  version: 4;
+  classNameByCache: DefineRulesPresetClassNameByCache;
+  writeKeyByCacheKey: Record<string, number>;
+  conditionById: Record<number, NormalizedCondition>;
+  propertyById: Record<number, string>;
+  writeKeyById: Record<number, DefineRulesPresetWriteKey>;
+};
+
 export type DefineRulesPresetInput =
   | DefineRulesPresetArtifactV3
+  | DefineRulesPresetArtifactV4
   | DefineRulesPresetClassNameByCache
   | readonly DefineRulesPresetInput[];
 
@@ -74,22 +127,47 @@ export type DefineRulesPresetMap = DefineRulesPresetClassNameByCache;
 
 export interface DefineRulesCss<CssInput> {
   (args: CssInput): string;
-  raw(args: CssInput): CSSProperties;
+  raw(args: CssInput): CSSRule;
 }
 
 export interface DefineRulesCtx<
   Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts, Conditions>,
+  Conditions extends DefineRulesConditions = DefineRulesEmptyConditions
 > {
   debugId?: string;
   presets?: DefineRulesPresetInput;
+  conditions?: Conditions;
   properties?: Properties;
   shortcuts?: Shortcuts;
 }
 
-type PropertiesInput<Properties extends DefineRulesProperties> = {
-  [Key in keyof Properties]?: ResolvePropertiesValue<Key, Properties[Key]>;
+type PropertiesInput<
+  Properties extends DefineRulesProperties,
+  Conditions extends DefineRulesConditions
+> = {
+  [Key in keyof Properties]?: ResolveConditionableValue<
+    ResolvePropertiesValue<Key, Properties[Key]>,
+    Conditions
+  >;
 };
+
+type ResolveConditionableValue<
+  Value,
+  Conditions extends DefineRulesConditions
+> = Value | DefineRulesPropertyConditionInput<Value, Conditions>;
+
+type DefineRulesPropertyConditionInput<
+  Value,
+  Conditions extends DefineRulesConditions
+> = keyof Conditions extends never
+  ? never
+  : { base?: Value } & {
+      [Alias in DefineRulesConditionAliasKey<Conditions>]?: ResolveConditionableValue<
+        Value,
+        Conditions
+      >;
+    };
 
 type ResolvePropertiesValue<Key, Value> =
   Value extends ReadonlyArray<infer Item>
@@ -108,56 +186,89 @@ type ResolvePropertiesValue<Key, Value> =
 
 type ShortcutsInput<
   Properties extends Record<string, unknown>,
-  Shortcuts extends Record<string, unknown>
+  Shortcuts extends Record<string, unknown>,
+  Conditions extends DefineRulesConditions
 > = {
-  [Key in keyof Shortcuts]?: ResolveShortcutValue<
-    Properties,
-    Shortcuts,
-    Shortcuts[Key]
+  [Key in keyof Shortcuts]?: ResolveConditionableValue<
+    ResolveShortcutValue<Properties, Shortcuts, Conditions, Shortcuts[Key]>,
+    Conditions
   >;
 };
 
 type ResolveShortcutValue<
   Properties extends Record<string, unknown>,
   Shortcuts extends Record<string, unknown>,
+  Conditions extends DefineRulesConditions,
   Value
 > = Value extends readonly unknown[]
-  ? ResolveShortcutArrayRef<Properties, Shortcuts, Value>
+  ? ResolveShortcutArrayRef<Properties, Shortcuts, Conditions, Value>
   : Value extends (arg: infer Arg) => unknown
     ? Arg
     : Value extends Record<string, unknown>
       ? boolean
-      : ResolveShortcutRef<Properties, Shortcuts, Value>;
+      : ResolveShortcutRef<Properties, Shortcuts, Conditions, Value>;
 
 type ResolveShortcutArrayRef<
   Properties extends Record<string, unknown>,
   Shortcuts extends Record<string, unknown>,
+  Conditions extends DefineRulesConditions,
   Targets extends readonly unknown[]
 > = Targets extends readonly [infer H, ...infer R]
-  ? ResolveShortcutRef<Properties, Shortcuts, H> &
-      ResolveShortcutArrayRef<Properties, Shortcuts, R>
+  ? ResolveShortcutRef<Properties, Shortcuts, Conditions, H> &
+      ResolveShortcutArrayRef<Properties, Shortcuts, Conditions, R>
   : unknown;
 
 type ResolveShortcutRef<
   Properties extends Record<string, unknown>,
   Shortcuts extends Record<string, unknown>,
+  Conditions extends DefineRulesConditions,
   Ref
 > = [Ref] extends [keyof Properties]
   ? Properties[Ref]
   : [Ref] extends [keyof Shortcuts]
-    ? ShortcutsInput<Properties, Shortcuts>[Ref]
+    ? ShortcutsInput<Properties, Shortcuts, Conditions>[Ref]
     : never;
+
+type DefineRulesNestedConditionInput<
+  Properties extends DefineRulesProperties,
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts, Conditions>,
+  Conditions extends DefineRulesConditions
+> = keyof Conditions extends never
+  ? DefineRulesEmptyConditions
+  : {
+      [Alias in DefineRulesConditionAliasKey<Conditions>]?: DefineRulesNestedCssInput<
+        Properties,
+        Shortcuts,
+        Conditions
+      >;
+    };
+
+type DefineRulesNestedCssInput<
+  Properties extends DefineRulesProperties,
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts, Conditions>,
+  Conditions extends DefineRulesConditions
+> = DefineRulesCssInput<Properties, Shortcuts, Conditions> &
+  DefineRulesTransformNestedInput;
+
+type DefineRulesTransformNestedInput = Record<string, unknown>;
 
 export type DefineRulesCssInput<
   Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
-> = PropertiesInput<Properties> &
-  ShortcutsInput<PropertiesInput<Properties>, Shortcuts>;
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts, Conditions>,
+  Conditions extends DefineRulesConditions = DefineRulesEmptyConditions
+> = PropertiesInput<Properties, Conditions> &
+  ShortcutsInput<
+    PropertiesInput<Properties, Conditions>,
+    Shortcuts,
+    Conditions
+  > &
+  DefineRulesNestedConditionInput<Properties, Shortcuts, Conditions>;
 
 export type DefineRulesInlineCssInput<
   Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>,
-  CssInput = DefineRulesCssInput<Properties, Shortcuts>
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts, Conditions>,
+  Conditions extends DefineRulesConditions = DefineRulesEmptyConditions,
+  CssInput = DefineRulesCssInput<Properties, Shortcuts, Conditions>
 > = keyof {
   [Key in keyof CssInput as boolean extends CssInput[Key]
     ? Key
@@ -166,13 +277,14 @@ export type DefineRulesInlineCssInput<
 
 export type DefineRulesComplexCssInput<
   Properties extends DefineRulesProperties,
-  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
+  Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts, Conditions>,
+  Conditions extends DefineRulesConditions = DefineRulesEmptyConditions
 > =
-  | DefineRulesCssInput<Properties, Shortcuts>
-  | DefineRulesInlineCssInput<Properties, Shortcuts>
+  | DefineRulesCssInput<Properties, Shortcuts, Conditions>
+  | DefineRulesInlineCssInput<Properties, Shortcuts, Conditions>
   | Array<
-      | DefineRulesCssInput<Properties, Shortcuts>
-      | DefineRulesInlineCssInput<Properties, Shortcuts>
+      | DefineRulesCssInput<Properties, Shortcuts, Conditions>
+      | DefineRulesInlineCssInput<Properties, Shortcuts, Conditions>
     >;
 
 // == Tests ====================================================================
@@ -187,13 +299,20 @@ if (import.meta.vitest) {
   describe.concurrent("DefineRules Type Test", () => {
     function createDefineRulesTypeCase<
       const Properties extends DefineRulesProperties,
-      const Shortcuts extends DefineRulesShortcuts<Properties, Shortcuts>
-    >(defineRulesCtx: DefineRulesCtx<Properties, Shortcuts>) {
+      const Shortcuts extends DefineRulesShortcuts<
+        Properties,
+        Shortcuts,
+        Conditions
+      >,
+      const Conditions extends DefineRulesConditions =
+        DefineRulesEmptyConditions
+    >(defineRulesCtx: DefineRulesCtx<Properties, Shortcuts, Conditions>) {
       return {
         defineRulesCtx,
         _cssInput: defineRulesCtx as unknown as DefineRulesComplexCssInput<
           Properties,
-          Shortcuts
+          Shortcuts,
+          Conditions
         >
       };
     }
@@ -399,31 +518,57 @@ if (import.meta.vitest) {
     });
 
     describe.concurrent("DefineRulesPresetInput Type", () => {
-      it("Accepts raw preset records", () => {
-        const { defineRulesCtx } = createDefineRulesTypeCase({
-          presets: {
-            colorRed: "color_red",
-            displayFlex: "display_flex"
-          },
-          properties: {
-            color: true
-          }
-        });
-
-        assertType<DefineRulesPresetInput | undefined>(defineRulesCtx.presets);
-      });
-
-      it("Accepts v3 preset artifacts and recursive arrays", () => {
-        const rawPreset: DefineRulesPresetClassNameByCache = {
-          colorRed: "color_red"
+      it("Accepts artifact-safe v4 metadata helper types", () => {
+        const knownEntry: DefineRulesPresetCompiledKnownEntry = {
+          kind: "known",
+          className: "color_red",
+          writeKeyId: 0
         };
-        const artifact: DefineRulesPresetArtifactV3 = {
+        const unknownEntry: DefineRulesPresetCompiledUnknownEntry = {
+          kind: "unknown",
+          className: "external"
+        };
+        const segment: DefineRulesPresetCompiledSegment = {
+          entries: [knownEntry, unknownEntry],
+          hasKnownAtomicClass: true
+        };
+        const writeKey: DefineRulesPresetWriteKey = {
+          conditionId: 0,
+          propertyId: 0
+        };
+        const artifact: DefineRulesPresetArtifactV4 = {
           schema: "mincho.defineRulesPreset",
-          version: 3,
-          classNameByCache: rawPreset
+          version: 4,
+          classNameByCache: {
+            colorRed: "color_red"
+          },
+          writeKeyByCacheKey: {
+            colorRed: 0
+          },
+          conditionById: {
+            0: {
+              layer: null,
+              supports: null,
+              media: null,
+              container: null,
+              selector: "&"
+            }
+          },
+          propertyById: {
+            0: "color"
+          },
+          writeKeyById: {
+            0: writeKey
+          }
         };
+
+        assertType<DefineRulesPresetCompiledEntry>(knownEntry);
+        assertType<DefineRulesPresetCompiledEntry>(unknownEntry);
+        assertType<DefineRulesPresetCompiledSegment>(segment);
+        assertType<DefineRulesPresetArtifactV4>(artifact);
+
         const { defineRulesCtx } = createDefineRulesTypeCase({
-          presets: [artifact, rawPreset, [artifact]],
+          presets: [artifact, [artifact]],
           properties: {
             color: true
           }
@@ -444,8 +589,122 @@ if (import.meta.vitest) {
           properties: {
             color: true
           },
-          // @ts-expect-error: presets accepts raw records, v3 artifacts, or arrays only.
+          // @ts-expect-error: presets accepts v4 artifacts or arrays only.
           presets: owner
+        });
+      });
+    });
+
+    describe.concurrent("DefineRulesConditions Type", () => {
+      it("accepts configured condition aliases in nested and property-level inputs", () => {
+        const { defineRulesCtx: _defineRulesCtx, _cssInput } =
+          createDefineRulesTypeCase({
+            conditions: {
+              mobile: {},
+              tablet: "@media screen and (min-width: 768px)",
+              desktop: {
+                "@media": "screen and (min-width: 1024px)"
+              },
+              interactive: {
+                selector: "&:hover",
+                "@supports": "(display: grid)"
+              }
+            },
+            properties: {
+              color: true,
+              display: ["none", "flex"],
+              fontSize: true
+            },
+            shortcuts: {
+              inline: {
+                display: "flex",
+                _tablet: {
+                  color: "blue"
+                }
+              }
+            }
+          });
+
+        assertType<"_mobile" | "_tablet" | "_desktop" | "_interactive">(
+          "" as DefineRulesConditionAliasKey<
+            NonNullable<typeof _defineRulesCtx.conditions>
+          >
+        );
+        assertType<typeof _cssInput>({
+          _mobile: {
+            color: "red",
+            _tablet: {
+              display: "flex"
+            },
+            "nav li > &": {
+              "@supports": {
+                "(display: grid)": {
+                  _hover: {
+                    fontSize: 12
+                  }
+                }
+              }
+            }
+          },
+          _desktop: {
+            display: "flex"
+          },
+          color: {
+            base: "black",
+            _tablet: "blue",
+            _interactive: {
+              _mobile: "green"
+            }
+          },
+          inline: true
+        });
+      });
+
+      it("rejects unconfigured condition aliases in nested and property-level inputs", () => {
+        const { _cssInput } = createDefineRulesTypeCase({
+          conditions: {
+            mobile: {}
+          },
+          properties: {
+            color: true
+          }
+        });
+
+        assertType<typeof _cssInput>({
+          // @ts-expect-error: _desktop is not configured.
+          _desktop: {
+            color: "red"
+          }
+        });
+        assertType<typeof _cssInput>({
+          color: {
+            base: "red",
+            _mobile: "blue"
+          }
+        });
+        assertType<typeof _cssInput>({
+          color: {
+            base: "red",
+            _mobile: {
+              _mobile: "blue"
+            }
+          }
+        });
+      });
+
+      it("rejects arbitrary nested condition config objects", () => {
+        createDefineRulesTypeCase({
+          conditions: {
+            mobile: {
+              // @ts-expect-error: condition config objects only support known condition keys.
+              nested: {
+                "@media": "screen and (min-width: 768px)"
+              }
+            }
+          },
+          properties: {
+            color: true
+          }
         });
       });
     });
@@ -656,6 +915,41 @@ if (import.meta.vitest) {
         assertType<typeof _cssInput>({
           // @ts-expect-error: invalid value
           center: "flex"
+        });
+      });
+
+      it("Function shortcut returns nested style objects", () => {
+        const { _cssInput } = createDefineRulesTypeCase({
+          properties: {
+            display: ["none", "inline", "block"],
+            paddingLeft: [0, 4, 8],
+            paddingRight: [0, 4, 8]
+          },
+          shortcuts: {
+            px: ["paddingLeft", "paddingRight"],
+            responsiveCenter(arg: "none" | "inline" | "block") {
+              return {
+                "@media": {
+                  "screen and (min-width: 768px)": {
+                    display: arg,
+                    px: 4
+                  }
+                },
+                "&:hover": {
+                  display: "block",
+                  px: 8
+                }
+              } as const;
+            }
+          }
+        });
+
+        assertType<typeof _cssInput>({
+          responsiveCenter: "inline"
+        });
+        assertType<typeof _cssInput>({
+          // @ts-expect-error: invalid value
+          responsiveCenter: "flex"
         });
       });
     });

--- a/packages/css/src/defineRules/utils.ts
+++ b/packages/css/src/defineRules/utils.ts
@@ -2,7 +2,7 @@ import type { CSSRule } from "@mincho-js/transform-to-vanilla";
 import { setFileScope } from "@vanilla-extract/css/fileScope";
 import hash from "@emotion/hash";
 import { css } from "../css/index.js";
-import { identifierName } from "../utils.js";
+import { identifierName, isUnSafeObjectKey } from "../utils.js";
 
 type CanonicalNode =
   | ["null"]
@@ -172,6 +172,10 @@ export function createCanonicalStyleCache(debugId?: string) {
 
   function importSnapshot(entries: Record<string, string>): void {
     for (const [cacheKey, className] of Object.entries(entries)) {
+      if (isUnSafeObjectKey(cacheKey)) {
+        continue;
+      }
+
       fragmentCacheKeys.add(cacheKey);
 
       if (!hasCacheKey(cacheKey)) {
@@ -473,6 +477,24 @@ if (import.meta.vitest) {
 
       expect(cache.exportSnapshot()).toEqual(seededSnapshot);
       expect(cache.size).toBe(2);
+    });
+
+    it("should ignore unsafe object keys when importing fragment snapshots", () => {
+      const cache = createCanonicalStyleCache(debugId);
+      const snapshot: Record<string, string> = {
+        constructor: "unsafe-constructor",
+        prototype: "unsafe-prototype"
+      };
+
+      Object.defineProperty(snapshot, "__proto__", {
+        value: "unsafe-proto",
+        enumerable: true
+      });
+
+      cache.importSnapshot(snapshot);
+
+      expect(cache.exportSnapshot()).toEqual({});
+      expect(cache.size).toBe(0);
     });
 
     it("should reuse seeded fragment entries without overwriting imported class names", () => {

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -1,8 +1,13 @@
 export type {
+  CollectStyleDeclarationsOptions,
+  CollectedStyleDeclaration,
+  ConditionAliasMap,
+  ConditionAliasValue,
   CSSProperties,
   ComplexCSSRule,
   GlobalCSSRule,
-  CSSRule
+  CSSRule,
+  NormalizedCondition
 } from "@mincho-js/transform-to-vanilla";
 
 export type { Adapter, FileScope } from "@vanilla-extract/css";
@@ -62,13 +67,25 @@ export { cx } from "./classname/index.js";
 export type { ClassValue, Cx } from "./classname/index.js";
 export { defineRules } from "./defineRules/index.js";
 export type {
-  DefineRulesCtx,
-  DefineRulesEmptyConditions,
-  DefineRulesProperties,
-  DefineRulesShortcuts,
-  DefineRulesPresetArtifactV3,
-  DefineRulesPresetMap,
+  DefineRulesComplexCssInput,
+  DefineRulesCondition,
+  DefineRulesConditionAliasKey,
+  DefineRulesConditions,
   DefineRulesCss,
   DefineRulesCssInput,
-  DefineRulesComplexCssInput
+  DefineRulesCtx,
+  DefineRulesEmptyConditions,
+  DefineRulesInlineCssInput,
+  DefineRulesPresetArtifactV3,
+  DefineRulesPresetArtifactV4,
+  DefineRulesPresetCompiledEntry,
+  DefineRulesPresetCompiledKnownEntry,
+  DefineRulesPresetCompiledSegment,
+  DefineRulesPresetCompiledUnknownEntry,
+  DefineRulesPresetInput,
+  DefineRulesPresetMap,
+  DefineRulesPresetWriteKey,
+  DefineRulesProperties,
+  DefineRulesShortcuts
 } from "./defineRules/types.js";
+export type { DefineRulesConditionObject } from "./defineRules/conditions.js";

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -63,6 +63,7 @@ export type { ClassValue, Cx } from "./classname/index.js";
 export { defineRules } from "./defineRules/index.js";
 export type {
   DefineRulesCtx,
+  DefineRulesEmptyConditions,
   DefineRulesProperties,
   DefineRulesShortcuts,
   DefineRulesPresetArtifactV3,

--- a/packages/css/src/utils.ts
+++ b/packages/css/src/utils.ts
@@ -14,6 +14,12 @@ export function getDebugName(debugId: string | undefined, name: string) {
   return debugId ? `${debugId}_${name}` : name;
 }
 
+// Prevent prototype-polluting assignment.
+// https://codeql.github.com/codeql-query-help/javascript/js-prototype-polluting-assignment/
+export function isUnSafeObjectKey(key: string): boolean {
+  return key === "__proto__" || key === "constructor" || key === "prototype";
+}
+
 // Optimized version
 // https://github.com/vanilla-extract-css/vanilla-extract/blob/master/packages/private/src/getVarName.ts
 const VAR_PREFIX_LENGTH = "var(".length;

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -399,30 +399,55 @@ if (import.meta.vitest) {
     };
   }
 
-  function createV3PresetBuildSource(className: string): string {
+  function createV4PresetBuildSource(className: string): string {
     return `
       export const preset = {
         schema: "${DEFINE_RULES_PRESET_SCHEMA}",
-        version: 3,
+        version: 4,
         classNameByCache: {
           shared: "${className}"
+        },
+        writeKeyByCacheKey: {
+          shared: 0
+        },
+        conditionById: {
+          0: {
+            layer: null,
+            supports: null,
+            media: null,
+            container: null,
+            selector: "&"
+          }
+        },
+        propertyById: {
+          0: "background"
+        },
+        writeKeyById: {
+          0: {
+            conditionId: 0,
+            propertyId: 0
+          }
         }
       };
       export const shared = "${className}";
     `;
   }
 
-  function expectSourceToContainV3PresetArtifact(source: string): void {
+  function expectSourceToContainV4PresetArtifact(source: string): void {
     expect(source).toMatch(
       new RegExp(
         `["']?schema["']?\\s*:\\s*["']${escapeRegExp(DEFINE_RULES_PRESET_SCHEMA)}["']`
       )
     );
-    expect(source).toMatch(/["']?version["']?\s*:\s*3/);
+    expect(source).toMatch(/["']?version["']?\s*:\s*4/);
     expect(source).toMatch(/["']?classNameByCache["']?\s*:\s*\{/);
+    expect(source).toMatch(/["']?writeKeyByCacheKey["']?\s*:\s*\{/);
+    expect(source).toMatch(/["']?conditionById["']?\s*:\s*\{/);
+    expect(source).toMatch(/["']?propertyById["']?\s*:\s*\{/);
+    expect(source).toMatch(/["']?writeKeyById["']?\s*:\s*\{/);
   }
 
-  function countV3PresetArtifacts(source: string): number {
+  function countV4PresetArtifacts(source: string): number {
     return Array.from(
       source.matchAll(
         /["']?schema["']?\s*:\s*["']mincho\.defineRulesPreset["']/g
@@ -442,7 +467,7 @@ if (import.meta.vitest) {
     source: string,
     className: string
   ): void {
-    expectSourceToContainV3PresetArtifact(source);
+    expectSourceToContainV4PresetArtifact(source);
     expect(source).toMatch(
       new RegExp(
         `["']?classNameByCache["']?\\s*:\\s*\\{[\\s\\S]*["']${escapeRegExp(className)}["']`
@@ -899,7 +924,7 @@ if (import.meta.vitest) {
           await buildRealEsbuildRegistryFixture(fixtureCase);
 
         expect(registrySource).not.toBe("");
-        expectSourceToContainV3PresetArtifact(registrySource);
+        expectSourceToContainV4PresetArtifact(registrySource);
         expectSourceToContainPopulatedClassNameByCache(registrySource);
         if (fixtureCase.expectedRegistryInstances > 1) {
           const artifactCount = Array.from(
@@ -922,8 +947,8 @@ if (import.meta.vitest) {
         await buildRealEsbuildRegistryFixture(fixtureCase);
 
       expect(registrySource).not.toBe("");
-      expect(countV3PresetArtifacts(registrySource)).toBe(0);
-      expect(countV3PresetArtifacts(js)).toBe(0);
+      expect(countV4PresetArtifacts(registrySource)).toBe(0);
+      expect(countV4PresetArtifacts(js)).toBe(0);
       expect(registrySource).toContain("rebeccapurple");
     });
 
@@ -1038,7 +1063,7 @@ if (import.meta.vitest) {
 
       expect(registrySpy).toHaveBeenCalledTimes(1);
       expect(loadResult.loader).toBe("js");
-      expect(countV3PresetArtifacts(loadResult.contents)).toBe(0);
+      expect(countV4PresetArtifacts(loadResult.contents)).toBe(0);
       expect(loadResult.contents).toContain("blue");
     });
 
@@ -1057,7 +1082,7 @@ if (import.meta.vitest) {
       const registrySpy = vi
         .spyOn(integrationHelpers, "processDefineRulesPresetRegistryFile")
         .mockResolvedValue(
-          createRegistryResult(createV3PresetBuildSource("shared_class"))
+          createRegistryResult(createV4PresetBuildSource("shared_class"))
         );
 
       const harness = createBuildHarness();
@@ -1099,7 +1124,7 @@ if (import.meta.vitest) {
       const registrySpy = vi
         .spyOn(integrationHelpers, "processDefineRulesPresetRegistryFile")
         .mockResolvedValue(
-          createRegistryResult(createV3PresetBuildSource("short_class"))
+          createRegistryResult(createV4PresetBuildSource("short_class"))
         );
 
       const harness = createBuildHarness({ minify: true });
@@ -1162,7 +1187,7 @@ if (import.meta.vitest) {
         expect(registrySpy).toHaveBeenCalledTimes(1);
         expect(loadResult.loader).toBe("js");
         expect(loadResult.resolveDir).toBe(dirname(resolveResult.path));
-        expectSourceToContainV3PresetArtifact(loadResult.contents);
+        expectSourceToContainV4PresetArtifact(loadResult.contents);
         expectSourceToContainPopulatedClassNameByCache(loadResult.contents);
       }
     });
@@ -1215,7 +1240,7 @@ if (import.meta.vitest) {
 
       expect(registrySpy).toHaveBeenCalledTimes(1);
       expect(loadResult.loader).toBe("js");
-      expect(countV3PresetArtifacts(loadResult.contents)).toBe(0);
+      expect(countV4PresetArtifacts(loadResult.contents)).toBe(0);
       expect(loadResult.contents).toContain("rebeccapurple");
     }, 20000);
 
@@ -1417,7 +1442,7 @@ if (import.meta.vitest) {
         ]);
       });
 
-      firstDeferred.resolve(createV3PresetBuildSource("provider-a_class"));
+      firstDeferred.resolve(createV4PresetBuildSource("provider-a_class"));
       const firstLoadResult = await firstLoadPromise;
 
       await vi.waitFor(() => {
@@ -1428,7 +1453,7 @@ if (import.meta.vitest) {
         ]);
       });
 
-      secondDeferred.resolve(createV3PresetBuildSource("provider-b_class"));
+      secondDeferred.resolve(createV4PresetBuildSource("provider-b_class"));
       const secondLoadResult = await secondLoadPromise;
 
       expect(processOrder).toEqual([

--- a/packages/integration/src/defineRulesPreset.ts
+++ b/packages/integration/src/defineRulesPreset.ts
@@ -278,10 +278,22 @@ if (import.meta.vitest) {
           config,
           presetArtifact: {
             schema: "mincho.defineRulesPreset",
-            version: 3,
-            classNameByCache: {}
+            version: 4,
+            classNameByCache: {},
+            writeKeyByCacheKey: {},
+            conditionById: {},
+            propertyById: {},
+            writeKeyById: {}
           },
-          getPresetSnapshot: () => ({})
+          getPresetSnapshot: () => ({
+            schema: "mincho.defineRulesPreset",
+            version: 4,
+            classNameByCache: {},
+            writeKeyByCacheKey: {},
+            conditionById: {},
+            propertyById: {},
+            writeKeyById: {}
+          })
         }
       ],
       nextRegistrationIndex: 1,
@@ -390,14 +402,18 @@ if (import.meta.vitest) {
     }
   }
 
-  function expectSourceToContainV3PresetArtifact(source: string): void {
+  function expectSourceToContainV4PresetArtifact(source: string): void {
     const normalizedSource = normalizeSource(source);
 
     expect(normalizedSource).toMatch(
       /schema:["']mincho\.defineRulesPreset["']/
     );
-    expect(normalizedSource).toContain("version:3");
+    expect(normalizedSource).toContain("version:4");
     expect(normalizedSource).toContain("classNameByCache:{");
+    expect(normalizedSource).toContain("writeKeyByCacheKey:{");
+    expect(normalizedSource).toContain("conditionById:{");
+    expect(normalizedSource).toContain("propertyById:{");
+    expect(normalizedSource).toContain("writeKeyById:{");
   }
 
   function expectSerializedPresetArtifactsToOmitCx(
@@ -435,8 +451,12 @@ if (import.meta.vitest) {
         artifactEndIndex
       );
 
-      expect(artifactSource).toContain("version:3");
+      expect(artifactSource).toContain("version:4");
       expect(artifactSource).toContain("classNameByCache:{");
+      expect(artifactSource).toContain("writeKeyByCacheKey:{");
+      expect(artifactSource).toContain("conditionById:{");
+      expect(artifactSource).toContain("propertyById:{");
+      expect(artifactSource).toContain("writeKeyById:{");
       expect(artifactSource).not.toContain("cx:");
       expect(artifactSource).not.toContain('"cx":');
       expect(artifactSource).not.toContain("'cx':");
@@ -446,7 +466,7 @@ if (import.meta.vitest) {
     }
   }
 
-  function countV3PresetArtifacts(source: string): number {
+  function countV4PresetArtifacts(source: string): number {
     return Array.from(
       normalizeSource(source).matchAll(
         /schema:["']mincho\.defineRulesPreset["']/g
@@ -586,8 +606,12 @@ if (import.meta.vitest) {
         expect(normalizedSource).toMatch(
           /schema:["']mincho\.defineRulesPreset["']/
         );
-        expect(normalizedSource).toContain("version:3");
+        expect(normalizedSource).toContain("version:4");
         expect(normalizedSource).toContain("classNameByCache:{");
+        expect(normalizedSource).toContain("writeKeyByCacheKey:{");
+        expect(normalizedSource).toContain("conditionById:{");
+        expect(normalizedSource).toContain("propertyById:{");
+        expect(normalizedSource).toContain("writeKeyById:{");
         expectRegistryInstancesToHaveClassNameByCache(registrySession);
         expect(classNames.length).toBeGreaterThan(0);
         for (const className of classNames) {
@@ -598,7 +622,7 @@ if (import.meta.vitest) {
   });
 
   describe("defineRules preset registry wrapper", () => {
-    it("registry serializes live v3 preset artifacts from processed css calls", async () => {
+    it("registry serializes live v4 preset artifacts from processed css calls", async () => {
       const { source, registrySession, emittedCss } =
         await processRegistryFixture(
           `
@@ -627,15 +651,19 @@ if (import.meta.vitest) {
       expect(normalizedSource).toMatch(
         /schema:["']mincho\.defineRulesPreset["']/
       );
-      expect(normalizedSource).toContain("version:3");
+      expect(normalizedSource).toContain("version:4");
       expect(normalizedSource).toContain("classNameByCache:{");
+      expect(normalizedSource).toContain("writeKeyByCacheKey:{");
+      expect(normalizedSource).toContain("conditionById:{");
+      expect(normalizedSource).toContain("propertyById:{");
+      expect(normalizedSource).toContain("writeKeyById:{");
       expect(classNames).toHaveLength(1);
       expect(source).toContain(classNames[0]!);
       expect(emittedCss).toMatch(/color:\s*red/);
       expect(getActiveDefineRulesRegistrySession()).toBe(undefined);
     });
 
-    it("registry fixture validates v3 artifact extraction and consumer reuse", async () => {
+    it("registry fixture validates v4 artifact extraction and consumer reuse", async () => {
       const { source, registrySession } = await processRegistryFixture(
         `
           import { defineRules } from "@mincho-js/css";
@@ -679,7 +707,7 @@ if (import.meta.vitest) {
       );
 
       expect(registrySession.instances).toHaveLength(2);
-      expectSourceToContainV3PresetArtifact(source);
+      expectSourceToContainV4PresetArtifact(source);
       expectRegistryInstancesToHaveClassNameByCache(registrySession);
       const reusedClassName = providerClassNames.join(" ");
 
@@ -755,7 +783,7 @@ if (import.meta.vitest) {
       const ownerClassNames = getRegistryInstanceClassNames(ownerInstance);
 
       expect(registrySession.instances).toHaveLength(1);
-      expectSourceToContainV3PresetArtifact(source);
+      expectSourceToContainV4PresetArtifact(source);
       expectSerializedPresetArtifactsToOmitCx(source, registrySession);
       expectRegistryInstancesToHaveClassNameByCache(registrySession);
       expect(ownerClassNames).toHaveLength(1);
@@ -790,7 +818,7 @@ if (import.meta.vitest) {
         getRegistryInstanceClassNames(destructuredInstance);
 
       expect(registrySession.instances).toHaveLength(1);
-      expectSourceToContainV3PresetArtifact(source);
+      expectSourceToContainV4PresetArtifact(source);
       expectSerializedPresetArtifactsToOmitCx(source, registrySession);
       expectRegistryInstancesToHaveClassNameByCache(registrySession);
       expect(destructuredClassNames).toHaveLength(1);
@@ -914,10 +942,10 @@ if (import.meta.vitest) {
             secondResult.registrySession.instances[0]?.fileScope.filePath ?? ""
           )
         ).toBe(true);
-        expect(countV3PresetArtifacts(firstResult.source)).toBe(1);
-        expect(countV3PresetArtifacts(secondResult.source)).toBe(1);
-        expectSourceToContainV3PresetArtifact(firstResult.source);
-        expectSourceToContainV3PresetArtifact(secondResult.source);
+        expect(countV4PresetArtifacts(firstResult.source)).toBe(1);
+        expect(countV4PresetArtifacts(secondResult.source)).toBe(1);
+        expectSourceToContainV4PresetArtifact(firstResult.source);
+        expectSourceToContainV4PresetArtifact(secondResult.source);
         expectRegistryInstancesToHaveClassNameByCache(
           firstResult.registrySession
         );
@@ -989,7 +1017,7 @@ if (import.meta.vitest) {
         expectRegistryInstancesToHaveClassNameByCache(
           successfulResult.registrySession
         );
-        expectSourceToContainV3PresetArtifact(successfulResult.source);
+        expectSourceToContainV4PresetArtifact(successfulResult.source);
         expect(successfulResult.source).not.toContain(
           cleanupState.failedClassName
         );
@@ -1018,8 +1046,8 @@ if (import.meta.vitest) {
           (instance) => instance.registrationIndex
         )
       ).toEqual([0, 1]);
-      expect(countV3PresetArtifacts(firstResult.source)).toBe(2);
-      expectSourceToContainV3PresetArtifact(firstResult.source);
+      expect(countV4PresetArtifacts(firstResult.source)).toBe(2);
+      expectSourceToContainV4PresetArtifact(firstResult.source);
       expectRegistryInstancesToHaveClassNameByCache(
         firstResult.registrySession
       );
@@ -1038,8 +1066,8 @@ if (import.meta.vitest) {
 
       expect(secondResult.registrySession.instances).toHaveLength(1);
       expect(secondCurrentInstance?.registrationIndex).toBe(0);
-      expect(countV3PresetArtifacts(secondResult.source)).toBe(1);
-      expectSourceToContainV3PresetArtifact(secondResult.source);
+      expect(countV4PresetArtifacts(secondResult.source)).toBe(1);
+      expectSourceToContainV4PresetArtifact(secondResult.source);
       expectRegistryInstancesToHaveClassNameByCache(
         secondResult.registrySession
       );

--- a/packages/transform-to-vanilla/README.md
+++ b/packages/transform-to-vanilla/README.md
@@ -49,3 +49,45 @@ const initTransformContext: TransformContext = {
   variantReference: {}
 };
 ```
+
+### collectStyleDeclarations()
+
+`collectStyleDeclarations()` walks a Mincho style object and returns source-order declarations instead of a Vanilla Extract object. Each entry contains the normalized condition tuple, the expanded property, and the raw value.
+
+```typescript
+import {
+  collectStyleDeclarations,
+  type CollectedStyleDeclaration,
+  type ConditionAliasMap,
+  type ConditionAliasValue,
+  type NormalizedCondition
+} from "@mincho-js/transform-to-vanilla";
+
+const conditions = {
+  _tablet: "screen and (min-width: 768px)",
+  _desktop: {
+    "@media": "screen and (min-width: 1024px)",
+    selector: "&[data-layout=wide]"
+  }
+} satisfies ConditionAliasMap;
+
+const declarations = collectStyleDeclarations(
+  {
+    color: {
+      base: "black",
+      _tablet: "blue"
+    },
+    _desktop: {
+      fontSize: 20
+    }
+  },
+  { conditions }
+) satisfies CollectedStyleDeclaration[];
+
+type DeclarationCondition = NormalizedCondition;
+type AliasValue = ConditionAliasValue;
+```
+
+`ConditionAliasMap` is keyed by underscore aliases, such as `_tablet`. A string `ConditionAliasValue` is a media condition. Object values may use `"@layer"`, `"@supports"`, `"@media"`, `"@container"`, and `selector`.
+
+The collector is meant for runtimes, build plugins, analyzers, and code generators that need declaration metadata before CSS emission. It is reusable and is not tied to one higher-level API.

--- a/packages/transform-to-vanilla/src/index.ts
+++ b/packages/transform-to-vanilla/src/index.ts
@@ -1,5 +1,13 @@
 export { transform } from "./transform.js";
 export {
+  collectStyleDeclarations,
+  type CollectStyleDeclarationsOptions,
+  type CollectedStyleDeclaration,
+  type ConditionAliasMap,
+  type ConditionAliasValue,
+  type NormalizedCondition
+} from "./transform-object/declaration-collection.js";
+export {
   initTransformContext,
   type TransformContext
 } from "./transform-object/index.js";

--- a/packages/transform-to-vanilla/src/transform-object/declaration-collection.ts
+++ b/packages/transform-to-vanilla/src/transform-object/declaration-collection.ts
@@ -1,0 +1,786 @@
+import {
+  atRuleKeyInfo,
+  atRuleKeyMerge,
+  isRuleKey
+} from "../transform-keys/at-rules.js";
+import {
+  isComplexKey,
+  isSelectorsKey,
+  isSimpleSelectorKey,
+  nestedSelectorKey
+} from "../transform-keys/complex-selectors.js";
+import {
+  isCSSVarKey,
+  isPureCSSVarKey,
+  isVarsKey,
+  replaceCSSVarKey
+} from "../transform-keys/css-var.js";
+import {
+  mergeKeyInfo,
+  removeMergeSymbol
+} from "../transform-keys/merge-key.js";
+import {
+  isSimplePseudoSelectorKey,
+  replacePseudoSelectors
+} from "../transform-keys/simple-pseudo-selectors.js";
+import type { CSSRule } from "../types/style-rule.js";
+import { isUppercase } from "../utils/string.js";
+import type { AtRulesPrefix, TransformContext } from "./index.js";
+
+export interface NormalizedCondition {
+  layer: string | null;
+  supports: string | null;
+  media: string | null;
+  container: string | null;
+  selector: string;
+}
+
+export interface CollectedStyleDeclaration {
+  condition: NormalizedCondition;
+  property: string;
+  value: unknown;
+}
+
+export type ConditionAliasValue =
+  | string
+  | {
+      "@layer"?: string;
+      "@supports"?: string;
+      "@media"?: string;
+      "@container"?: string;
+      selector?: string;
+    };
+export type ConditionAliasMap = Record<`_${string}`, ConditionAliasValue>;
+
+export interface CollectStyleDeclarationsOptions {
+  conditions?: ConditionAliasMap;
+}
+
+type ConditionKey = Exclude<keyof NormalizedCondition, "selector">;
+
+const defaultCondition = {
+  layer: null,
+  supports: null,
+  media: null,
+  container: null,
+  selector: "&"
+} satisfies NormalizedCondition;
+
+const conditionAtRules = {
+  layer: "@layer",
+  supports: "@supports",
+  media: "@media",
+  container: "@container"
+} as const satisfies Record<ConditionKey, AtRulesPrefix>;
+
+export function collectStyleDeclarations(
+  style: CSSRule,
+  options: CollectStyleDeclarationsOptions = {}
+): CollectedStyleDeclaration[] {
+  const declarations: CollectedStyleDeclaration[] = [];
+
+  collectStyle(style, defaultCondition, options.conditions ?? {}, declarations);
+
+  return declarations;
+}
+
+function collectStyle(
+  style: CSSRule,
+  condition: NormalizedCondition,
+  aliases: ConditionAliasMap,
+  declarations: CollectedStyleDeclaration[]
+) {
+  for (const [key, value] of Object.entries(style)) {
+    if (isSelectorsKey(key)) {
+      collectSelectors(value, condition, aliases, declarations);
+    } else if (isComplexKey(key)) {
+      collectStyleValue(
+        value,
+        composeSelectorCondition(condition, key),
+        aliases,
+        declarations
+      );
+    } else if (hasAlias(key, aliases)) {
+      const aliasKey = key as `_${string}`;
+      collectStyleValue(
+        value,
+        composeAliasCondition(condition, aliases[aliasKey]),
+        aliases,
+        declarations
+      );
+    } else if (isSimplePseudoSelectorKey(key)) {
+      collectStyleValue(
+        value,
+        composeSelectorCondition(condition, `&${replacePseudoSelectors(key)}`),
+        aliases,
+        declarations
+      );
+    } else if (isSimpleSelectorKey(key)) {
+      collectStyleValue(
+        value,
+        composeSelectorCondition(condition, `&${key}`),
+        aliases,
+        declarations
+      );
+    } else if (isVarsKey(key)) {
+      collectVars(value, condition, declarations);
+    } else if (isCSSVarKey(key)) {
+      collectDeclaration(replaceCSSVarKey(key), value, condition, declarations);
+    } else if (isPureCSSVarKey(key)) {
+      collectDeclaration(key, value, condition, declarations);
+    } else if (isRuleKey(key)) {
+      collectAtRuleValue(key, value, condition, aliases, declarations);
+    } else {
+      collectPropertyValue(
+        normalizePropertyName(key),
+        value,
+        condition,
+        aliases,
+        declarations
+      );
+    }
+  }
+}
+
+function collectSelectors(
+  value: unknown,
+  condition: NormalizedCondition,
+  aliases: ConditionAliasMap,
+  declarations: CollectedStyleDeclaration[]
+) {
+  if (!isRecord(value)) {
+    return;
+  }
+
+  for (const [selector, selectorStyle] of Object.entries(value)) {
+    collectStyleValue(
+      selectorStyle,
+      composeSelectorCondition(condition, selector),
+      aliases,
+      declarations
+    );
+  }
+}
+
+function collectVars(
+  value: unknown,
+  condition: NormalizedCondition,
+  declarations: CollectedStyleDeclaration[]
+) {
+  if (!isRecord(value)) {
+    return;
+  }
+
+  for (const [key, varValue] of Object.entries(value)) {
+    collectDeclaration(
+      isCSSVarKey(key) ? replaceCSSVarKey(key) : key,
+      varValue,
+      condition,
+      declarations
+    );
+  }
+}
+
+function collectStyleValue(
+  value: unknown,
+  condition: NormalizedCondition,
+  aliases: ConditionAliasMap,
+  declarations: CollectedStyleDeclaration[]
+) {
+  if (isRecord(value)) {
+    collectStyle(value as CSSRule, condition, aliases, declarations);
+  }
+}
+
+function collectAtRuleValue(
+  key: string,
+  value: unknown,
+  condition: NormalizedCondition,
+  aliases: ConditionAliasMap,
+  declarations: CollectedStyleDeclaration[],
+  property?: string
+) {
+  const { isToplevelRules, atRuleKey, atRuleNestedKey } = atRuleKeyInfo(key);
+
+  if (isToplevelRules) {
+    collectConditionValue(
+      value,
+      composeAtRuleCondition(condition, atRuleKey, atRuleNestedKey),
+      aliases,
+      declarations,
+      property
+    );
+    return;
+  }
+
+  if (!isRecord(value)) {
+    return;
+  }
+
+  for (const [atRuleNestedKey, atRuleValue] of Object.entries(value)) {
+    collectConditionValue(
+      atRuleValue,
+      composeAtRuleCondition(condition, atRuleKey, atRuleNestedKey),
+      aliases,
+      declarations,
+      property
+    );
+  }
+}
+
+function collectConditionValue(
+  value: unknown,
+  condition: NormalizedCondition,
+  aliases: ConditionAliasMap,
+  declarations: CollectedStyleDeclaration[],
+  property?: string
+) {
+  if (property) {
+    collectPropertyValue(property, value, condition, aliases, declarations);
+    return;
+  }
+
+  collectStyleValue(value, condition, aliases, declarations);
+}
+
+function collectPropertyValue(
+  property: string,
+  value: unknown,
+  condition: NormalizedCondition,
+  aliases: ConditionAliasMap,
+  declarations: CollectedStyleDeclaration[]
+) {
+  if (isPropertyConditionMap(value, aliases)) {
+    collectPropertyMap(property, value, condition, aliases, declarations);
+    return;
+  }
+
+  collectDeclaration(property, value, condition, declarations);
+}
+
+function collectPropertyMap(
+  property: string,
+  value: Record<string, unknown>,
+  condition: NormalizedCondition,
+  aliases: ConditionAliasMap,
+  declarations: CollectedStyleDeclaration[]
+) {
+  for (const [key, nestedValue] of Object.entries(value)) {
+    if (key === "base") {
+      collectPropertyValue(
+        property,
+        nestedValue,
+        condition,
+        aliases,
+        declarations
+      );
+    } else if (isUppercase(key)) {
+      collectPropertyValue(
+        `${property}${key}`,
+        nestedValue,
+        condition,
+        aliases,
+        declarations
+      );
+    } else if (hasAlias(key, aliases)) {
+      const aliasKey = key as `_${string}`;
+      collectPropertyValue(
+        property,
+        nestedValue,
+        composeAliasCondition(condition, aliases[aliasKey]),
+        aliases,
+        declarations
+      );
+    } else if (isSelectorsKey(key)) {
+      collectPropertySelectors(
+        property,
+        nestedValue,
+        condition,
+        aliases,
+        declarations
+      );
+    } else if (isComplexKey(key)) {
+      collectPropertyValue(
+        property,
+        nestedValue,
+        composeSelectorCondition(condition, key),
+        aliases,
+        declarations
+      );
+    } else if (isSimplePseudoSelectorKey(key)) {
+      collectPropertyValue(
+        property,
+        nestedValue,
+        composeSelectorCondition(condition, `&${replacePseudoSelectors(key)}`),
+        aliases,
+        declarations
+      );
+    } else if (isSimpleSelectorKey(key)) {
+      collectPropertyValue(
+        property,
+        nestedValue,
+        composeSelectorCondition(condition, `&${key}`),
+        aliases,
+        declarations
+      );
+    } else if (isRuleKey(key)) {
+      collectAtRuleValue(
+        key,
+        nestedValue,
+        condition,
+        aliases,
+        declarations,
+        property
+      );
+    } else {
+      collectPropertyValue(
+        normalizePropertyName(key),
+        nestedValue,
+        condition,
+        aliases,
+        declarations
+      );
+    }
+  }
+}
+
+function collectPropertySelectors(
+  property: string,
+  value: unknown,
+  condition: NormalizedCondition,
+  aliases: ConditionAliasMap,
+  declarations: CollectedStyleDeclaration[]
+) {
+  if (!isRecord(value)) {
+    return;
+  }
+
+  for (const [selector, selectorValue] of Object.entries(value)) {
+    collectPropertyValue(
+      property,
+      selectorValue,
+      composeSelectorCondition(condition, selector),
+      aliases,
+      declarations
+    );
+  }
+}
+
+function collectDeclaration(
+  property: string,
+  value: unknown,
+  condition: NormalizedCondition,
+  declarations: CollectedStyleDeclaration[]
+) {
+  declarations.push({
+    condition: cloneCondition(condition),
+    property,
+    value
+  });
+}
+
+function isPropertyConditionMap(
+  value: unknown,
+  aliases: ConditionAliasMap
+): value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return Object.keys(value).some(
+    (key) =>
+      key === "base" ||
+      isUppercase(key) ||
+      hasAlias(key, aliases) ||
+      isSelectorsKey(key) ||
+      isComplexKey(key) ||
+      isSimplePseudoSelectorKey(key) ||
+      isSimpleSelectorKey(key) ||
+      isRuleKey(key)
+  );
+}
+
+function composeAliasCondition(
+  condition: NormalizedCondition,
+  alias: ConditionAliasValue
+) {
+  if (typeof alias === "string") {
+    return composeCondition(condition, {
+      media: normalizeMediaCondition(alias)
+    });
+  }
+
+  return composeCondition(condition, normalizeAliasCondition(alias));
+}
+
+function normalizeMediaCondition(value: string | undefined) {
+  if (value === undefined) {
+    return value;
+  }
+
+  return value.startsWith("@media ") ? value.substring(7) : value;
+}
+
+function normalizeAliasCondition(
+  alias: Exclude<ConditionAliasValue, string>
+): Partial<NormalizedCondition> {
+  return {
+    layer: alias["@layer"],
+    supports: alias["@supports"],
+    media: normalizeMediaCondition(alias["@media"]),
+    container: alias["@container"],
+    selector: alias.selector
+  };
+}
+
+function composeCondition(
+  condition: NormalizedCondition,
+  nextCondition: Partial<NormalizedCondition>
+) {
+  let result = cloneCondition(condition);
+
+  for (const key of Object.keys(conditionAtRules) as ConditionKey[]) {
+    const value = nextCondition[key];
+
+    if (value !== undefined && value !== null) {
+      result = composeAtRuleCondition(result, conditionAtRules[key], value);
+    }
+  }
+
+  if (nextCondition.selector !== undefined && nextCondition.selector !== null) {
+    result = composeSelectorCondition(result, nextCondition.selector);
+  }
+
+  return result;
+}
+
+function composeAtRuleCondition(
+  condition: NormalizedCondition,
+  atRuleKey: string,
+  atRuleValue: string
+) {
+  const conditionKey = getConditionKey(atRuleKey);
+
+  if (!conditionKey) {
+    return cloneCondition(condition);
+  }
+
+  return {
+    ...condition,
+    [conditionKey]: atRuleKeyMerge(
+      atRuleKey as AtRulesPrefix,
+      condition[conditionKey] ?? "",
+      atRuleValue
+    )
+  } satisfies NormalizedCondition;
+}
+
+function composeSelectorCondition(
+  condition: NormalizedCondition,
+  selector: string
+) {
+  const normalizedSelector = selector.includes("&") ? selector : `&${selector}`;
+  const nextSelector =
+    condition.selector === "&"
+      ? normalizedSelector
+      : nestedSelectorKey(normalizedSelector, {
+          parentSelector: condition.selector
+        } as TransformContext);
+
+  return {
+    ...condition,
+    selector: nextSelector
+  } satisfies NormalizedCondition;
+}
+
+function getConditionKey(atRuleKey: string): ConditionKey | null {
+  switch (atRuleKey) {
+    case "@layer":
+      return "layer";
+    case "@supports":
+      return "supports";
+    case "@media":
+      return "media";
+    case "@container":
+      return "container";
+    default:
+      return null;
+  }
+}
+
+function normalizePropertyName(key: string) {
+  const { isMergeSymbol } = mergeKeyInfo(key);
+
+  return replacePseudoSelectors(isMergeSymbol ? removeMergeSymbol(key) : key);
+}
+
+function cloneCondition(condition: NormalizedCondition) {
+  return { ...condition } satisfies NormalizedCondition;
+}
+
+function hasAlias(
+  key: string,
+  aliases: ConditionAliasMap
+): key is `_${string}` {
+  return Object.prototype.hasOwnProperty.call(aliases, key);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// Ignore errors when compiling to CommonJS.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+  const { describe, it, expect, expectTypeOf } = import.meta.vitest;
+
+  const baseCondition = {
+    layer: null,
+    supports: null,
+    media: null,
+    container: null,
+    selector: "&"
+  } satisfies NormalizedCondition;
+
+  describe.concurrent("collectStyleDeclarations", () => {
+    it("collects base declarations and configured aliases before pseudos", () => {
+      expect(
+        collectStyleDeclarations(
+          {
+            color: "black",
+            _mobile: {
+              color: "green"
+            },
+            _tablet: {
+              color: "blue"
+            },
+            _desktop: {
+              color: "purple"
+            },
+            _hover: {
+              color: "orange"
+            }
+          } as unknown as CSSRule,
+          {
+            conditions: {
+              _mobile: {},
+              _tablet: "@media screen and (min-width: 768px)",
+              _desktop: {
+                "@media": "screen and (min-width: 1024px)"
+              }
+            }
+          }
+        )
+      ).toStrictEqual([
+        {
+          condition: baseCondition,
+          property: "color",
+          value: "black"
+        },
+        {
+          condition: baseCondition,
+          property: "color",
+          value: "green"
+        },
+        {
+          condition: {
+            ...baseCondition,
+            media: "screen and (min-width: 768px)"
+          },
+          property: "color",
+          value: "blue"
+        },
+        {
+          condition: {
+            ...baseCondition,
+            media: "screen and (min-width: 1024px)"
+          },
+          property: "color",
+          value: "purple"
+        },
+        {
+          condition: {
+            ...baseCondition,
+            selector: "&:hover"
+          },
+          property: "color",
+          value: "orange"
+        }
+      ] satisfies CollectedStyleDeclaration[]);
+    });
+
+    it("normalizes object media aliases with redundant @media prefix", () => {
+      expect(
+        collectStyleDeclarations(
+          {
+            _desktop: {
+              color: "purple"
+            }
+          } as unknown as CSSRule,
+          {
+            conditions: {
+              _desktop: {
+                "@media": "@media screen and (min-width: 1024px)"
+              }
+            }
+          }
+        )
+      ).toStrictEqual([
+        {
+          condition: {
+            ...baseCondition,
+            media: "screen and (min-width: 1024px)"
+          },
+          property: "color",
+          value: "purple"
+        }
+      ] satisfies CollectedStyleDeclaration[]);
+    });
+
+    it("collects nested selector, media, and pseudo declarations", () => {
+      expect(
+        collectStyleDeclarations({
+          "nav li > &": {
+            "@media (prefers-color-scheme: dark)": {
+              _hover: {
+                background: "red"
+              }
+            }
+          }
+        })
+      ).toStrictEqual([
+        {
+          condition: {
+            ...baseCondition,
+            media: "(prefers-color-scheme: dark)",
+            selector: "nav li > &:hover"
+          },
+          property: "background",
+          value: "red"
+        }
+      ] satisfies CollectedStyleDeclaration[]);
+    });
+
+    it("collects property-level condition maps in source order", () => {
+      expect(
+        collectStyleDeclarations(
+          {
+            background: {
+              base: "red",
+              _tablet: "blue",
+              "@media (prefers-reduced-motion)": "green",
+              Color: {
+                base: "transparent",
+                _hover: "yellow",
+                _desktop: "black"
+              }
+            }
+          },
+          {
+            conditions: {
+              _tablet: "screen and (min-width: 768px)",
+              _desktop: {
+                "@media": "screen and (min-width: 1024px)"
+              }
+            }
+          }
+        )
+      ).toStrictEqual([
+        {
+          condition: baseCondition,
+          property: "background",
+          value: "red"
+        },
+        {
+          condition: {
+            ...baseCondition,
+            media: "screen and (min-width: 768px)"
+          },
+          property: "background",
+          value: "blue"
+        },
+        {
+          condition: {
+            ...baseCondition,
+            media: "(prefers-reduced-motion)"
+          },
+          property: "background",
+          value: "green"
+        },
+        {
+          condition: baseCondition,
+          property: "backgroundColor",
+          value: "transparent"
+        },
+        {
+          condition: {
+            ...baseCondition,
+            selector: "&:hover"
+          },
+          property: "backgroundColor",
+          value: "yellow"
+        },
+        {
+          condition: {
+            ...baseCondition,
+            media: "screen and (min-width: 1024px)"
+          },
+          property: "backgroundColor",
+          value: "black"
+        }
+      ] satisfies CollectedStyleDeclaration[]);
+    });
+
+    it("keeps unconfigured underscore keys as transform pseudos", async () => {
+      const { transform } = await import("../transform.js");
+
+      expect(
+        transform({
+          _mobile: {
+            color: "red"
+          }
+        } as unknown as CSSRule)
+      ).toStrictEqual({
+        selectors: {
+          "&:mobile": {
+            color: "red"
+          }
+        }
+      });
+    });
+
+    it("types condition aliases as underscore-prefixed public at-rule keys", () => {
+      expectTypeOf({
+        _tablet: "@media screen and (min-width: 768px)",
+        _desktop: {
+          "@media": "screen and (min-width: 1024px)"
+        }
+      }).toExtend<ConditionAliasMap>();
+
+      expectTypeOf({
+        _supportsGrid: {
+          "@supports": "(display: grid)",
+          selector: "&:focus"
+        }
+      }).toExtend<ConditionAliasMap>();
+
+      const nonUnderscoreAlias = {
+        // @ts-expect-error: public aliases must be underscore-prefixed.
+        tablet: "screen and (min-width: 768px)"
+      } satisfies ConditionAliasMap;
+
+      const normalizedAlias = {
+        _desktop: {
+          // @ts-expect-error: public object aliases use at-rule keys, not normalized condition keys.
+          media: "screen and (min-width: 1024px)"
+        }
+      } satisfies ConditionAliasMap;
+
+      expect(nonUnderscoreAlias).toBeTypeOf("object");
+      expect(normalizedAlias).toBeTypeOf("object");
+    });
+  });
+}

--- a/packages/transform-to-vanilla/src/transform-object/rule-context.ts
+++ b/packages/transform-to-vanilla/src/transform-object/rule-context.ts
@@ -1,7 +1,7 @@
 import { setFileScope } from "@vanilla-extract/css/fileScope";
 import { isRuleKey, atRuleKeyMerge } from "../transform-keys/at-rules.js";
 import { initTransformContext } from "./index.js";
-import { mergeObject } from "../utils/object.js";
+import { isUnSafeObjectKey, mergeObject } from "../utils/object.js";
 import type { StyleResult, AtRulesPrefix, TransformContext } from "./index.js";
 import type { VanillaStyleRuleValue } from "../types/style-rule.js";
 
@@ -47,22 +47,22 @@ export function createPathSetter(
   const variantResult: StyleResult = {};
   return (key: string, value: VanillaStyleRuleValue) => {
     let current = isVariantReference ? variantResult : result;
-    // Prevent  Prototype-polluting assignment
-    // https://codeql.github.com/codeql-query-help/javascript/js-prototype-polluting-assignment/
     for (const path of nestedPath) {
-      if (
-        path !== "__proto__" &&
-        path !== "constructor" &&
-        path !== "prototype" &&
-        current[path] === undefined
-      ) {
+      if (isUnSafeObjectKey(path)) {
+        return;
+      }
+
+      if (current[path] === undefined) {
         current[path] = {};
       }
       current = (current[path] as StyleResult) || ({} as StyleResult);
     }
-    if (key !== "__proto__" && key !== "constructor" && key !== "prototype") {
-      current[key] = value;
+
+    if (isUnSafeObjectKey(key)) {
+      return;
     }
+
+    current[key] = value;
 
     if (isVariantReference) {
       context.variantReference = mergeObject(context.variantReference, {
@@ -227,6 +227,61 @@ if (import.meta.vitest) {
           "nav li > &": { color: "red" }
         }
       });
+    });
+
+    it("should skip unsafe object keys", () => {
+      const context: TransformContext = {
+        ...structuredClone(initTransformContext),
+        parentSelector: "",
+        parentAtRules: {
+          "@layer": "",
+          "@supports": "",
+          "@media": "",
+          "@container": ""
+        }
+      };
+      const target: StyleResult = { color: "red" };
+
+      Object.defineProperty(target, "__proto__", {
+        value: { minchoPrototypePolluted: true },
+        enumerable: true
+      });
+      Object.defineProperty(target, "constructor", {
+        value: { minchoPrototypePolluted: true },
+        enumerable: true
+      });
+      Object.defineProperty(target, "prototype", {
+        value: { minchoPrototypePolluted: true },
+        enumerable: true
+      });
+
+      expect(createNestedObject(context, target)).toStrictEqual({
+        color: "red"
+      });
+    });
+
+    it("should stop before traversing unsafe path segments", () => {
+      const objectPrototype = Object.prototype as Record<string, unknown>;
+      const context: TransformContext = {
+        ...structuredClone(initTransformContext),
+        parentSelector: "__proto__",
+        parentAtRules: {
+          "@layer": "",
+          "@supports": "",
+          "@media": "",
+          "@container": ""
+        }
+      };
+      const target: StyleResult = { minchoPrototypePolluted: "true" };
+
+      try {
+        expect(createNestedObject(context, target)).toStrictEqual({
+          selectors: {}
+        });
+        expect(objectPrototype.minchoPrototypePolluted).toBe(undefined);
+      } finally {
+        delete objectPrototype.minchoPrototypePolluted;
+      }
     });
 
     it("should handle parentSelector", () => {

--- a/packages/transform-to-vanilla/src/utils/object.ts
+++ b/packages/transform-to-vanilla/src/utils/object.ts
@@ -10,6 +10,12 @@ export const mergeObject = deepmerge() as <
   source: T2
 ) => T1 & T2;
 
+// Prevent prototype-polluting assignment.
+// https://codeql.github.com/codeql-query-help/javascript/js-prototype-polluting-assignment/
+export function isUnSafeObjectKey(key: string): boolean {
+  return key === "__proto__" || key === "constructor" || key === "prototype";
+}
+
 export function isEmptyObject(obj: object) {
   return Object.keys(obj).length === 0;
 }

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -482,30 +482,66 @@ if (import.meta.vitest) {
     };
   }
 
-  function createV3PresetBuildSource(className: string): string {
+  function createV4PresetBuildSource(className: string): string {
     return `
       export const preset = {
         schema: "${DEFINE_RULES_PRESET_SCHEMA}",
-        version: 3,
+        version: 4,
         classNameByCache: {
           shared: "${className}"
+        },
+        writeKeyByCacheKey: {
+          shared: 0
+        },
+        conditionById: {
+          0: {
+            layer: null,
+            supports: null,
+            media: null,
+            container: null,
+            selector: "&"
+          }
+        },
+        propertyById: {
+          0: "background"
+        },
+        writeKeyById: {
+          0: {
+            conditionId: 0,
+            propertyId: 0
+          }
         }
       };
       export const shared = "${className}";
     `;
   }
 
-  function expectSourceToContainV3PresetArtifact(source: string): void {
+  function expectSourceToContainV4PresetArtifact(source: string): void {
     expect(source).toMatch(
       new RegExp(
         `["']?schema["']?\\s*:\\s*["']${escapeRegExp(DEFINE_RULES_PRESET_SCHEMA)}["']`
       )
     );
-    expect(source).toMatch(/["']?version["']?\s*:\s*3/);
+    expect(source).toMatch(/["']?version["']?\s*:\s*4/);
     expect(source).toMatch(/["']?classNameByCache["']?\s*:\s*\{/);
+    expect(source).toMatch(/["']?writeKeyByCacheKey["']?\s*:\s*\{/);
+    expect(source).toMatch(/["']?conditionById["']?\s*:\s*\{/);
+    expect(source).toMatch(/["']?propertyById["']?\s*:\s*\{/);
+    expect(source).toMatch(/["']?writeKeyById["']?\s*:\s*\{/);
   }
 
-  function countV3PresetArtifacts(source: string): number {
+  function expectSourceToContainV4RuntimePresetSeed(source: string): void {
+    expect(source).toMatch(
+      new RegExp(
+        `["']?schema["']?\\s*:\\s*["']${escapeRegExp(DEFINE_RULES_PRESET_SCHEMA)}["']`
+      )
+    );
+    expect(source).toMatch(/["']?version["']?\s*:\s*4/);
+    expect(source).toMatch(/["']?classNameByCache["']?\s*:\s*\{/);
+    expect(source).toMatch(/["']?writeKeyByCacheKey["']?\s*:\s*\{/);
+  }
+
+  function countV4PresetArtifacts(source: string): number {
     return Array.from(
       source.matchAll(
         /["']?schema["']?\s*:\s*["']mincho\.defineRulesPreset["']/g
@@ -525,7 +561,7 @@ if (import.meta.vitest) {
     source: string,
     className: string
   ): void {
-    expectSourceToContainV3PresetArtifact(source);
+    expectSourceToContainV4PresetArtifact(source);
     expect(source).toMatch(
       new RegExp(
         `["']?classNameByCache["']?\\s*:\\s*\\{[\\s\\S]*["']${escapeRegExp(className)}["']`
@@ -1035,7 +1071,7 @@ if (import.meta.vitest) {
         expect(processOrder).toEqual([`start:${firstFixture.extractedId}`]);
       });
 
-      firstDeferred.resolve(createV3PresetBuildSource("provider-a_class"));
+      firstDeferred.resolve(createV4PresetBuildSource("provider-a_class"));
       const firstTransformResult = await firstTransformPromise;
       assertString(
         firstTransformResult,
@@ -1050,7 +1086,7 @@ if (import.meta.vitest) {
         ]);
       });
 
-      secondDeferred.resolve(createV3PresetBuildSource("provider-b_class"));
+      secondDeferred.resolve(createV4PresetBuildSource("provider-b_class"));
       const secondTransformResult = await secondTransformPromise;
       assertString(
         secondTransformResult,
@@ -1107,7 +1143,7 @@ if (import.meta.vitest) {
       const registrySpy = vi
         .spyOn(integrationModule, "processDefineRulesPresetRegistryFile")
         .mockResolvedValue(
-          createRegistryResult(createV3PresetBuildSource("shared_class"))
+          createRegistryResult(createV4PresetBuildSource("shared_class"))
         );
 
       const harness = await createViteHarness();
@@ -1200,7 +1236,7 @@ if (import.meta.vitest) {
         }
 
         const fillBlueClassName = extractFillBlueClassName(jsOutput.code);
-        expectSourceToContainV3PresetArtifact(jsOutput.code);
+        expectSourceToContainV4RuntimePresetSeed(jsOutput.code);
         expect(jsOutput.code).not.toContain('background: "blue"');
         expect(cssOutput.source).toContain(`.${fillBlueClassName}`);
         expect(cssOutput.source).toContain("background: blue;");
@@ -1230,7 +1266,7 @@ if (import.meta.vitest) {
           await buildRealViteRegistryFixture(fixtureCase);
 
         expect(registrySource).not.toBe("");
-        expectSourceToContainV3PresetArtifact(registrySource);
+        expectSourceToContainV4PresetArtifact(registrySource);
         expectSourceToContainPopulatedClassNameByCache(registrySource);
         if (fixtureCase.expectedRegistryInstances > 1) {
           const artifactCount = Array.from(
@@ -1253,8 +1289,8 @@ if (import.meta.vitest) {
         await buildRealViteRegistryFixture(fixtureCase);
 
       expect(registrySource).not.toBe("");
-      expect(countV3PresetArtifacts(registrySource)).toBe(0);
-      expect(countV3PresetArtifacts(js)).toBe(0);
+      expect(countV4PresetArtifacts(registrySource)).toBe(0);
+      expect(countV4PresetArtifacts(js)).toBe(0);
       expect(registrySource).toContain("rebeccapurple");
     }, 20000);
 
@@ -1368,52 +1404,27 @@ if (import.meta.vitest) {
       );
 
       expect(registrySpy).toHaveBeenCalledTimes(1);
-      expect(countV3PresetArtifacts(transformedExtractedCss)).toBe(0);
+      expect(countV4PresetArtifacts(transformedExtractedCss)).toBe(0);
       expect(transformedExtractedCss).toContain("blue");
     });
 
-    it("bubbles registry validation errors from build-time preset serialization", async () => {
+    it("bubbles registry processing errors from build-time preset serialization", async () => {
       const integrationModule = await import("@mincho-js/integration");
       const consoleErrorSpy = vi
         .spyOn(console, "error")
         .mockImplementation(() => {});
-      const invalidShortcutBuildSource = `
-        import { defineRules } from "@mincho-js/css";
-
-        const invalid = defineRules({
-          properties: {
-            color: true
-          },
-          shortcuts: {
-            tone: [
-              { color: "red" },
-              {
-                dynamic(value: string) {
-                  return { color: value };
-                }
-              }
-            ]
-          }
-        });
-        export const raw = invalid.css.raw({ color: "red" });
-      `;
 
       vi.spyOn(integrationModule, "babelTransform").mockResolvedValue({
         code: 'import "extracted_rules.css.ts";\nexport { raw };',
         result: ["extracted_rules.css.ts", "resolver contents"]
       });
-      const compileFixtureSource: typeof compile = integrationModule.compile;
-      vi.spyOn(integrationModule, "compile").mockImplementation(
-        (options: Parameters<typeof compileFixtureSource>[0]) =>
-          compileFixtureSource({
-            ...options,
-            contents: invalidShortcutBuildSource
-          })
-      );
-      const registrySpy = vi.spyOn(
-        integrationModule,
-        "processDefineRulesPresetRegistryFile"
-      );
+      vi.spyOn(integrationModule, "compile").mockResolvedValue({
+        source: "compiled source",
+        watchFiles: []
+      } as Awaited<ReturnType<typeof compile>>);
+      const registrySpy = vi
+        .spyOn(integrationModule, "processDefineRulesPresetRegistryFile")
+        .mockRejectedValue(new Error("registry processing failure"));
 
       const harness = await createViteHarness();
       const { extractedId, extractedSource } =
@@ -1421,7 +1432,7 @@ if (import.meta.vitest) {
 
       await expect(
         harness.transform(extractedId, extractedSource)
-      ).rejects.toThrow("config.shortcuts.tone[1].dynamic");
+      ).rejects.toThrow("registry processing failure");
       expect(registrySpy).toHaveBeenCalledTimes(1);
       expect(consoleErrorSpy).not.toHaveBeenCalled();
     });
@@ -1475,7 +1486,7 @@ if (import.meta.vitest) {
           })
         );
         expect(registrySpy).toHaveBeenCalledTimes(1);
-        expectSourceToContainV3PresetArtifact(transformedExtractedCss);
+        expectSourceToContainV4PresetArtifact(transformedExtractedCss);
         expectSourceToContainPopulatedClassNameByCache(transformedExtractedCss);
       }
     });
@@ -1522,7 +1533,7 @@ if (import.meta.vitest) {
       );
 
       expect(registrySpy).toHaveBeenCalledTimes(1);
-      expect(countV3PresetArtifacts(transformedExtractedCss)).toBe(0);
+      expect(countV4PresetArtifacts(transformedExtractedCss)).toBe(0);
       expect(transformedExtractedCss).toContain("rebeccapurple");
     }, 20000);
 
@@ -1708,7 +1719,7 @@ if (import.meta.vitest) {
           serializeVirtualCssPath: expect.any(Function)
         })
       );
-      expect(countV3PresetArtifacts(firstTransform)).toBe(2);
+      expect(countV4PresetArtifacts(firstTransform)).toBe(2);
       expectSourceToContainClassNameByCacheValue(
         firstTransform,
         currentClassName
@@ -1746,7 +1757,7 @@ if (import.meta.vitest) {
           serializeVirtualCssPath: expect.any(Function)
         })
       );
-      expect(countV3PresetArtifacts(secondTransform)).toBe(1);
+      expect(countV4PresetArtifacts(secondTransform)).toBe(1);
       expectSourceToContainClassNameByCacheValue(
         secondTransform,
         secondCurrentClassName


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->

Adds core conditional `defineRules` support across the CSS runtime and transform layer.
This PR introduces the condition metadata/type model, compiles conditional atomics in the `defineRules` runtime, exposes `cx` from `defineRules`, and adds declaration collection support for downstream transforms.

### Changes
- Expose `cx` from the `defineRules` result
- Add condition metadata and condition-related type definitions
- Add condition object support for `defineRules`
- Compile conditional atomics in the `defineRules` runtime
- Update runtime registry behavior for conditional rule output
- Add transform-to-vanilla declaration collection support
- Export the new transform and condition-related types from public entrypoints

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #336

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added advanced condition support to `defineRules`, including validation and normalization of condition shapes.
  * Introduced `collectStyleDeclarations()` to extract ordered `{ condition, property, value }` declarations.
  * Added benchmarks for `defineRules` metadata and `cx` caching behavior.
* **Security**
  * Hardened object traversal and snapshot import to skip unsafe keys and prevent prototype pollution.
* **Chores**
  * Migrated preset artifact handling and tests to v4 across the toolchain.
  * Added a scheduled/manual dependency audit workflow and tightened CI checkout/audit steps.
* **Documentation**
  * Documented the new `collectStyleDeclarations()` API and condition/value formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

Included:
- CSS package runtime/API changes
- Condition metadata and type modeling
- Transform declaration collection utility
- Public exports required by the new runtime/transform model

Not included:
- esbuild/vite preset serialization wiring
- integration preset fixture updates
- final conditional defineRules README/example expansion
Those are handled in the follow-up PR.

## Checklist
<!-- Tell us what reviewers should look for. -->
