### PR TITLE
Feat: CSS - Serialize conditional defineRules presets

### DIFF
--- a/examples/shared-component/src/index.ts
+++ b/examples/shared-component/src/index.ts
@@ -1,2 +1,2 @@
-export { cx, css, preset } from "./preset.css.js";
+export { css, preset, sharedCardClassName } from "./preset.css.js";
 export { SharedExampleCard } from "./SharedExampleCard.js";

--- a/examples/shared-component/src/preset.css.ts
+++ b/examples/shared-component/src/preset.css.ts
@@ -2,22 +2,40 @@ import { defineRules } from "@mincho-js/css";
 
 export const { cx, css, preset } = defineRules({
   debugId: "sharedPreset",
+  conditions: {
+    mobile: {},
+    tablet: "screen and (min-width: 768px)",
+    desktop: {
+      "@media": "screen and (min-width: 1024px)",
+      selector: "&[data-layout=wide]"
+    }
+  },
   properties: {
     background: true,
     color: true,
     padding: true,
     borderRadius: true,
-    display: true
+    display: true,
+    fontSize: true
   }
 });
 
 export const sharedCardClassName = cx(
   css({
     background: "rebeccapurple",
-    color: "white",
+    color: {
+      base: "white",
+      _desktop: "lavender"
+    },
     padding: 16,
     borderRadius: 12,
-    display: "block"
+    display: "block",
+    _tablet: {
+      fontSize: 16
+    },
+    fontSize: {
+      _desktop: 20
+    }
   }),
   "shared-card"
 );

--- a/packages/css/README.md
+++ b/packages/css/README.md
@@ -197,28 +197,54 @@ export function MyButton() {
 
 ### defineRules()
 
-The `defineRules()` function creates a scoped authoring API and returns `css`, `cx`, and `preset` together. The returned `cx` is the existing root `cx` from `@mincho-js/css`, so it has the same class-composition behavior as importing `cx` directly.
+The `defineRules()` function creates a scoped authoring API and returns `css`, `cx`, and `preset` together. Use it when you want a typed styling surface for a shared package, preset, or design-system layer.
+
+`conditions` lets you name condition aliases once in the config. Config keys are bare names, and style input uses the same names with an underscore prefix. An empty object means the base condition. A string is treated as a media query, with a leading `@media` stripped if present. Object form supports `"@layer"`, `"@supports"`, `"@media"`, `"@container"`, and `selector`.
 
 ```typescript
 import { defineRules } from "@mincho-js/css";
 
-const { css, cx } = defineRules({
+const { css, cx, preset } = defineRules({
+  conditions: {
+    mobile: {},
+    tablet: "screen and (min-width: 768px)",
+    desktop: {
+      "@media": "screen and (min-width: 1024px)",
+      selector: "&[data-layout=wide]"
+    }
+  },
   properties: {
     color: true,
+    fontSize: true,
     padding: true
   }
 });
 
-export const className = cx(
-  css({
-    color: "white",
-    padding: 12
-  }),
-  "external"
-);
+export const card = css({
+  color: {
+    base: "black",
+    _desktop: "white"
+  },
+  padding: 12,
+  _tablet: {
+    fontSize: 16
+  },
+  fontSize: {
+    _desktop: 20
+  }
+});
+
+export const cardClassName = cx(card, "external");
+export const cardPreset = preset;
 ```
 
-Duplicate classes and conflicting utility-like classes are preserved in input order. No tailwind-merge-style conflict resolution, dedupe, or sorting is performed.
+The `preset` export is a V4 artifact. Pass it to another `defineRules({ presets })` call to reuse class names and the metadata needed by scoped `cx`.
+
+`defineRules().cx` is scoped and metadata aware. It flattens inputs like the root `cx`, then uses V4 preset metadata from its own scope and imported presets to keep the later known class for the same write key. The root `cx` export remains global and clsx-compatible. It does not read defineRules metadata.
+
+Unknown or external class tokens are preserved after root `cx` has flattened the inputs. They are not dropped, deduped, sorted, or moved relative to other unknown tokens.
+
+Known conflicts merge only when the normalized condition tuple and expanded write property are exactly equal. The condition tuple is `layer`, `supports`, `media`, `container`, and `selector`. For example, a `color` write under `_desktop` only conflicts with another `color` write under that exact tuple. There is no media range subsumption, selector equivalence, or cross-layer precedence inference.
 
 ## Features
 

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -238,20 +238,6 @@ if (import.meta.vitest) {
     );
   }
 
-  function getRegistryFixtureCase(
-    caseId: string
-  ): DefineRulesPresetSerializationFixtureCase {
-    const fixtureCase = registryFixtureMatrixCases.find(
-      (candidate) => candidate.caseId === caseId
-    );
-
-    if (fixtureCase == null) {
-      throw new Error(`Missing registry fixture case ${caseId}`);
-    }
-
-    return fixtureCase;
-  }
-
   beforeAll(async () => {
     initializeDefineRulesPresetSerializationFixtures(
       await loadDefineRulesPresetSerializationManifest()
@@ -445,14 +431,46 @@ if (import.meta.vitest) {
     expect(source).toMatch(/["']?conditionById["']?\s*:\s*\{/);
     expect(source).toMatch(/["']?propertyById["']?\s*:\s*\{/);
     expect(source).toMatch(/["']?writeKeyById["']?\s*:\s*\{/);
+    expectSourceV4PresetArtifactToOmitRuntimeFields(source);
   }
 
-  function countV4PresetArtifacts(source: string): number {
-    return Array.from(
-      source.matchAll(
-        /["']?schema["']?\s*:\s*["']mincho\.defineRulesPreset["']/g
+  function expectSourceV4PresetArtifactToOmitRuntimeFields(
+    source: string
+  ): void {
+    const artifactSource = extractV4PresetArtifactSource(source);
+    expect(artifactSource).not.toMatch(/["']?registeredSegments["']?\s*:/);
+    expect(artifactSource).not.toMatch(/["']?segmentCache["']?\s*:/);
+    expect(artifactSource).not.toMatch(/["']?fullResultCache["']?\s*:/);
+    expect(artifactSource).not.toMatch(/["']?atomicClassByClassName["']?\s*:/);
+    expect(artifactSource).not.toMatch(/["']?cx["']?\s*:/);
+  }
+
+  function extractV4PresetArtifactSource(source: string): string {
+    const schemaMatch = source.match(
+      new RegExp(
+        `["']?schema["']?\\s*:\\s*["']${escapeRegExp(DEFINE_RULES_PRESET_SCHEMA)}["']`
       )
-    ).length;
+    );
+    if (schemaMatch?.index == null) {
+      throw new Error("Expected defineRules preset schema in source");
+    }
+
+    const artifactStart = source.lastIndexOf("{", schemaMatch.index);
+    if (artifactStart === -1) {
+      throw new Error("Expected defineRules preset artifact object in source");
+    }
+
+    let depth = 0;
+    for (let index = artifactStart; index < source.length; index += 1) {
+      const char = source[index];
+      if (char === "{") depth += 1;
+      if (char === "}") depth -= 1;
+      if (depth === 0) {
+        return source.slice(artifactStart, index + 1);
+      }
+    }
+
+    throw new Error("Expected defineRules preset artifact object to close");
   }
 
   function expectSourceToContainPopulatedClassNameByCache(
@@ -473,6 +491,14 @@ if (import.meta.vitest) {
         `["']?classNameByCache["']?\\s*:\\s*\\{[\\s\\S]*["']${escapeRegExp(className)}["']`
       )
     );
+  }
+
+  function countV4PresetArtifacts(source: string): number {
+    return Array.from(
+      source.matchAll(
+        /["']?schema["']?\s*:\s*["']mincho\.defineRulesPreset["']/g
+      )
+    ).length;
   }
 
   function createLivePresetBuildSource(): string {
@@ -500,17 +526,8 @@ if (import.meta.vitest) {
     `;
   }
 
-  function getEsbuildTestCacheRoot(): string {
-    const cwd = process.cwd();
-    const packagePathSuffix = join("packages", "esbuild");
-
-    return cwd.endsWith(packagePathSuffix)
-      ? join(cwd, ".cache")
-      : join(cwd, packagePathSuffix, ".cache");
-  }
-
   async function createLivePresetSmokeFixture(prefix: string) {
-    const cacheRoot = getEsbuildTestCacheRoot();
+    const cacheRoot = join(process.cwd(), "packages/esbuild/.cache");
     await fs.promises.mkdir(cacheRoot, { recursive: true });
     const root = await fs.promises.mkdtemp(join(cacheRoot, prefix));
     const srcRoot = join(root, "src");
@@ -602,7 +619,7 @@ if (import.meta.vitest) {
   async function createRealEsbuildRegistryFixture(
     fixtureCase: DefineRulesPresetSerializationFixtureCase
   ) {
-    const cacheRoot = getEsbuildTestCacheRoot();
+    const cacheRoot = join(process.cwd(), "packages/esbuild/.cache");
     await fs.promises.mkdir(cacheRoot, { recursive: true });
     const root = await fs.promises.mkdtemp(
       join(cacheRoot, `${fixtureCase.caseId}-`)
@@ -663,7 +680,6 @@ if (import.meta.vitest) {
         entryPoints: [entryPath],
         external: ["@mincho-js/css"],
         format: "esm",
-        logLevel: "silent",
         minify: false,
         outdir: join(root, "dist"),
         plugins: minchoEsbuildPlugins(),
@@ -828,17 +844,6 @@ if (import.meta.vitest) {
   });
 
   describe("minchoEsbuildPlugin", () => {
-    it("extracts variable initializers from named export lists", () => {
-      const source = `
-        const fillBlue = "blue_class";
-        export { css, fillBlue as fillBlueClass };
-      `;
-
-      expect(
-        extractExportedVariableInitFromBuildSource(source, "fillBlue")
-      ).toBe('"blue_class"');
-    });
-
     it("builds a real esbuild fixture and emits defineRules preset registry artifact", async () => {
       const realEsbuild = await import("esbuild");
       const { entryPath, root } = await createLivePresetSmokeFixture(
@@ -940,9 +945,13 @@ if (import.meta.vitest) {
     });
 
     it("real esbuild function-valued config build skips registry artifacts", async () => {
-      const fixtureCase = getRegistryFixtureCase(
-        "registry-function-config-invalid"
+      const fixtureCase = registryFixtureMatrixCases.find(
+        (candidate) => candidate.caseId === "registry-function-config-invalid"
       );
+      if (fixtureCase == null) {
+        throw new Error("Missing registry function config fixture case");
+      }
+
       const { js, registrySource } =
         await buildRealEsbuildRegistryFixture(fixtureCase);
 
@@ -1019,14 +1028,14 @@ if (import.meta.vitest) {
       const functionValuedConfigBuildSource = `
         import { defineRules } from "@mincho-js/css";
 
-        const functionConfig = defineRules({
+        const invalid = defineRules({
           properties: {
             color(value: "brand" | "neutral") {
               return value === "brand" ? "blue" : "gray";
             }
           }
         });
-        export const raw = functionConfig.css.raw({ color: "brand" });
+        export const raw = invalid.css.raw({ color: "brand" });
       `;
       const realEsbuild = await import("esbuild");
       const entryPath = join(
@@ -1193,9 +1202,13 @@ if (import.meta.vitest) {
     });
 
     it("skips function-valued config fixture registry artifacts through the esbuild registry path", async () => {
-      const fixtureCase = getRegistryFixtureCase(
-        "registry-function-config-invalid"
+      const fixtureCase = registryFixtureMatrixCases.find(
+        (candidate) => candidate.caseId === "registry-function-config-invalid"
       );
+      if (fixtureCase == null) {
+        throw new Error("Missing registry function config fixture case");
+      }
+
       const fixtureSource = readFixtureSource(fixtureCase.fixturePath);
       for (const expectedSourceSnippet of fixtureCase.expectedSourceSnippets) {
         expectSourceToContainSnippet(fixtureSource, expectedSourceSnippet);

--- a/packages/integration/src/__fixtures__/defineRules-preset-serialization/README.md
+++ b/packages/integration/src/__fixtures__/defineRules-preset-serialization/README.md
@@ -16,19 +16,40 @@ The registry fixtures describe what actually executes while the extracted CSS mo
 
 `registry-function-config-invalid` is the function-valued config boundary. Function-valued `properties` or `shortcuts` can't be represented in the preset artifact, so public `defineRules(...)` calls with function-valued config are not registered and do not serialize a preset artifact. Their local `css.raw(...)` usage still executes normally.
 
-Serialized preset artifacts use the V3 shape:
+Serialized preset artifacts use the V4 shape:
 
 ```ts
 {
   schema: "mincho.defineRulesPreset",
-  version: 3,
+  version: 4,
   classNameByCache: {
     "<cache-key>": "<class-name>"
+  },
+  writeKeyByCacheKey: {
+    "<cache-key>": 0
+  },
+  conditionById: {
+    0: {
+      layer: null,
+      supports: null,
+      media: null,
+      container: null,
+      selector: "&"
+    }
+  },
+  propertyById: {
+    0: "<property-name>"
+  },
+  writeKeyById: {
+    0: {
+      conditionId: 0,
+      propertyId: 0
+    }
   }
 }
 ```
 
-`classNameByCache` must be populated from executed `css(...)` calls. Empty artifacts only belong to cases where no `defineRules(...)` instance ran during evaluation.
+`classNameByCache` and `writeKeyByCacheKey` must be populated from executed `css(...)` calls. Empty artifacts only belong to cases where no `defineRules(...)` instance ran during evaluation.
 
 ## Regeneration and verification contract
 
@@ -45,7 +66,7 @@ yarn vitest run "packages/esbuild/src/index.ts" -t "defineRules|preset|fixture|e
 Expected fixture diffs are limited to:
 
 - class-name changes caused by intentional preset/style changes;
-- serialized V3 preset artifact changes that match the source fixture's executed `css(...)` calls;
+- serialized V4 preset artifact changes that match the source fixture's executed `css(...)` calls;
 - sidecar CSS changes required for provider exports consumed through package imports.
 
 Unexpected fixture diffs include removed sidecar imports, missing fake package metadata, or runtime `css({ ... })` calls left where a static class literal should be emitted.

--- a/packages/integration/src/__fixtures__/defineRules-preset-serialization/README.md
+++ b/packages/integration/src/__fixtures__/defineRules-preset-serialization/README.md
@@ -14,7 +14,7 @@ The registry fixtures describe what actually executes while the extracted CSS mo
 
 `registry-exported-factory-not-executed` is the exported factory boundary. A factory that would call `defineRules(...)` does not serialize a preset artifact until the factory runs during `.css.ts` evaluation.
 
-`registry-function-config-invalid` is the function-valued config boundary. Function-valued `properties` or `shortcuts` can't be represented in the preset artifact, so public `defineRules(...)` calls with function-valued config are not registered and do not serialize a preset artifact. Their local `css.raw(...)` usage still executes normally.
+`registry-function-config-invalid` is the function-valued config boundary. Function-valued `conditions`, `properties`, or `shortcuts` can't be represented in the preset artifact, so public `defineRules(...)` calls with function-valued config are not registered and do not serialize a preset artifact. Their local `css.raw(...)` usage still executes normally.
 
 Serialized preset artifacts use the V4 shape:
 

--- a/packages/integration/src/defineRulesPreset.ts
+++ b/packages/integration/src/defineRulesPreset.ts
@@ -7,7 +7,7 @@ import {
 import { processVanillaFile } from "@vanilla-extract/integration";
 
 const DEFINE_RULES_REGISTRY_SERIALIZABLE_CONFIG_DIAGNOSTIC =
-  "defineRules registry serialization does not support function-valued properties or shortcuts";
+  "defineRules registry serialization does not support function-valued conditions, properties, or shortcuts";
 
 type Awaitable<Value> = Value | PromiseLike<Value>;
 
@@ -65,6 +65,11 @@ export function validateDefineRulesRegistrySession(
     };
 
     validateSerializableConfigEntry(
+      getConfigEntry(instance.config, "conditions"),
+      "config.conditions",
+      diagnosticContext
+    );
+    validateSerializableConfigEntry(
       getConfigEntry(instance.config, "properties"),
       "config.properties",
       diagnosticContext
@@ -92,7 +97,7 @@ function formatDefineRulesRegistryDiagnosticContext(
 
 function getConfigEntry(
   config: unknown,
-  key: "properties" | "shortcuts"
+  key: "conditions" | "properties" | "shortcuts"
 ): unknown {
   if (config == null || typeof config !== "object") {
     return undefined;
@@ -457,12 +462,64 @@ if (import.meta.vitest) {
       expect(artifactSource).toContain("conditionById:{");
       expect(artifactSource).toContain("propertyById:{");
       expect(artifactSource).toContain("writeKeyById:{");
+      expect(artifactSource).not.toContain("registeredSegments:");
+      expect(artifactSource).not.toContain("segmentCache:");
+      expect(artifactSource).not.toContain("fullResultCache:");
+      expect(artifactSource).not.toContain("atomicClassByClassName:");
       expect(artifactSource).not.toContain("cx:");
       expect(artifactSource).not.toContain('"cx":');
       expect(artifactSource).not.toContain("'cx':");
     }
     for (const instance of registrySession.instances) {
       expect(Object.hasOwn(instance.presetArtifact, "cx")).toBe(false);
+    }
+  }
+
+  function expectSerializedSourcePresetArtifactsToOmitCx(source: string): void {
+    const normalizedSource = normalizeSource(source);
+    const artifactMatches = Array.from(
+      normalizedSource.matchAll(/\{schema:["']mincho\.defineRulesPreset["']/g)
+    );
+
+    expect(artifactMatches.length).toBeGreaterThan(0);
+    for (const artifactMatch of artifactMatches) {
+      let depth = 0;
+      let artifactEndIndex = artifactMatch.index;
+      for (
+        let index = artifactMatch.index;
+        index < normalizedSource.length;
+        index += 1
+      ) {
+        const character = normalizedSource[index];
+        if (character === "{") {
+          depth += 1;
+        }
+        if (character === "}") {
+          depth -= 1;
+          if (depth === 0) {
+            artifactEndIndex = index + 1;
+            break;
+          }
+        }
+      }
+      const artifactSource = normalizedSource.slice(
+        artifactMatch.index,
+        artifactEndIndex
+      );
+
+      expect(artifactSource).toContain("version:4");
+      expect(artifactSource).toContain("classNameByCache:{");
+      expect(artifactSource).toContain("writeKeyByCacheKey:{");
+      expect(artifactSource).toContain("conditionById:{");
+      expect(artifactSource).toContain("propertyById:{");
+      expect(artifactSource).toContain("writeKeyById:{");
+      expect(artifactSource).not.toContain("registeredSegments:");
+      expect(artifactSource).not.toContain("segmentCache:");
+      expect(artifactSource).not.toContain("fullResultCache:");
+      expect(artifactSource).not.toContain("atomicClassByClassName:");
+      expect(artifactSource).not.toContain("cx:");
+      expect(artifactSource).not.toContain('"cx":');
+      expect(artifactSource).not.toContain("'cx':");
     }
   }
 
@@ -478,6 +535,243 @@ if (import.meta.vitest) {
     instance: DefineRulesRegistrySession["instances"][number] | undefined
   ): string[] {
     return Object.values(instance?.presetArtifact.classNameByCache ?? {});
+  }
+
+  type DefineRulesPresetArtifact =
+    DefineRulesRegistrySession["instances"][number]["presetArtifact"];
+
+  interface PresetWriteClassNameFilter {
+    property: string;
+    media: string | null;
+    excludeClassNames?: readonly string[];
+  }
+
+  const tabletMedia = "screen and (min-width: 768px)";
+  const desktopMedia = "screen and (min-width: 1024px)";
+
+  function getPresetWriteClassNames(
+    artifact: DefineRulesPresetArtifact,
+    filter: PresetWriteClassNameFilter
+  ): string[] {
+    const excludedClassNames = new Set(filter.excludeClassNames ?? []);
+    const classNames: string[] = [];
+
+    for (const [cacheKey, writeKeyId] of Object.entries(
+      artifact.writeKeyByCacheKey
+    )) {
+      const writeKey = artifact.writeKeyById[writeKeyId];
+      if (writeKey == null) {
+        continue;
+      }
+
+      const property = artifact.propertyById[writeKey.propertyId];
+      const condition = artifact.conditionById[writeKey.conditionId];
+      const className = artifact.classNameByCache[cacheKey];
+
+      if (
+        condition != null &&
+        property === filter.property &&
+        condition.media === filter.media &&
+        condition.selector === "&" &&
+        className != null &&
+        excludedClassNames.has(className) === false
+      ) {
+        classNames.push(className);
+      }
+    }
+
+    return classNames;
+  }
+
+  function expectSinglePresetWriteClassName(
+    artifact: DefineRulesPresetArtifact,
+    filter: PresetWriteClassNameFilter
+  ): string {
+    const classNames = getPresetWriteClassNames(artifact, filter);
+    expect(classNames).toHaveLength(1);
+    return classNames[0]!;
+  }
+
+  function expectPresetArtifactToContainConditionalWrites(
+    artifact: DefineRulesPresetArtifact
+  ): void {
+    expect(Object.values(artifact.conditionById)).toEqual(
+      expect.arrayContaining([
+        {
+          layer: null,
+          supports: null,
+          media: null,
+          container: null,
+          selector: "&"
+        },
+        {
+          layer: null,
+          supports: null,
+          media: tabletMedia,
+          container: null,
+          selector: "&"
+        },
+        {
+          layer: null,
+          supports: null,
+          media: desktopMedia,
+          container: null,
+          selector: "&"
+        }
+      ])
+    );
+    expect(Object.values(artifact.propertyById)).toEqual(
+      expect.arrayContaining(["color", "fontSize"])
+    );
+  }
+
+  function createCrossPackageConditionalProviderSource(): string {
+    return `
+      import { defineRules } from "@mincho-js/css";
+
+      const sharedConditions = {
+        mobile: {},
+        tablet: "@media screen and (min-width: 768px)",
+        desktop: { "@media": "screen and (min-width: 1024px)" }
+      } as const;
+      Object.setPrototypeOf(sharedConditions.mobile, null);
+      Object.setPrototypeOf(sharedConditions.desktop, null);
+      const sharedProperties = {
+        color: true,
+        fontSize: true
+      } as const;
+      const sharedShortcuts = {
+        responsiveText: {
+          _tablet: { fontSize: 16 },
+          fontSize: { _desktop: 20 }
+        }
+      } as const;
+
+      const provider = defineRules({
+        debugId: "cross-package-provider",
+        conditions: sharedConditions,
+        properties: sharedProperties,
+        shortcuts: sharedShortcuts
+      });
+
+      export const providerMobileClass = provider.css({
+        _mobile: { color: "navy" }
+      });
+      export const providerClass = provider.css({
+        _tablet: { fontSize: 16 },
+        fontSize: { _desktop: 20 }
+      });
+      export const providerTabletClass = provider.css({
+        _tablet: { fontSize: 16 }
+      });
+      export const providerDesktopClass = provider.css({
+        fontSize: { _desktop: 20 }
+      });
+      export const providerPreset = provider.preset;
+    `;
+  }
+
+  function createCrossPackageConditionalConsumerSource(
+    includeCxMergeExports: boolean
+  ): string {
+    const cxMergeExports = includeCxMergeExports
+      ? `
+          export const consumerDesktopOverride = consumer.css({
+            fontSize: { _desktop: 24 }
+          });
+          export const consumerTabletOverride = consumer.css({
+            _tablet: { fontSize: 18 }
+          });
+          export const mergedSameCondition = consumer.cx(
+            providerClass,
+            consumerDesktopOverride
+          );
+          export const mergedDifferentCondition = consumer.cx(
+            providerDesktopClass,
+            consumerTabletOverride
+          );
+        `
+      : "";
+
+    return `
+      import {
+        providerClass,
+        providerDesktopClass,
+        providerPreset,
+        providerTabletClass
+      } from "./provider.css.ts";
+      import { defineRules } from "@mincho-js/css";
+
+      const sharedConditions = {
+        mobile: {},
+        tablet: "@media screen and (min-width: 768px)",
+        desktop: { "@media": "screen and (min-width: 1024px)" }
+      } as const;
+      Object.setPrototypeOf(sharedConditions.mobile, null);
+      Object.setPrototypeOf(sharedConditions.desktop, null);
+      const sharedProperties = {
+        color: true,
+        fontSize: true
+      } as const;
+      const sharedShortcuts = {
+        responsiveText: {
+          _tablet: { fontSize: 16 },
+          fontSize: { _desktop: 20 }
+        }
+      } as const;
+
+      const consumer = defineRules({
+        debugId: "cross-package-consumer",
+        presets: providerPreset,
+        conditions: sharedConditions,
+        properties: sharedProperties,
+        shortcuts: sharedShortcuts
+      });
+
+      export const consumerClass = consumer.css({
+        _tablet: { fontSize: 16 },
+        fontSize: { _desktop: 20 }
+      });
+      ${cxMergeExports}
+      export const importedProviderClass = providerClass;
+      export const importedProviderTabletClass = providerTabletClass;
+      export const importedProviderDesktopClass = providerDesktopClass;
+      export const importedProviderPreset = providerPreset;
+      export const consumerPreset = consumer.preset;
+    `;
+  }
+
+  async function createCrossPackageConditionalRegistryFixture(
+    label: string,
+    includeCxMergeExports: boolean
+  ): Promise<{
+    consumerPath: string;
+    source: string;
+    cleanup: () => Promise<void>;
+  }> {
+    const fs = await import("node:fs/promises");
+    const path = await import("node:path");
+    fixtureIndex += 1;
+    const fixtureRoot = path.join(
+      process.env.TMPDIR ?? `${process.cwd()}/temps`,
+      `defineRulesPreset-cross-package-${fixtureIndex}-${label}`
+    );
+    const providerPath = path.join(fixtureRoot, "provider.css.ts");
+
+    await fs.mkdir(fixtureRoot, { recursive: true });
+    await fs.writeFile(
+      providerPath,
+      createCrossPackageConditionalProviderSource(),
+      "utf8"
+    );
+
+    return {
+      consumerPath: path.join(fixtureRoot, "consumer.css.ts"),
+      source: createCrossPackageConditionalConsumerSource(
+        includeCxMergeExports
+      ),
+      cleanup: () => fs.rm(fixtureRoot, { recursive: true, force: true })
+    };
   }
 
   function createConcurrentRegistryFixtureSource({
@@ -596,22 +890,14 @@ if (import.meta.vitest) {
           fixtureCase.caseId,
           fixtureCase.fixturePath
         );
-        const normalizedSource = normalizeSource(source);
         const classNames = collectClassNameByCacheValues(registrySession);
 
         expect(registrySession.instances).toHaveLength(
           fixtureCase.expectedRegistryInstances
         );
 
-        expect(normalizedSource).toMatch(
-          /schema:["']mincho\.defineRulesPreset["']/
-        );
-        expect(normalizedSource).toContain("version:4");
-        expect(normalizedSource).toContain("classNameByCache:{");
-        expect(normalizedSource).toContain("writeKeyByCacheKey:{");
-        expect(normalizedSource).toContain("conditionById:{");
-        expect(normalizedSource).toContain("propertyById:{");
-        expect(normalizedSource).toContain("writeKeyById:{");
+        expectSourceToContainV4PresetArtifact(source);
+        expectSerializedPresetArtifactsToOmitCx(source, registrySession);
         expectRegistryInstancesToHaveClassNameByCache(registrySession);
         expect(classNames.length).toBeGreaterThan(0);
         for (const className of classNames) {
@@ -644,19 +930,11 @@ if (import.meta.vitest) {
       const classNames = Object.values(
         registeredInstance?.presetArtifact.classNameByCache ?? {}
       );
-      const normalizedSource = normalizeSource(source);
 
       expect(registrySession.instances).toHaveLength(1);
       expect(registeredInstance?.registrationIndex).toBe(0);
-      expect(normalizedSource).toMatch(
-        /schema:["']mincho\.defineRulesPreset["']/
-      );
-      expect(normalizedSource).toContain("version:4");
-      expect(normalizedSource).toContain("classNameByCache:{");
-      expect(normalizedSource).toContain("writeKeyByCacheKey:{");
-      expect(normalizedSource).toContain("conditionById:{");
-      expect(normalizedSource).toContain("propertyById:{");
-      expect(normalizedSource).toContain("writeKeyById:{");
+      expectSourceToContainV4PresetArtifact(source);
+      expectSerializedPresetArtifactsToOmitCx(source, registrySession);
       expect(classNames).toHaveLength(1);
       expect(source).toContain(classNames[0]!);
       expect(emittedCss).toMatch(/color:\s*red/);
@@ -708,6 +986,7 @@ if (import.meta.vitest) {
 
       expect(registrySession.instances).toHaveLength(2);
       expectSourceToContainV4PresetArtifact(source);
+      expectSerializedPresetArtifactsToOmitCx(source, registrySession);
       expectRegistryInstancesToHaveClassNameByCache(registrySession);
       const reusedClassName = providerClassNames.join(" ");
 
@@ -715,6 +994,153 @@ if (import.meta.vitest) {
       expect(consumerClassNames).toEqual(providerClassNames);
       expect(source).toContain(`providerClass = '${reusedClassName}'`);
       expect(source).toContain(`consumerClass = '${reusedClassName}'`);
+    });
+
+    it("reuses conditional provider preset metadata across package fixture boundaries", async () => {
+      const fixture = await createCrossPackageConditionalRegistryFixture(
+        "conditional-reuse",
+        false
+      );
+
+      try {
+        const { source, registrySession, emittedCss } =
+          await processRegistryFixture(
+            fixture.source,
+            "conditional-reuse",
+            fixture.consumerPath
+          );
+        const [providerInstance, consumerInstance] = registrySession.instances;
+
+        expect(registrySession.instances).toHaveLength(2);
+        expect(providerInstance?.fileScope.filePath).toContain(
+          "provider.css.ts"
+        );
+        expect(consumerInstance?.fileScope.filePath).toContain(
+          "consumer.css.ts"
+        );
+        expectSourceToContainV4PresetArtifact(source);
+        expectSerializedSourcePresetArtifactsToOmitCx(source);
+        expectRegistryInstancesToHaveClassNameByCache(registrySession);
+        for (const instance of registrySession.instances) {
+          expect(Object.hasOwn(instance.presetArtifact, "cx")).toBe(false);
+        }
+
+        const providerArtifact = providerInstance!.presetArtifact;
+        const consumerArtifact = consumerInstance!.presetArtifact;
+        expectPresetArtifactToContainConditionalWrites(providerArtifact);
+        expectPresetArtifactToContainConditionalWrites(consumerArtifact);
+
+        const providerTabletClass = expectSinglePresetWriteClassName(
+          providerArtifact,
+          { property: "fontSize", media: tabletMedia }
+        );
+        const providerDesktopClass = expectSinglePresetWriteClassName(
+          providerArtifact,
+          { property: "fontSize", media: desktopMedia }
+        );
+        const consumerTabletClass = expectSinglePresetWriteClassName(
+          consumerArtifact,
+          { property: "fontSize", media: tabletMedia }
+        );
+        const consumerDesktopClass = expectSinglePresetWriteClassName(
+          consumerArtifact,
+          { property: "fontSize", media: desktopMedia }
+        );
+        const reusedClassName = `${providerTabletClass} ${providerDesktopClass}`;
+
+        expect(consumerTabletClass).toBe(providerTabletClass);
+        expect(consumerDesktopClass).toBe(providerDesktopClass);
+        expect(source).toContain(`consumerClass = '${reusedClassName}'`);
+        expect(source).toContain(
+          `importedProviderClass = '${reusedClassName}'`
+        );
+        expect(countV4PresetArtifacts(source)).toBe(2);
+        expect(emittedCss).toMatch(/@media\s+screen and \(min-width: 768px\)/);
+        expect(emittedCss).toMatch(/@media\s+screen and \(min-width: 1024px\)/);
+        expect(emittedCss).toMatch(/font-size:\s*16(?:px)?/);
+        expect(emittedCss).toMatch(/font-size:\s*20(?:px)?/);
+      } finally {
+        await fixture.cleanup();
+      }
+    });
+
+    it("merges conditional provider and consumer known classes through scoped cx", async () => {
+      const fixture = await createCrossPackageConditionalRegistryFixture(
+        "conditional-cx-merge",
+        true
+      );
+
+      try {
+        const { source, registrySession, emittedCss } =
+          await processRegistryFixture(
+            fixture.source,
+            "conditional-cx-merge",
+            fixture.consumerPath
+          );
+        const [providerInstance, consumerInstance] = registrySession.instances;
+
+        expect(registrySession.instances).toHaveLength(2);
+        expectSourceToContainV4PresetArtifact(source);
+        expectSerializedSourcePresetArtifactsToOmitCx(source);
+        expectRegistryInstancesToHaveClassNameByCache(registrySession);
+        for (const instance of registrySession.instances) {
+          expect(Object.hasOwn(instance.presetArtifact, "cx")).toBe(false);
+        }
+
+        const providerArtifact = providerInstance!.presetArtifact;
+        const consumerArtifact = consumerInstance!.presetArtifact;
+        expectPresetArtifactToContainConditionalWrites(providerArtifact);
+        expectPresetArtifactToContainConditionalWrites(consumerArtifact);
+
+        const providerTabletClass = expectSinglePresetWriteClassName(
+          providerArtifact,
+          { property: "fontSize", media: tabletMedia }
+        );
+        const providerDesktopClass = expectSinglePresetWriteClassName(
+          providerArtifact,
+          { property: "fontSize", media: desktopMedia }
+        );
+        const consumerDesktopOverride = expectSinglePresetWriteClassName(
+          consumerArtifact,
+          {
+            property: "fontSize",
+            media: desktopMedia,
+            excludeClassNames: [providerDesktopClass]
+          }
+        );
+        const consumerTabletOverride = expectSinglePresetWriteClassName(
+          consumerArtifact,
+          {
+            property: "fontSize",
+            media: tabletMedia,
+            excludeClassNames: [providerTabletClass]
+          }
+        );
+
+        expect(source).toContain(
+          `importedProviderClass = '${providerTabletClass} ${providerDesktopClass}'`
+        );
+        expect(countV4PresetArtifacts(source)).toBe(2);
+        expect(source).toContain(
+          `consumerDesktopOverride = '${consumerDesktopOverride}'`
+        );
+        expect(source).toContain(
+          `consumerTabletOverride = '${consumerTabletOverride}'`
+        );
+        expect(source).toContain(
+          `mergedSameCondition = '${providerTabletClass} ${consumerDesktopOverride}'`
+        );
+        expect(source).not.toContain(
+          `mergedSameCondition = '${providerTabletClass} ${providerDesktopClass} ${consumerDesktopOverride}'`
+        );
+        expect(source).toContain(
+          `mergedDifferentCondition = '${providerDesktopClass} ${consumerTabletOverride}'`
+        );
+        expect(emittedCss).toMatch(/font-size:\s*18(?:px)?/);
+        expect(emittedCss).toMatch(/font-size:\s*24(?:px)?/);
+      } finally {
+        await fixture.cleanup();
+      }
     });
 
     it("cleanup ends sessions after success, evaluation errors, and skipped registration", async () => {
@@ -742,18 +1168,18 @@ if (import.meta.vitest) {
 
       const functionConfigResult = await processRegistryFixture(
         `
-          import { defineRules } from "@mincho-js/css";
+            import { defineRules } from "@mincho-js/css";
 
-          const functionConfig = defineRules({
-            properties: {
-              color(value: string) {
-                return value;
+            const functionConfig = defineRules({
+              properties: {
+                color(value: string) {
+                  return value;
+                }
               }
-            }
-          });
+            });
 
-          export const raw = functionConfig.css.raw({ color: "red" });
-        `,
+            export const raw = functionConfig.css.raw({ color: "red" });
+          `,
         "cleanup-skipped-registration"
       );
 
@@ -1084,7 +1510,46 @@ if (import.meta.vitest) {
       expect(getActiveDefineRulesRegistrySession()).toBe(undefined);
     });
 
-    it("invalid config validation rejects function-valued properties and shortcuts with paths and registry metadata", () => {
+    it("valid config validation accepts serializable condition data", () => {
+      expect(() =>
+        validateDefineRulesRegistrySession(
+          createRegistrySession({
+            conditions: {
+              mobile: {},
+              tablet: "screen and (min-width: 768px)",
+              desktop: {
+                "@media": "screen and (min-width: 1024px)",
+                selector: "&[data-desktop]"
+              }
+            },
+            properties: {
+              color: true
+            },
+            shortcuts: {
+              layout: ["color"]
+            }
+          })
+        )
+      ).not.toThrow();
+    });
+
+    it("invalid config validation rejects function-valued conditions, properties, and shortcuts with paths and registry metadata", () => {
+      expect(() =>
+        validateDefineRulesRegistrySession(
+          createRegistrySession({
+            conditions: {
+              dynamic: {
+                selector(value: string) {
+                  return value;
+                }
+              }
+            }
+          })
+        )
+      ).toThrow(
+        "defineRules registry serialization does not support function-valued conditions, properties, or shortcuts at config.conditions.dynamic.selector (fileScope: test:registry.css.ts, registrationIndex: 0)"
+      );
+
       expect(() =>
         validateDefineRulesRegistrySession(
           createRegistrySession({
@@ -1096,7 +1561,7 @@ if (import.meta.vitest) {
           })
         )
       ).toThrow(
-        "defineRules registry serialization does not support function-valued properties or shortcuts at config.properties.color (fileScope: test:registry.css.ts, registrationIndex: 0)"
+        "defineRules registry serialization does not support function-valued conditions, properties, or shortcuts at config.properties.color (fileScope: test:registry.css.ts, registrationIndex: 0)"
       );
 
       expect(() =>
@@ -1120,7 +1585,7 @@ if (import.meta.vitest) {
           })
         )
       ).toThrow(
-        "defineRules registry serialization does not support function-valued properties or shortcuts at config.shortcuts.layout[1].tone (fileScope: test:registry.css.ts, registrationIndex: 0)"
+        "defineRules registry serialization does not support function-valued conditions, properties, or shortcuts at config.shortcuts.layout[1].tone (fileScope: test:registry.css.ts, registrationIndex: 0)"
       );
     });
 

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -431,20 +431,6 @@ if (import.meta.vitest) {
     );
   }
 
-  function getRegistryFixtureCase(
-    caseId: string
-  ): DefineRulesPresetSerializationFixtureCase {
-    const fixtureCase = registryFixtureMatrixCases.find(
-      (candidate) => candidate.caseId === caseId
-    );
-
-    if (fixtureCase == null) {
-      throw new Error(`Missing registry fixture case ${caseId}`);
-    }
-
-    return fixtureCase;
-  }
-
   beforeAll(async () => {
     initializeDefineRulesPresetSerializationFixtures(
       await loadDefineRulesPresetSerializationManifest()
@@ -528,6 +514,7 @@ if (import.meta.vitest) {
     expect(source).toMatch(/["']?conditionById["']?\s*:\s*\{/);
     expect(source).toMatch(/["']?propertyById["']?\s*:\s*\{/);
     expect(source).toMatch(/["']?writeKeyById["']?\s*:\s*\{/);
+    expectSourceV4PresetArtifactToOmitRuntimeFields(source);
   }
 
   function expectSourceToContainV4RuntimePresetSeed(source: string): void {
@@ -539,6 +526,45 @@ if (import.meta.vitest) {
     expect(source).toMatch(/["']?version["']?\s*:\s*4/);
     expect(source).toMatch(/["']?classNameByCache["']?\s*:\s*\{/);
     expect(source).toMatch(/["']?writeKeyByCacheKey["']?\s*:\s*\{/);
+  }
+
+  function expectSourceV4PresetArtifactToOmitRuntimeFields(
+    source: string
+  ): void {
+    const artifactSource = extractV4PresetArtifactSource(source);
+    expect(artifactSource).not.toMatch(/["']?registeredSegments["']?\s*:/);
+    expect(artifactSource).not.toMatch(/["']?segmentCache["']?\s*:/);
+    expect(artifactSource).not.toMatch(/["']?fullResultCache["']?\s*:/);
+    expect(artifactSource).not.toMatch(/["']?atomicClassByClassName["']?\s*:/);
+    expect(artifactSource).not.toMatch(/["']?cx["']?\s*:/);
+  }
+
+  function extractV4PresetArtifactSource(source: string): string {
+    const schemaMatch = source.match(
+      new RegExp(
+        `["']?schema["']?\\s*:\\s*["']${escapeRegExp(DEFINE_RULES_PRESET_SCHEMA)}["']`
+      )
+    );
+    if (schemaMatch?.index == null) {
+      throw new Error("Expected defineRules preset schema in source");
+    }
+
+    const artifactStart = source.lastIndexOf("{", schemaMatch.index);
+    if (artifactStart === -1) {
+      throw new Error("Expected defineRules preset artifact object in source");
+    }
+
+    let depth = 0;
+    for (let index = artifactStart; index < source.length; index += 1) {
+      const char = source[index];
+      if (char === "{") depth += 1;
+      if (char === "}") depth -= 1;
+      if (depth === 0) {
+        return source.slice(artifactStart, index + 1);
+      }
+    }
+
+    throw new Error("Expected defineRules preset artifact object to close");
   }
 
   function countV4PresetArtifacts(source: string): number {
@@ -1282,9 +1308,13 @@ if (import.meta.vitest) {
     }, 20000);
 
     it("real Vite function-valued config build skips registry artifacts", async () => {
-      const fixtureCase = getRegistryFixtureCase(
-        "registry-function-config-invalid"
+      const fixtureCase = registryFixtureMatrixCases.find(
+        (candidate) => candidate.caseId === "registry-function-config-invalid"
       );
+      if (fixtureCase == null) {
+        throw new Error("Missing registry function config fixture case");
+      }
+
       const { js, registrySource } =
         await buildRealViteRegistryFixture(fixtureCase);
 
@@ -1358,19 +1388,19 @@ if (import.meta.vitest) {
       ).toBe(false);
     });
 
-    it("defineRules exported css skips function-valued config registry artifacts", async () => {
+    it("defineRules exported css skips function-valued registry artifacts", async () => {
       const integrationModule = await import("@mincho-js/integration");
       const functionValuedConfigBuildSource = `
         import { defineRules } from "@mincho-js/css";
 
-        const functionConfig = defineRules({
+        const invalid = defineRules({
           properties: {
             color(value: "brand" | "neutral") {
               return value === "brand" ? "blue" : "gray";
             }
           }
         });
-        export const raw = functionConfig.css.raw({ color: "brand" });
+        export const raw = invalid.css.raw({ color: "brand" });
       `;
 
       vi.spyOn(integrationModule, "babelTransform").mockResolvedValue({
@@ -1492,9 +1522,13 @@ if (import.meta.vitest) {
     });
 
     it("keeps function-valued config fixture artifact-free through the Vite registry path", async () => {
-      const fixtureCase = getRegistryFixtureCase(
-        "registry-function-config-invalid"
+      const fixtureCase = registryFixtureMatrixCases.find(
+        (candidate) => candidate.caseId === "registry-function-config-invalid"
       );
+      if (fixtureCase == null) {
+        throw new Error("Missing registry function config fixture case");
+      }
+
       const fixtureSource = readFixtureSource(fixtureCase.fixturePath);
       for (const expectedSourceSnippet of fixtureCase.expectedSourceSnippets) {
         expectSourceToContainSnippet(fixtureSource, expectedSourceSnippet);


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->
Wires conditional `defineRules` support into preset serialization and updates the related docs/examples.
This PR builds on the core conditional `defineRules` support from the previous PR and makes the new conditional preset data flow through integration, esbuild, and vite serialization paths.

- Serialize conditional `defineRules` preset data in the integration layer
- Update esbuild preset serialization handling
- Update vite preset serialization handling
- Update preset serialization fixture documentation
- Add README/example coverage for conditional `defineRules` usage


## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #338

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added responsive styling conditions (`mobile`, `tablet`, `desktop`) and enabled `fontSize` as a supported CSS property.
  * Updated shared example card styles to use responsive `color` and `fontSize` (with desktop/tablet overrides).

* **Documentation**
  * Expanded `defineRules()` docs to cover the `conditions` option and scoped usage, including the `{ css, cx, preset }` return shape and condition/conflict merge behavior.

* **Breaking/Behavior Change**
  * Updated shared-component preset exports to provide `css`, `preset`, and `sharedCardClassName` (removing the previous `cx` re-export).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

Included:
- Integration preset serialization
- esbuild/vite plugin wiring
- Fixture README update
- CSS README and shared-component example update

Not included:
- Core condition metadata model
- Runtime conditional atomics compilation
- transform-to-vanilla declaration collector

## Checklist
<!-- Tell us what reviewers should look for. -->
