### PR TITLE
Feat: CSS - Add positional css.with mixins

### DIFF
--- a/packages/css/src/classname/cx.ts
+++ b/packages/css/src/classname/cx.ts
@@ -287,7 +287,7 @@ if (import.meta.vitest) {
       expect(responsive("text-sm")).toBe("text-sm");
     });
 
-    it("supports one-argument object mixins with tuple multiple values", () => {
+    it("supports one-argument object mixins with direct multiple values", () => {
       const responsive = cx.with<{ base: string; md?: string }>(
         ({ base, md }) => [base, md && `md:${md}`]
       );
@@ -297,8 +297,8 @@ if (import.meta.vitest) {
       );
       expect(
         responsive.multiple({
-          body: [{ base: "text-sm", md: "text-base" }],
-          caption: [{ base: "text-xs" }]
+          body: { base: "text-sm", md: "text-base" },
+          caption: { base: "text-xs" }
         } as const)
       ).toEqual({ body: "text-sm md:text-base", caption: "text-xs" });
     });

--- a/packages/css/src/classname/cx.ts
+++ b/packages/css/src/classname/cx.ts
@@ -2,7 +2,12 @@ import { clsx } from "clsx";
 import type {
   ClassValue,
   ClassMultipleInput,
-  ClassMultipleResult
+  ClassMultipleResult,
+  CxWith,
+  CxWithCallback,
+  CxWithCallbackArgs,
+  CxWithMixin,
+  CxWithTupleValue
 } from "./types.js";
 
 const cxImpl: (...inputs: ClassValue[]) => string = clsx;
@@ -49,29 +54,44 @@ function cxMultiple<T extends ClassMultipleInput>(
   return result;
 }
 
-function cxWith<const T extends ClassValue>(
-  callback?: (params: T) => ClassValue
-) {
-  const cxFunction = callback ?? ((className: T) => className);
+function cxWith<const T extends ClassValue>(): CxWith<T>;
+function cxWith<const F extends CxWithCallback>(
+  callback: F
+): CxWithMixin<CxWithCallbackArgs<F>>;
+function cxWith<const Input>(
+  callback: (params: Input) => ClassValue
+): CxWithMixin<[params: Input]>;
+function cxWith<const T extends ClassValue, const F extends CxWithCallback>(
+  callback?: ((params: T) => ClassValue) | F
+): CxWith<T> & CxWithMixin<CxWithCallbackArgs<F>> {
+  type CxWithRuntimeCallback = (...className: unknown[]) => ClassValue;
+  const cxFunction = (callback ??
+    ((...className: ClassValue[]) => className)) as CxWithRuntimeCallback;
 
-  function cxWithImpl(...className: T[]) {
-    const result = className.map((cn) => cxFunction(cn));
-    return cxImpl(...result);
+  function cxWithImpl(...className: unknown[]) {
+    return cxImpl(cxFunction(...className));
   }
 
-  function cxWithMultiple<ClassNameMap extends ClassMultipleInput<T>>(
-    classNameMap: ClassNameMap
-  ): ClassMultipleResult<ClassNameMap> {
+  function cxWithMultiple<
+    ClassNameMap extends Record<
+      string,
+      T | CxWithTupleValue<CxWithCallbackArgs<F>>
+    >
+  >(classNameMap: ClassNameMap): ClassMultipleResult<ClassNameMap> {
     type TransformedClassNameMap = Record<keyof ClassNameMap, ClassValue>;
     const transformedClassNameMap: TransformedClassNameMap =
       {} as TransformedClassNameMap;
     for (const key in classNameMap) {
-      transformedClassNameMap[key] = cxFunction(classNameMap[key]);
+      const value = classNameMap[key];
+      transformedClassNameMap[key] = Array.isArray(value)
+        ? cxFunction(...value)
+        : cxFunction(value);
     }
     return cxMultiple(transformedClassNameMap);
   }
 
-  return Object.assign(cxWithImpl, { multiple: cxWithMultiple });
+  return Object.assign(cxWithImpl, { multiple: cxWithMultiple }) as CxWith<T> &
+    CxWithMixin<CxWithCallbackArgs<F>>;
 }
 
 // == Tests ====================================================================
@@ -80,7 +100,7 @@ function cxWith<const T extends ClassValue>(
 if (import.meta.vitest) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore error TS1343
-  const { describe, it, expect, assertType } = import.meta.vitest;
+  const { describe, it, expect, assertType, vi } = import.meta.vitest;
 
   describe.concurrent("cx()", () => {
     it("handles string inputs (variadic)", () => {
@@ -251,15 +271,36 @@ if (import.meta.vitest) {
       expect(layout("grid", { block: false, "m-1": true })).toBe("grid m-1");
     });
 
-    it("creates a typed constraint with transformer", () => {
-      const responsive = cx.with<{ base: string; md?: string; lg?: string }>(
-        ({ base, md, lg }) => [base, md && `md:${md}`, lg && `lg:${lg}`]
+    it("creates a typed positional mixin with transformer", () => {
+      const responsive = cx.with((base: string, md?: string, lg?: string) => [
+        base,
+        md && `md:${md}`,
+        lg && `lg:${lg}`
+      ]);
+
+      assertType<(base: string, md?: string, lg?: string) => string>(
+        responsive
+      );
+      expect(responsive("text-sm", "text-base", "text-lg")).toBe(
+        "text-sm md:text-base lg:text-lg"
+      );
+      expect(responsive("text-sm")).toBe("text-sm");
+    });
+
+    it("supports one-argument object mixins with tuple multiple values", () => {
+      const responsive = cx.with<{ base: string; md?: string }>(
+        ({ base, md }) => [base, md && `md:${md}`]
       );
 
+      expect(responsive({ base: "text-sm", md: "text-base" })).toBe(
+        "text-sm md:text-base"
+      );
       expect(
-        responsive({ base: "text-sm", md: "text-base", lg: "text-lg" })
-      ).toBe("text-sm md:text-base lg:text-lg");
-      expect(responsive({ base: "text-sm" })).toBe("text-sm");
+        responsive.multiple({
+          body: [{ base: "text-sm", md: "text-base" }],
+          caption: [{ base: "text-xs" }]
+        } as const)
+      ).toEqual({ body: "text-sm md:text-base", caption: "text-xs" });
     });
 
     it("filters out non-string and empty values without transformer", () => {
@@ -275,14 +316,31 @@ if (import.meta.vitest) {
       expect(test({ required: "foo", optional: "" })).toBe("required");
     });
 
-    it("transformer receives all params", () => {
-      const test = cx.with<{ a: string; b: boolean }>(({ a, b }) => [
-        a,
-        b && "active"
+    it("mixin transformer receives all direct call args at once", () => {
+      const callback = vi.fn((base: string, active: boolean) => [
+        base,
+        active && "active"
       ]);
+      const test = cx.with(callback);
 
-      expect(test({ a: "base", b: true })).toBe("base active");
-      expect(test({ a: "base", b: false })).toBe("base");
+      expect(test("base", true)).toBe("base active");
+      expect(test("base", false)).toBe("base");
+      expect(callback).toHaveBeenNthCalledWith(1, "base", true);
+      expect(callback).toHaveBeenNthCalledWith(2, "base", false);
+    });
+
+    it("expresses mapper behavior as a rest-args mixin", () => {
+      const prefixed = cx.with((...classNames: string[]) =>
+        classNames.map((className) => `ui-${className}`)
+      );
+
+      expect(prefixed("button", "active")).toBe("ui-button ui-active");
+      expect(
+        prefixed.multiple({
+          button: ["button", "active"],
+          icon: ["icon"]
+        })
+      ).toEqual({ button: "ui-button ui-active", icon: "ui-icon" });
     });
 
     it("cx.with().multiple() processes a map with typed constraint", () => {
@@ -299,16 +357,18 @@ if (import.meta.vitest) {
       expect(result.container).toBe("grid");
     });
 
-    it("cx.with().multiple() with transformer", () => {
-      const responsive = cx.with<{ base: string; md?: string; lg?: string }>(
-        ({ base, md, lg }) => [base, md && `md:${md}`, lg && `lg:${lg}`]
-      );
+    it("cx.with().multiple() with positional mixin transformer", () => {
+      const responsive = cx.with((base: string, md?: string, lg?: string) => [
+        base,
+        md && `md:${md}`,
+        lg && `lg:${lg}`
+      ]);
 
       const result = responsive.multiple({
-        heading: { base: "text-xl", md: "text-2xl", lg: "text-3xl" },
-        body: { base: "text-sm", md: "text-base" },
-        caption: { base: "text-xs" }
-      });
+        heading: ["text-xl", "text-2xl", "text-3xl"],
+        body: ["text-sm", "text-base"],
+        caption: ["text-xs"]
+      } as const);
 
       expect(result.heading).toBe("text-xl md:text-2xl lg:text-3xl");
       expect(result.body).toBe("text-sm md:text-base");

--- a/packages/css/src/classname/types.ts
+++ b/packages/css/src/classname/types.ts
@@ -79,7 +79,8 @@ export type CxWithCallbackArgs<F extends CxWithCallback> = Parameters<F>;
 
 export type CxWithTupleValue<Args extends unknown[]> =
   | Args
-  | readonly [...Args];
+  | readonly [...Args]
+  | (Args extends [input: infer Input] ? Input : never);
 
 export interface CxWith<Input extends ClassValue> {
   (...className: Input[]): string;
@@ -456,6 +457,27 @@ if (import.meta.vitest) {
       void _rootClass;
       void _labelClass;
       void _invalidKey;
+    });
+  });
+
+  describe.concurrent("Cx Type Test", () => {
+    it("accepts direct one-argument mixin values in multiple maps", () => {
+      type Params = { readonly base: string; readonly md?: string };
+
+      function assertCxType(typedCx: Cx) {
+        const responsive = typedCx.with<Params>(({ base, md }) => [
+          base,
+          md && `md:${md}`
+        ]);
+        const result = responsive.multiple({
+          body: { base: "text-sm", md: "text-base" },
+          caption: { base: "text-xs" }
+        });
+
+        assertType<{ body: string; caption: string }>(result);
+      }
+
+      void assertCxType;
     });
   });
 }

--- a/packages/css/src/classname/types.ts
+++ b/packages/css/src/classname/types.ts
@@ -69,13 +69,28 @@ export type ClassMultipleInput<Input extends ClassValue = ClassValue> = Record<
   Input
 >;
 
-export type ClassMultipleResult<T extends ClassMultipleInput> = {
+export type ClassMultipleResult<T extends Record<string, unknown>> = {
   [K in keyof T]: string;
 };
+
+export type CxWithCallback = (...args: never[]) => ClassValue;
+
+export type CxWithCallbackArgs<F extends CxWithCallback> = Parameters<F>;
+
+export type CxWithTupleValue<Args extends unknown[]> =
+  | Args
+  | readonly [...Args];
 
 export interface CxWith<Input extends ClassValue> {
   (...className: Input[]): string;
   multiple<ClassNameMap extends Record<string, Input>>(
+    classNameMap: ClassNameMap
+  ): { [K in keyof ClassNameMap]: string };
+}
+
+export interface CxWithMixin<Args extends unknown[]> {
+  (...className: Args): string;
+  multiple<ClassNameMap extends Record<string, CxWithTupleValue<Args>>>(
     classNameMap: ClassNameMap
   ): { [K in keyof ClassNameMap]: string };
 }
@@ -85,9 +100,13 @@ export interface Cx {
   multiple<ClassNameMap extends Record<string, ClassValue>>(
     map: ClassNameMap
   ): { [K in keyof ClassNameMap]: string };
-  with<const Input extends ClassValue>(
-    callback?: (params: Input) => ClassValue
-  ): CxWith<Input>;
+  with<const Input extends ClassValue>(): CxWith<Input>;
+  with<const F extends CxWithCallback>(
+    callback: F
+  ): CxWithMixin<CxWithCallbackArgs<F>>;
+  with<const Input>(
+    callback: (params: Input) => ClassValue
+  ): CxWithMixin<[params: Input]>;
 }
 
 // == Tests ====================================================================

--- a/packages/css/src/css/index.ts
+++ b/packages/css/src/css/index.ts
@@ -137,28 +137,86 @@ export function cssImpl(style: ComplexCSSRule, debugId?: string) {
   return vStyle(transform(style), debugId);
 }
 
-function cssWith<const T extends CSSRule>(
-  callback?: (style: CSSRuleWith<T>) => ComplexCSSRule
-) {
-  type RestrictedCSSRule = CSSRuleWith<T>;
-  const cssFunction = callback ?? ((style: RestrictedCSSRule) => style);
+type CssWithStyleResult<T extends CSSRule> = ((
+  style: CSSRuleWith<T>,
+  debugId?: string
+) => string) & {
+  raw(style: CSSRuleWith<T>): ComplexCSSRule;
+  multiple<StyleMap extends Record<string | number, CSSRuleWith<T>>>(
+    styleMap: StyleMap,
+    debugId?: string
+  ): Record<keyof StyleMap, string>;
+};
 
-  function cssWithImpl(style: RestrictedCSSRule, debugId?: string) {
-    return cssImpl(cssFunction(style), debugId);
+type CssWithCallback = (...args: never[]) => ComplexCSSRule;
+
+type CssWithCallbackArgs<F extends CssWithCallback> = Parameters<F>;
+
+type IsMultiArgCallback<F extends CssWithCallback> =
+  2 extends CssWithCallbackArgs<F>["length"] ? F : never;
+
+type CssWithTupleValue<Args extends unknown[]> = Args | readonly [...Args];
+
+type CssWithMixinResult<Args extends unknown[]> = ((
+  ...args: Args
+) => string) & {
+  raw(...args: Args): ComplexCSSRule;
+  multiple<StyleMap extends Record<string | number, CssWithTupleValue<Args>>>(
+    styleMap: StyleMap,
+    debugId?: string
+  ): Record<keyof StyleMap, string>;
+};
+
+function cssWith<const T extends CSSRule>(): CssWithStyleResult<T>;
+function cssWith<const T extends CSSRule>(
+  callback: (style: CSSRuleWith<T>) => ComplexCSSRule
+): CssWithStyleResult<T>;
+function cssWith<const F extends CssWithCallback>(
+  callback: F & IsMultiArgCallback<F>
+): CssWithMixinResult<CssWithCallbackArgs<F>>;
+function cssWith<const T extends CSSRule, const F extends CssWithCallback>(
+  callback?:
+    | ((style: CSSRuleWith<T>) => ComplexCSSRule)
+    | (F & IsMultiArgCallback<F>)
+): CssWithStyleResult<T> & CssWithMixinResult<CssWithCallbackArgs<F>> {
+  type RestrictedCSSRule = CSSRuleWith<T>;
+  type CssWithRuntimeCallback = (...args: unknown[]) => ComplexCSSRule;
+  const cssFunction = (callback ??
+    ((style: RestrictedCSSRule) => style)) as CssWithRuntimeCallback;
+
+  function getCssWithDebugId(args: readonly unknown[]) {
+    // Legacy object-first calls keep runtime debug-label precedence: an object-first
+    // positional mixin still receives both args, but may use the second string as
+    // the compatibility debug label. Positional mixin direct debug IDs are not a public typed API.
+    return args.length === 2 &&
+      typeof args[1] === "string" &&
+      typeof args[0] === "object" &&
+      args[0] !== null &&
+      !Array.isArray(args[0])
+      ? args[1]
+      : undefined;
   }
-  function cssWithRaw(style: RestrictedCSSRule) {
-    return cssRaw(cssFunction(style));
+
+  function cssWithImpl(...args: unknown[]) {
+    return cssImpl(cssFunction(...args), getCssWithDebugId(args));
+  }
+  function cssWithRaw(...args: unknown[]) {
+    return cssRaw(cssFunction(...args));
   }
 
   function cssWithMultiple<
-    StyleMap extends Record<string | number, RestrictedCSSRule>
+    StyleMap extends Record<
+      string | number,
+      RestrictedCSSRule | CssWithTupleValue<CssWithCallbackArgs<F>>
+    >
   >(styleMap: StyleMap, debugId?: string): Record<keyof StyleMap, string> {
-    // TODO: Use css.with supported data mapping when available
-    // Transform each value using cssFunction
     type TransformedStyleMap = Record<keyof StyleMap, ComplexCSSRule>;
     const transformedStyleMap: TransformedStyleMap = {} as TransformedStyleMap;
     for (const key in styleMap) {
-      transformedStyleMap[key] = cssFunction(styleMap[key]);
+      const value = styleMap[key];
+      transformedStyleMap[key] = Array.isArray(value)
+        ? cssFunction(...value)
+        : cssFunction(value);
     }
     return cssMultiple(transformedStyleMap, debugId);
   }
@@ -166,7 +224,7 @@ function cssWith<const T extends CSSRule>(
   return Object.assign(cssWithImpl, {
     raw: cssWithRaw,
     multiple: cssWithMultiple
-  });
+  }) as CssWithStyleResult<T> & CssWithMixinResult<CssWithCallbackArgs<F>>;
 }
 
 // == CSS Multiple =============================================================
@@ -224,7 +282,7 @@ export function selector(selector: string): `&` {
 if (import.meta.vitest) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
-  const { describe, it, assert, expect, vi } = import.meta.vitest;
+  const { describe, it, assert, expect, expectTypeOf, vi } = import.meta.vitest;
 
   const debugId = "myCSS";
   setFileScope("test");
@@ -650,6 +708,90 @@ if (import.meta.vitest) {
       myCss2.raw({ radius: 10 });
     });
 
+    it("css.with() overload type regressions", () => {
+      const restrictedCss = css.with<{ color: true; border: false }>();
+
+      restrictedCss({ color: "red" }, debugId);
+      restrictedCss.raw({ color: "red" });
+      restrictedCss.multiple({ primary: { color: "red" } }, debugId);
+      // @ts-expect-error: color is required
+      restrictedCss({});
+      // @ts-expect-error: color is required
+      restrictedCss.raw({});
+      restrictedCss({
+        color: "red",
+        // @ts-expect-error: border is not included in the restriction
+        border: "none"
+      });
+
+      const objectParamMixin = css.with<{ size: number }>(({ size }) => ({
+        width: size
+      }));
+
+      objectParamMixin({ size: 12 }, debugId);
+      objectParamMixin.raw({ size: 12 });
+      objectParamMixin.multiple({ sm: { size: 12 } }, debugId);
+      // @ts-expect-error: size is required
+      objectParamMixin.raw({});
+
+      const positionalMixin = css.with((size: number, radius?: number) => ({
+        width: size,
+        height: size,
+        ...(radius === undefined ? {} : { borderRadius: radius })
+      }));
+
+      expectTypeOf<Parameters<typeof positionalMixin>>().toEqualTypeOf<
+        [size: number, radius?: number]
+      >();
+      expectTypeOf<Parameters<typeof positionalMixin.raw>>().toEqualTypeOf<
+        [size: number, radius?: number]
+      >();
+      expectTypeOf<
+        ReturnType<typeof positionalMixin>
+      >().toEqualTypeOf<string>();
+      expectTypeOf<
+        ReturnType<typeof positionalMixin.raw>
+      >().toEqualTypeOf<ComplexCSSRule>();
+
+      const runTypeOnlyCalls: boolean = false;
+      if (runTypeOnlyCalls) {
+        positionalMixin(12);
+        positionalMixin(12, 4);
+        positionalMixin.raw(12);
+        positionalMixin.raw(12, 4);
+        const result = positionalMixin.multiple(
+          {
+            sm: [12],
+            md: [16, 4],
+            lg: [24, 8] as const
+          },
+          debugId
+        );
+        expectTypeOf(result).toEqualTypeOf<{
+          sm: string;
+          md: string;
+          lg: string;
+        }>();
+
+        // @ts-expect-error: one-argument positional mixins are not introduced
+        css.with((size: number) => ({ width: size }));
+        // @ts-expect-error: direct positional mixin calls do not accept object style args
+        positionalMixin({ size: 12 });
+        // @ts-expect-error: raw positional mixin calls do not accept object style args
+        positionalMixin.raw({ size: 12 });
+        // @ts-expect-error: multiple positional mixin maps require tuple values
+        positionalMixin.multiple({ sm: { size: 12 } });
+        // @ts-expect-error: multiple positional mixin maps require the first tuple element
+        positionalMixin.multiple({ xs: [] });
+        // @ts-expect-error: multiple positional mixin maps reject extra tuple elements
+        positionalMixin.multiple({ xl: [24, 8, 2] });
+        // @ts-expect-error: multiple positional mixin maps reject invalid tuple element types
+        positionalMixin.multiple({ bad: ["large", 8] });
+        // @ts-expect-error: direct positional mixin calls do not expose debugId args
+        positionalMixin(12, debugId);
+      }
+    });
+
     it("Basic callback transformation", () => {
       const withRedBackground = css.with((style) => ({
         ...style,
@@ -660,6 +802,54 @@ if (import.meta.vitest) {
 
       assert.isString(result);
       expect(result).toMatch(identifierName(debugId));
+    });
+
+    it("css.with().raw() forwards positional callback args", () => {
+      const mixin = css.with((size: number, radius?: number) => ({
+        width: size,
+        height: size,
+        borderRadius: radius ?? 0
+      }));
+
+      const result = mixin.raw(100, 8);
+
+      expect(result).toEqual({
+        width: 100,
+        height: 100,
+        borderRadius: 8
+      });
+    });
+
+    it("css.with() forwards direct and raw string args without positional debug labels", () => {
+      const callback = vi.fn((color: string, size: string) => ({
+        color,
+        fontFamily: size
+      }));
+      const mixin = css.with(callback);
+
+      const result = mixin("red", "lg");
+      const rawResult = mixin.raw("red", "lg");
+
+      expect(callback).toHaveBeenNthCalledWith(1, "red", "lg");
+      expect(callback).toHaveBeenNthCalledWith(2, "red", "lg");
+      expect(result).not.toMatch(identifierName("lg"));
+      expect(rawResult).toEqual({
+        color: "red",
+        fontFamily: "lg"
+      });
+    });
+
+    it("css.with() preserves object-first debug labels while forwarding both args", () => {
+      const callback = vi.fn((style: { color: string }, label: string) => ({
+        ...style,
+        fontFamily: label
+      }));
+      const mixin = css.with(callback);
+
+      const result = mixin({ color: "red" }, "lg");
+
+      expect(callback).toHaveBeenCalledWith({ color: "red" }, "lg");
+      expect(result).toMatch(identifierName("lg"));
     });
 
     it("css.with().raw()", () => {
@@ -693,6 +883,51 @@ if (import.meta.vitest) {
       assert.hasAllKeys(result, ["primary", "secondary"]);
       expect(result.primary).toMatch(identifierName(`${debugId}_primary`));
       expect(result.secondary).toMatch(identifierName(`${debugId}_secondary`));
+    });
+
+    it("css.with().multiple() forwards tuple map values as positional args", () => {
+      const callback = vi.fn((size: number, label: string) => ({
+        width: size,
+        height: size,
+        fontFamily: label
+      }));
+      const mixin = css.with(callback);
+
+      const result = mixin.multiple(
+        {
+          sm: [12, "sm"],
+          lg: [20, "lg"]
+        } as const,
+        debugId
+      );
+
+      assert.hasAllKeys(result, ["sm", "lg"]);
+      expect(result.sm).toMatch(identifierName(`${debugId}_sm`));
+      expect(result.lg).toMatch(identifierName(`${debugId}_lg`));
+      expect(callback.mock.calls).toEqual([
+        [12, "sm"],
+        [20, "lg"]
+      ]);
+    });
+
+    it("css.with().multiple() forwards optional tuple elements", () => {
+      const callback = vi.fn((size: number, radius?: number) => ({
+        width: size,
+        height: size,
+        borderRadius: radius ?? 0
+      }));
+      const mixin = css.with(callback);
+
+      const result = mixin.multiple(
+        {
+          compact: [8]
+        } as const,
+        debugId
+      );
+
+      assert.hasAllKeys(result, ["compact"]);
+      expect(result.compact).toMatch(identifierName(`${debugId}_compact`));
+      expect(callback.mock.calls).toEqual([[8]]);
     });
 
     it("css.with() with like mixin", () => {

--- a/packages/css/src/css/index.ts
+++ b/packages/css/src/css/index.ts
@@ -153,7 +153,13 @@ type CssWithCallback = (...args: never[]) => ComplexCSSRule;
 type CssWithCallbackArgs<F extends CssWithCallback> = Parameters<F>;
 
 type IsMultiArgCallback<F extends CssWithCallback> =
-  2 extends CssWithCallbackArgs<F>["length"] ? F : never;
+  CssWithCallbackArgs<F> extends [unknown, ...infer Rest]
+    ? Rest extends []
+      ? never
+      : F
+    : number extends CssWithCallbackArgs<F>["length"]
+      ? F
+      : never;
 
 type CssWithTupleValue<Args extends unknown[]> = Args | readonly [...Args];
 
@@ -885,18 +891,18 @@ if (import.meta.vitest) {
       expect(result.secondary).toMatch(identifierName(`${debugId}_secondary`));
     });
 
-    it("css.with().multiple() forwards tuple map values as positional args", () => {
-      const callback = vi.fn((size: number, label: string) => ({
-        width: size,
-        height: size,
+    it("css.with().multiple() forwards 3+ tuple map values as positional args", () => {
+      const callback = vi.fn((width: number, height: number, label: string) => ({
+        width,
+        height,
         fontFamily: label
       }));
       const mixin = css.with(callback);
 
       const result = mixin.multiple(
         {
-          sm: [12, "sm"],
-          lg: [20, "lg"]
+          sm: [12, 16, "sm"],
+          lg: [20, 24, "lg"]
         } as const,
         debugId
       );
@@ -905,8 +911,8 @@ if (import.meta.vitest) {
       expect(result.sm).toMatch(identifierName(`${debugId}_sm`));
       expect(result.lg).toMatch(identifierName(`${debugId}_lg`));
       expect(callback.mock.calls).toEqual([
-        [12, "sm"],
-        [20, "lg"]
+        [12, 16, "sm"],
+        [20, 24, "lg"]
       ]);
     });
 

--- a/packages/css/src/defineRules/index.ts
+++ b/packages/css/src/defineRules/index.ts
@@ -201,7 +201,8 @@ function formatConfigPathSegment(key: string): string {
 if (import.meta.vitest) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
-  const { describe, it, expect, afterEach, assertType } = import.meta.vitest;
+  const { describe, it, expect, afterEach, assertType, vi } = import.meta
+    .vitest;
 
   const debugId = "myCSS";
   setFileScope("test");
@@ -666,20 +667,22 @@ if (import.meta.vitest) {
         const owner = createDefineRulesAuthoringShapeOwner("cxWithKnownMerge");
         const displayNone = owner.css({ display: "none" });
         const displayFlex = owner.css({ display: "flex" });
-        const composed = owner.cx.with<{
-          base: string;
-          override?: string;
-        }>(({ base, override }) => [base, override]);
+        const callback = vi.fn((base: string, override?: string) => [
+          base,
+          override
+        ]);
+        const composed = owner.cx.with(callback);
 
-        expect(composed({ base: displayNone, override: displayFlex })).toBe(
-          displayFlex
-        );
+        expect(composed(displayNone, displayFlex)).toBe(displayFlex);
+        expect(callback).toHaveBeenNthCalledWith(1, displayNone, displayFlex);
         expect(
           composed.multiple({
-            inactive: { base: displayNone },
-            active: { base: displayNone, override: displayFlex }
-          })
+            inactive: [displayNone],
+            active: [displayNone, displayFlex]
+          } as const)
         ).toEqual({ inactive: displayNone, active: displayFlex });
+        expect(callback).toHaveBeenNthCalledWith(2, displayNone);
+        expect(callback).toHaveBeenNthCalledWith(3, displayNone, displayFlex);
       });
 
       it("preserves repeated full cx inputs while using the private full-result cache", () => {
@@ -724,17 +727,13 @@ if (import.meta.vitest) {
         assertType<(...classNames: LayoutClass[]) => string>(constrained);
         expect(constrained("flex", "grid")).toBe("flex grid");
 
-        const composed = owner.cx.with<{
-          base: string;
-          active?: string;
-        }>(({ base, active }) => [base, active && `active-${active}`]);
+        const composed = owner.cx.with((base: string, active?: string) => [
+          base,
+          active && `active-${active}`
+        ]);
 
-        assertType<(params: { base: string; active?: string }) => string>(
-          composed
-        );
-        expect(composed({ base: "btn", active: "primary" })).toBe(
-          "btn active-primary"
-        );
+        assertType<(base: string, active?: string) => string>(composed);
+        expect(composed("btn", "primary")).toBe("btn active-primary");
       });
     });
 

--- a/packages/css/src/defineRules/runtime.ts
+++ b/packages/css/src/defineRules/runtime.ts
@@ -13,7 +13,12 @@ import { cx as rootCx } from "../classname/cx.js";
 import type {
   ClassMultipleInput,
   ClassMultipleResult,
-  ClassValue
+  ClassValue,
+  CxWith,
+  CxWithCallback,
+  CxWithCallbackArgs,
+  CxWithMixin,
+  CxWithTupleValue
 } from "../classname/types.js";
 import type { Cx } from "../classname/index.js";
 import { isUnSafeObjectKey } from "../utils.js";
@@ -186,29 +191,45 @@ function createDefineRulesCx(metadata: EngineMetadata): DefineRulesRuntimeCx {
     return result;
   }
 
-  function cxWith<const T extends ClassValue>(
-    callback?: (params: T) => ClassValue
-  ) {
-    const cxFunction = callback ?? ((className: T) => className);
+  function cxWith<const T extends ClassValue>(): CxWith<T>;
+  function cxWith<const F extends CxWithCallback>(
+    callback: F
+  ): CxWithMixin<CxWithCallbackArgs<F>>;
+  function cxWith<const Input>(
+    callback: (params: Input) => ClassValue
+  ): CxWithMixin<[params: Input]>;
+  function cxWith<const T extends ClassValue, const F extends CxWithCallback>(
+    callback?: ((params: T) => ClassValue) | F
+  ): CxWith<T> & CxWithMixin<CxWithCallbackArgs<F>> {
+    type CxWithRuntimeCallback = (...className: unknown[]) => ClassValue;
+    const cxFunction = (callback ??
+      ((...className: ClassValue[]) => className)) as CxWithRuntimeCallback;
 
-    function cxWithImpl(...className: T[]) {
-      const result = className.map((cn) => cxFunction(cn));
-      return cxImpl(...result);
+    function cxWithImpl(...className: unknown[]) {
+      return cxImpl(cxFunction(...className));
     }
 
-    function cxWithMultiple<ClassNameMap extends ClassMultipleInput<T>>(
-      classNameMap: ClassNameMap
-    ): ClassMultipleResult<ClassNameMap> {
+    function cxWithMultiple<
+      ClassNameMap extends Record<
+        string,
+        T | CxWithTupleValue<CxWithCallbackArgs<F>>
+      >
+    >(classNameMap: ClassNameMap): ClassMultipleResult<ClassNameMap> {
       type TransformedClassNameMap = Record<keyof ClassNameMap, ClassValue>;
       const transformedClassNameMap: TransformedClassNameMap =
         {} as TransformedClassNameMap;
       for (const key in classNameMap) {
-        transformedClassNameMap[key] = cxFunction(classNameMap[key]);
+        const value = classNameMap[key];
+        transformedClassNameMap[key] = Array.isArray(value)
+          ? cxFunction(...value)
+          : cxFunction(value);
       }
       return cxMultiple(transformedClassNameMap);
     }
 
-    return Object.assign(cxWithImpl, { multiple: cxWithMultiple });
+    return Object.assign(cxWithImpl, {
+      multiple: cxWithMultiple
+    }) as CxWith<T> & CxWithMixin<CxWithCallbackArgs<F>>;
   }
 
   return Object.assign(cxImpl, {

--- a/site/src/content/classname.mdx
+++ b/site/src/content/classname.mdx
@@ -156,7 +156,7 @@ buttonStates.secondary;
 
 ## cx.with()
 
-Create a typed class name utility with constraints on allowed values:
+Create a typed class name utility. Without a callback, `cx.with<T>()` constrains allowed class values while keeping the normal variadic `cx()` call shape:
 
 ```typescript
 import { cx } from '@mincho-js/css';
@@ -174,40 +174,51 @@ layout('flex', 'p-4');
 // layout('inline'); // Error!
 ```
 
-### With Transformer Function
+### Positional Mixin Pattern
 
-Transform parameters into class names:
+Pass a callback when you want `cx.with()` to act like a class-name mixin. The returned function mirrors the callback parameters and converts the callback result with `cx()`:
 
 ```typescript
-const responsive = cx.with<{ base: string; md?: string; lg?: string }>(
-  ({ base, md, lg }) => [
-    base,
-    md && `md:${md}`,
-    lg && `lg:${lg}`
-  ]
-);
+const responsive = cx.with((base: string, md?: string, lg?: string) => [
+  base,
+  md && `md:${md}`,
+  lg && `lg:${lg}`
+]);
 
-responsive({ base: 'text-sm', md: 'text-base', lg: 'text-lg' });
+responsive('text-sm', 'text-base', 'text-lg');
 // => 'text-sm md:text-base lg:text-lg'
 
-responsive({ base: 'text-sm' });
+responsive('text-sm');
 // => 'text-sm'
+```
+
+If you need mapper-style behavior, express it as a rest-args mixin:
+
+```typescript
+const prefixed = cx.with((...classNames: string[]) =>
+  classNames.map((className) => `ui-${className}`)
+);
+
+prefixed('button', 'active');
+// => 'ui-button ui-active'
 ```
 
 ### cx.with().multiple()
 
-Combine `cx.with()` with `multiple()` for typed class name maps:
+Combine callback-based `cx.with()` with `multiple()` by passing tuple values that match the callback parameters:
 
 ```typescript
-const responsive = cx.with<{ base: string; md?: string; lg?: string }>(
-  ({ base, md, lg }) => [base, md && `md:${md}`, lg && `lg:${lg}`]
-);
+const responsive = cx.with((base: string, md?: string, lg?: string) => [
+  base,
+  md && `md:${md}`,
+  lg && `lg:${lg}`
+]);
 
 const result = responsive.multiple({
-  heading: { base: 'text-xl', md: 'text-2xl', lg: 'text-3xl' },
-  body: { base: 'text-sm', md: 'text-base' },
-  caption: { base: 'text-xs' }
-});
+  heading: ['text-xl', 'text-2xl', 'text-3xl'],
+  body: ['text-sm', 'text-base'],
+  caption: ['text-xs']
+} as const);
 
 result.heading;
 // => 'text-xl md:text-2xl lg:text-3xl'
@@ -217,6 +228,19 @@ result.body;
 
 result.caption;
 // => 'text-xs'
+```
+
+For one-argument object mixins, wrap the object in a tuple when using `multiple()`:
+
+```typescript
+const responsiveObject = cx.with<{ base: string; md?: string }>(
+  ({ base, md }) => [base, md && `md:${md}`]
+);
+
+const objectResult = responsiveObject.multiple({
+  body: [{ base: 'text-sm', md: 'text-base' }],
+  caption: [{ base: 'text-xs' }]
+} as const);
 ```
 
 ---

--- a/site/src/content/literal.mdx
+++ b/site/src/content/literal.mdx
@@ -1074,7 +1074,7 @@ const backgrounds = css.multiple({
 
 ### css.with()
 
-Creates a constrained CSS function with type restrictions or transformation logic.
+Creates a constrained CSS function in either style/object mode or positional mixin mode. No-callback mode and one callback parameter mode use `CSSRuleWith<T>` style objects. A callback with 2 or more parameters uses positional mixin mode.
 
 #### Type Restrictions
 
@@ -1094,12 +1094,12 @@ myCss({
 })
 ```
 
-#### Mixin Pattern
+#### Object Parameter Mixin Pattern
 
-Transform input parameters into styles:
+Use one object parameter when the callback transforms a `CSSRuleWith<T>` style object. This stays in style/object mode, so direct calls and `.multiple()` pass object values.
 
 ```ts
-const boxMixin = css.with<{ size: number; radius?: number }>(
+const objectBoxMixin = css.with<{ size: number; radius?: number }>(
   ({ size, radius = 0 }) => ({
     width: size,
     height: size,
@@ -1107,28 +1107,35 @@ const boxMixin = css.with<{ size: number; radius?: number }>(
   })
 )
 
-const smallBox = boxMixin({ size: 50 })
-const roundedBox = boxMixin({ size: 100, radius: 8 })
-```
-
-#### Chaining with Other Methods
-
-The returned function also has `raw()` and `multiple()` methods:
-
-```ts
-const coloredBox = css.with<{ color: string }>(
-  ({ color }) => ({ backgroundColor: color })
-)
-
-// Use raw() to get the style object
-const rawStyles = coloredBox.raw({ color: 'blue' })
-
-// Use multiple() to create variants
-const colorVariants = coloredBox.multiple({
-  primary: { color: 'blue' },
-  secondary: { color: 'green' }
+const smallBox = objectBoxMixin({ size: 50 })
+const roundedBox = objectBoxMixin({ size: 100, radius: 8 })
+const objectBoxVariants = objectBoxMixin.multiple({
+  small: { size: 50 },
+  rounded: { size: 100, radius: 8 }
 })
 ```
+
+#### Positional Mixin Pattern
+
+Use 2 or more callback parameters when you want calls to mirror the callback arguments. Direct calls and `.raw()` receive positional arguments. In this mode, `.multiple()` uses tuple values.
+
+```ts
+const boxMixin = css.with((size: number, radius?: number) => ({
+  width: size,
+  height: size,
+  borderRadius: radius ?? 0
+}))
+
+const smallBox = boxMixin(50)
+const roundedBox = boxMixin(100, 8)
+const rawBox = boxMixin.raw(100, 8)
+const boxVariants = boxMixin.multiple({
+  small: [50],
+  rounded: [100, 8]
+} as const)
+```
+
+One positional argument is not supported because one callback argument remains the `CSSRuleWith<T>` style-transform mode. Use an object parameter for single value mixins. Style/object mode `.multiple()` uses object values. Positional mixin mode `.multiple()` uses tuple values.
 
 ## Backward Compatibility
 


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is. -->

- `css.with` mixin support #226
- `cx.with` mixin support #290

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `cx.with()` and `css.with()` to accept more callback styles, including positional argument callbacks and tuple/array-backed variant values for `.multiple()`.
  * Improved type inference and constraint handling for safer mixin composition.
* **Bug Fixes**
  * Fixed argument forwarding so callbacks receive the expected values for `.raw()` and `.multiple()`, including correct ordering.
  * Updated variant map handling to support tuple/array inputs alongside single values.
* **Documentation**
  * Refreshed `cx.with()` and `css.with()` examples to reflect the new object vs positional mixin patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
<!-- Add any other context about the commit here. -->

## Checklist
<!-- Tell us what reviewers should look for. -->
