### PR TITLE
Feat: CSS Prop - Support v2 branches and arrays

### DIFF
--- a/.changeset/cool-lions-compare.md
+++ b/.changeset/cool-lions-compare.md
@@ -6,4 +6,4 @@
 "@mincho-js/esbuild": minor
 ---
 
-Add optional React JSX `css` prop support for intrinsic elements through scoped React JSX runtime exports and opt-in `jsxCssProp` transform, integration, Vite, and Esbuild options.
+Add optional React JSX `css` prop v2 support through scoped React JSX runtime exports and opt-in `jsxCssProp` transform, integration, Vite, and Esbuild options. Inline object `css` props compile through Mincho CSS-rule extraction, existing class values compile through `cx(...)`, and custom/member/custom-element targets rely on a `className` forwarding contract with runtime guards for missed transforms.

--- a/examples/react-babel/src/App.tsx
+++ b/examples/react-babel/src/App.tsx
@@ -1,8 +1,24 @@
 import "@examples/shared-component/style.css";
 import { SharedExampleCard } from "@examples/shared-component";
+import { css } from "@mincho-js/css";
 import { styled } from "@mincho-js/react";
+import type { ReactNode } from "react";
 
 import { sharedCardHostClassName } from "./App.css.ts";
+
+const styleA = css({
+  display: "block",
+});
+
+function ClassNameForwardingExample({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return <section className={className}>{children}</section>;
+}
 
 const BaseComponent = styled.div({
   base: {
@@ -66,6 +82,10 @@ function App() {
       <Container size="large" color="blue">
         Hello World
       </Container>
+      <div css={styleA}>Class-value css prop mode</div>
+      <ClassNameForwardingExample css={styleA}>
+        Custom component css prop forwarding
+      </ClassNameForwardingExample>
       <div
         className={sharedCardHostClassName}
         css={{

--- a/examples/react-swc/src/App.tsx
+++ b/examples/react-swc/src/App.tsx
@@ -1,14 +1,29 @@
 import "@examples/shared-component/style.css";
 import { SharedExampleCard } from "@examples/shared-component";
-import { useState } from "react";
+import { css } from "@mincho-js/css";
+import { type ReactNode, useState } from "react";
 import reactLogo from "./assets/react.svg";
 import viteLogo from "/vite.svg";
+
+const styleA = css({
+  display: "block",
+});
 
 const cardClassName = "card";
 const logoClassName = "logo";
 const reactLogoClassName = `${logoClassName} react`;
 const readTheDocsClassName = "read-the-docs";
 const sharedCardContainerClassName = `${cardClassName} shared-card-consumer`;
+
+function ClassNameForwardingExample({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return <section className={className}>{children}</section>;
+}
 
 function App() {
   const [count, setCount] = useState(0);
@@ -32,6 +47,10 @@ function App() {
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>
       </div>
+      <div css={styleA}>Class-value css prop mode</div>
+      <ClassNameForwardingExample css={styleA}>
+        Custom component css prop forwarding
+      </ClassNameForwardingExample>
       <div
         className={sharedCardContainerClassName}
         css={{

--- a/packages/babel/src/__snapshots__/index.ts.snap
+++ b/packages/babel/src/__snapshots__/index.ts.snap
@@ -19,6 +19,69 @@ function App() {
 }"
 `;
 
+exports[`minchoBabelPlugin > aggregates multiple spreads and className before inline object css prop 1`] = `
+[
+  "extracted_17cnpin.css.ts",
+  "import { css as _css, cx as _cx } from "@mincho-js/css";
+export var _$mincho$$App = _css({
+  color: "red"
+});
+var _$mincho$$App2 = _$mincho$$App;",
+]
+`;
+
+exports[`minchoBabelPlugin > aggregates multiple spreads and className before inline object css prop 2`] = `
+"import { _$mincho$$App as _$mincho$$App2 } from "extracted_17cnpin.css.ts";
+import { css as _css, cx as _cx } from "@mincho-js/css";
+const a = {
+  id: "a"
+};
+const b = {
+  className: "from-b"
+};
+function App() {
+  const _minchoProps = {
+    ...a,
+    className: "base",
+    ...b
+  };
+  const {
+    css: _minchoCssProp,
+    className: _minchoClassName,
+    ..._minchoRest
+  } = _minchoProps;
+  return <div {..._minchoRest} className={_cx(_minchoClassName, _$mincho$$App2)} />;
+}"
+`;
+
+exports[`minchoBabelPlugin > aggregates spread props before explicit class-value css prop 1`] = `
+[
+  "extracted_48djc5.css.ts",
+  "",
+]
+`;
+
+exports[`minchoBabelPlugin > aggregates spread props before explicit class-value css prop 2`] = `
+"import { cx as _cx } from "@mincho-js/css";
+const styleA = "style-a";
+const props = {
+  className: "base",
+  css: "leaked",
+  id: "root"
+};
+function App() {
+  const _minchoProps = {
+    ...props
+  };
+  const {
+    css: _minchoCssProp,
+    className: _minchoClassName,
+    ..._minchoRest
+  } = _minchoProps;
+  return <div {..._minchoRest} className={_cx(_minchoClassName, styleA)} />;
+}"
+`;
+
 exports[`minchoBabelPlugin > already exported 1`] = `
 [
   "extracted_1etlg14.css.ts",
@@ -365,6 +428,27 @@ function App() {
 console.log(red);"
 `;
 
+exports[`minchoBabelPlugin > keeps inline object class dictionary syntax in css rule mode 1`] = `
+[
+  "extracted_1wvwi3h.css.ts",
+  "import { css as _css } from "@mincho-js/css";
+const isActive = true;
+export var _$mincho$$App = _css({
+  active: isActive
+});
+var _$mincho$$App2 = _$mincho$$App;",
+]
+`;
+
+exports[`minchoBabelPlugin > keeps inline object class dictionary syntax in css rule mode 2`] = `
+"import { _$mincho$$App as _$mincho$$App2 } from "extracted_1wvwi3h.css.ts";
+import { css as _css } from "@mincho-js/css";
+const isActive = true;
+function App() {
+  return <div className={_$mincho$$App2} />;
+}"
+`;
+
 exports[`minchoBabelPlugin > leaves jsx css prop unchanged when css prop lowering is disabled 1`] = `
 [
   "extracted_1a9gei1.css.ts",
@@ -380,7 +464,113 @@ exports[`minchoBabelPlugin > leaves jsx css prop unchanged when css prop lowerin
 }"
 `;
 
-exports[`minchoBabelPlugin > lowers jsx css prop without existing className 1`] = `
+exports[`minchoBabelPlugin > leaves spread-only runtime css props untransformed 1`] = `
+[
+  "extracted_1dre7mx.css.ts",
+  "",
+]
+`;
+
+exports[`minchoBabelPlugin > leaves spread-only runtime css props untransformed 2`] = `
+"const styleA = "style-a";
+function App() {
+  return <div {...{
+    css: styleA
+  }} />;
+}"
+`;
+
+exports[`minchoBabelPlugin > lowers array class-value jsx css prop through cx 1`] = `
+[
+  "extracted_1rdghqi.css.ts",
+  "",
+]
+`;
+
+exports[`minchoBabelPlugin > lowers array class-value jsx css prop through cx 2`] = `
+"import { cx as _cx } from "@mincho-js/css";
+const isActive = true;
+function App() {
+  return <div className={_cx(["base", isActive && "active"])} />;
+}"
+`;
+
+exports[`minchoBabelPlugin > lowers custom component class-value jsx css prop through cx 1`] = `
+[
+  "extracted_1ypr351.css.ts",
+  "",
+]
+`;
+
+exports[`minchoBabelPlugin > lowers custom component class-value jsx css prop through cx 2`] = `
+"import { cx as _cx } from "@mincho-js/css";
+const styleA = "base";
+function Button(props) {
+  return <button {...props} />;
+}
+function App() {
+  return <Button className={_cx(styleA)} />;
+}"
+`;
+
+exports[`minchoBabelPlugin > lowers custom component inline object jsx css prop through css rule mode 1`] = `
+[
+  "extracted_y60r8r.css.ts",
+  "import { css as _css } from "@mincho-js/css";
+export var _$mincho$$App = _css({
+  color: "red"
+});
+var _$mincho$$App2 = _$mincho$$App;",
+]
+`;
+
+exports[`minchoBabelPlugin > lowers custom component inline object jsx css prop through css rule mode 2`] = `
+"import { _$mincho$$App as _$mincho$$App2 } from "extracted_y60r8r.css.ts";
+import { css as _css } from "@mincho-js/css";
+function Button(props) {
+  return <button {...props} />;
+}
+function App() {
+  return <Button className={_$mincho$$App2} />;
+}"
+`;
+
+exports[`minchoBabelPlugin > lowers custom element class-value jsx css prop through className 1`] = `
+[
+  "extracted_k5klam.css.ts",
+  "",
+]
+`;
+
+exports[`minchoBabelPlugin > lowers custom element class-value jsx css prop through className 2`] = `
+"import { cx as _cx } from "@mincho-js/css";
+const styleA = "base";
+function App() {
+  return <my-element className={_cx(styleA)} />;
+}"
+`;
+
+exports[`minchoBabelPlugin > lowers identifier css result through cx without double wrapping 1`] = `
+[
+  "extracted_mcgo2u.css.ts",
+  "import { css, cx as _cx } from "@mincho-js/css";
+export var _$mincho$$styleA = css({
+  color: "red"
+});
+var _$mincho$$styleA2 = _$mincho$$styleA;",
+]
+`;
+
+exports[`minchoBabelPlugin > lowers identifier css result through cx without double wrapping 2`] = `
+"import { _$mincho$$styleA as _$mincho$$styleA2 } from "extracted_mcgo2u.css.ts";
+import { css, cx as _cx } from "@mincho-js/css";
+const styleA = _$mincho$$styleA2;
+function App() {
+  return <div className={_cx(styleA)} />;
+}"
+`;
+
+exports[`minchoBabelPlugin > lowers inline object jsx css prop through css rule mode 1`] = `
 [
   "extracted_1a9gei1.css.ts",
   "import { css as _css } from "@mincho-js/css";
@@ -391,7 +581,7 @@ var _$mincho$$App2 = _$mincho$$App;",
 ]
 `;
 
-exports[`minchoBabelPlugin > lowers jsx css prop without existing className 2`] = `
+exports[`minchoBabelPlugin > lowers inline object jsx css prop through css rule mode 2`] = `
 "import { _$mincho$$App as _$mincho$$App2 } from "extracted_1a9gei1.css.ts";
 import { css as _css } from "@mincho-js/css";
 function App() {
@@ -399,35 +589,62 @@ function App() {
 }"
 `;
 
-exports[`minchoBabelPlugin > merges expression className before generated css class 1`] = `
+exports[`minchoBabelPlugin > lowers literal class-value jsx css props through cx 1`] = `
 [
-  "extracted_inft06.css.ts",
-  "import { css as _css, cx as _cx } from "@mincho-js/css";
-const styles = {
-  root: {
-    color: "red"
-  }
-};
-export var _$mincho$$App = _css(styles.root);
-var _$mincho$$App2 = _$mincho$$App;",
+  "extracted_1nyqu7u.css.ts",
+  "",
 ]
 `;
 
-exports[`minchoBabelPlugin > merges expression className before generated css class 2`] = `
-"import { _$mincho$$App as _$mincho$$App2 } from "extracted_inft06.css.ts";
-import { css as _css, cx as _cx } from "@mincho-js/css";
-const base = "base";
-const styles = {
-  root: {
-    color: "red"
-  }
-};
+exports[`minchoBabelPlugin > lowers literal class-value jsx css props through cx 2`] = `
+"import { cx as _cx } from "@mincho-js/css";
 function App() {
-  return <div className={_cx(base, _$mincho$$App2)} />;
+  return <>
+            <div className={_cx("base")} />
+            <div className={_cx(1)} />
+            <div className={_cx(false)} />
+            <div className={_cx(null)} />
+          </>;
 }"
 `;
 
-exports[`minchoBabelPlugin > merges string literal className before generated css class 1`] = `
+exports[`minchoBabelPlugin > lowers member-expression class-value jsx css prop through cx 1`] = `
+[
+  "extracted_2bu5eg.css.ts",
+  "",
+]
+`;
+
+exports[`minchoBabelPlugin > lowers member-expression class-value jsx css prop through cx 2`] = `
+"import { cx as _cx } from "@mincho-js/css";
+const motion = {
+  div: "div"
+};
+const styleA = "base";
+function App() {
+  return <motion.div className={_cx(styleA)} />;
+}"
+`;
+
+exports[`minchoBabelPlugin > merges expression className before class-value css prop 1`] = `
+[
+  "extracted_i8fczg.css.ts",
+  "",
+]
+`;
+
+exports[`minchoBabelPlugin > merges expression className before class-value css prop 2`] = `
+"import { cx as _cx } from "@mincho-js/css";
+const base = "base";
+const styles = {
+  root: "root"
+};
+function App() {
+  return <div className={_cx(base, styles.root)} />;
+}"
+`;
+
+exports[`minchoBabelPlugin > merges string literal className before generated css rule class 1`] = `
 [
   "extracted_ucbrq2.css.ts",
   "import { css as _css, cx as _cx } from "@mincho-js/css";
@@ -438,7 +655,7 @@ var _$mincho$$App2 = _$mincho$$App;",
 ]
 `;
 
-exports[`minchoBabelPlugin > merges string literal className before generated css class 2`] = `
+exports[`minchoBabelPlugin > merges string literal className before generated css rule class 2`] = `
 "import { _$mincho$$App as _$mincho$$App2 } from "extracted_ucbrq2.css.ts";
 import { css as _css, cx as _cx } from "@mincho-js/css";
 function App() {

--- a/packages/babel/src/__snapshots__/index.ts.snap
+++ b/packages/babel/src/__snapshots__/index.ts.snap
@@ -173,6 +173,34 @@ const longClass = \`abc \${red}\`;
 console.log(longClass);"
 `;
 
+exports[`minchoBabelPlugin > direct-emits string-literal class-value jsx css props 1`] = `
+[
+  "extracted_fd2g76.css.ts",
+  "",
+]
+`;
+
+exports[`minchoBabelPlugin > direct-emits string-literal class-value jsx css props 2`] = `
+"const motion = {
+  div: "div"
+};
+function Button(props) {
+  return <button {...props} />;
+}
+function App() {
+  return <>
+            <div className="base" />
+            <div className="base" />
+            <div className="" />
+            <div className=" " />
+            <div className="base active" />
+            <Button className="base" />
+            <motion.div className="base" />
+            <my-element className="base" />
+          </>;
+}"
+`;
+
 exports[`minchoBabelPlugin > export default style 1`] = `
 [
   "extracted_w4qxwb.css.ts",
@@ -449,6 +477,43 @@ function App() {
 }"
 `;
 
+exports[`minchoBabelPlugin > keeps mixed literal class-value jsx css props in direct and cx modes 1`] = `
+[
+  "extracted_ihi0ar.css.ts",
+  "",
+]
+`;
+
+exports[`minchoBabelPlugin > keeps mixed literal class-value jsx css props in direct and cx modes 2`] = `
+"import { cx as _cx } from "@mincho-js/css";
+const styleA = "style-a";
+function App() {
+  return <>
+            <div className="base" />
+            <div className={_cx(styleA)} />
+          </>;
+}"
+`;
+
+exports[`minchoBabelPlugin > keeps non-string literal class-value jsx css props through cx 1`] = `
+[
+  "extracted_gvqbk7.css.ts",
+  "",
+]
+`;
+
+exports[`minchoBabelPlugin > keeps non-string literal class-value jsx css props through cx 2`] = `
+"import { cx as _cx } from "@mincho-js/css";
+function App() {
+  return <>
+            <div className={_cx(1)} />
+            <div className={_cx(false)} />
+            <div className={_cx(null)} />
+            <div className={_cx(undefined)} />
+          </>;
+}"
+`;
+
 exports[`minchoBabelPlugin > leaves jsx css prop unchanged when css prop lowering is disabled 1`] = `
 [
   "extracted_1a9gei1.css.ts",
@@ -607,25 +672,6 @@ exports[`minchoBabelPlugin > lowers inline object jsx css prop through css rule 
 import { css as _css } from "@mincho-js/css";
 function App() {
   return <div className={_$mincho$$App2} />;
-}"
-`;
-
-exports[`minchoBabelPlugin > lowers literal class-value jsx css props through cx 1`] = `
-[
-  "extracted_1nyqu7u.css.ts",
-  "",
-]
-`;
-
-exports[`minchoBabelPlugin > lowers literal class-value jsx css props through cx 2`] = `
-"import { cx as _cx } from "@mincho-js/css";
-function App() {
-  return <>
-            <div className={_cx("base")} />
-            <div className={_cx(1)} />
-            <div className={_cx(false)} />
-            <div className={_cx(null)} />
-          </>;
 }"
 `;
 

--- a/packages/babel/src/__snapshots__/index.ts.snap
+++ b/packages/babel/src/__snapshots__/index.ts.snap
@@ -480,18 +480,24 @@ function App() {
 }"
 `;
 
-exports[`minchoBabelPlugin > lowers array class-value jsx css prop through cx 1`] = `
+exports[`minchoBabelPlugin > lowers array literal jsx css prop through css rule mode 1`] = `
 [
-  "extracted_1rdghqi.css.ts",
-  "",
+  "extracted_1q6f771.css.ts",
+  "import { css as _css } from "@mincho-js/css";
+const base = "base";
+export var _$mincho$$App = _css([base, {
+  color: "red"
+}]);
+var _$mincho$$App2 = _$mincho$$App;",
 ]
 `;
 
-exports[`minchoBabelPlugin > lowers array class-value jsx css prop through cx 2`] = `
-"import { cx as _cx } from "@mincho-js/css";
-const isActive = true;
+exports[`minchoBabelPlugin > lowers array literal jsx css prop through css rule mode 2`] = `
+"import { _$mincho$$App as _$mincho$$App2 } from "extracted_1q6f771.css.ts";
+import { css as _css } from "@mincho-js/css";
+const base = "base";
 function App() {
-  return <div className={_cx(["base", isActive && "active"])} />;
+  return <div className={_$mincho$$App2} />;
 }"
 `;
 
@@ -547,6 +553,21 @@ exports[`minchoBabelPlugin > lowers custom element class-value jsx css prop thro
 const styleA = "base";
 function App() {
   return <my-element className={_cx(styleA)} />;
+}"
+`;
+
+exports[`minchoBabelPlugin > lowers explicit cx array class values through class-value mode 1`] = `
+[
+  "extracted_zgs157.css.ts",
+  "",
+]
+`;
+
+exports[`minchoBabelPlugin > lowers explicit cx array class values through class-value mode 2`] = `
+"import { cx, cx as _cx } from "@mincho-js/css";
+const isActive = true;
+function App() {
+  return <div className={_cx(cx(["base", isActive && "active"]))} />;
 }"
 `;
 

--- a/packages/babel/src/__snapshots__/index.ts.snap
+++ b/packages/babel/src/__snapshots__/index.ts.snap
@@ -173,6 +173,57 @@ const longClass = \`abc \${red}\`;
 console.log(longClass);"
 `;
 
+exports[`minchoBabelPlugin > classifies first-level primitive jsx css prop array branches 1`] = `
+[
+  "extracted_1mfmy2m.css.ts",
+  "import { css as _css, cx as _cx } from "@mincho-js/css";
+export var _$mincho$$App = _css(["base", "active"]);
+var _$mincho$$App2 = _$mincho$$App;
+export var _$mincho$$App3 = _css(["base", ""]);
+var _$mincho$$App4 = _$mincho$$App3;",
+]
+`;
+
+exports[`minchoBabelPlugin > classifies first-level primitive jsx css prop array branches 2`] = `
+"import { _$mincho$$App as _$mincho$$App2, _$mincho$$App3 as _$mincho$$App4 } from "extracted_1mfmy2m.css.ts";
+import { css as _css, cx as _cx } from "@mincho-js/css";
+const activeClass = "active-class";
+const styles = {
+  active: "styles-active"
+};
+const condition = true;
+const providedClass = "";
+const maybeClass = null;
+const suffix = "suffix";
+function getClassName() {
+  return "called";
+}
+function App() {
+  return <>
+            <div className={_$mincho$$App2} />
+            <div className={_$mincho$$App4} />
+            <div className={_cx("base", false)} />
+            <div className={_cx("base", true)} />
+            <div className={_cx("base", null)} />
+            <div className={_cx("base", undefined)} />
+            <div className={_cx("base", 0)} />
+            <div className={_cx("base", 1)} />
+            <div className={_cx("base", 0n)} />
+            <div className={_cx("base", 1n)} />
+            <div className={_cx("base", activeClass)} />
+            <div className={_cx("base", "", activeClass)} />
+            <div className={_cx("base", styles.active)} />
+            <div className={_cx("base", getClassName())} />
+            <div className={_cx("base", \`active \${suffix}\`)} />
+            <div className={_cx("base", condition && "active")} />
+            <div className={_cx("base", providedClass || "fallback")} />
+            <div className={_cx("base", maybeClass ?? "fallback")} />
+            <div className={_cx("base", condition ? "active" : "inactive")} />
+            <div className={_cx("external", "base", condition && "active")} />
+          </>;
+}"
+`;
+
 exports[`minchoBabelPlugin > direct-emits string-literal class-value jsx css props 1`] = `
 [
   "extracted_fd2g76.css.ts",
@@ -234,6 +285,109 @@ exports[`minchoBabelPlugin > extracts $mincho function 2`] = `
 import { mincho$ } from '@mincho-js/css';
 const red = _$mincho$$red2;
 console.log(red);"
+`;
+
+exports[`minchoBabelPlugin > extracts first-level CSS-rule branch array branches through cx 1`] = `
+[
+  "extracted_1evk0ii.css.ts",
+  "import { css as _css, cx as _cx } from "@mincho-js/css";
+export var _$mincho$$App = _css({
+  color: "red"
+});
+var _$mincho$$App2 = _$mincho$$App;
+export var _$mincho$$App3 = _css({
+  color: "red"
+});
+var _$mincho$$App4 = _$mincho$$App3;
+export var _$mincho$$App5 = _css({
+  color: "red"
+});
+var _$mincho$$App6 = _$mincho$$App5;
+export var _$mincho$$App7 = _css([{
+  color: "red"
+}]);
+var _$mincho$$App8 = _$mincho$$App7;
+export var _$mincho$$App9 = _css(["active", {
+  color: "red"
+}]);
+var _$mincho$$App0 = _$mincho$$App9;
+export var _$mincho$$App1 = _css([{
+  color: "red"
+}]);
+var _$mincho$$App10 = _$mincho$$App1;
+export var _$mincho$$App11 = _css(["active", {
+  color: "red"
+}]);
+var _$mincho$$App12 = _$mincho$$App11;
+export var _$mincho$$App13 = _css({
+  color: "red"
+});
+var _$mincho$$App14 = _$mincho$$App13;
+export var _$mincho$$App15 = _css([{
+  color: "red"
+}]);
+var _$mincho$$App16 = _$mincho$$App15;
+export var _$mincho$$App17 = _css({
+  color: "red"
+});
+var _$mincho$$App18 = _$mincho$$App17;
+export var _$mincho$$App19 = _css([{
+  color: "red"
+}]);
+var _$mincho$$App20 = _$mincho$$App19;
+export var _$mincho$$App21 = _css({
+  color: "blue"
+});
+var _$mincho$$App22 = _$mincho$$App21;
+export var _$mincho$$App23 = _css(["fallback", {
+  color: "blue"
+}]);
+var _$mincho$$App24 = _$mincho$$App23;
+export var _$mincho$$App25 = _css({
+  color: "red"
+});
+var _$mincho$$App26 = _$mincho$$App25;
+export var _$mincho$$App27 = _css({
+  color: "blue"
+});
+var _$mincho$$App28 = _$mincho$$App27;
+export var _$mincho$$App29 = _css(["red", {
+  color: "red"
+}]);
+var _$mincho$$App30 = _$mincho$$App29;
+export var _$mincho$$App31 = _css(["blue", {
+  color: "blue"
+}]);
+var _$mincho$$App32 = _$mincho$$App31;",
+]
+`;
+
+exports[`minchoBabelPlugin > extracts first-level CSS-rule branch array branches through cx 2`] = `
+"import { _$mincho$$App as _$mincho$$App2, _$mincho$$App3 as _$mincho$$App4, _$mincho$$App5 as _$mincho$$App6, _$mincho$$App7 as _$mincho$$App8, _$mincho$$App9 as _$mincho$$App0, _$mincho$$App1 as _$mincho$$App10, _$mincho$$App11 as _$mincho$$App12, _$mincho$$App13 as _$mincho$$App14, _$mincho$$App15 as _$mincho$$App16, _$mincho$$App17 as _$mincho$$App18, _$mincho$$App19 as _$mincho$$App20, _$mincho$$App21 as _$mincho$$App22, _$mincho$$App23 as _$mincho$$App24, _$mincho$$App25 as _$mincho$$App26, _$mincho$$App27 as _$mincho$$App28, _$mincho$$App29 as _$mincho$$App30, _$mincho$$App31 as _$mincho$$App32 } from "extracted_1evk0ii.css.ts";
+import { css as _css, cx as _cx } from "@mincho-js/css";
+const activeClass = "active-class";
+const condition = true;
+const providedClass = "";
+const maybeClass = null;
+function App() {
+  return <>
+            <div className={_cx("base", condition && _$mincho$$App2)} />
+            <div className={_cx("base", providedClass || _$mincho$$App4)} />
+            <div className={_cx("base", maybeClass ?? _$mincho$$App6)} />
+            <div className={_cx("base", providedClass || _$mincho$$App8)} />
+            <div className={_cx("base", maybeClass ?? _$mincho$$App0)} />
+            <div className={_cx("base", condition && _$mincho$$App10)} />
+            <div className={_cx("base", condition && _$mincho$$App12)} />
+            <div className={_cx("base", _$mincho$$App14, activeClass)} />
+            <div className={_cx("base", _$mincho$$App16, condition && "active")} />
+            <div className={_cx("base", condition ? _$mincho$$App18 : "inactive")} />
+            <div className={_cx("base", condition ? _$mincho$$App20 : "inactive")} />
+            <div className={_cx("base", condition ? "active" : _$mincho$$App22)} />
+            <div className={_cx("base", condition ? "active" : _$mincho$$App24)} />
+            <div className={_cx("base", condition ? _$mincho$$App26 : _$mincho$$App28)} />
+            <div className={_cx("base", condition ? _$mincho$$App30 : _$mincho$$App32)} />
+          </>;
+}"
 `;
 
 exports[`minchoBabelPlugin > extracts style function 1`] = `
@@ -547,10 +701,9 @@ function App() {
 
 exports[`minchoBabelPlugin > lowers array literal jsx css prop through css rule mode 1`] = `
 [
-  "extracted_1q6f771.css.ts",
+  "extracted_1e65177.css.ts",
   "import { css as _css } from "@mincho-js/css";
-const base = "base";
-export var _$mincho$$App = _css([base, {
+export var _$mincho$$App = _css(["base", {
   color: "red"
 }]);
 var _$mincho$$App2 = _$mincho$$App;",
@@ -558,9 +711,8 @@ var _$mincho$$App2 = _$mincho$$App;",
 `;
 
 exports[`minchoBabelPlugin > lowers array literal jsx css prop through css rule mode 2`] = `
-"import { _$mincho$$App as _$mincho$$App2 } from "extracted_1q6f771.css.ts";
+"import { _$mincho$$App as _$mincho$$App2 } from "extracted_1e65177.css.ts";
 import { css as _css } from "@mincho-js/css";
-const base = "base";
 function App() {
   return <div className={_$mincho$$App2} />;
 }"
@@ -621,18 +773,26 @@ function App() {
 }"
 `;
 
-exports[`minchoBabelPlugin > lowers explicit cx array class values through class-value mode 1`] = `
+exports[`minchoBabelPlugin > lowers explicit cx array and dictionary class values through class-value mode 1`] = `
 [
-  "extracted_zgs157.css.ts",
+  "extracted_g1q7fc.css.ts",
   "",
 ]
 `;
 
-exports[`minchoBabelPlugin > lowers explicit cx array class values through class-value mode 2`] = `
+exports[`minchoBabelPlugin > lowers explicit cx array and dictionary class values through class-value mode 2`] = `
 "import { cx, cx as _cx } from "@mincho-js/css";
 const isActive = true;
 function App() {
-  return <div className={_cx(cx(["base", isActive && "active"]))} />;
+  return <>
+            <div className={_cx(cx(["base", isActive && "active"]))} />
+            <div className={_cx(cx({
+      active: isActive
+    }))} />
+            <div className={_cx(cx(["base", {
+      active: isActive
+    }]))} />
+          </>;
 }"
 `;
 

--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -1,6 +1,9 @@
 import { type PluginObj, transformSync, types as t } from "@babel/core";
 import { transformCallExpression } from "./transforms/callExpression.js";
-import { preprocessJsxCssProp } from "./jsxCssProp.js";
+import {
+  preprocessJsxCssProp,
+  removeUnusedJsxCssPropCssModuleImports
+} from "./jsxCssProp.js";
 import { supportedJsxCssPropTags } from "./jsxCssPropTags.js";
 import postprocess from "./transforms/postprocess.js";
 import basePreprocess from "./transforms/preprocess.js";
@@ -21,7 +24,10 @@ export function minchoBabelPlugin(): PluginObj<PluginState> {
           preprocess(path, state);
           state.opts.jsxCssPropTransformed = preprocessJsxCssProp(path, state);
         },
-        exit: postprocess
+        exit(path, state) {
+          removeUnusedJsxCssPropCssModuleImports(path);
+          postprocess(path, state);
+        }
       },
       CallExpression: transformCallExpression
     }
@@ -104,6 +110,31 @@ if (import.meta.vitest) {
     return {
       visitor: {
         ImportDeclaration(importPath) {
+          if (importPath.node.source.value.endsWith(".css.ts")) {
+            const declarations = importPath.node.specifiers.flatMap(
+              (specifier) => {
+                if (!t.isImportSpecifier(specifier)) {
+                  return [];
+                }
+
+                return t.variableDeclaration("const", [
+                  t.variableDeclarator(
+                    t.cloneNode(specifier.local),
+                    t.stringLiteral("css-rule")
+                  )
+                ]);
+              }
+            );
+
+            if (declarations.length === 0) {
+              importPath.remove();
+              return;
+            }
+
+            importPath.replaceWithMultiple(declarations);
+            return;
+          }
+
           if (importPath.node.source.value !== "@mincho-js/css") {
             return;
           }
@@ -256,6 +287,8 @@ if (import.meta.vitest) {
     cssValue: "Mincho JSX css prop expects a Mincho CSS object/expression",
     unsupportedFunction:
       "Mincho JSX css prop does not support function values in compile-away mode",
+    unsupportedDynamicCssRule:
+      "Mincho JSX css prop does not support conditional, logical, or wrapped object/array CSS rule values in compile-away mode",
     duplicateCss: "Mincho JSX css prop must appear only once",
     duplicateClassName:
       "Mincho JSX css prop cannot merge duplicate className attributes",
@@ -393,15 +426,104 @@ if (import.meta.vitest) {
       expect(code).not.toContain("_css(styles.root)");
     });
 
-    it("lowers literal class-value jsx css props through cx", () => {
+    it("merges expression className before conditional string css prop", () => {
+      const { code } = babelTransform(
+        `
+        const base = "base";
+        const condition = true;
+
+        function App() {
+          return <div className={base} css={condition ? "active" : "inactive"} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(code).toMatch(
+        /className=\{_cx\(base, condition \? "active" : "inactive"\)\}/
+      );
+      expect(code).not.toContain(" css=");
+      expect(code).not.toContain("_css(condition ?");
+    });
+
+    it("keeps conditional string css prop in class-value mode", () => {
+      const { code } = babelTransform(
+        `
+        const condition = true;
+
+        function App() {
+          return <div css={condition ? "active" : "inactive"} />;
+        }
+        `,
+        { jsxCssProp: true }
+      );
+
+      expect(code).toContain(
+        'className={_cx(condition ? "active" : "inactive")}'
+      );
+      expect(code).not.toContain("_css(condition ?");
+    });
+
+    it("keeps intrinsic expression css props in class-value mode", () => {
+      const { code } = babelTransform(
+        `
+        const condition = true;
+        const flag = true;
+        const providedClass = "provided";
+        const maybeClass = null;
+
+        function getClassName() {
+          return "dynamic";
+        }
+
+        function App() {
+          return <>
+            <div css={condition ? "active" : "inactive"} />
+            <div css={flag && "active"} />
+            <div css={providedClass || "fallback"} />
+            <div css={maybeClass ?? "fallback"} />
+            <div css={getClassName()} />
+          </>;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(code).toContain(
+        'className={_cx(condition ? "active" : "inactive")}'
+      );
+      expect(code).toContain('className={_cx(flag && "active")}');
+      expect(code).toContain('className={_cx(providedClass || "fallback")}');
+      expect(code).toContain('className={_cx(maybeClass ?? "fallback")}');
+      expect(code).toContain("className={_cx(getClassName())}");
+      expect(code).not.toContain(" css=");
+      expect(code).not.toContain("_css(");
+      expect(code).not.toContain("_css(condition");
+      expect(code).not.toContain("_css(flag");
+      expect(code).not.toContain("_css(providedClass");
+      expect(code).not.toContain("_css(maybeClass");
+      expect(code).not.toContain("_css(getClassName");
+    });
+
+    it("direct-emits string-literal class-value jsx css props", () => {
       const { result, code } = babelTransform(
         `
+        const motion = { div: "div" };
+
+        function Button(props) {
+          return <button {...props} />;
+        }
+
         function App() {
           return <>
             <div css="base" />
-            <div css={1} />
-            <div css={false} />
-            <div css={null} />
+            <div css={"base"} />
+            <div css="" />
+            <div css=" " />
+            <div css="base active" />
+            <Button css="base" />
+            <motion.div css="base" />
+            <my-element css="base" />
           </>;
         }
       `,
@@ -411,10 +533,64 @@ if (import.meta.vitest) {
       expect(result).toMatchSnapshot();
       expect(code).toMatchSnapshot();
       expect(code).not.toContain(" css=");
-      expect(code).toContain('className={_cx("base")}');
+      expect(code).not.toContain("_cx(");
+      expect(code).not.toContain('from "@mincho-js/css"');
+      expect(code.match(/<div className="base" \/>/g) ?? []).toHaveLength(2);
+      expect(code).toContain('<div className="" />');
+      expect(code).toContain('<div className=" " />');
+      expect(code).toContain('<div className="base active" />');
+      expect(code).toContain('<Button className="base" />');
+      expect(code).toContain('<motion.div className="base" />');
+      expect(code).toContain('<my-element className="base" />');
+      expect(code).not.toContain("<my-element class=");
+    });
+
+    it("keeps non-string literal class-value jsx css props through cx", () => {
+      const { result, code } = babelTransform(
+        `
+        function App() {
+          return <>
+            <div css={1} />
+            <div css={false} />
+            <div css={null} />
+            <div css={undefined} />
+          </>;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(result).toMatchSnapshot();
+      expect(code).toMatchSnapshot();
+      expect(code).not.toContain(" css=");
       expect(code).toContain("className={_cx(1)}");
       expect(code).toContain("className={_cx(false)}");
       expect(code).toContain("className={_cx(null)}");
+      expect(code).toContain("className={_cx(undefined)}");
+    });
+
+    it("keeps mixed literal class-value jsx css props in direct and cx modes", () => {
+      const { result, code } = babelTransform(
+        `
+        const styleA = "style-a";
+
+        function App() {
+          return <>
+            <div css="base" />
+            <div css={styleA} />
+          </>;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(result).toMatchSnapshot();
+      expect(code).toMatchSnapshot();
+      expect(code).not.toContain(" css=");
+      expect(code).toContain('import { cx as _cx } from "@mincho-js/css"');
+      expect(code).toContain('<div className="base" />');
+      expect(code).toContain("<div className={_cx(styleA)} />");
+      expect(code).not.toContain('_cx("base")');
     });
 
     it("lowers array literal jsx css prop through css rule mode", () => {
@@ -436,6 +612,623 @@ if (import.meta.vitest) {
       expect(result[1]).toContain('color: "red"');
       expect(code).toContain("className={_$mincho$$App2}");
       expect(code).not.toContain("_cx([base");
+    });
+
+    it("lowers transparent wrapped direct jsx css prop rules through css rule mode", () => {
+      const fixtures = [
+        {
+          fixture: `<div css={{ color: "red" }!} />`,
+          expectedRule: "_css({"
+        },
+        {
+          fixture: `<div css={[{ color: "red" }]!} />`,
+          expectedRule: "_css([{"
+        },
+        {
+          fixture: `<div css={{ color: "red" } as const} />`,
+          expectedRule: "_css({"
+        },
+        {
+          fixture: `<div css={[{ color: "red" }] as const} />`,
+          expectedRule: "_css([{"
+        },
+        {
+          fixture: `<div css={{ color: "red" } satisfies ComplexCSSRule} />`,
+          expectedRule: "_css({"
+        },
+        {
+          fixture: `<div css={[{ color: "red" }] satisfies ComplexCSSRule} />`,
+          expectedRule: "_css([{"
+        },
+        {
+          fixture: `<div css={({ color: "red" })} />`,
+          expectedRule: "_css({"
+        },
+        {
+          fixture: `<div css={([base, { color: "red" }])} />`,
+          expectedRule: "_css([base, {"
+        }
+      ] as const;
+
+      for (const { fixture, expectedRule } of fixtures) {
+        const { result, code } = babelTransform(
+          `
+          type ComplexCSSRule = unknown;
+          const base = "base";
+
+          function App() {
+            return ${fixture};
+          }
+        `,
+          { jsxCssProp: true }
+        );
+
+        expect(code).not.toContain(" css=");
+        expect(code).toContain("className={_$mincho$$App2}");
+        expect(code).not.toContain("_cx(");
+        expect(result[1]).toContain(expectedRule);
+        expect(result[1]).toContain('color: "red"');
+      }
+    });
+
+    it("lowers conditional object and array jsx css prop branches through css rule mode", () => {
+      const fixtures = [
+        {
+          fixture: `<div css={condition ? { color: "red" } : { color: "blue" }} />`,
+          expectedRule: "_css({"
+        },
+        {
+          fixture: `<div css={condition ? [{ color: "red" }] : [{ color: "blue" }]} />`,
+          expectedRule: "_css([{"
+        }
+      ] as const;
+
+      for (const { fixture, expectedRule } of fixtures) {
+        const { result, code } = babelTransform(
+          `
+          const condition = true;
+
+          function App() {
+            return ${fixture};
+          }
+        `,
+          { jsxCssProp: true }
+        );
+        const output = `${code}\n${result.join("\n")}`;
+
+        expect(code).not.toContain(" css=");
+        expect(code).toMatch(
+          /className=\{condition \? _\$mincho\$\$App\d+ : _\$mincho\$\$App\d+\}/
+        );
+        expect(code).not.toContain("_cx(condition ?");
+        expect(output).not.toContain("_css(condition ?");
+        expect(output).not.toContain("css(condition ?");
+        expect(result[1]).toContain(expectedRule);
+        expect(result[1]).toContain('color: "red"');
+        expect(result[1]).toContain('color: "blue"');
+      }
+    });
+
+    it("merges explicit className before pure conditional css rule branches", () => {
+      const { result, code } = babelTransform(
+        `
+        const condition = true;
+
+        function App() {
+          return <div className="base" css={condition ? { color: "red" } : { color: "blue" }} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+      const output = `${code}\n${result.join("\n")}`;
+
+      expect(code).not.toContain(" css=");
+      expect(code).toMatch(
+        /className=\{_cx\("base", condition \? _\$mincho\$\$App\d+ : _\$mincho\$\$App\d+\)\}/
+      );
+      expect(output).not.toContain("_css(condition ?");
+      expect(output).not.toContain("css(condition ?");
+      expect(result[1]).toContain("_css({");
+      expect(result[1]).toContain('color: "red"');
+      expect(result[1]).toContain('color: "blue"');
+    });
+
+    it("lowers mixed and nullable conditional jsx css prop branches through cx", () => {
+      const fixtures = [
+        {
+          fixture: `<div css={condition ? styleA : { color: "red" }} />`,
+          expectedClassName:
+            /className=\{_cx\(condition \? styleA : _\$mincho\$\$App\d+\)\}/,
+          expectedRule: "_css({"
+        },
+        {
+          fixture: `<div css={condition ? classNameA : { color: "red" }} />`,
+          expectedClassName:
+            /className=\{_cx\(condition \? classNameA : _\$mincho\$\$App\d+\)\}/,
+          expectedRule: "_css({"
+        },
+        {
+          fixture: `<div css={condition ? { color: "red" } : null} />`,
+          expectedClassName:
+            /className=\{_cx\(condition \? _\$mincho\$\$App\d+ : null\)\}/,
+          expectedRule: "_css({"
+        },
+        {
+          fixture: `<div css={condition ? { color: "red" } : false} />`,
+          expectedClassName:
+            /className=\{_cx\(condition \? _\$mincho\$\$App\d+ : false\)\}/,
+          expectedRule: "_css({"
+        },
+        {
+          fixture: `<div css={condition ? null : { color: "red" }} />`,
+          expectedClassName:
+            /className=\{_cx\(condition \? null : _\$mincho\$\$App\d+\)\}/,
+          expectedRule: "_css({"
+        },
+        {
+          fixture: `<div css={condition ? false : { color: "red" }} />`,
+          expectedClassName:
+            /className=\{_cx\(condition \? false : _\$mincho\$\$App\d+\)\}/,
+          expectedRule: "_css({"
+        },
+        {
+          fixture: `<div css={condition ? ({ color: "red" } as const) : styleA} />`,
+          expectedClassName:
+            /className=\{_cx\(condition \? _\$mincho\$\$App\d+ : styleA\)\}/,
+          expectedRule: "_css({"
+        },
+        {
+          fixture: `<div css={condition ? ({ color: "red" }!) : styleA} />`,
+          expectedClassName:
+            /className=\{_cx\(condition \? _\$mincho\$\$App\d+ : styleA\)\}/,
+          expectedRule: "_css({"
+        },
+        {
+          fixture: `<div css={condition ? ([{ color: "red" }] as const) : styleA} />`,
+          expectedClassName:
+            /className=\{_cx\(condition \? _\$mincho\$\$App\d+ : styleA\)\}/,
+          expectedRule: "_css([{"
+        },
+        {
+          fixture: `<div css={condition ? styleA : ({ color: "red" } satisfies ComplexCSSRule)} />`,
+          expectedClassName:
+            /className=\{_cx\(condition \? styleA : _\$mincho\$\$App\d+\)\}/,
+          expectedRule: "_css({"
+        }
+      ] as const;
+
+      for (const { fixture, expectedClassName, expectedRule } of fixtures) {
+        const { result, code } = babelTransform(
+          `
+          type ComplexCSSRule = unknown;
+          const condition = true;
+          const styleA = "style-a";
+          const classNameA = "class-name-a";
+
+          function App() {
+            return ${fixture};
+          }
+        `,
+          { jsxCssProp: true }
+        );
+        const output = `${code}\n${result.join("\n")}`;
+
+        expect(code).not.toContain(" css=");
+        expect(code).toMatch(expectedClassName);
+        expect(output).not.toContain("_css(condition ?");
+        expect(output).not.toContain("css(condition ?");
+        expect(output).not.toContain("_css(styleA)");
+        expect(output).not.toContain("_css(classNameA)");
+        expect(output).not.toContain("css(styleA)");
+        expect(output).not.toContain("css(classNameA)");
+        expect(result[1]).toContain(expectedRule);
+        expect(result[1]).toContain('color: "red"');
+      }
+    });
+
+    it("lowers logical and jsx css prop branches through css rule mode", () => {
+      const fixtures = [
+        {
+          fixture: `<div css={condition && { color: "red" }} />`,
+          expectedClassName:
+            /className=\{_cx\(condition && _\$mincho\$\$App\d+\)\}/,
+          expectedRule: "_css({"
+        },
+        {
+          fixture: `<div css={condition && [{ color: "red" }]} />`,
+          expectedClassName:
+            /className=\{_cx\(condition && _\$mincho\$\$App\d+\)\}/,
+          expectedRule: "_css([{"
+        },
+        {
+          fixture: `<div css={condition && ([{ color: "red" }] as const)} />`,
+          expectedClassName:
+            /className=\{_cx\(condition && _\$mincho\$\$App\d+\)\}/,
+          expectedRule: "_css([{"
+        },
+        {
+          fixture: `<div css={condition && ({ color: "red" } as const)} />`,
+          expectedClassName:
+            /className=\{_cx\(condition && _\$mincho\$\$App\d+\)\}/,
+          expectedRule: "_css({"
+        },
+        {
+          fixture: `<div className="base" css={condition && { color: "red" }} />`,
+          expectedClassName:
+            /className=\{_cx\("base", condition && _\$mincho\$\$App\d+\)\}/,
+          expectedRule: "_css({"
+        },
+        {
+          fixture: `<div {...props} css={condition && { color: "red" }} />`,
+          expectedClassName:
+            /className=\{_cx\(_minchoClassName, condition && _\$mincho\$\$App\d+\)\}/,
+          expectedRule: "_css({"
+        }
+      ] as const;
+
+      for (const { fixture, expectedClassName, expectedRule } of fixtures) {
+        const { result, code } = babelTransform(
+          `
+          const condition = true;
+          const props = { className: "base" };
+
+          function App() {
+            return ${fixture};
+          }
+        `,
+          { jsxCssProp: true }
+        );
+        const output = `${code}\n${result.join("\n")}`;
+
+        expect(code).not.toContain(" css=");
+        expect(code).toMatch(expectedClassName);
+        expect(output).not.toContain("_css(condition &&");
+        expect(output).not.toContain("css(condition &&");
+        expect(result[1]).toContain(expectedRule);
+        expect(result[1]).toContain('color: "red"');
+      }
+    });
+
+    it("lowers logical OR and nullish right-side css rule fallbacks", () => {
+      const fixtures = [
+        {
+          fixture: `<div css={providedClass || { color: "red" }} />`,
+          expectedClassName:
+            /className=\{_cx\(providedClass \|\| _\$mincho\$\$App\d+\)\}/,
+          expectedRule: "_css({"
+        },
+        {
+          fixture: `<div css={providedClass || [{ color: "red" }]} />`,
+          expectedClassName:
+            /className=\{_cx\(providedClass \|\| _\$mincho\$\$App\d+\)\}/,
+          expectedRule: "_css([{"
+        },
+        {
+          fixture: `<div css={maybeClass ?? { color: "red" }} />`,
+          expectedClassName:
+            /className=\{_cx\(maybeClass \?\? _\$mincho\$\$App\d+\)\}/,
+          expectedRule: "_css({"
+        },
+        {
+          fixture: `<div css={maybeClass ?? [{ color: "red" }]} />`,
+          expectedClassName:
+            /className=\{_cx\(maybeClass \?\? _\$mincho\$\$App\d+\)\}/,
+          expectedRule: "_css([{"
+        },
+        {
+          fixture: `<div css={providedClass || ({ color: "red" } as const)} />`,
+          expectedClassName:
+            /className=\{_cx\(providedClass \|\| _\$mincho\$\$App\d+\)\}/,
+          expectedRule: "_css({"
+        },
+        {
+          fixture: `<div css={maybeClass ?? ([{ color: "red" }] satisfies ComplexCSSRule)} />`,
+          expectedClassName:
+            /className=\{_cx\(maybeClass \?\? _\$mincho\$\$App\d+\)\}/,
+          expectedRule: "_css([{"
+        }
+      ] as const;
+
+      for (const { fixture, expectedClassName, expectedRule } of fixtures) {
+        const { result, code } = babelTransform(
+          `
+          type ComplexCSSRule = unknown;
+          const providedClass = "provided";
+          const maybeClass = null;
+
+          function App() {
+            return ${fixture};
+          }
+        `,
+          { jsxCssProp: true }
+        );
+        const output = `${code}\n${result.join("\n")}`;
+
+        expect(code).not.toContain(" css=");
+        expect(code).toMatch(expectedClassName);
+        expect(code).not.toMatch(/_cx\((providedClass|maybeClass), _\$mincho/);
+        expect(output).not.toContain("_css(providedClass");
+        expect(output).not.toContain("_css(maybeClass");
+        expect(output).not.toContain("css(providedClass");
+        expect(output).not.toContain("css(maybeClass");
+        expect(result[1]).toContain(expectedRule);
+        expect(result[1].match(/color: "red"/g) ?? []).toHaveLength(1);
+      }
+    });
+
+    it("simplifies static-left logical OR and nullish css rule operands", () => {
+      const fixtures = [
+        {
+          fixture: `<div css={{ color: "red" } || providedClass} />`,
+          expectedRule: "_css({",
+          forbiddenValues: ["providedClass", 'color: "blue"']
+        },
+        {
+          fixture: `<div css={[{ color: "red" }] || providedClass} />`,
+          expectedRule: "_css([{",
+          forbiddenValues: ["providedClass", 'color: "blue"']
+        },
+        {
+          fixture: `<div css={{ color: "red" } ?? maybeClass} />`,
+          expectedRule: "_css({",
+          forbiddenValues: ["maybeClass", 'color: "blue"']
+        },
+        {
+          fixture: `<div css={[{ color: "red" }] ?? maybeClass} />`,
+          expectedRule: "_css([{",
+          forbiddenValues: ["maybeClass", 'color: "blue"']
+        },
+        {
+          fixture: `<div css={{ color: "red" } || { color: "blue" }} />`,
+          expectedRule: "_css({",
+          forbiddenValues: ['color: "blue"']
+        },
+        {
+          fixture: `<div css={{ color: "red" } ?? { color: "blue" }} />`,
+          expectedRule: "_css({",
+          forbiddenValues: ['color: "blue"']
+        }
+      ] as const;
+
+      for (const { fixture, expectedRule, forbiddenValues } of fixtures) {
+        const { result, code } = babelTransform(
+          `
+          function App() {
+            return ${fixture};
+          }
+        `,
+          { jsxCssProp: true }
+        );
+        const output = `${code}\n${result.join("\n")}`;
+
+        expect(code).not.toContain(" css=");
+        expect(code).toMatch(/className=\{_\$mincho\$\$App\d+\}/);
+        expect(code).not.toMatch(/className=\{_cx\(_\$mincho\$\$App\d+\)\}/);
+        expect(code).not.toContain("_cx(");
+        expect(result[1]).toContain(expectedRule);
+        expect(result[1].match(/color: "red"/g) ?? []).toHaveLength(1);
+
+        for (const forbiddenValue of forbiddenValues) {
+          expect(output).not.toContain(forbiddenValue);
+        }
+      }
+    });
+
+    it("treats static-left logical AND css rule operands as truthy guards", () => {
+      const fixtures = [
+        `<div css={{ color: "red" } && providedClass} />`,
+        `<div css={[{ color: "red" }] && providedClass} />`,
+        `<div css={({ color: "red" } as const) && providedClass} />`
+      ] as const;
+
+      for (const fixture of fixtures) {
+        const { result, code } = babelTransform(
+          `
+          const providedClass = "provided";
+
+          function App() {
+            return ${fixture};
+          }
+        `,
+          { jsxCssProp: true }
+        );
+        const output = `${code}\n${result.join("\n")}`;
+
+        expect(code).not.toContain(" css=");
+        expect(code).toMatch(/className=\{_cx\(providedClass\)\}/);
+        expect(result[1]).not.toContain("_css(");
+        expect(output).not.toContain('color: "red"');
+      }
+    });
+
+    it("extracts only the right css rule for both-side static logical AND", () => {
+      const { result, code } = babelTransform(
+        `
+        function App() {
+          return <div css={{ color: "red" } && { color: "blue" }} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+      const output = `${code}\n${result.join("\n")}`;
+
+      expect(code).not.toContain(" css=");
+      expect(code).toMatch(/className=\{_\$mincho\$\$App\d+\}/);
+      expect(code).not.toMatch(/className=\{_cx\(_\$mincho\$\$App\d+\)\}/);
+      expect(code).not.toContain("_cx(");
+      expect(result[1]).toContain("_css({");
+      expect(result[1].match(/color: "blue"/g) ?? []).toHaveLength(1);
+      expect(output).not.toContain('color: "red"');
+    });
+
+    it("merges explicit className before generated-only static logical css rule", () => {
+      const { result, code } = babelTransform(
+        `
+        function App() {
+          return <div className="base" css={{ color: "red" } || providedClass} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+      const output = `${code}\n${result.join("\n")}`;
+
+      expect(code).not.toContain(" css=");
+      expect(code).toMatch(/className=\{_cx\("base", _\$mincho\$\$App\d+\)\}/);
+      expect(output).not.toContain("providedClass");
+      expect(result[1]).toContain("_css({");
+      expect(result[1].match(/color: "red"/g) ?? []).toHaveLength(1);
+    });
+
+    it("aggregates spread props before generated-only static logical css rule", () => {
+      const { result, code } = babelTransform(
+        `
+        const props = {
+          className: "base",
+          css: "leaked",
+          id: "root"
+        };
+
+        function App() {
+          return <div {...props} css={{ color: "red" } || providedClass} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+      const output = `${code}\n${result.join("\n")}`;
+
+      expect(code).not.toContain(" css=");
+      expect(code).toContain("css: _minchoCssProp");
+      expect(code).toContain("className: _minchoClassName");
+      expect(code).toContain("..._minchoRest");
+      expect(code).toMatch(
+        /className=\{_cx\(_minchoClassName, _\$mincho\$\$App\d+\)\}/
+      );
+      expect(output).not.toContain("providedClass");
+      expect(result[1]).toContain("_css({");
+      expect(result[1].match(/color: "red"/g) ?? []).toHaveLength(1);
+    });
+
+    it("omits cx import for generated-only static logical css rules", () => {
+      const { result, code } = babelTransform(
+        `
+        function App() {
+          return <>
+            <div css={{ color: "red" } || providedClass} />
+            <div css={[{ color: "green" }] ?? maybeClass} />
+            <div css={{ color: "blue" } && { color: "purple" }} />
+          </>;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+      const output = `${code}\n${result.join("\n")}`;
+      const generatedClassNames = code.match(
+        /className=\{_\$mincho\$\$App\d+\}/g
+      );
+
+      expect(code).not.toContain(" css=");
+      expect(generatedClassNames ?? []).toHaveLength(3);
+      expect(code).not.toContain("_cx(");
+      expect(code).not.toContain('from "@mincho-js/css"');
+      expect(result[1].match(/_css\(/g) ?? []).toHaveLength(3);
+      expect(result[1]).toContain('color: "red"');
+      expect(result[1]).toContain('color: "green"');
+      expect(result[1]).toContain('color: "purple"');
+      expect(output).not.toContain('color: "blue"');
+      expect(output).not.toContain("providedClass");
+      expect(output).not.toContain("maybeClass");
+    });
+
+    it("preserves static-left logical css branch runtime side effects", () => {
+      const observed = runJsxCssPropRuntime(
+        `
+        let fallbackCalls = 0;
+        let providedCalls = 0;
+
+        function getFallback() {
+          fallbackCalls += 1;
+          return "fallback";
+        }
+
+        function getProvided() {
+          providedCalls += 1;
+          return "provided";
+        }
+
+        function App() {
+          const orProps = <div css={{ color: "red" } || getFallback()} />;
+          const nullishProps = <div css={[{ color: "green" }] ?? getFallback()} />;
+          const andProps = <div css={{ color: "blue" } && getProvided()} />;
+          return { orProps, nullishProps, andProps };
+        }
+      `,
+        "return { result: App(), fallbackCalls, providedCalls };"
+      ) as {
+        result: {
+          orProps: Record<string, unknown>;
+          nullishProps: Record<string, unknown>;
+          andProps: Record<string, unknown>;
+        };
+        fallbackCalls: number;
+        providedCalls: number;
+      };
+
+      expect(observed.fallbackCalls).toBe(0);
+      expect(observed.providedCalls).toBe(1);
+      expect(observed.result.orProps.className).toBe("css-rule");
+      expect(observed.result.nullishProps.className).toBe("css-rule");
+      expect(observed.result.andProps.className).toBe("provided");
+    });
+
+    it("lowers transparent wrapped branch jsx css prop expressions", () => {
+      const fixtures = [
+        {
+          fixture: `<div css={(condition ? { color: "red" } : { color: "blue" }) as const} />`,
+          expectedClassName:
+            /className=\{condition \? _\$mincho\$\$App\d+ : _\$mincho\$\$App\d+\}/,
+          expectedRule: "_css({",
+          expectedBlueRule: true
+        },
+        {
+          fixture: `<div css={(condition && { color: "red" }) as unknown} />`,
+          expectedClassName:
+            /className=\{_cx\(condition && _\$mincho\$\$App\d+\)\}/,
+          expectedRule: "_css({",
+          expectedBlueRule: false
+        }
+      ] as const;
+
+      for (const {
+        fixture,
+        expectedClassName,
+        expectedRule,
+        expectedBlueRule
+      } of fixtures) {
+        const { result, code } = babelTransform(
+          `
+          const condition = true;
+
+          function App() {
+            return ${fixture};
+          }
+        `,
+          { jsxCssProp: true }
+        );
+        const output = `${code}\n${result.join("\n")}`;
+
+        expect(code).not.toContain(" css=");
+        expect(code).toMatch(expectedClassName);
+        expect(output).not.toContain("_css(condition ?");
+        expect(output).not.toContain("css(condition ?");
+        expect(output).not.toContain("_css(condition &&");
+        expect(output).not.toContain("css(condition &&");
+        expect(result[1]).toContain(expectedRule);
+        expect(result[1]).toContain('color: "red"');
+
+        if (expectedBlueRule) {
+          expect(result[1]).toContain('color: "blue"');
+        }
+      }
     });
 
     it("lowers explicit cx array class values through class-value mode", () => {
@@ -482,6 +1275,24 @@ if (import.meta.vitest) {
       expect(code).not.toContain("css(styleA)");
     });
 
+    it("lowers non-null identifier css result through cx without double wrapping", () => {
+      const { code } = babelTransform(
+        `
+        const styleA = "base";
+
+        function App() {
+          return <div css={styleA!} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(code).not.toContain(" css=");
+      expect(code).toContain("className={_cx(styleA)}");
+      expect(code).not.toContain("_css(styleA)");
+      expect(code).not.toContain("css(styleA)");
+    });
+
     it("keeps inline object class dictionary syntax in css rule mode", () => {
       const { result, code } = babelTransform(
         `
@@ -522,6 +1333,29 @@ if (import.meta.vitest) {
       expect(code).toMatchSnapshot();
       expect(code).not.toContain(" css=");
       expect(code).toContain("return <Button className={_cx(styleA)} />");
+    });
+
+    it("forwards expression css prop through custom component className", () => {
+      const { code } = babelTransform(
+        `
+        const flag = true;
+
+        function Button(props) {
+          return <button {...props} />;
+        }
+
+        function App() {
+          return <Button css={flag && "active"} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(code).toContain(
+        'return <Button className={_cx(flag && "active")} />'
+      );
+      expect(code).not.toContain(" css=");
+      expect(code).not.toContain("_css(flag &&");
     });
 
     it("lowers custom component inline object jsx css prop through css rule mode", () => {
@@ -584,6 +1418,62 @@ if (import.meta.vitest) {
       expect(code).not.toContain("<my-element class=");
     });
 
+    it("lowers mixed conditional rule branches across jsx target kinds", () => {
+      const fixtures = [
+        {
+          fixture: `<div css={condition ? { color: "red" } : styleA} />`,
+          expectedClassName:
+            /return <div className=\{_cx\(condition \? _\$mincho\$\$App\d+ : styleA\)\} \/>/
+        },
+        {
+          fixture: `<Button css={condition ? { color: "red" } : styleA} />`,
+          expectedClassName:
+            /return <Button className=\{_cx\(condition \? _\$mincho\$\$App\d+ : styleA\)\} \/>/
+        },
+        {
+          fixture: `<motion.div css={condition ? { color: "red" } : styleA} />`,
+          expectedClassName:
+            /return <motion\.div className=\{_cx\(condition \? _\$mincho\$\$App\d+ : styleA\)\} \/>/
+        },
+        {
+          fixture: `<my-element css={condition ? { color: "red" } : styleA} />`,
+          expectedClassName:
+            /return <my-element className=\{_cx\(condition \? _\$mincho\$\$App\d+ : styleA\)\} \/>/
+        }
+      ] as const;
+
+      for (const { fixture, expectedClassName } of fixtures) {
+        const { result, code } = babelTransform(
+          `
+          const condition = true;
+          const styleA = "style-a";
+          const motion = { div: "div" };
+
+          function Button(props) {
+            return <button {...props} />;
+          }
+
+          function App() {
+            return ${fixture};
+          }
+        `,
+          { jsxCssProp: true }
+        );
+        const output = `${code}\n${result.join("\n")}`;
+
+        expect(code).not.toContain(" css=");
+        expect(code).toMatch(expectedClassName);
+        expect(code).toMatch(/condition \? _\$mincho\$\$App\d+ : styleA/);
+        expect(code).not.toContain("<my-element class=");
+        expect(output).not.toContain("_css(condition ?");
+        expect(output).not.toContain("css(condition ?");
+        expect(output).not.toContain("_css(styleA)");
+        expect(output).not.toContain("css(styleA)");
+        expect(result[1]).toContain("_css({");
+        expect(result[1]).toContain('color: "red"');
+      }
+    });
+
     it("aggregates spread props before explicit class-value css prop", () => {
       const { result, code } = babelTransform(
         `
@@ -633,6 +1523,41 @@ if (import.meta.vitest) {
       expect(code).toContain(
         "className={_cx(_minchoClassName, _$mincho$$App2)}"
       );
+    });
+
+    it("aggregates spread props before conditional object css prop branches", () => {
+      const { result, code } = babelTransform(
+        `
+        const condition = true;
+        const styleA = "style-a";
+        const props = {
+          className: "base",
+          css: "leaked",
+          id: "root"
+        };
+
+        function App() {
+          return <div {...props} css={condition ? { color: "red" } : styleA} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+      const output = `${code}\n${result.join("\n")}`;
+
+      expect(code).not.toContain(" css=");
+      expect(code).toContain("css: _minchoCssProp");
+      expect(code).toContain("className: _minchoClassName");
+      expect(code).toContain("..._minchoRest");
+      expect(code).toContain("<div {..._minchoRest} className=");
+      expect(code).toMatch(
+        /className=\{_cx\(_minchoClassName, condition \? _\$mincho\$\$App\d+ : styleA\)\}/
+      );
+      expect(output).not.toContain("_css(condition ?");
+      expect(output).not.toContain("css(condition ?");
+      expect(output).not.toContain("_css(styleA)");
+      expect(output).not.toContain("css(styleA)");
+      expect(result[1]).toContain("_css({");
+      expect(result[1]).toContain('color: "red"');
     });
 
     it("evaluates spread aggregation inputs once in source order", () => {
@@ -694,6 +1619,72 @@ if (import.meta.vitest) {
       expect(observed.props).toMatchObject({
         id: "root",
         className: "base style-a"
+      });
+      expect("css" in observed.props).toBe(false);
+    });
+
+    it("reads branch-lowered spread and className getters once in source order", () => {
+      const observed = runJsxCssPropRuntime(
+        `
+        const condition = true;
+        const styleA = "style-a";
+        const events: string[] = [];
+        const reads = {
+          spreadA: 0,
+          explicit: 0,
+          spreadB: 0
+        };
+        const spreadA = {
+          id: "a",
+          get className() {
+            reads.spreadA += 1;
+            events.push("spread-a.className");
+            return "from-a";
+          },
+          css: "leak-a"
+        };
+        const explicitClassName = {
+          get value() {
+            reads.explicit += 1;
+            events.push("explicit.className");
+            return "base";
+          }
+        };
+        const spreadB = {
+          title: "b",
+          get className() {
+            reads.spreadB += 1;
+            events.push("spread-b.className");
+            return "from-b";
+          },
+          css: "leak-b"
+        };
+
+        function App() {
+          return <div {...spreadA} className={explicitClassName.value} {...spreadB} css={condition ? { color: "red" } : styleA} />;
+        }
+      `,
+        "return { props: App(), events, reads };"
+      ) as {
+        props: Record<string, unknown>;
+        events: string[];
+        reads: Record<string, number>;
+      };
+
+      expect(observed.events).toEqual([
+        "spread-a.className",
+        "explicit.className",
+        "spread-b.className"
+      ]);
+      expect(observed.reads).toEqual({
+        spreadA: 1,
+        explicit: 1,
+        spreadB: 1
+      });
+      expect(observed.props).toMatchObject({
+        id: "a",
+        title: "b",
+        className: "from-b css-rule"
       });
       expect("css" in observed.props).toBe(false);
     });
@@ -821,6 +1812,36 @@ if (import.meta.vitest) {
         name: "rejects inline function expression css values",
         fixture: `<div css={function () { return { color: "red" }; }} />`,
         message: jsxCssPropErrorMessages.unsupportedFunction
+      },
+      {
+        name: "rejects chained logical object literal css rule values",
+        fixture: `<div css={condition && flag && { color: "red" }} />`,
+        message: jsxCssPropErrorMessages.unsupportedDynamicCssRule
+      },
+      {
+        name: "rejects nested logical object literal css rule fallback values",
+        fixture: `<div css={(condition && flag) || { color: "red" }} />`,
+        message: jsxCssPropErrorMessages.unsupportedDynamicCssRule
+      },
+      {
+        name: "rejects chained OR logical object literal css rule values",
+        fixture: `<div css={a || b || { color: "red" }} />`,
+        message: jsxCssPropErrorMessages.unsupportedDynamicCssRule
+      },
+      {
+        name: "rejects nested conditional object literal css rule values",
+        fixture: `<div css={outer ? inner ? { color: "red" } : { color: "blue" } : styleA} />`,
+        message: jsxCssPropErrorMessages.unsupportedDynamicCssRule
+      },
+      {
+        name: "rejects sequence object literal css rule values",
+        fixture: `<div css={(0, { color: "red" })} />`,
+        message: jsxCssPropErrorMessages.unsupportedDynamicCssRule
+      },
+      {
+        name: "rejects sequence array literal css rule values",
+        fixture: `<div css={(0, [{ color: "red" }])} />`,
+        message: jsxCssPropErrorMessages.unsupportedDynamicCssRule
       },
       {
         name: "rejects duplicate css attributes",

--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -417,13 +417,13 @@ if (import.meta.vitest) {
       expect(code).toContain("className={_cx(null)}");
     });
 
-    it("lowers array class-value jsx css prop through cx", () => {
+    it("lowers array literal jsx css prop through css rule mode", () => {
       const { result, code } = babelTransform(
         `
-        const isActive = true;
+        const base = "base";
 
         function App() {
-          return <div css={["base", isActive && "active"]} />;
+          return <div css={[base, { color: "red" }]} />;
         }
       `,
         { jsxCssProp: true }
@@ -432,7 +432,32 @@ if (import.meta.vitest) {
       expect(result).toMatchSnapshot();
       expect(code).toMatchSnapshot();
       expect(code).not.toContain(" css=");
-      expect(code).toContain('className={_cx(["base", isActive && "active"])}');
+      expect(result[1]).toContain("_css([base, {");
+      expect(result[1]).toContain('color: "red"');
+      expect(code).toContain("className={_$mincho$$App2}");
+      expect(code).not.toContain("_cx([base");
+    });
+
+    it("lowers explicit cx array class values through class-value mode", () => {
+      const { result, code } = babelTransform(
+        `
+        import { cx } from "@mincho-js/css";
+
+        const isActive = true;
+
+        function App() {
+          return <div css={cx(["base", isActive && "active"])} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(result).toMatchSnapshot();
+      expect(code).toMatchSnapshot();
+      expect(code).not.toContain(" css=");
+      expect(code).toContain(
+        'className={_cx(cx(["base", isActive && "active"]))}'
+      );
     });
 
     it("lowers identifier css result through cx without double wrapping", () => {

--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -1,4 +1,4 @@
-import { type PluginObj, transformSync } from "@babel/core";
+import { type PluginObj, transformSync, types as t } from "@babel/core";
 import { transformCallExpression } from "./transforms/callExpression.js";
 import { preprocessJsxCssProp } from "./jsxCssProp.js";
 import { supportedJsxCssPropTags } from "./jsxCssPropTags.js";
@@ -19,7 +19,7 @@ export function minchoBabelPlugin(): PluginObj<PluginState> {
       Program: {
         enter(path, state) {
           preprocess(path, state);
-          preprocessJsxCssProp(path, state);
+          state.opts.jsxCssPropTransformed = preprocessJsxCssProp(path, state);
         },
         exit: postprocess
       },
@@ -51,22 +51,211 @@ if (import.meta.vitest) {
       filename: "test.tsx"
     });
 
-    if (result === null || result.code === null) {
+    if (result === null || result.code == null) {
       throw new Error("Failed to transform code");
     }
 
     return { result: options.result, code: result.code };
   }
 
+  type RuntimeJsx = (
+    tag: unknown,
+    props?: Record<string, unknown>
+  ) => Record<string, unknown>;
+  type RuntimeCx = (...values: unknown[]) => string;
+  type RuntimeCss = (styles: unknown) => string;
+
+  function runJsxCssPropRuntime(
+    source: string,
+    returnStatement: string
+  ): unknown {
+    const { code } = babelTransform(source, { jsxCssProp: true });
+    const result = transformSync(code, {
+      plugins: [jsxRuntimeTransformPlugin()],
+      presets: ["@babel/preset-typescript"],
+      filename: "runtime-test.tsx"
+    });
+
+    if (result === null) {
+      throw new Error("Failed to transform runtime test code");
+    }
+
+    const runtimeCode = result.code;
+
+    if (runtimeCode == null) {
+      throw new Error("Failed to transform runtime test code");
+    }
+
+    const execute = new Function(
+      "__minchoJsx",
+      "__minchoCx",
+      "__minchoCss",
+      `${runtimeCode}\n${returnStatement}`
+    ) as (jsx: RuntimeJsx, cx: RuntimeCx, css: RuntimeCss) => unknown;
+
+    return execute(
+      (_tag, props = {}) => props,
+      (...values) => values.filter(Boolean).join(" "),
+      () => "css-rule"
+    );
+  }
+
+  function jsxRuntimeTransformPlugin(): PluginObj {
+    return {
+      visitor: {
+        ImportDeclaration(importPath) {
+          if (importPath.node.source.value !== "@mincho-js/css") {
+            return;
+          }
+
+          const declarations = importPath.node.specifiers.flatMap(
+            (specifier) => {
+              if (
+                !t.isImportSpecifier(specifier) ||
+                !t.isIdentifier(specifier.imported)
+              ) {
+                return [];
+              }
+
+              const runtimeIdentifier = getRuntimeImportIdentifier(
+                specifier.imported.name
+              );
+
+              if (!runtimeIdentifier) {
+                return [];
+              }
+
+              return t.variableDeclaration("const", [
+                t.variableDeclarator(
+                  t.cloneNode(specifier.local),
+                  runtimeIdentifier
+                )
+              ]);
+            }
+          );
+
+          if (declarations.length === 0) {
+            importPath.remove();
+            return;
+          }
+
+          importPath.replaceWithMultiple(declarations);
+        },
+        JSXElement(jsxPath) {
+          jsxPath.replaceWith(
+            t.callExpression(t.identifier("__minchoJsx"), [
+              createRuntimeJsxTagExpression(jsxPath.node.openingElement.name),
+              createRuntimeJsxPropsExpression(jsxPath.node.openingElement)
+            ])
+          );
+        }
+      }
+    };
+  }
+
+  function getRuntimeImportIdentifier(methodName: string): t.Identifier | null {
+    if (methodName === "cx") {
+      return t.identifier("__minchoCx");
+    }
+
+    if (methodName === "css") {
+      return t.identifier("__minchoCss");
+    }
+
+    return null;
+  }
+
+  function createRuntimeJsxTagExpression(
+    name: t.JSXOpeningElement["name"]
+  ): t.Expression {
+    if (t.isJSXIdentifier(name)) {
+      if (/^[a-z]/.test(name.name)) {
+        return t.stringLiteral(name.name);
+      }
+
+      return t.identifier(name.name);
+    }
+
+    if (t.isJSXMemberExpression(name)) {
+      return t.memberExpression(
+        createRuntimeJsxTagExpression(name.object),
+        t.identifier(name.property.name)
+      );
+    }
+
+    return t.stringLiteral(`${name.namespace.name}:${name.name.name}`);
+  }
+
+  function createRuntimeJsxPropsExpression(
+    openingElement: t.JSXOpeningElement
+  ): t.ObjectExpression {
+    return t.objectExpression(
+      openingElement.attributes.map((attribute) => {
+        if (t.isJSXSpreadAttribute(attribute)) {
+          return t.spreadElement(t.cloneNode(attribute.argument));
+        }
+
+        return t.objectProperty(
+          createRuntimeJsxAttributeKey(attribute.name),
+          createRuntimeJsxAttributeValue(attribute)
+        );
+      })
+    );
+  }
+
+  function createRuntimeJsxAttributeKey(
+    name: t.JSXAttribute["name"]
+  ): t.Identifier | t.StringLiteral {
+    if (t.isJSXNamespacedName(name)) {
+      return t.stringLiteral(`${name.namespace.name}:${name.name.name}`);
+    }
+
+    if (t.isValidIdentifier(name.name)) {
+      return t.identifier(name.name);
+    }
+
+    return t.stringLiteral(name.name);
+  }
+
+  function createRuntimeJsxAttributeValue(
+    attribute: t.JSXAttribute
+  ): t.Expression {
+    if (attribute.value === null) {
+      return t.booleanLiteral(true);
+    }
+
+    if (t.isStringLiteral(attribute.value)) {
+      return t.cloneNode(attribute.value);
+    }
+
+    if (t.isJSXExpressionContainer(attribute.value)) {
+      const { expression } = attribute.value;
+
+      if (t.isJSXEmptyExpression(expression)) {
+        return t.identifier("undefined");
+      }
+
+      return t.cloneNode(expression);
+    }
+
+    return t.identifier("undefined");
+  }
+
   const jsxCssPropErrorMessages = {
-    intrinsicElement:
-      "Mincho JSX css prop only supports intrinsic elements in v1",
-    supportedTag:
-      "Mincho JSX css prop only supports supported React DOM/SVG tags in v1",
-    spread:
-      "Mincho JSX css prop does not support spreads on elements with css in v1",
+    fragmentTarget:
+      "Mincho JSX css prop does not support fragments because fragments cannot receive className",
+    namespacedTarget:
+      "Mincho JSX css prop does not support namespaced JSX elements",
+    spreadAfterCss:
+      "Mincho JSX css prop does not support spreads after css in compile-away mode",
+    keyRefSpread:
+      "Mincho JSX css prop does not support key/ref on spread elements in compile-away mode",
+    spreadAggregationContext:
+      "Mincho JSX css prop spread aggregation only supports direct return or expression statement JSX in compile-away mode",
     expressionValue: "Mincho JSX css prop requires an expression value",
     cssValue: "Mincho JSX css prop expects a Mincho CSS object/expression",
+    unsupportedFunction:
+      "Mincho JSX css prop does not support function values in compile-away mode",
     duplicateCss: "Mincho JSX css prop must appear only once",
     duplicateClassName:
       "Mincho JSX css prop cannot merge duplicate className attributes",
@@ -150,7 +339,7 @@ if (import.meta.vitest) {
       expect(enabled.code).toMatchSnapshot();
     });
 
-    it("lowers jsx css prop without existing className", () => {
+    it("lowers inline object jsx css prop through css rule mode", () => {
       const { result, code } = babelTransform(
         `
         function App() {
@@ -166,7 +355,7 @@ if (import.meta.vitest) {
       expect(code).toContain("className={_$mincho$$App2}");
     });
 
-    it("merges string literal className before generated css class", () => {
+    it("merges string literal className before generated css rule class", () => {
       const { result, code } = babelTransform(
         `
         function App() {
@@ -182,12 +371,12 @@ if (import.meta.vitest) {
       expect(code).toContain('className={_cx("base", _$mincho$$App2)}');
     });
 
-    it("merges expression className before generated css class", () => {
+    it("merges expression className before class-value css prop", () => {
       const { result, code } = babelTransform(
         `
         const base = "base";
         const styles = {
-          root: { color: "red" }
+          root: "root"
         };
 
         function App() {
@@ -200,39 +389,398 @@ if (import.meta.vitest) {
       expect(result).toMatchSnapshot();
       expect(code).toMatchSnapshot();
       expect(code).not.toContain(" css=");
-      expect(code).toContain("className={_cx(base, _$mincho$$App2)}");
+      expect(code).toContain("className={_cx(base, styles.root)}");
+      expect(code).not.toContain("_css(styles.root)");
+    });
+
+    it("lowers literal class-value jsx css props through cx", () => {
+      const { result, code } = babelTransform(
+        `
+        function App() {
+          return <>
+            <div css="base" />
+            <div css={1} />
+            <div css={false} />
+            <div css={null} />
+          </>;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(result).toMatchSnapshot();
+      expect(code).toMatchSnapshot();
+      expect(code).not.toContain(" css=");
+      expect(code).toContain('className={_cx("base")}');
+      expect(code).toContain("className={_cx(1)}");
+      expect(code).toContain("className={_cx(false)}");
+      expect(code).toContain("className={_cx(null)}");
+    });
+
+    it("lowers array class-value jsx css prop through cx", () => {
+      const { result, code } = babelTransform(
+        `
+        const isActive = true;
+
+        function App() {
+          return <div css={["base", isActive && "active"]} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(result).toMatchSnapshot();
+      expect(code).toMatchSnapshot();
+      expect(code).not.toContain(" css=");
+      expect(code).toContain('className={_cx(["base", isActive && "active"])}');
+    });
+
+    it("lowers identifier css result through cx without double wrapping", () => {
+      const { result, code } = babelTransform(
+        `
+        import { css } from "@mincho-js/css";
+
+        const styleA = css({ color: "red" });
+
+        function App() {
+          return <div css={styleA} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(result).toMatchSnapshot();
+      expect(code).toMatchSnapshot();
+      expect(code).not.toContain(" css=");
+      expect(code).toContain("className={_cx(styleA)}");
+      expect(code).not.toContain("_css(styleA)");
+      expect(code).not.toContain("css(styleA)");
+    });
+
+    it("keeps inline object class dictionary syntax in css rule mode", () => {
+      const { result, code } = babelTransform(
+        `
+        const isActive = true;
+
+        function App() {
+          return <div css={{ active: isActive }} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(result).toMatchSnapshot();
+      expect(code).toMatchSnapshot();
+      expect(code).not.toContain(" css=");
+      expect(result[1]).toContain("active: isActive");
+      expect(code).toContain("className={_$mincho$$App2}");
+      expect(code).not.toContain("_cx({");
+    });
+
+    it("lowers custom component class-value jsx css prop through cx", () => {
+      const { result, code } = babelTransform(
+        `
+        const styleA = "base";
+
+        function Button(props) {
+          return <button {...props} />;
+        }
+
+        function App() {
+          return <Button css={styleA} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(result).toMatchSnapshot();
+      expect(code).toMatchSnapshot();
+      expect(code).not.toContain(" css=");
+      expect(code).toContain("return <Button className={_cx(styleA)} />");
+    });
+
+    it("lowers custom component inline object jsx css prop through css rule mode", () => {
+      const { result, code } = babelTransform(
+        `
+        function Button(props) {
+          return <button {...props} />;
+        }
+
+        function App() {
+          return <Button css={{ color: "red" }} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(result).toMatchSnapshot();
+      expect(code).toMatchSnapshot();
+      expect(result[1]).toContain("_css({");
+      expect(result[1]).toContain('color: "red"');
+      expect(code).not.toContain(" css=");
+      expect(code).toContain("return <Button className={_$mincho$$App2} />");
+    });
+
+    it("lowers member-expression class-value jsx css prop through cx", () => {
+      const { result, code } = babelTransform(
+        `
+        const motion = { div: "div" };
+        const styleA = "base";
+
+        function App() {
+          return <motion.div css={styleA} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(result).toMatchSnapshot();
+      expect(code).toMatchSnapshot();
+      expect(code).not.toContain(" css=");
+      expect(code).toContain("return <motion.div className={_cx(styleA)} />");
+    });
+
+    it("lowers custom element class-value jsx css prop through className", () => {
+      const { result, code } = babelTransform(
+        `
+        const styleA = "base";
+
+        function App() {
+          return <my-element css={styleA} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(result).toMatchSnapshot();
+      expect(code).toMatchSnapshot();
+      expect(code).not.toContain(" css=");
+      expect(code).toContain("return <my-element className={_cx(styleA)} />");
+      expect(code).not.toContain("<my-element class=");
+    });
+
+    it("aggregates spread props before explicit class-value css prop", () => {
+      const { result, code } = babelTransform(
+        `
+        const styleA = "style-a";
+        const props = {
+          className: "base",
+          css: "leaked",
+          id: "root"
+        };
+
+        function App() {
+          return <div {...props} css={styleA} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(result).toMatchSnapshot();
+      expect(code).toMatchSnapshot();
+      expect(code).not.toContain(" css=");
+      expect(code).toContain("css: _minchoCssProp");
+      expect(code).toContain("..._minchoRest");
+      expect(code).toContain("className={_cx(_minchoClassName, styleA)}");
+    });
+
+    it("aggregates multiple spreads and className before inline object css prop", () => {
+      const { result, code } = babelTransform(
+        `
+        const a = { id: "a" };
+        const b = { className: "from-b" };
+
+        function App() {
+          return <div {...a} className="base" {...b} css={{ color: "red" }} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(result).toMatchSnapshot();
+      expect(code).toMatchSnapshot();
+      expect(result[1]).toContain("_css({");
+      expect(result[1]).toContain('color: "red"');
+      expect(code).not.toContain(" css=");
+      expect(code).toContain("...a");
+      expect(code).toContain('className: "base"');
+      expect(code).toContain("...b");
+      expect(code).toContain(
+        "className={_cx(_minchoClassName, _$mincho$$App2)}"
+      );
+    });
+
+    it("evaluates spread aggregation inputs once in source order", () => {
+      const observed = runJsxCssPropRuntime(
+        `
+        const styleA = "style-a";
+        const events: string[] = [];
+        const spreadA = () => {
+          events.push("spread-a");
+          return { id: "a", className: "from-a", css: "leak-a" };
+        };
+        const spreadB = () => {
+          events.push("spread-b");
+          return { title: "b", className: "from-b", css: "leak-b" };
+        };
+        const named = () => {
+          events.push("className");
+          return "base";
+        };
+
+        function App() {
+          return <div {...spreadA()} className={named()} {...spreadB()} css={styleA} />;
+        }
+      `,
+        "return { props: App(), events };"
+      ) as { props: Record<string, unknown>; events: string[] };
+
+      expect(observed.events).toEqual(["spread-a", "className", "spread-b"]);
+      expect(observed.props).toMatchObject({
+        id: "a",
+        title: "b",
+        className: "from-b style-a"
+      });
+      expect("css" in observed.props).toBe(false);
+    });
+
+    it("reads spread-provided className once through aggregate props", () => {
+      const observed = runJsxCssPropRuntime(
+        `
+        const styleA = "style-a";
+        let classNameReads = 0;
+        const props = {
+          get className() {
+            classNameReads += 1;
+            return "base";
+          },
+          css: "leak",
+          id: "root"
+        };
+
+        function App() {
+          return <div {...props} css={styleA} />;
+        }
+      `,
+        "return { props: App(), classNameReads };"
+      ) as { props: Record<string, unknown>; classNameReads: number };
+
+      expect(observed.classNameReads).toBe(1);
+      expect(observed.props).toMatchObject({
+        id: "root",
+        className: "base style-a"
+      });
+      expect("css" in observed.props).toBe(false);
+    });
+
+    it("leaves spread-only runtime css props untransformed", () => {
+      const { result, code } = babelTransform(
+        `
+        const styleA = "style-a";
+
+        function App() {
+          return <div {...{ css: styleA }} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(result).toMatchSnapshot();
+      expect(code).toMatchSnapshot();
+      expect(code).toContain("css: styleA");
+      expect(code).not.toContain("className=");
+      expect(code).not.toContain("_cx");
+    });
+
+    it("rejects unbraced if return spread aggregation", () => {
+      expect(() =>
+        babelTransform(
+          `
+          const styleA = "style-a";
+
+          function App(props, ok) {
+            if (ok) return <div {...props} css={styleA} />;
+            return null;
+          }
+        `,
+          { jsxCssProp: true }
+        )
+      ).toThrow(jsxCssPropErrorMessages.spreadAggregationContext);
+    });
+
+    it("rejects unbraced if expression statement spread aggregation", () => {
+      expect(() =>
+        babelTransform(
+          `
+          const styleA = "style-a";
+
+          function App(props, ok) {
+            if (ok) <div {...props} css={styleA} />;
+          }
+        `,
+          { jsxCssProp: true }
+        )
+      ).toThrow(jsxCssPropErrorMessages.spreadAggregationContext);
     });
 
     const unsupportedJsxCssPropFixtures = [
       {
-        name: "rejects custom components",
-        fixture: `<Button css={{ color: "red" }} />`,
-        message: jsxCssPropErrorMessages.intrinsicElement
-      },
-      {
-        name: "rejects member-expression components",
-        fixture: `<motion.div css={{ color: "red" }} />`,
-        message: jsxCssPropErrorMessages.intrinsicElement
-      },
-      {
-        name: "rejects fragment components",
+        name: "rejects React.Fragment css prop targets",
         fixture: `<React.Fragment css={{ color: "red" }} />`,
-        message: jsxCssPropErrorMessages.intrinsicElement
+        message: jsxCssPropErrorMessages.fragmentTarget
       },
       {
-        name: "rejects unsupported custom elements",
-        fixture: `<my-element css={{ color: "red" }} />`,
-        message: jsxCssPropErrorMessages.supportedTag
+        name: "rejects Fragment identifier css prop targets",
+        fixture: `<Fragment css={{ color: "red" }} />`,
+        message: jsxCssPropErrorMessages.fragmentTarget
       },
       {
-        name: "rejects spreads before css on css-prop elements",
-        fixture: `<div {...props} css={{ color: "red" }} />`,
-        message: jsxCssPropErrorMessages.spread
+        name: "rejects namespaced JSX css prop targets",
+        fixture: `<svg:path css={{ color: "red" }} />`,
+        message: jsxCssPropErrorMessages.namespacedTarget
       },
       {
         name: "rejects spreads after css on css-prop elements",
-        fixture: `<div css={{ color: "red" }} {...props} />`,
-        message: jsxCssPropErrorMessages.spread
+        fixture: `<div css={styleA} {...props} />`,
+        message: jsxCssPropErrorMessages.spreadAfterCss
+      },
+      {
+        name: "rejects spreads after css even when earlier spreads exist",
+        fixture: `<div {...a} css={styleA} {...b} />`,
+        message: jsxCssPropErrorMessages.spreadAfterCss
+      },
+      {
+        name: "rejects explicit key on spread-aggregated css-prop elements",
+        fixture: `<div key="x" {...props} css={styleA} />`,
+        message: jsxCssPropErrorMessages.keyRefSpread
+      },
+      {
+        name: "rejects explicit ref on spread-aggregated css-prop components",
+        fixture: `<Component ref={ref} {...props} css={styleA} />`,
+        message: jsxCssPropErrorMessages.keyRefSpread
+      },
+      {
+        name: "rejects expression-bodied arrow spread aggregation",
+        fixture: `(() => {
+          const App = (props) => <div {...props} css={styleA} />;
+          return <App />;
+        })()`,
+        message: jsxCssPropErrorMessages.spreadAggregationContext
+      },
+      {
+        name: "rejects conditional spread aggregation",
+        fixture: `ok ? <div {...props} css={styleA} /> : null`,
+        message: jsxCssPropErrorMessages.spreadAggregationContext
+      },
+      {
+        name: "rejects logical spread aggregation",
+        fixture: `ok && <div {...props} css={styleA} />`,
+        message: jsxCssPropErrorMessages.spreadAggregationContext
+      },
+      {
+        name: "rejects call-argument spread aggregation",
+        fixture: `render(<div {...props} css={styleA} />)`,
+        message: jsxCssPropErrorMessages.spreadAggregationContext
       },
       {
         name: "rejects shorthand css",
@@ -240,34 +788,14 @@ if (import.meta.vitest) {
         message: jsxCssPropErrorMessages.expressionValue
       },
       {
-        name: "rejects raw string css values",
-        fixture: `<div css="color: red" />`,
-        message: jsxCssPropErrorMessages.cssValue
-      },
-      {
-        name: "rejects template literal css values",
-        fixture: `<div css={\`color: red\`} />`,
-        message: jsxCssPropErrorMessages.cssValue
-      },
-      {
-        name: "rejects raw number css values",
-        fixture: `<div css={1} />`,
-        message: jsxCssPropErrorMessages.cssValue
-      },
-      {
-        name: "rejects raw boolean css values",
-        fixture: `<div css={true} />`,
-        message: jsxCssPropErrorMessages.cssValue
-      },
-      {
-        name: "rejects raw null css values",
-        fixture: `<div css={null} />`,
-        message: jsxCssPropErrorMessages.cssValue
-      },
-      {
-        name: "rejects direct function css values",
+        name: "rejects inline arrow function css values",
         fixture: `<div css={() => ({ color: "red" })} />`,
-        message: jsxCssPropErrorMessages.cssValue
+        message: jsxCssPropErrorMessages.unsupportedFunction
+      },
+      {
+        name: "rejects inline function expression css values",
+        fixture: `<div css={function () { return { color: "red" }; }} />`,
+        message: jsxCssPropErrorMessages.unsupportedFunction
       },
       {
         name: "rejects duplicate css attributes",

--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -289,6 +289,10 @@ if (import.meta.vitest) {
       "Mincho JSX css prop does not support function values in compile-away mode",
     unsupportedDynamicCssRule:
       "Mincho JSX css prop does not support conditional, logical, or wrapped object/array CSS rule values in compile-away mode",
+    unsupportedArraySpread:
+      "Mincho JSX css prop array values do not support spread elements in compile-away mode",
+    unsupportedFirstLevelArrayBranch:
+      "Mincho JSX css prop array branch extraction only supports first-level dynamic branches",
     duplicateCss: "Mincho JSX css prop must appear only once",
     duplicateClassName:
       "Mincho JSX css prop cannot merge duplicate className attributes",
@@ -596,10 +600,8 @@ if (import.meta.vitest) {
     it("lowers array literal jsx css prop through css rule mode", () => {
       const { result, code } = babelTransform(
         `
-        const base = "base";
-
         function App() {
-          return <div css={[base, { color: "red" }]} />;
+          return <div css={["base", { color: "red" }]} />;
         }
       `,
         { jsxCssProp: true }
@@ -608,10 +610,203 @@ if (import.meta.vitest) {
       expect(result).toMatchSnapshot();
       expect(code).toMatchSnapshot();
       expect(code).not.toContain(" css=");
-      expect(result[1]).toContain("_css([base, {");
+      expect(result[1]).toContain('_css(["base", {');
       expect(result[1]).toContain('color: "red"');
       expect(code).toContain("className={_$mincho$$App2}");
       expect(code).not.toContain("_cx([base");
+    });
+
+    it("classifies first-level primitive jsx css prop array branches", () => {
+      const { result, code } = babelTransform(
+        `
+        const activeClass = "active-class";
+        const styles = { active: "styles-active" };
+        const condition = true;
+        const providedClass = "";
+        const maybeClass = null;
+        const suffix = "suffix";
+
+        function getClassName() {
+          return "called";
+        }
+
+        function App() {
+          return <>
+            <div css={["base", "active"]} />
+            <div css={["base", ""]} />
+            <div css={["base", false]} />
+            <div css={["base", true]} />
+            <div css={["base", null]} />
+            <div css={["base", undefined]} />
+            <div css={["base", 0]} />
+            <div css={["base", 1]} />
+            <div css={["base", 0n]} />
+            <div css={["base", 1n]} />
+            <div css={["base", activeClass]} />
+            <div css={["base", "", activeClass]} />
+            <div css={["base", styles.active]} />
+            <div css={["base", getClassName()]} />
+            <div css={["base", \`active \${suffix}\`]} />
+            <div css={["base", condition && "active"]} />
+            <div css={["base", providedClass || "fallback"]} />
+            <div css={["base", maybeClass ?? "fallback"]} />
+            <div css={["base", condition ? "active" : "inactive"]} />
+            <div className="external" css={["base", condition && "active"]} />
+          </>;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(result).toMatchSnapshot();
+      expect(code).toMatchSnapshot();
+      expect(code).not.toContain(" css=");
+      expect(code).not.toContain('_cx(["base"');
+      expect(result[1].match(/_css\(/g) ?? []).toHaveLength(2);
+      expect(result[1]).toContain('_css(["base", "active"])');
+      expect(result[1]).toContain('_css(["base", ""])');
+      expect(result[1]).not.toContain("activeClass");
+      expect(result[1]).not.toContain("getClassName");
+      expect(result[1]).not.toContain("suffix");
+      expect(code).toContain('className={_cx("base", false)}');
+      expect(code).toContain('className={_cx("base", true)}');
+      expect(code).toContain('className={_cx("base", null)}');
+      expect(code).toContain('className={_cx("base", undefined)}');
+      expect(code).toContain('className={_cx("base", 0)}');
+      expect(code).toContain('className={_cx("base", 1)}');
+      expect(code).toContain('className={_cx("base", 0n)}');
+      expect(code).toContain('className={_cx("base", 1n)}');
+      expect(code).toContain('className={_cx("base", activeClass)}');
+      expect(code).toContain('className={_cx("base", "", activeClass)}');
+      expect(code).toContain('className={_cx("base", styles.active)}');
+      expect(code).toContain('className={_cx("base", getClassName())}');
+      expect(code).toContain('className={_cx("base", `active ${suffix}`)}');
+      expect(code).toContain('className={_cx("base", condition && "active")}');
+      expect(code).toContain(
+        'className={_cx("base", providedClass || "fallback")}'
+      );
+      expect(code).toContain(
+        'className={_cx("base", maybeClass ?? "fallback")}'
+      );
+      expect(code).toContain(
+        'className={_cx("base", condition ? "active" : "inactive")}'
+      );
+      expect(code).toContain(
+        'className={_cx("external", "base", condition && "active")}'
+      );
+    });
+
+    it("extracts first-level CSS-rule branch array branches through cx", () => {
+      const { result, code } = babelTransform(
+        `
+        const activeClass = "active-class";
+        const condition = true;
+        const providedClass = "";
+        const maybeClass = null;
+
+        function App() {
+          return <>
+            <div css={["base", condition && { color: "red" }]} />
+            <div css={["base", providedClass || { color: "red" }]} />
+            <div css={["base", maybeClass ?? { color: "red" }]} />
+            <div css={["base", providedClass || [{ color: "red" }]]} />
+            <div css={["base", maybeClass ?? ["active", { color: "red" }]]} />
+            <div css={["base", condition && [{ color: "red" }]]} />
+            <div css={["base", condition && ["active", { color: "red" }]]} />
+            <div css={["base", { color: "red" }, activeClass]} />
+            <div css={["base", [{ color: "red" }], condition && "active"]} />
+            <div css={["base", condition ? { color: "red" } : "inactive"]} />
+            <div css={["base", condition ? [{ color: "red" }] : "inactive"]} />
+            <div css={["base", condition ? "active" : { color: "blue" }]} />
+            <div css={["base", condition ? "active" : ["fallback", { color: "blue" }]]} />
+            <div css={["base", condition ? { color: "red" } : { color: "blue" }]} />
+            <div css={["base", condition ? ["red", { color: "red" }] : ["blue", { color: "blue" }]]} />
+          </>;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+      const expectedClassNames = [
+        /className=\{_cx\("base", condition && _\$mincho\$\$App\d+\)\}/,
+        /className=\{_cx\("base", providedClass \|\| _\$mincho\$\$App\d+\)\}/,
+        /className=\{_cx\("base", maybeClass \?\? _\$mincho\$\$App\d+\)\}/,
+        /className=\{_cx\("base", _\$mincho\$\$App\d+, activeClass\)\}/,
+        /className=\{_cx\("base", _\$mincho\$\$App\d+, condition && "active"\)\}/,
+        /className=\{_cx\("base", condition \? _\$mincho\$\$App\d+ : "inactive"\)\}/,
+        /className=\{_cx\("base", condition \? "active" : _\$mincho\$\$App\d+\)\}/,
+        /className=\{_cx\("base", condition \? _\$mincho\$\$App\d+ : _\$mincho\$\$App\d+\)\}/
+      ] as const;
+
+      expect(result).toMatchSnapshot();
+      expect(code).toMatchSnapshot();
+      expect(code).not.toContain(" css=");
+      expect(code).not.toContain("_css(");
+      expect(code).not.toContain('color: "red"');
+      expect(code).not.toContain('color: "blue"');
+      expect(code).not.toContain("[{");
+      expect(code).not.toContain('["active", {');
+      expect(code).not.toContain('["fallback", {');
+      expect(result[1].match(/_css\(/g) ?? []).toHaveLength(17);
+      expect(result[1].match(/_css\(\{/g) ?? []).toHaveLength(8);
+      expect(result[1].match(/_css\(\[/g) ?? []).toHaveLength(9);
+      expect(result[1]).toContain('_css(["active", {');
+      expect(result[1]).toContain('_css(["fallback", {');
+      expect(result[1]).toContain('_css(["red", {');
+      expect(result[1]).toContain('_css(["blue", {');
+
+      for (const expectedClassName of expectedClassNames) {
+        expect(code).toMatch(expectedClassName);
+      }
+    });
+
+    it("supports first-level dynamic branches with static array CSS-rule units", () => {
+      const { result, code } = babelTransform(
+        `
+        const condition = true;
+
+        function App() {
+          return <>
+            <div css={["base", condition && [{ color: "red" }]]} />
+            <div css={["base", condition && ["active", { color: "red" }]]} />
+          </>;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(code).not.toContain(" css=");
+      expect(
+        code.match(
+          /className=\{_cx\("base", condition && _\$mincho\$\$App\d+\)\}/g
+        ) ?? []
+      ).toHaveLength(2);
+      expect(code).not.toContain("[{");
+      expect(code).not.toContain('["active", {');
+      expect(result[1].match(/_css\(\[/g) ?? []).toHaveLength(2);
+      expect(result[1]).toContain("_css([{");
+      expect(result[1]).toContain('_css(["active", {');
+    });
+
+    it("evaluates first-level array call branches once", () => {
+      const observed = runJsxCssPropRuntime(
+        `
+        let callCount = 0;
+
+        function getClassName() {
+          callCount += 1;
+          return "dynamic";
+        }
+
+        function App() {
+          return <div css={["base", getClassName()]} />;
+        }
+      `,
+        "return { props: App(), callCount };"
+      ) as { props: Record<string, unknown>; callCount: number };
+
+      expect(observed.callCount).toBe(1);
+      expect(observed.props.className).toBe("base dynamic");
+      expect("css" in observed.props).toBe(false);
     });
 
     it("lowers transparent wrapped direct jsx css prop rules through css rule mode", () => {
@@ -645,8 +840,8 @@ if (import.meta.vitest) {
           expectedRule: "_css({"
         },
         {
-          fixture: `<div css={([base, { color: "red" }])} />`,
-          expectedRule: "_css([base, {"
+          fixture: `<div css={(["base", { color: "red" }])} />`,
+          expectedRule: '_css(["base", {'
         }
       ] as const;
 
@@ -1231,7 +1426,7 @@ if (import.meta.vitest) {
       }
     });
 
-    it("lowers explicit cx array class values through class-value mode", () => {
+    it("lowers explicit cx array and dictionary class values through class-value mode", () => {
       const { result, code } = babelTransform(
         `
         import { cx } from "@mincho-js/css";
@@ -1239,7 +1434,11 @@ if (import.meta.vitest) {
         const isActive = true;
 
         function App() {
-          return <div css={cx(["base", isActive && "active"])} />;
+          return <>
+            <div css={cx(["base", isActive && "active"])} />
+            <div css={cx({ active: isActive })} />
+            <div css={cx(["base", { active: isActive }])} />
+          </>;
         }
       `,
         { jsxCssProp: true }
@@ -1251,6 +1450,13 @@ if (import.meta.vitest) {
       expect(code).toContain(
         'className={_cx(cx(["base", isActive && "active"]))}'
       );
+      expect(code).toMatch(
+        /className=\{_cx\(cx\(\{\s+active: isActive\s+\}\)\)\}/
+      );
+      expect(code).toMatch(
+        /className=\{_cx\(cx\(\["base", \{\s+active: isActive\s+\}\]\)\)\}/
+      );
+      expect(result[1]).not.toContain("_css(");
     });
 
     it("lowers identifier css result through cx without double wrapping", () => {
@@ -1842,6 +2048,21 @@ if (import.meta.vitest) {
         name: "rejects sequence array literal css rule values",
         fixture: `<div css={(0, [{ color: "red" }])} />`,
         message: jsxCssPropErrorMessages.unsupportedDynamicCssRule
+      },
+      {
+        name: "rejects array spread css prop array values",
+        fixture: `<div css={["base", ...classes]} />`,
+        message: jsxCssPropErrorMessages.unsupportedArraySpread
+      },
+      {
+        name: "rejects unsupported first-level dynamic branches in nested css prop arrays",
+        fixture: `<div css={["base", ["nested", condition && { color: "red" }]]} />`,
+        message: jsxCssPropErrorMessages.unsupportedFirstLevelArrayBranch
+      },
+      {
+        name: "rejects unsupported first-level dynamic branches inside static array branches",
+        fixture: `<div css={["base", condition && ["active", nested && { color: "red" }]]} />`,
+        message: jsxCssPropErrorMessages.unsupportedFirstLevelArrayBranch
       },
       {
         name: "rejects duplicate css attributes",

--- a/packages/babel/src/jsxCssProp.ts
+++ b/packages/babel/src/jsxCssProp.ts
@@ -27,6 +27,10 @@ const unsupportedFunctionCssValueErrorMessage =
   "Mincho JSX css prop does not support function values in compile-away mode";
 const unsupportedDynamicCssRuleValueErrorMessage =
   "Mincho JSX css prop does not support conditional, logical, or wrapped object/array CSS rule values in compile-away mode";
+const unsupportedArraySpreadCssValueErrorMessage =
+  "Mincho JSX css prop array values do not support spread elements in compile-away mode";
+const unsupportedFirstLevelArrayBranchCssValueErrorMessage =
+  "Mincho JSX css prop array branch extraction only supports first-level dynamic branches";
 const duplicateCssErrorMessage = "Mincho JSX css prop must appear only once";
 const duplicateClassNameErrorMessage =
   "Mincho JSX css prop cannot merge duplicate className attributes";
@@ -39,6 +43,8 @@ type CssPropValueClassification =
   | "branch-css-rule"
   | "class-value"
   | "unsupported-dynamic-css-rule"
+  | "unsupported-array-spread"
+  | "unsupported-first-level-array-branch"
   | "unsupported-function";
 
 export function preprocessJsxCssProp(
@@ -216,6 +222,18 @@ function normalizeOpeningElement(
     );
   }
 
+  if (cssValueClassification === "unsupported-array-spread") {
+    throw openingElementPath.buildCodeFrameError(
+      unsupportedArraySpreadCssValueErrorMessage
+    );
+  }
+
+  if (cssValueClassification === "unsupported-first-level-array-branch") {
+    throw openingElementPath.buildCodeFrameError(
+      unsupportedFirstLevelArrayBranchCssValueErrorMessage
+    );
+  }
+
   return {
     cssAttribute,
     cssExpression,
@@ -266,7 +284,7 @@ function createClassNameExpression(
     aggregateClassNameExpression?: t.Expression;
   }
 ): t.Expression {
-  const cssClassNameExpression = createCssClassNameExpression(
+  const cssClassNameExpressions = createCssClassNameExpressions(
     path,
     normalizedElement.cssExpression,
     normalizedElement.cssValueClassification
@@ -287,7 +305,7 @@ function createClassNameExpression(
     !normalizedElement.classNameAttribute &&
     canEmitDirectly
   ) {
-    return cssClassNameExpression;
+    return cssClassNameExpressions[0];
   }
 
   const cxIdentifier = registerImportMethod(path, "cx", cssModuleName);
@@ -296,7 +314,7 @@ function createClassNameExpression(
     !normalizedElement.aggregateClassNameExpression &&
     !normalizedElement.classNameAttribute
   ) {
-    return t.callExpression(cxIdentifier, [cssClassNameExpression]);
+    return t.callExpression(cxIdentifier, cssClassNameExpressions);
   }
 
   const classNameExpressions = [];
@@ -315,7 +333,7 @@ function createClassNameExpression(
 
   return t.callExpression(cxIdentifier, [
     ...classNameExpressions,
-    cssClassNameExpression
+    ...cssClassNameExpressions
   ]);
 }
 
@@ -334,7 +352,7 @@ function createClassNameAttributeValue(
     !normalizedElement.aggregateClassNameExpression &&
     !normalizedElement.classNameAttribute
   ) {
-    return t.cloneNode(normalizedElement.cssExpression);
+    return createStaticStringExpression(normalizedElement.cssExpression);
   }
 
   return t.jsxExpressionContainer(
@@ -570,6 +588,68 @@ function createCssClassNameExpression(
   return t.cloneNode(cssExpression);
 }
 
+function createCssClassNameExpressions(
+  path: NodePath<t.JSXOpeningElement>,
+  cssExpression: t.Expression,
+  cssValueClassification: CssPropValueClassification
+): t.Expression[] {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(cssExpression);
+
+  if (
+    cssValueClassification === "class-value" &&
+    isArrayClassValueExpression(unwrappedExpression)
+  ) {
+    return createArrayClassNameExpressions(path, unwrappedExpression);
+  }
+
+  return [
+    createCssClassNameExpression(path, cssExpression, cssValueClassification)
+  ];
+}
+
+function createArrayClassNameExpressions(
+  path: NodePath<t.JSXOpeningElement>,
+  expression: t.ArrayExpression
+): t.Expression[] {
+  return expression.elements.map((element) => {
+    return createArrayClassNameExpression(path, element as t.Expression);
+  });
+}
+
+function createArrayClassNameExpression(
+  path: NodePath<t.JSXOpeningElement>,
+  expression: t.Expression
+): t.Expression {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+
+  if (t.isStringLiteral(unwrappedExpression)) {
+    return createStaticStringExpression(unwrappedExpression);
+  }
+
+  if (isDirectCssRuleExpression(unwrappedExpression)) {
+    return createCssRuleClassNameExpression(path, unwrappedExpression);
+  }
+
+  if (
+    t.isConditionalExpression(unwrappedExpression) &&
+    isConditionalCssRuleBranchExpression(unwrappedExpression)
+  ) {
+    return createConditionalCssRuleClassNameExpression(
+      path,
+      unwrappedExpression
+    );
+  }
+
+  if (
+    t.isLogicalExpression(unwrappedExpression) &&
+    isLogicalCssRuleBranchExpression(unwrappedExpression)
+  ) {
+    return createLogicalCssRuleClassNameExpression(path, unwrappedExpression);
+  }
+
+  return t.cloneNode(expression);
+}
+
 function createCssRuleClassNameExpression(
   path: NodePath<t.JSXOpeningElement>,
   cssExpression: t.Expression
@@ -698,6 +778,13 @@ function getCssExpression(
 function classifyCssPropValue(
   expression: t.Expression
 ): CssPropValueClassification {
+  const unsupportedArrayValueClassification =
+    classifyUnsupportedCssPropArrayValue(expression);
+
+  if (unsupportedArrayValueClassification) {
+    return unsupportedArrayValueClassification;
+  }
+
   if (isDirectCssRuleExpression(expression)) {
     return "css-rule";
   }
@@ -727,9 +814,205 @@ function classifyCssPropValue(
 function isDirectCssRuleExpression(expression: t.Expression): boolean {
   const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
 
+  if (t.isObjectExpression(unwrappedExpression)) {
+    return true;
+  }
+
   return (
-    t.isObjectExpression(unwrappedExpression) ||
-    t.isArrayExpression(unwrappedExpression)
+    t.isArrayExpression(unwrappedExpression) &&
+    isDirectCssRuleArrayExpression(unwrappedExpression)
+  );
+}
+
+function isDirectCssRuleArrayExpression(
+  expression: t.ArrayExpression
+): boolean {
+  let hasClassValueBranch = false;
+
+  for (const element of expression.elements) {
+    if (!element || t.isSpreadElement(element)) {
+      return true;
+    }
+
+    const unwrappedElement = unwrapTransparentCssRuleExpression(element);
+
+    if (t.isObjectExpression(unwrappedElement)) {
+      continue;
+    }
+
+    if (t.isArrayExpression(unwrappedElement)) {
+      if (!isDirectCssRuleArrayExpression(unwrappedElement)) {
+        hasClassValueBranch = true;
+      }
+
+      continue;
+    }
+
+    if (t.isStringLiteral(unwrappedElement)) {
+      continue;
+    }
+
+    if (!isFirstLevelArrayClassValueBranch(unwrappedElement)) {
+      return true;
+    }
+
+    hasClassValueBranch = true;
+  }
+
+  return !hasClassValueBranch;
+}
+
+function isArrayClassValueExpression(
+  expression: t.Expression
+): expression is t.ArrayExpression {
+  return (
+    t.isArrayExpression(expression) &&
+    !isDirectCssRuleArrayExpression(expression)
+  );
+}
+
+function classifyUnsupportedCssPropArrayValue(
+  expression: t.Expression
+): Extract<
+  CssPropValueClassification,
+  "unsupported-array-spread" | "unsupported-first-level-array-branch"
+> | null {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+
+  if (!t.isArrayExpression(unwrappedExpression)) {
+    return null;
+  }
+
+  if (hasArraySpreadElement(unwrappedExpression)) {
+    return "unsupported-array-spread";
+  }
+
+  if (hasUnsupportedNestedDynamicArray(unwrappedExpression)) {
+    return "unsupported-first-level-array-branch";
+  }
+
+  return null;
+}
+
+function hasArraySpreadElement(expression: t.ArrayExpression): boolean {
+  return expression.elements.some((element) => {
+    if (!element) {
+      return false;
+    }
+
+    if (t.isSpreadElement(element)) {
+      return true;
+    }
+
+    return containsArraySpreadElement(element);
+  });
+}
+
+function containsArraySpreadElement(expression: t.Expression): boolean {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+
+  if (t.isArrayExpression(unwrappedExpression)) {
+    return hasArraySpreadElement(unwrappedExpression);
+  }
+
+  if (t.isSequenceExpression(unwrappedExpression)) {
+    return unwrappedExpression.expressions.some((sequenceExpression) =>
+      containsArraySpreadElement(sequenceExpression)
+    );
+  }
+
+  if (t.isConditionalExpression(unwrappedExpression)) {
+    return (
+      containsArraySpreadElement(unwrappedExpression.consequent) ||
+      containsArraySpreadElement(unwrappedExpression.alternate)
+    );
+  }
+
+  if (t.isLogicalExpression(unwrappedExpression)) {
+    return (
+      containsArraySpreadElement(unwrappedExpression.left) ||
+      containsArraySpreadElement(unwrappedExpression.right)
+    );
+  }
+
+  return false;
+}
+
+function hasUnsupportedNestedDynamicArray(
+  expression: t.ArrayExpression
+): boolean {
+  return expression.elements.some((element) => {
+    if (!element || t.isSpreadElement(element)) {
+      return false;
+    }
+
+    return containsUnsupportedNestedDynamicArray(element, true);
+  });
+}
+
+function containsUnsupportedNestedDynamicArray(
+  expression: t.Expression,
+  isNestedArray: boolean
+): boolean {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+
+  if (t.isArrayExpression(unwrappedExpression)) {
+    if (isNestedArray && !isDirectCssRuleArrayExpression(unwrappedExpression)) {
+      return true;
+    }
+
+    return hasUnsupportedNestedDynamicArray(unwrappedExpression);
+  }
+
+  if (t.isSequenceExpression(unwrappedExpression)) {
+    return unwrappedExpression.expressions.some((sequenceExpression) =>
+      containsUnsupportedNestedDynamicArray(sequenceExpression, isNestedArray)
+    );
+  }
+
+  if (t.isConditionalExpression(unwrappedExpression)) {
+    return (
+      containsUnsupportedNestedDynamicArray(
+        unwrappedExpression.consequent,
+        isNestedArray
+      ) ||
+      containsUnsupportedNestedDynamicArray(
+        unwrappedExpression.alternate,
+        isNestedArray
+      )
+    );
+  }
+
+  if (t.isLogicalExpression(unwrappedExpression)) {
+    return (
+      containsUnsupportedNestedDynamicArray(
+        unwrappedExpression.left,
+        isNestedArray
+      ) ||
+      containsUnsupportedNestedDynamicArray(
+        unwrappedExpression.right,
+        isNestedArray
+      )
+    );
+  }
+
+  return false;
+}
+
+function isFirstLevelArrayClassValueBranch(expression: t.Expression): boolean {
+  return (
+    t.isBooleanLiteral(expression) ||
+    t.isNullLiteral(expression) ||
+    t.isIdentifier(expression) ||
+    t.isNumericLiteral(expression) ||
+    t.isBigIntLiteral(expression) ||
+    t.isTemplateLiteral(expression) ||
+    t.isMemberExpression(expression) ||
+    t.isOptionalMemberExpression(expression) ||
+    t.isCallExpression(expression) ||
+    t.isOptionalCallExpression(expression) ||
+    t.isLogicalExpression(expression) ||
+    t.isConditionalExpression(expression)
   );
 }
 
@@ -912,7 +1195,12 @@ function isUnsupportedDynamicCssRuleValue(
     t.isObjectExpression(unwrappedExpression) ||
     t.isArrayExpression(unwrappedExpression)
   ) {
-    return isBranchExpression || unwrappedExpression !== expression;
+    return (
+      isBranchExpression ||
+      (unwrappedExpression !== expression &&
+        (!t.isArrayExpression(unwrappedExpression) ||
+          isDirectCssRuleArrayExpression(unwrappedExpression)))
+    );
   }
 
   if (t.isSequenceExpression(unwrappedExpression)) {
@@ -952,6 +1240,12 @@ function unwrapTransparentCssRuleExpression(
   }
 
   return currentExpression;
+}
+
+function createStaticStringExpression(
+  expression: t.StringLiteral
+): t.StringLiteral {
+  return t.cloneNode(expression);
 }
 
 function isTransparentCssRuleWrapperExpression(

--- a/packages/babel/src/jsxCssProp.ts
+++ b/packages/babel/src/jsxCssProp.ts
@@ -1,6 +1,6 @@
 import { types as t } from "@babel/core";
 import type { NodePath } from "@babel/core";
-import type { PluginState } from "./types.js";
+import type { PluginState, ProgramScope } from "./types.js";
 import { registerImportMethod } from "./utils.js";
 
 const cssAttributeName = "css";
@@ -25,15 +25,20 @@ const cssValueErrorMessage =
   "Mincho JSX css prop expects a Mincho CSS object/expression";
 const unsupportedFunctionCssValueErrorMessage =
   "Mincho JSX css prop does not support function values in compile-away mode";
+const unsupportedDynamicCssRuleValueErrorMessage =
+  "Mincho JSX css prop does not support conditional, logical, or wrapped object/array CSS rule values in compile-away mode";
 const duplicateCssErrorMessage = "Mincho JSX css prop must appear only once";
 const duplicateClassNameErrorMessage =
   "Mincho JSX css prop cannot merge duplicate className attributes";
 const classNameValueErrorMessage =
   "Mincho JSX css prop requires className to be a string literal or expression";
+const directLogicalCssRuleScopes = new WeakSet<ProgramScope>();
 
 type CssPropValueClassification =
   | "css-rule"
+  | "branch-css-rule"
   | "class-value"
+  | "unsupported-dynamic-css-rule"
   | "unsupported-function";
 
 export function preprocessJsxCssProp(
@@ -61,13 +66,12 @@ export function preprocessJsxCssProp(
         return;
       }
 
-      const nextClassNameExpression = createClassNameExpression(
+      const classNameValue = createClassNameAttributeValue(
         openingElementPath,
         normalizedElement
       );
 
       const attributes = openingElementPath.node.attributes;
-      const classNameValue = t.jsxExpressionContainer(nextClassNameExpression);
 
       if (classNameAttribute) {
         classNameAttribute.value = classNameValue;
@@ -93,6 +97,50 @@ export function preprocessJsxCssProp(
   }
 
   return transformed;
+}
+
+export function removeUnusedJsxCssPropCssModuleImports(
+  path: NodePath<t.Program>
+): void {
+  const programScope = path.scope as ProgramScope;
+
+  if (!directLogicalCssRuleScopes.has(programScope)) {
+    return;
+  }
+
+  path.scope.crawl();
+
+  for (const statementPath of path.get("body")) {
+    if (
+      !statementPath.isImportDeclaration() ||
+      statementPath.node.source.value !== cssModuleName ||
+      !isUnusedCssModuleHelperImport(statementPath)
+    ) {
+      continue;
+    }
+
+    statementPath.remove();
+  }
+}
+
+function isUnusedCssModuleHelperImport(
+  path: NodePath<t.ImportDeclaration>
+): boolean {
+  return (
+    path.node.specifiers.length > 0 &&
+    path.node.specifiers.every((specifier) => {
+      if (
+        !t.isImportSpecifier(specifier) ||
+        !t.isIdentifier(specifier.imported) ||
+        (specifier.imported.name !== "css" && specifier.imported.name !== "cx")
+      ) {
+        return false;
+      }
+
+      const binding = path.scope.getBinding(specifier.local.name);
+      return !binding || binding.referencePaths.length === 0;
+    })
+  );
 }
 
 function normalizeOpeningElement(
@@ -162,6 +210,12 @@ function normalizeOpeningElement(
     );
   }
 
+  if (cssValueClassification === "unsupported-dynamic-css-rule") {
+    throw openingElementPath.buildCodeFrameError(
+      unsupportedDynamicCssRuleValueErrorMessage
+    );
+  }
+
   return {
     cssAttribute,
     cssExpression,
@@ -217,11 +271,21 @@ function createClassNameExpression(
     normalizedElement.cssExpression,
     normalizedElement.cssValueClassification
   );
+  const canEmitDirectly = canEmitCssClassNameDirectly(
+    normalizedElement.cssExpression,
+    normalizedElement.cssValueClassification
+  );
+
+  if (isDirectLogicalCssRuleExpression(normalizedElement.cssExpression)) {
+    directLogicalCssRuleScopes.add(
+      path.scope.getProgramParent() as ProgramScope
+    );
+  }
 
   if (
     !normalizedElement.aggregateClassNameExpression &&
     !normalizedElement.classNameAttribute &&
-    normalizedElement.cssValueClassification === "css-rule"
+    canEmitDirectly
   ) {
     return cssClassNameExpression;
   }
@@ -253,6 +317,29 @@ function createClassNameExpression(
     ...classNameExpressions,
     cssClassNameExpression
   ]);
+}
+
+function createClassNameAttributeValue(
+  path: NodePath<t.JSXOpeningElement>,
+  normalizedElement: {
+    cssExpression: t.Expression;
+    cssValueClassification: CssPropValueClassification;
+    classNameAttribute: t.JSXAttribute | null;
+    aggregateClassNameExpression?: t.Expression;
+  }
+): t.JSXAttribute["value"] {
+  if (
+    normalizedElement.cssValueClassification === "class-value" &&
+    t.isStringLiteral(normalizedElement.cssExpression) &&
+    !normalizedElement.aggregateClassNameExpression &&
+    !normalizedElement.classNameAttribute
+  ) {
+    return t.cloneNode(normalizedElement.cssExpression);
+  }
+
+  return t.jsxExpressionContainer(
+    createClassNameExpression(path, normalizedElement)
+  );
 }
 
 function transformSpreadAggregatedCssProp(
@@ -460,12 +547,94 @@ function createCssClassNameExpression(
   cssExpression: t.Expression,
   cssValueClassification: CssPropValueClassification
 ): t.Expression {
+  const cssRuleExpression = unwrapTransparentCssRuleExpression(cssExpression);
+
   if (cssValueClassification === "css-rule") {
-    const cssIdentifier = registerImportMethod(path, "css", cssModuleName);
-    return t.callExpression(cssIdentifier, [t.cloneNode(cssExpression)]);
+    return createCssRuleClassNameExpression(path, cssRuleExpression);
+  }
+
+  if (
+    cssValueClassification === "branch-css-rule" &&
+    t.isConditionalExpression(cssRuleExpression)
+  ) {
+    return createConditionalCssRuleClassNameExpression(path, cssRuleExpression);
+  }
+
+  if (
+    cssValueClassification === "branch-css-rule" &&
+    t.isLogicalExpression(cssRuleExpression)
+  ) {
+    return createLogicalCssRuleClassNameExpression(path, cssRuleExpression);
   }
 
   return t.cloneNode(cssExpression);
+}
+
+function createCssRuleClassNameExpression(
+  path: NodePath<t.JSXOpeningElement>,
+  cssExpression: t.Expression
+): t.Expression {
+  const cssIdentifier = registerImportMethod(path, "css", cssModuleName);
+  const cssRuleExpression = unwrapTransparentCssRuleExpression(cssExpression);
+  return t.callExpression(cssIdentifier, [t.cloneNode(cssRuleExpression)]);
+}
+
+function createConditionalCssRuleClassNameExpression(
+  path: NodePath<t.JSXOpeningElement>,
+  cssExpression: t.ConditionalExpression
+): t.Expression {
+  return t.conditionalExpression(
+    t.cloneNode(cssExpression.test),
+    createConditionalBranchClassNameExpression(path, cssExpression.consequent),
+    createConditionalBranchClassNameExpression(path, cssExpression.alternate)
+  );
+}
+
+function createConditionalBranchClassNameExpression(
+  path: NodePath<t.JSXOpeningElement>,
+  expression: t.Expression
+): t.Expression {
+  if (isDirectCssRuleExpression(expression)) {
+    return createCssRuleClassNameExpression(path, expression);
+  }
+
+  return t.cloneNode(expression);
+}
+
+function createLogicalCssRuleClassNameExpression(
+  path: NodePath<t.JSXOpeningElement>,
+  cssExpression: t.LogicalExpression
+): t.Expression {
+  if (
+    isStaticLeftLogicalCssRuleOperator(cssExpression.operator) &&
+    isDirectCssRuleExpression(cssExpression.left)
+  ) {
+    return createCssRuleClassNameExpression(path, cssExpression.left);
+  }
+
+  if (
+    isStaticLeftLogicalCssRuleGuardOperator(cssExpression.operator) &&
+    isDirectCssRuleExpression(cssExpression.left)
+  ) {
+    return createLogicalAndRightClassNameExpression(path, cssExpression.right);
+  }
+
+  return t.logicalExpression(
+    cssExpression.operator,
+    t.cloneNode(cssExpression.left),
+    createCssRuleClassNameExpression(path, cssExpression.right)
+  );
+}
+
+function createLogicalAndRightClassNameExpression(
+  path: NodePath<t.JSXOpeningElement>,
+  expression: t.Expression
+): t.Expression {
+  if (isDirectCssRuleExpression(expression)) {
+    return createCssRuleClassNameExpression(path, expression);
+  }
+
+  return t.cloneNode(expression);
 }
 
 function getJsxAttributes(
@@ -529,8 +698,20 @@ function getCssExpression(
 function classifyCssPropValue(
   expression: t.Expression
 ): CssPropValueClassification {
-  if (t.isObjectExpression(expression) || t.isArrayExpression(expression)) {
+  if (isDirectCssRuleExpression(expression)) {
     return "css-rule";
+  }
+
+  if (isConditionalCssRuleBranchExpression(expression)) {
+    return "branch-css-rule";
+  }
+
+  if (isLogicalCssRuleBranchExpression(expression)) {
+    return "branch-css-rule";
+  }
+
+  if (isUnsupportedDynamicCssRuleValue(expression)) {
+    return "unsupported-dynamic-css-rule";
   }
 
   if (
@@ -541,6 +722,249 @@ function classifyCssPropValue(
   }
 
   return "class-value";
+}
+
+function isDirectCssRuleExpression(expression: t.Expression): boolean {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+
+  return (
+    t.isObjectExpression(unwrappedExpression) ||
+    t.isArrayExpression(unwrappedExpression)
+  );
+}
+
+type ConditionalCssRuleBranchClassification = "css-rule" | "class-value";
+
+function isConditionalCssRuleBranchExpression(
+  expression: t.Expression
+): boolean {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+
+  if (!t.isConditionalExpression(unwrappedExpression)) {
+    return false;
+  }
+
+  const consequentClassification = classifyConditionalCssRuleBranch(
+    unwrappedExpression.consequent
+  );
+  const alternateClassification = classifyConditionalCssRuleBranch(
+    unwrappedExpression.alternate
+  );
+
+  if (!consequentClassification || !alternateClassification) {
+    return false;
+  }
+
+  return (
+    consequentClassification === "css-rule" ||
+    alternateClassification === "css-rule"
+  );
+}
+
+function isLogicalCssRuleBranchExpression(expression: t.Expression): boolean {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+
+  if (!t.isLogicalExpression(unwrappedExpression)) {
+    return false;
+  }
+
+  const leftClassification = classifyLogicalCssRuleOperand(
+    unwrappedExpression.left
+  );
+  const rightClassification = classifyLogicalCssRuleOperand(
+    unwrappedExpression.right
+  );
+
+  if (!leftClassification || !rightClassification) {
+    return false;
+  }
+
+  if (
+    isStaticLeftLogicalCssRuleOperator(unwrappedExpression.operator) &&
+    leftClassification === "css-rule"
+  ) {
+    return true;
+  }
+
+  if (
+    isStaticLeftLogicalCssRuleGuardOperator(unwrappedExpression.operator) &&
+    leftClassification === "css-rule"
+  ) {
+    return true;
+  }
+
+  return (
+    isSupportedRightLogicalCssRuleOperator(unwrappedExpression.operator) &&
+    leftClassification === "class-value" &&
+    rightClassification === "css-rule"
+  );
+}
+
+function isStaticLeftLogicalCssRuleOperator(
+  operator: t.LogicalExpression["operator"]
+): boolean {
+  return operator === "||" || operator === "??";
+}
+
+function isStaticLeftLogicalCssRuleGuardOperator(
+  operator: t.LogicalExpression["operator"]
+): boolean {
+  return operator === "&&";
+}
+
+function isSupportedRightLogicalCssRuleOperator(
+  operator: t.LogicalExpression["operator"]
+): boolean {
+  return operator === "&&" || operator === "||" || operator === "??";
+}
+
+function classifyLogicalCssRuleOperand(
+  expression: t.Expression
+): ConditionalCssRuleBranchClassification | null {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+
+  if (isDirectCssRuleExpression(unwrappedExpression)) {
+    return "css-rule";
+  }
+
+  if (
+    t.isLogicalExpression(unwrappedExpression) ||
+    isUnsupportedDynamicCssRuleValue(unwrappedExpression, true)
+  ) {
+    return null;
+  }
+
+  return "class-value";
+}
+
+function classifyConditionalCssRuleBranch(
+  expression: t.Expression
+): ConditionalCssRuleBranchClassification | null {
+  if (isDirectCssRuleExpression(expression)) {
+    return "css-rule";
+  }
+
+  if (
+    t.isFunctionExpression(expression) ||
+    t.isArrowFunctionExpression(expression) ||
+    isUnsupportedDynamicCssRuleValue(expression, true)
+  ) {
+    return null;
+  }
+
+  return "class-value";
+}
+
+function canEmitCssClassNameDirectly(
+  expression: t.Expression,
+  classification: CssPropValueClassification
+): boolean {
+  if (classification === "css-rule") {
+    return true;
+  }
+
+  if (classification !== "branch-css-rule") {
+    return false;
+  }
+
+  if (isPureConditionalCssRuleExpression(expression)) {
+    return true;
+  }
+
+  return isDirectLogicalCssRuleExpression(expression);
+}
+
+function isDirectLogicalCssRuleExpression(expression: t.Expression): boolean {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+
+  if (!t.isLogicalExpression(unwrappedExpression)) {
+    return false;
+  }
+
+  if (isStaticLeftLogicalCssRuleOperator(unwrappedExpression.operator)) {
+    return isDirectCssRuleExpression(unwrappedExpression.left);
+  }
+
+  return (
+    isStaticLeftLogicalCssRuleGuardOperator(unwrappedExpression.operator) &&
+    isDirectCssRuleExpression(unwrappedExpression.left) &&
+    isDirectCssRuleExpression(unwrappedExpression.right)
+  );
+}
+
+function isPureConditionalCssRuleExpression(expression: t.Expression): boolean {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+
+  return (
+    t.isConditionalExpression(unwrappedExpression) &&
+    isDirectCssRuleExpression(unwrappedExpression.consequent) &&
+    isDirectCssRuleExpression(unwrappedExpression.alternate)
+  );
+}
+
+function isUnsupportedDynamicCssRuleValue(
+  expression: t.Expression,
+  isBranchExpression = false
+): boolean {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+
+  if (
+    t.isObjectExpression(unwrappedExpression) ||
+    t.isArrayExpression(unwrappedExpression)
+  ) {
+    return isBranchExpression || unwrappedExpression !== expression;
+  }
+
+  if (t.isSequenceExpression(unwrappedExpression)) {
+    return unwrappedExpression.expressions.some((sequenceExpression) =>
+      isUnsupportedDynamicCssRuleValue(sequenceExpression, true)
+    );
+  }
+
+  if (t.isConditionalExpression(unwrappedExpression)) {
+    return (
+      isUnsupportedDynamicCssRuleValue(unwrappedExpression.consequent, true) ||
+      isUnsupportedDynamicCssRuleValue(unwrappedExpression.alternate, true)
+    );
+  }
+
+  if (t.isLogicalExpression(unwrappedExpression)) {
+    return (
+      isUnsupportedDynamicCssRuleValue(unwrappedExpression.left, true) ||
+      isUnsupportedDynamicCssRuleValue(unwrappedExpression.right, true)
+    );
+  }
+
+  return false;
+}
+
+type TransparentCssRuleWrapperExpression = t.Expression & {
+  expression: t.Expression;
+};
+
+function unwrapTransparentCssRuleExpression(
+  expression: t.Expression
+): t.Expression {
+  let currentExpression = expression;
+
+  while (isTransparentCssRuleWrapperExpression(currentExpression)) {
+    currentExpression = currentExpression.expression;
+  }
+
+  return currentExpression;
+}
+
+function isTransparentCssRuleWrapperExpression(
+  expression: t.Expression
+): expression is TransparentCssRuleWrapperExpression {
+  return (
+    expression.type === "TSNonNullExpression" ||
+    expression.type === "TSAsExpression" ||
+    expression.type === "TSSatisfiesExpression" ||
+    expression.type === "ParenthesizedExpression" ||
+    expression.type === "TypeCastExpression" ||
+    expression.type === "TSTypeAssertion"
+  );
 }
 
 function getClassNameExpression(

--- a/packages/babel/src/jsxCssProp.ts
+++ b/packages/babel/src/jsxCssProp.ts
@@ -529,7 +529,7 @@ function getCssExpression(
 function classifyCssPropValue(
   expression: t.Expression
 ): CssPropValueClassification {
-  if (t.isObjectExpression(expression)) {
+  if (t.isObjectExpression(expression) || t.isArrayExpression(expression)) {
     return "css-rule";
   }
 

--- a/packages/babel/src/jsxCssProp.ts
+++ b/packages/babel/src/jsxCssProp.ts
@@ -1,6 +1,5 @@
 import { types as t } from "@babel/core";
 import type { NodePath } from "@babel/core";
-import { supportedJsxCssPropTags } from "./jsxCssPropTags.js";
 import type { PluginState } from "./types.js";
 import { registerImportMethod } from "./utils.js";
 
@@ -8,28 +7,41 @@ const cssAttributeName = "css";
 const classNameAttributeName = "className";
 const cssModuleName = "@mincho-js/css";
 
-const intrinsicElementErrorMessage =
-  "Mincho JSX css prop only supports intrinsic elements in v1";
-const supportedTagErrorMessage =
-  "Mincho JSX css prop only supports supported React DOM/SVG tags in v1";
-const spreadErrorMessage =
-  "Mincho JSX css prop does not support spreads on elements with css in v1";
+const fragmentTargetErrorMessage =
+  "Mincho JSX css prop does not support fragments because fragments cannot receive className";
+const namespacedTargetErrorMessage =
+  "Mincho JSX css prop does not support namespaced JSX elements";
+const unsupportedTargetErrorMessage =
+  "Mincho JSX css prop only supports JSX identifiers and member expressions";
+const spreadAfterCssErrorMessage =
+  "Mincho JSX css prop does not support spreads after css in compile-away mode";
+const keyRefSpreadErrorMessage =
+  "Mincho JSX css prop does not support key/ref on spread elements in compile-away mode";
+const spreadAggregationContextErrorMessage =
+  "Mincho JSX css prop spread aggregation only supports direct return or expression statement JSX in compile-away mode";
 const cssExpressionValueErrorMessage =
   "Mincho JSX css prop requires an expression value";
 const cssValueErrorMessage =
   "Mincho JSX css prop expects a Mincho CSS object/expression";
+const unsupportedFunctionCssValueErrorMessage =
+  "Mincho JSX css prop does not support function values in compile-away mode";
 const duplicateCssErrorMessage = "Mincho JSX css prop must appear only once";
 const duplicateClassNameErrorMessage =
   "Mincho JSX css prop cannot merge duplicate className attributes";
 const classNameValueErrorMessage =
   "Mincho JSX css prop requires className to be a string literal or expression";
 
+type CssPropValueClassification =
+  | "css-rule"
+  | "class-value"
+  | "unsupported-function";
+
 export function preprocessJsxCssProp(
   path: NodePath<t.Program>,
   state: PluginState
-): void {
+): boolean {
   if (state.opts.jsxCssProp !== true) {
-    return;
+    return false;
   }
 
   let transformed = false;
@@ -42,21 +54,16 @@ export function preprocessJsxCssProp(
         return;
       }
 
-      const { cssAttribute, cssExpression, classNameAttribute } =
-        normalizedElement;
+      const { cssAttribute, classNameAttribute } = normalizedElement;
+      if (normalizedElement.hasSpreadBeforeCss) {
+        transformSpreadAggregatedCssProp(openingElementPath, normalizedElement);
+        transformed = true;
+        return;
+      }
 
-      const cssIdentifier = registerImportMethod(
-        openingElementPath,
-        "css",
-        cssModuleName
-      );
-      const cssClassNameExpression = t.callExpression(cssIdentifier, [
-        t.cloneNode(cssExpression)
-      ]);
       const nextClassNameExpression = createClassNameExpression(
         openingElementPath,
-        classNameAttribute,
-        cssClassNameExpression
+        normalizedElement
       );
 
       const attributes = openingElementPath.node.attributes;
@@ -84,6 +91,8 @@ export function preprocessJsxCssProp(
   if (transformed) {
     path.scope.crawl();
   }
+
+  return transformed;
 }
 
 function normalizeOpeningElement(
@@ -91,9 +100,14 @@ function normalizeOpeningElement(
 ): {
   cssAttribute: t.JSXAttribute;
   cssExpression: t.Expression;
+  cssValueClassification: CssPropValueClassification;
   classNameAttribute: t.JSXAttribute | null;
+  attributesBeforeCss: Array<t.JSXAttribute | t.JSXSpreadAttribute>;
+  attributesAfterCss: Array<t.JSXAttribute | t.JSXSpreadAttribute>;
+  hasSpreadBeforeCss: boolean;
 } | null {
   const { node: openingElement } = openingElementPath;
+  const { attributes } = openingElement;
   const cssAttributes = getJsxAttributes(openingElement, cssAttributeName);
 
   if (cssAttributes.length === 0) {
@@ -102,16 +116,30 @@ function normalizeOpeningElement(
 
   assertSupportedCssPropElement(openingElementPath);
 
-  if (
-    openingElement.attributes.some((attribute) =>
-      t.isJSXSpreadAttribute(attribute)
-    )
-  ) {
-    throw openingElementPath.buildCodeFrameError(spreadErrorMessage);
-  }
-
   if (cssAttributes.length > 1) {
     throw openingElementPath.buildCodeFrameError(duplicateCssErrorMessage);
+  }
+
+  const cssAttribute = cssAttributes[0];
+  const cssAttributeIndex = attributes.indexOf(cssAttribute);
+  const attributesBeforeCss = attributes.slice(0, cssAttributeIndex);
+  const attributesAfterCss = attributes.slice(cssAttributeIndex + 1);
+  const hasSpreadBeforeCss = attributesBeforeCss.some((attribute) =>
+    t.isJSXSpreadAttribute(attribute)
+  );
+
+  if (
+    attributesAfterCss.some((attribute) => t.isJSXSpreadAttribute(attribute))
+  ) {
+    throw openingElementPath.buildCodeFrameError(spreadAfterCssErrorMessage);
+  }
+
+  if (hasSpreadBeforeCss && hasExplicitKeyOrRefAttribute(attributes)) {
+    throw openingElementPath.buildCodeFrameError(keyRefSpreadErrorMessage);
+  }
+
+  if (hasSpreadBeforeCss) {
+    assertSupportedSpreadAggregationContext(openingElementPath);
   }
 
   const classNameAttributes = getJsxAttributes(
@@ -125,13 +153,23 @@ function normalizeOpeningElement(
     );
   }
 
-  const cssAttribute = cssAttributes[0];
   const cssExpression = getCssExpression(openingElementPath, cssAttribute);
+  const cssValueClassification = classifyCssPropValue(cssExpression);
+
+  if (cssValueClassification === "unsupported-function") {
+    throw openingElementPath.buildCodeFrameError(
+      unsupportedFunctionCssValueErrorMessage
+    );
+  }
 
   return {
     cssAttribute,
     cssExpression,
-    classNameAttribute: classNameAttributes[0] ?? null
+    cssValueClassification,
+    classNameAttribute: classNameAttributes[0] ?? null,
+    attributesBeforeCss,
+    attributesAfterCss,
+    hasSpreadBeforeCss
   };
 }
 
@@ -140,41 +178,294 @@ function assertSupportedCssPropElement(
 ): void {
   const { name } = openingElementPath.node;
 
-  if (!t.isJSXIdentifier(name)) {
-    throw openingElementPath.buildCodeFrameError(intrinsicElementErrorMessage);
+  if (t.isJSXNamespacedName(name)) {
+    throw openingElementPath.buildCodeFrameError(namespacedTargetErrorMessage);
   }
 
-  if (supportedJsxCssPropTags.has(name.name)) {
+  if (isFragmentTarget(name)) {
+    throw openingElementPath.buildCodeFrameError(fragmentTargetErrorMessage);
+  }
+
+  if (t.isJSXIdentifier(name) || t.isJSXMemberExpression(name)) {
     return;
   }
 
-  if (isCustomComponentTagName(name.name)) {
-    throw openingElementPath.buildCodeFrameError(intrinsicElementErrorMessage);
-  }
-
-  throw openingElementPath.buildCodeFrameError(supportedTagErrorMessage);
+  throw openingElementPath.buildCodeFrameError(unsupportedTargetErrorMessage);
 }
 
-function isCustomComponentTagName(tagName: string): boolean {
-  return /^[A-Z]/.test(tagName);
+function isFragmentTarget(name: t.JSXOpeningElement["name"]): boolean {
+  return (
+    (t.isJSXIdentifier(name) && name.name === "Fragment") ||
+    (t.isJSXMemberExpression(name) &&
+      t.isJSXIdentifier(name.object) &&
+      name.object.name === "React" &&
+      name.property.name === "Fragment")
+  );
 }
 
 function createClassNameExpression(
   path: NodePath<t.JSXOpeningElement>,
-  classNameAttribute: t.JSXAttribute | null,
-  cssClassNameExpression: t.Expression
+  normalizedElement: {
+    cssExpression: t.Expression;
+    cssValueClassification: CssPropValueClassification;
+    classNameAttribute: t.JSXAttribute | null;
+    aggregateClassNameExpression?: t.Expression;
+  }
 ): t.Expression {
-  if (!classNameAttribute) {
+  const cssClassNameExpression = createCssClassNameExpression(
+    path,
+    normalizedElement.cssExpression,
+    normalizedElement.cssValueClassification
+  );
+
+  if (
+    !normalizedElement.aggregateClassNameExpression &&
+    !normalizedElement.classNameAttribute &&
+    normalizedElement.cssValueClassification === "css-rule"
+  ) {
     return cssClassNameExpression;
   }
 
-  const classNameExpression = getClassNameExpression(path, classNameAttribute);
   const cxIdentifier = registerImportMethod(path, "cx", cssModuleName);
 
+  if (
+    !normalizedElement.aggregateClassNameExpression &&
+    !normalizedElement.classNameAttribute
+  ) {
+    return t.callExpression(cxIdentifier, [cssClassNameExpression]);
+  }
+
+  const classNameExpressions = [];
+
+  if (normalizedElement.aggregateClassNameExpression) {
+    classNameExpressions.push(
+      t.cloneNode(normalizedElement.aggregateClassNameExpression)
+    );
+  }
+
+  if (normalizedElement.classNameAttribute) {
+    classNameExpressions.push(
+      getClassNameExpression(path, normalizedElement.classNameAttribute)
+    );
+  }
+
   return t.callExpression(cxIdentifier, [
-    classNameExpression,
+    ...classNameExpressions,
     cssClassNameExpression
   ]);
+}
+
+function transformSpreadAggregatedCssProp(
+  path: NodePath<t.JSXOpeningElement>,
+  normalizedElement: {
+    cssAttribute: t.JSXAttribute;
+    cssExpression: t.Expression;
+    cssValueClassification: CssPropValueClassification;
+    classNameAttribute: t.JSXAttribute | null;
+    attributesBeforeCss: Array<t.JSXAttribute | t.JSXSpreadAttribute>;
+    attributesAfterCss: Array<t.JSXAttribute | t.JSXSpreadAttribute>;
+  }
+): void {
+  const aggregateIdentifier = path.scope.generateUidIdentifier("minchoProps");
+  const cssPropIdentifier = path.scope.generateUidIdentifier("minchoCssProp");
+  const classNameIdentifier =
+    path.scope.generateUidIdentifier("minchoClassName");
+  const restIdentifier = path.scope.generateUidIdentifier("minchoRest");
+  const statementPath = path.getStatementParent();
+
+  if (!statementPath) {
+    throw path.buildCodeFrameError(
+      "Mincho JSX css prop could not find a statement for spread aggregation"
+    );
+  }
+
+  statementPath.insertBefore([
+    t.variableDeclaration("const", [
+      t.variableDeclarator(
+        t.cloneNode(aggregateIdentifier),
+        createAggregatePropsExpression(
+          path,
+          normalizedElement.attributesBeforeCss
+        )
+      )
+    ]),
+    t.variableDeclaration("const", [
+      t.variableDeclarator(
+        t.objectPattern([
+          t.objectProperty(
+            t.identifier(cssAttributeName),
+            t.cloneNode(cssPropIdentifier)
+          ),
+          t.objectProperty(
+            t.identifier(classNameAttributeName),
+            t.cloneNode(classNameIdentifier)
+          ),
+          t.restElement(t.cloneNode(restIdentifier))
+        ]),
+        t.cloneNode(aggregateIdentifier)
+      )
+    ])
+  ]);
+
+  const classNameAttributeAfterCss = normalizedElement.attributesAfterCss.find(
+    (attribute) => isNamedJsxAttribute(attribute, classNameAttributeName)
+  );
+  const nextClassNameExpression = createClassNameExpression(path, {
+    cssExpression: normalizedElement.cssExpression,
+    cssValueClassification: normalizedElement.cssValueClassification,
+    classNameAttribute: t.isJSXAttribute(classNameAttributeAfterCss)
+      ? classNameAttributeAfterCss
+      : null,
+    aggregateClassNameExpression: t.cloneNode(classNameIdentifier)
+  });
+  const nextAttributes: Array<t.JSXAttribute | t.JSXSpreadAttribute> = [
+    t.jsxSpreadAttribute(t.cloneNode(restIdentifier)),
+    t.jsxAttribute(
+      t.jsxIdentifier(classNameAttributeName),
+      t.jsxExpressionContainer(nextClassNameExpression)
+    ),
+    ...normalizedElement.attributesAfterCss.filter(
+      (attribute) => !isNamedJsxAttribute(attribute, classNameAttributeName)
+    )
+  ];
+
+  path.node.attributes = nextAttributes;
+}
+
+function assertSupportedSpreadAggregationContext(
+  path: NodePath<t.JSXOpeningElement>
+): void {
+  const jsxElementPath = path.parentPath;
+
+  if (!jsxElementPath.isJSXElement()) {
+    throw path.buildCodeFrameError(spreadAggregationContextErrorMessage);
+  }
+
+  const expressionParentPath = jsxElementPath.parentPath;
+
+  if (
+    expressionParentPath.isReturnStatement() &&
+    expressionParentPath.node.argument === jsxElementPath.node
+  ) {
+    assertStatementListParent(path, expressionParentPath);
+    return;
+  }
+
+  if (
+    expressionParentPath.isExpressionStatement() &&
+    expressionParentPath.node.expression === jsxElementPath.node
+  ) {
+    assertStatementListParent(path, expressionParentPath);
+    return;
+  }
+
+  throw path.buildCodeFrameError(spreadAggregationContextErrorMessage);
+}
+
+function assertStatementListParent(
+  sourcePath: NodePath<t.JSXOpeningElement>,
+  statementPath: NodePath<t.Node>
+): void {
+  const statementParentPath = statementPath.parentPath;
+
+  if (!statementParentPath) {
+    throw sourcePath.buildCodeFrameError(spreadAggregationContextErrorMessage);
+  }
+
+  if (
+    statementParentPath.isProgram() ||
+    statementParentPath.isBlockStatement() ||
+    statementParentPath.isSwitchCase()
+  ) {
+    return;
+  }
+
+  throw sourcePath.buildCodeFrameError(spreadAggregationContextErrorMessage);
+}
+
+function createAggregatePropsExpression(
+  path: NodePath<t.JSXOpeningElement>,
+  attributes: Array<t.JSXAttribute | t.JSXSpreadAttribute>
+): t.ObjectExpression {
+  return t.objectExpression(
+    attributes.map((attribute) => {
+      if (t.isJSXSpreadAttribute(attribute)) {
+        return t.spreadElement(t.cloneNode(attribute.argument));
+      }
+
+      return createAggregateObjectProperty(path, attribute);
+    })
+  );
+}
+
+function createAggregateObjectProperty(
+  path: NodePath<t.JSXOpeningElement>,
+  attribute: t.JSXAttribute
+): t.ObjectProperty {
+  return t.objectProperty(
+    createObjectPropertyKey(attribute.name),
+    getAggregateAttributeValue(path, attribute)
+  );
+}
+
+function createObjectPropertyKey(
+  name: t.JSXAttribute["name"]
+): t.Identifier | t.StringLiteral {
+  if (t.isJSXNamespacedName(name)) {
+    return t.stringLiteral(`${name.namespace.name}:${name.name.name}`);
+  }
+
+  if (t.isValidIdentifier(name.name)) {
+    return t.identifier(name.name);
+  }
+
+  return t.stringLiteral(name.name);
+}
+
+function getAggregateAttributeValue(
+  path: NodePath<t.JSXOpeningElement>,
+  attribute: t.JSXAttribute
+): t.Expression {
+  if (isNamedJsxAttribute(attribute, classNameAttributeName)) {
+    return getClassNameExpression(path, attribute);
+  }
+
+  if (attribute.value === null) {
+    return t.booleanLiteral(true);
+  }
+
+  if (t.isStringLiteral(attribute.value)) {
+    return t.cloneNode(attribute.value);
+  }
+
+  if (t.isJSXExpressionContainer(attribute.value)) {
+    const { expression } = attribute.value;
+
+    if (t.isJSXEmptyExpression(expression)) {
+      throw path.buildCodeFrameError(classNameValueErrorMessage);
+    }
+
+    return t.cloneNode(expression);
+  }
+
+  if (t.isJSXElement(attribute.value) || t.isJSXFragment(attribute.value)) {
+    return t.cloneNode(attribute.value);
+  }
+
+  throw path.buildCodeFrameError(classNameValueErrorMessage);
+}
+
+function createCssClassNameExpression(
+  path: NodePath<t.JSXOpeningElement>,
+  cssExpression: t.Expression,
+  cssValueClassification: CssPropValueClassification
+): t.Expression {
+  if (cssValueClassification === "css-rule") {
+    const cssIdentifier = registerImportMethod(path, "css", cssModuleName);
+    return t.callExpression(cssIdentifier, [t.cloneNode(cssExpression)]);
+  }
+
+  return t.cloneNode(cssExpression);
 }
 
 function getJsxAttributes(
@@ -189,12 +480,37 @@ function getJsxAttributes(
   );
 }
 
+function isNamedJsxAttribute(
+  attribute: t.JSXAttribute | t.JSXSpreadAttribute,
+  attributeName: string
+): boolean {
+  return (
+    t.isJSXAttribute(attribute) &&
+    t.isJSXIdentifier(attribute.name) &&
+    attribute.name.name === attributeName
+  );
+}
+
+function hasExplicitKeyOrRefAttribute(
+  attributes: Array<t.JSXAttribute | t.JSXSpreadAttribute>
+): boolean {
+  return attributes.some(
+    (attribute) =>
+      isNamedJsxAttribute(attribute, "key") ||
+      isNamedJsxAttribute(attribute, "ref")
+  );
+}
+
 function getCssExpression(
   path: NodePath<t.JSXOpeningElement>,
   attribute: t.JSXAttribute
 ): t.Expression {
   if (attribute.value === null) {
     throw path.buildCodeFrameError(cssExpressionValueErrorMessage);
+  }
+
+  if (t.isStringLiteral(attribute.value)) {
+    return attribute.value;
   }
 
   if (!t.isJSXExpressionContainer(attribute.value)) {
@@ -207,23 +523,24 @@ function getCssExpression(
     throw path.buildCodeFrameError(cssExpressionValueErrorMessage);
   }
 
-  if (isUnsupportedCssExpression(expression)) {
-    throw path.buildCodeFrameError(cssValueErrorMessage);
-  }
-
   return expression;
 }
 
-function isUnsupportedCssExpression(expression: t.Expression): boolean {
-  return (
-    t.isTemplateLiteral(expression) ||
-    t.isStringLiteral(expression) ||
-    t.isNumericLiteral(expression) ||
-    t.isBooleanLiteral(expression) ||
-    t.isNullLiteral(expression) ||
+function classifyCssPropValue(
+  expression: t.Expression
+): CssPropValueClassification {
+  if (t.isObjectExpression(expression)) {
+    return "css-rule";
+  }
+
+  if (
     t.isFunctionExpression(expression) ||
     t.isArrowFunctionExpression(expression)
-  );
+  ) {
+    return "unsupported-function";
+  }
+
+  return "class-value";
 }
 
 function getClassNameExpression(

--- a/packages/babel/src/types.ts
+++ b/packages/babel/src/types.ts
@@ -4,6 +4,7 @@ import type { Scope } from "@babel/traverse";
 export interface PluginOptions {
   result: [string, string];
   jsxCssProp?: boolean;
+  jsxCssPropTransformed?: boolean;
 }
 
 export interface PluginState extends PluginPass {

--- a/packages/css/src/classname/cx.ts
+++ b/packages/css/src/classname/cx.ts
@@ -118,6 +118,14 @@ if (import.meta.vitest) {
       expect(cx("foo", undefined, "baz")).toBe("foo baz");
     });
 
+    it("handles direct runtime fallback expressions", () => {
+      const providedClass = "";
+      const maybeClass = null;
+
+      expect(cx("base", providedClass || "fallback")).toBe("base fallback");
+      expect(cx("base", maybeClass ?? "fallback")).toBe("base fallback");
+    });
+
     it("handles object inputs", () => {
       expect(cx({ foo: true, bar: false, baz: true })).toBe("foo baz");
       expect(cx({ foo: true })).toBe("foo");

--- a/packages/css/src/classname/index.ts
+++ b/packages/css/src/classname/index.ts
@@ -1,3 +1,3 @@
 export { cx } from "./cx.js";
 
-export type { ClassValue, Cx } from "./types.js";
+export type { ClassPrimitive, ClassValue, Cx } from "./types.js";

--- a/packages/css/src/classname/types.ts
+++ b/packages/css/src/classname/types.ts
@@ -31,7 +31,7 @@ type ClassIgnored = true | bigint;
 /**
  * All primitive values
  */
-type ClassPrimitive = ClassStringable | ClassFalsy | ClassIgnored;
+export type ClassPrimitive = ClassStringable | ClassFalsy | ClassIgnored;
 
 // -- Composite Types (complex values, processed recursively) ------------------
 /**

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -65,7 +65,7 @@ export type {
   ResolveTheme
 } from "./theme/types.js";
 export { cx } from "./classname/index.js";
-export type { ClassValue, Cx } from "./classname/index.js";
+export type { ClassPrimitive, ClassValue, Cx } from "./classname/index.js";
 export { defineRules } from "./defineRules/index.js";
 export type {
   DefineRulesComplexCssInput,

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -561,23 +561,58 @@ if (import.meta.vitest) {
     };
   }
 
-  async function createJsxCssPropFixture(prefix: string) {
+  function createJsxCssPropFixtureSource(): string {
+    return `
+      function App() {
+        return <div className="base" css={{ color: "red" }} />;
+      }
+    `;
+  }
+
+  function createJsxCssPropV2ClassValueFixtureSource(): string {
+    return `
+      const styleA = "style-a";
+      const styleB = ["style-b"];
+      const spreadProps = {
+        className: "from-spread",
+        css: "leaked-css",
+        id: "root"
+      };
+      const motion = { div: "div" };
+
+      function Button(props) {
+        return <button {...props} />;
+      }
+
+      function App() {
+        return <>
+          <Button css={styleA} />
+          <motion.div css={styleB} />
+        </>;
+      }
+
+      function SpreadApp() {
+        return <div {...spreadProps} css={styleA} />;
+      }
+    `;
+  }
+
+  async function createJsxCssPropFixture(
+    prefix: string,
+    source = createJsxCssPropFixtureSource()
+  ) {
     const cacheRoot = join(process.cwd(), "packages/esbuild/.cache");
     await fs.promises.mkdir(cacheRoot, { recursive: true });
     const root = await fs.promises.mkdtemp(join(cacheRoot, prefix));
     const srcRoot = join(root, "src");
     const entryPath = join(srcRoot, "entry.tsx");
-    const source = `
-      function App() {
-        return <div className="base" css={{ color: "red" }} />;
-      }
-    `;
     await fs.promises.mkdir(srcRoot, { recursive: true });
     await fs.promises.writeFile(entryPath, source, "utf8");
 
     return {
       entryPath,
-      root
+      root,
+      source
     };
   }
 
@@ -862,6 +897,42 @@ if (import.meta.vitest) {
     };
   }
 
+  function extractCxIdentifierFromSource(source: string): string {
+    const cxImportMatch =
+      /import \{ [^}]*\bcx(?: as ([A-Za-z_$][\w$]*))?[^}]*\} from "@mincho-js\/css";/.exec(
+        source
+      );
+
+    if (cxImportMatch == null) {
+      throw new Error("Expected transformed source to import cx");
+    }
+
+    return cxImportMatch[1] ?? "cx";
+  }
+
+  function expectSourceToContainV2ClassValueCssPropLowering(
+    source: string,
+    cxIdentifier: string
+  ): void {
+    expect(source).toMatch(
+      new RegExp(
+        `<Button className=\\{${escapeRegExp(cxIdentifier)}\\(styleA\\)\\} />`
+      )
+    );
+    expect(source).toMatch(
+      new RegExp(
+        `<motion\\.div className=\\{${escapeRegExp(cxIdentifier)}\\(styleB\\)\\} />`
+      )
+    );
+    expect(source).toContain("css: _minchoCssProp");
+    expect(source).toContain("..._minchoRest");
+    expect(source).toMatch(
+      new RegExp(
+        `className=\\{${escapeRegExp(cxIdentifier)}\\(_minchoClassName, styleA\\)\\}`
+      )
+    );
+  }
+
   function createDeferred<Value>() {
     let resolve!: (value: Value | PromiseLike<Value>) => void;
     let reject!: (reason?: unknown) => void;
@@ -993,17 +1064,55 @@ if (import.meta.vitest) {
       }
     });
 
+    it("lowers v2 class-value component and pre-css spread css props with jsxCssProp enabled", async () => {
+      const { entryPath, root } = await createJsxCssPropFixture(
+        "jsx-css-prop-v2-class-value-",
+        createJsxCssPropV2ClassValueFixtureSource()
+      );
+      const babelTransformSpy = vi.spyOn(integrationHelpers, "babelTransform");
+
+      try {
+        const harness = createBuildHarness({
+          plugin: minchoEsbuildPlugin({ jsxCssProp: true })
+        });
+        const scriptLoadResult = (await harness.loadScript({
+          path: entryPath
+        })) as ScriptLoadResult;
+        const cxIdentifier = extractCxIdentifierFromSource(
+          scriptLoadResult.contents
+        );
+        const missingResolveResult = await harness.resolveExtractedCss({
+          path: "extracted_missing.css.ts",
+          importer: entryPath,
+          pluginData: scriptLoadResult.pluginData
+        });
+
+        expect(babelTransformSpy).toHaveBeenCalledWith(entryPath, {
+          jsxCssProp: true
+        });
+        expect(scriptLoadResult.loader).toBe("tsx");
+        expect(scriptLoadResult.contents).not.toContain(" css=");
+        expect(scriptLoadResult.contents).not.toContain("css={styleA}");
+        expect(scriptLoadResult.contents).not.toContain("css={styleB}");
+        expect(scriptLoadResult.contents).not.toContain("css(styleA)");
+        expect(scriptLoadResult.contents).not.toContain("_css(styleA)");
+        expectSourceToContainV2ClassValueCssPropLowering(
+          scriptLoadResult.contents,
+          cxIdentifier
+        );
+        expect(missingResolveResult).toBeUndefined();
+      } finally {
+        await fs.promises.rm(root, { force: true, recursive: true });
+      }
+    });
+
     it("forwards jsxCssProp through the exported plugin array", async () => {
       const { entryPath, root } = await createJsxCssPropFixture(
-        "jsx-css-prop-plugin-array-"
+        "jsx-css-prop-plugin-array-",
+        createJsxCssPropV2ClassValueFixtureSource()
       );
       const minchoPlugin = minchoEsbuildPlugins({ jsxCssProp: true })[0];
-      const babelTransformSpy = vi
-        .spyOn(integrationHelpers, "babelTransform")
-        .mockResolvedValue({
-          code: "export const app = {};",
-          result: ["", ""]
-        });
+      const babelTransformSpy = vi.spyOn(integrationHelpers, "babelTransform");
 
       if (minchoPlugin == null) {
         throw new Error(
@@ -1013,11 +1122,21 @@ if (import.meta.vitest) {
 
       try {
         const harness = createBuildHarness({ plugin: minchoPlugin });
-        await harness.loadScript({ path: entryPath });
+        const scriptLoadResult = (await harness.loadScript({
+          path: entryPath
+        })) as ScriptLoadResult;
+        const cxIdentifier = extractCxIdentifierFromSource(
+          scriptLoadResult.contents
+        );
 
         expect(babelTransformSpy).toHaveBeenCalledWith(entryPath, {
           jsxCssProp: true
         });
+        expect(scriptLoadResult.contents).not.toContain(" css=");
+        expectSourceToContainV2ClassValueCssPropLowering(
+          scriptLoadResult.contents,
+          cxIdentifier
+        );
       } finally {
         await fs.promises.rm(root, { force: true, recursive: true });
       }

--- a/packages/integration/src/babel.ts
+++ b/packages/integration/src/babel.ts
@@ -17,7 +17,16 @@ export type BabelOptions = Omit<
   jsxCssProp?: boolean;
 };
 
-export async function babelTransform(path: string, babel: BabelOptions = {}) {
+export type BabelTransformResult = {
+  code: string;
+  readonly jsxCssPropTransformed?: boolean;
+  result: [string, string];
+};
+
+export async function babelTransform(
+  path: string,
+  babel: BabelOptions = {}
+): Promise<BabelTransformResult> {
   const { jsxCssProp = false, ...babelCoreOptions } = babel;
   const options: PluginOptions & { jsxCssProp?: boolean } = {
     result: ["", ""],
@@ -45,7 +54,11 @@ export async function babelTransform(path: string, babel: BabelOptions = {}) {
     throw new Error(`Failed to transform ${path}`);
   }
 
-  return { result: options.result, code: result.code };
+  return {
+    result: options.result,
+    code: result.code,
+    jsxCssPropTransformed: options.jsxCssPropTransformed === true
+  };
 }
 
 // == Tests ====================================================================
@@ -144,6 +157,79 @@ if (import.meta.vitest) {
       expect(code).not.toContain(" css=");
       expect(code).not.toContain("css={{");
       expect(code).not.toContain('color: "red"');
+    });
+
+    it("keeps class-value css props on the cx path without double wrapping", async () => {
+      const fixturePath = await createBabelFixture(
+        `
+          import { css } from "@mincho-js/css";
+
+          const styleA = css({ color: "blue" });
+
+          function App() {
+            return <>
+              <div className="base" css={{ color: "red" }} />
+              <div css={styleA} />
+              <div css="literal-class" />
+            </>;
+          }
+        `,
+        "css-prop-v2-classification"
+      );
+      const { result, code } = await babelTransform(fixturePath, {
+        jsxCssProp: true
+      });
+      const [sidecarFile, sidecarSource] = result;
+      const exportedDeclarations = sidecarSource.match(/export var/g) ?? [];
+      const cxImportMatch =
+        /import \{ [^}]*\bcx(?: as ([A-Za-z_$][\w$]*))?[^}]*\} from "@mincho-js\/css";/.exec(
+          code
+        );
+      const cxIdentifier = cxImportMatch?.[1] ?? "cx";
+
+      expect(sidecarFile).toMatch(/^extracted_[a-z0-9]+\.css\.ts$/);
+      expect(exportedDeclarations).toHaveLength(2);
+      expect(sidecarSource).toMatch(
+        /export var [A-Za-z_$][\w$]* = [A-Za-z_$][\w$]*\(\{\s*color: "blue"\s*\}\);/s
+      );
+      expect(sidecarSource).toMatch(
+        /export var [A-Za-z_$][\w$]* = [A-Za-z_$][\w$]*\(\{\s*color: "red"\s*\}\);/s
+      );
+      expect(sidecarSource).not.toMatch(/\bcss\(styleA\)/);
+      expect(sidecarSource).not.toMatch(
+        /export var [A-Za-z_$][\w$]* = [A-Za-z_$][\w$]*cx\(/s
+      );
+      expect(cxImportMatch).not.toBeNull();
+      expect(code).not.toContain(" css=");
+      expect(code).not.toContain("css={styleA}");
+      expect(code).not.toContain("css(styleA)");
+      expect(code).not.toContain("_css(styleA)");
+      expect(code).toMatch(
+        new RegExp(`className=\\{${escapeRegExp(cxIdentifier)}\\(styleA\\)\\}`)
+      );
+      expect(code).toMatch(
+        new RegExp(
+          `className=\\{${escapeRegExp(cxIdentifier)}\\("literal-class"\\)\\}`
+        )
+      );
+    });
+
+    it("leaves jsx css prop lowering disabled by default", async () => {
+      const fixturePath = await createBabelFixture(
+        `
+          function App() {
+            return <div className="base" css={{ color: "red" }} />;
+          }
+        `,
+        "css-prop-disabled-default"
+      );
+      const { result, code } = await babelTransform(fixturePath);
+
+      expect(result[1]).toBe("");
+      expect(code).toContain('className="base"');
+      expect(code).toContain("css={{");
+      expect(code).toContain('color: "red"');
+      expect(code).not.toContain("extracted_");
     });
   });
 }

--- a/packages/integration/src/babel.ts
+++ b/packages/integration/src/babel.ts
@@ -159,18 +159,31 @@ if (import.meta.vitest) {
       expect(code).not.toContain('color: "red"');
     });
 
-    it("keeps class-value css props on the cx path without double wrapping", async () => {
+    it("lowers bare string css props directly and dynamic values through cx", async () => {
       const fixturePath = await createBabelFixture(
         `
           import { css } from "@mincho-js/css";
 
           const styleA = css({ color: "blue" });
+          const condition = true;
+          const flag = false;
+          const providedClass = "provided";
+          const maybeClass = null;
+
+          function getClassName() {
+            return "call-class";
+          }
 
           function App() {
             return <>
               <div className="base" css={{ color: "red" }} />
               <div css={styleA} />
               <div css="literal-class" />
+              <div css={condition ? "active" : "inactive"} />
+              <div css={flag && "active"} />
+              <div css={providedClass || "fallback"} />
+              <div css={maybeClass ?? "fallback"} />
+              <div css={getClassName()} />
             </>;
           }
         `,
@@ -207,11 +220,136 @@ if (import.meta.vitest) {
       expect(code).toMatch(
         new RegExp(`className=\\{${escapeRegExp(cxIdentifier)}\\(styleA\\)\\}`)
       );
+      expect(code).toContain('className="literal-class"');
       expect(code).toMatch(
         new RegExp(
-          `className=\\{${escapeRegExp(cxIdentifier)}\\("literal-class"\\)\\}`
+          `className=\\{${escapeRegExp(cxIdentifier)}\\(${escapeRegExp(
+            'condition ? "active" : "inactive"'
+          )}\\)\\}`
         )
       );
+      expect(code).toMatch(
+        new RegExp(
+          `className=\\{${escapeRegExp(cxIdentifier)}\\(${escapeRegExp(
+            'flag && "active"'
+          )}\\)\\}`
+        )
+      );
+      expect(code).toMatch(
+        new RegExp(
+          `className=\\{${escapeRegExp(cxIdentifier)}\\(${escapeRegExp(
+            'providedClass || "fallback"'
+          )}\\)\\}`
+        )
+      );
+      expect(code).toMatch(
+        new RegExp(
+          `className=\\{${escapeRegExp(cxIdentifier)}\\(${escapeRegExp(
+            'maybeClass ?? "fallback"'
+          )}\\)\\}`
+        )
+      );
+      expect(code).toMatch(
+        new RegExp(
+          `className=\\{${escapeRegExp(cxIdentifier)}\\(${escapeRegExp(
+            "getClassName()"
+          )}\\)\\}`
+        )
+      );
+    });
+
+    it("lowers representative logical css rule branches", async () => {
+      const fixturePath = await createBabelFixture(
+        `
+          const providedClass = "provided";
+          const maybeClass = null;
+          const andClass = "and-class";
+
+          function App() {
+            return <>
+              <div css={providedClass || { color: "red" }} />
+              <div css={maybeClass ?? [{ color: "green" }]} />
+              <div css={{ color: "blue" } || unreachableClass} />
+              <div css={{ color: "yellow" } && andClass} />
+              <div css={{ color: "purple" } && { color: "orange" }} />
+            </>;
+          }
+        `,
+        "css-prop-logical-rule-branches"
+      );
+      const { result, code } = await babelTransform(fixturePath, {
+        jsxCssProp: true
+      });
+      const [sidecarFile, sidecarSource] = result;
+      const exportedDeclarations = sidecarSource.match(/export var/g) ?? [];
+      const sidecarImportMatch = new RegExp(
+        `import \\{ ([^}]+) \\} from "${escapeRegExp(sidecarFile)}";`
+      ).exec(code);
+      const sidecarRuntimeNames = [
+        ...((sidecarImportMatch?.[1] ?? "").matchAll(
+          /(?:^|, )([A-Za-z_$][\w$]*)(?: as ([A-Za-z_$][\w$]*))?/g
+        ) ?? [])
+      ].map(([, importedName, localName]) => localName ?? importedName);
+      const cxImportMatch =
+        /import \{ [^}]*\bcx(?: as ([A-Za-z_$][\w$]*))?[^}]*\} from "@mincho-js\/css";/.exec(
+          code
+        );
+      const cxIdentifier = cxImportMatch?.[1] ?? "cx";
+      const rightOrClassNameMatch = new RegExp(
+        `className=\\{${escapeRegExp(
+          cxIdentifier
+        )}\\(providedClass \\|\\| ([A-Za-z_$][\\w$]*)\\)\\}`
+      ).exec(code);
+      const rightNullishClassNameMatch = new RegExp(
+        `className=\\{${escapeRegExp(
+          cxIdentifier
+        )}\\(maybeClass \\?\\? ([A-Za-z_$][\\w$]*)\\)\\}`
+      ).exec(code);
+      const generatedOnlyClassNameMatches = [
+        ...code.matchAll(/className=\{([A-Za-z_$][\w$]*)\}/g)
+      ];
+      const orangeCssMatches = [...sidecarSource.matchAll(/color: "orange"/g)];
+
+      expect(sidecarFile).toMatch(/^extracted_[a-z0-9]+\.css\.ts$/);
+      expect(sidecarImportMatch).not.toBeNull();
+      expect(cxImportMatch).not.toBeNull();
+      expect(exportedDeclarations).toHaveLength(4);
+      expect(sidecarSource).toMatch(
+        /export var [A-Za-z_$][\w$]* = [A-Za-z_$][\w$]*\(\{\s*color: "red"\s*\}\);/s
+      );
+      expect(sidecarSource).toMatch(
+        /export var [A-Za-z_$][\w$]* = [A-Za-z_$][\w$]*\(\[\{\s*color: "green"\s*\}\]\);/s
+      );
+      expect(sidecarSource).toMatch(
+        /export var [A-Za-z_$][\w$]* = [A-Za-z_$][\w$]*\(\{\s*color: "blue"\s*\}\);/s
+      );
+      expect(sidecarSource).toMatch(
+        /export var [A-Za-z_$][\w$]* = [A-Za-z_$][\w$]*\(\{\s*color: "orange"\s*\}\);/s
+      );
+      expect(orangeCssMatches).toHaveLength(1);
+      expect(code).not.toContain(" css=");
+      expect(rightOrClassNameMatch).not.toBeNull();
+      expect(rightNullishClassNameMatch).not.toBeNull();
+      expect(sidecarRuntimeNames).toContain(rightOrClassNameMatch?.[1]);
+      expect(sidecarRuntimeNames).toContain(rightNullishClassNameMatch?.[1]);
+      expect(
+        generatedOnlyClassNameMatches.some(([, className]) =>
+          sidecarRuntimeNames.includes(className)
+        )
+      ).toBe(true);
+      expect(
+        generatedOnlyClassNameMatches.filter(([, className]) =>
+          sidecarRuntimeNames.includes(className)
+        )
+      ).toHaveLength(2);
+      expect(code).toMatch(
+        new RegExp(
+          `className=\\{${escapeRegExp(cxIdentifier)}\\(andClass\\)\\}`
+        )
+      );
+      expect(`${code}\n${sidecarSource}`).not.toContain("unreachableClass");
+      expect(`${code}\n${sidecarSource}`).not.toContain('color: "yellow"');
+      expect(`${code}\n${sidecarSource}`).not.toContain('color: "purple"');
     });
 
     it("leaves jsx css prop lowering disabled by default", async () => {

--- a/packages/integration/src/index.ts
+++ b/packages/integration/src/index.ts
@@ -1,4 +1,8 @@
-export { babelTransform, type BabelOptions } from "./babel.js";
+export {
+  babelTransform,
+  type BabelOptions,
+  type BabelTransformResult
+} from "./babel.js";
 export { compile } from "./compile.js";
 export {
   processDefineRulesPresetRegistryFile,

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -66,12 +66,82 @@ With `jsxCssProp: true`, supported values are lowered to either the existing Min
 
 The scoped React JSX types define the `css` prop value as `ComplexCSSRule | ClassValue`.
 
-- Inline object expressions are CSS-rule mode through `css(...)`, so `<div css={{ color: "red" }} />` extracts a Mincho CSS rule. Inline object class dictionaries are not supported in this position; assign a `ClassValue` to an identifier, call, member expression, conditional, or literal value instead.
-- Inline array expressions are also CSS-rule mode through `css([...])`, so `<div css={[baseClass, { color: "red" }]} />` composes class names and CSS rule objects through Mincho's `ComplexCSSRule` path.
-- Identifiers, calls, member expressions, conditionals, strings, numbers, booleans, `null`, and `undefined` are class-value mode through `cx(...)` semantics. This is the migration path for existing Mincho class values: `const styleA = css(...); <div css={styleA} />`.
+- Inline object expressions are CSS-rule mode through `css(...)`, so `<div css={{ color: "red" }} />` extracts a Mincho CSS rule. Transparent direct wrappers keep that mode, including `<div css={{ color: "red" }!} />`, `<div css={{ color: "red" } as const} />`, `<div css={{ color: "red" } satisfies ComplexCSSRule} />`, and `<div css={({ color: "red" })} />`.
+- Inline array expressions are also CSS-rule mode through `css([...])`, so `<div css={[baseClass, { color: "red" }]} />` composes class names and CSS rule objects through Mincho's `ComplexCSSRule` path. Transparent direct array wrappers are supported too, for example `<div css={[{ color: "red" }] as const} />` and `<div css={([{ color: "red" }])} />`.
+- All dynamic class values lower through `cx(...)`. This includes identifiers, members, calls, conditionals, logicals, non-string literals, template literals, and explicit `cx(...)` calls. This is the migration path for existing Mincho class values: `const styleA = css(...); <div css={styleA} />`.
 - Class-value arrays must be explicit, for example `<div css={cx(["base", active && "active"])} />`, or assigned to an identifier before being passed to `css`.
-- Strings are class values, not raw CSS declarations. `css="base"` means `cx("base")`, not a serialized CSS body.
+- Strings are class values, not raw CSS declarations. Bare string-literal class values such as `<div css="base" />` and `<div css={"base"} />` lower directly to `className="base"` without `cx(...)` when no explicit `className` or spread-derived `className` must be merged.
+- If an explicit `className` or pre-css spread aggregate contributes an existing class, string-literal class values still merge through `cx(existing, cssValue)` with the existing class first.
 - Function values are unsupported in compile-away mode.
+
+Supported expression-valued `css` props are class values and lower through `cx(...)`:
+
+```tsx
+<div css={condition ? "panel active" : "panel"} />
+<div css={flag && "panel-active"} />
+<div css={providedClass || "panel-fallback"} />
+<div css={maybeClass ?? "panel-fallback"} />
+<div css={getClassName()} />
+```
+
+First-level static CSS-rule branches are also supported. Mincho lowers each object or array branch with the same CSS-rule extraction path used for direct `css` rules, then composes the generated class names. It does not call `css(condition ? ...)` and does not generate CSS at runtime.
+
+```tsx
+<div css={condition ? { color: "red" } : { color: "blue" }} />
+<div css={condition ? [{ color: "red" }] : [{ color: "blue" }]} />
+<div css={condition && { color: "red" }} />
+<div css={condition && [{ color: "red" }]} />
+<div css={condition ? styleA : { color: "red" }} />
+<div css={condition ? classNameA : { color: "red" }} />
+```
+
+Pure object/object or array/array ternaries compile to a `className` conditional between generated class identifiers. Mixed class-value/object branches keep the class-value branch as written and lower only the static CSS-rule branch inside `cx(...)`. Logical `condition && { ... }` and `condition && [{ ... }]` lower the right branch and compose through `cx(condition && generatedClass)`, so `false` does not become class text.
+
+First-level `||` and `??` rule fallbacks are supported when a direct object or array rule is the right operand. The generated class stays inside one logical `_cx(...)` expression, for example `_cx(providedClass || generatedClass)`, not `_cx(providedClass, generatedClass)`.
+
+```tsx
+<div css={providedClass || { color: "red" }} />
+<div css={providedClass || [{ color: "red" }]} />
+<div css={maybeClass ?? { color: "red" }} />
+<div css={maybeClass ?? [{ color: "red" }]} />
+```
+
+Static-left `||` and `??` rule operands simplify to the generated class for the left rule. The right fallback is unreachable, so Mincho does not evaluate it, reference it, or extract CSS from it. When no explicit `className` or spread aggregate must be merged, the generated-only result emits the generated class directly, not `cx(generatedClass)`. If an explicit `className` or spread aggregate is present, Mincho still merges the existing class first, equivalent to `cx(existing, generated)`.
+
+```tsx
+<div css={{ color: "red" } || providedClass} />
+<div css={[{ color: "red" }] || providedClass} />
+<div css={{ color: "red" } ?? providedClass} />
+<div css={[{ color: "red" }] ?? providedClass} />
+```
+
+Static-left `&&` object and array rules are truthy guards only. The left rule is not applied as a style, and Mincho emits no dead CSS for it. A dynamic right operand remains `cx(dynamicRight)` because the right operand is a class-value expression, so `{ color: "red" } && providedClass` lowers as `_cx(providedClass)` or equivalent. When both sides are static rules, `{ color: "red" } && { color: "blue" }` extracts only the blue right rule and, when no merge is needed, emits that generated class directly instead of `cx(generatedClass)`. Explicit `className` or spread aggregate merges still use `cx(existing, generated)`.
+
+```tsx
+<div css={{ color: "red" } && providedClass} />
+<div css={[{ color: "red" }] && providedClass} />
+<div css={{ color: "red" } && { color: "blue" }} />
+```
+
+The static-rule support is first-level only. Nested, chained, permutation-style, and sequence-expression object/array CSS-rule branches remain unsupported:
+
+```tsx
+<div css={outer ? inner ? { color: "red" } : { color: "blue" } : styleA} />
+<div css={condition && flag && { color: "red" }} />
+<div css={(condition && flag) || { color: "red" }} />
+<div css={a || b || { color: "red" }} />
+<div css={(0, { color: "red" })} />
+<div css={(0, [{ color: "red" }])} />
+```
+
+Class-value-only `||` and `??` still lower through `cx(...)` without CSS-rule extraction:
+
+```tsx
+<div css={providedClass || "panel-fallback"} />
+<div css={maybeClass ?? "panel-fallback"} />
+```
+
+The transform only treats syntactic `ObjectExpression` and `ArrayExpression` values, after transparent wrapper normalization, as static CSS rules. It does not evaluate identifiers, member expressions, imports, object variables, constants, or function calls into CSS rules. There is no static evaluation for identifier, member, call, or import-based CSS-rule discovery.
 
 ### v2 Targets and Forwarding
 
@@ -95,6 +165,8 @@ Spread-only css values are not transformed by Babel. If an own `css` prop reache
 
 `@mincho-js/react/jsx-runtime` and `@mincho-js/react/jsx-dev-runtime` are thin wrappers around React's automatic JSX runtimes. They only guard missed transforms for own `css` props.
 
+Supported static rule branches are converted to generated class names before JSX reaches the runtime. Mincho does not provide StyleX `stylex.props` fallback behavior, inject a StyleX helper namespace, evaluate imported files for CSS rules, or fall back to runtime CSS generation.
+
 If an own `css` prop reaches either runtime, Mincho throws:
 
 ```text
@@ -117,6 +189,7 @@ When `jsxCssProp: true` is enabled, unsupported v2 cases fail during the transfo
 | Explicit `key` or `ref` on a spread css-prop element | `Mincho JSX css prop does not support key/ref on spread elements in compile-away mode` |
 | Shorthand `css` | `Mincho JSX css prop requires an expression value` |
 | Function value | `Mincho JSX css prop does not support function values in compile-away mode` |
+| Nested, chained, sequence, unsupported logical, or dynamically resolved object/array CSS-rule value | `Mincho JSX css prop does not support conditional, logical, or wrapped object/array CSS rule values in compile-away mode` |
 | Duplicate `css` | `Mincho JSX css prop must appear only once` |
 | Duplicate `className` | `Mincho JSX css prop cannot merge duplicate className attributes` |
 | Shorthand or unsupported `className` value | `Mincho JSX css prop requires className to be a string literal or expression` |

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -66,8 +66,10 @@ With `jsxCssProp: true`, supported values are lowered to either the existing Min
 
 The scoped React JSX types define the `css` prop value as `ComplexCSSRule | ClassValue`.
 
-- Inline object expressions are CSS-rule mode through `css(...)`, so `<div css={{ color: "red" }} />` extracts a Mincho CSS rule. Inline object class dictionaries are not supported in this position; assign a `ClassValue` to an identifier, call, member expression, array, conditional, or literal value instead.
-- Identifiers, calls, member expressions, arrays, conditionals, strings, numbers, booleans, `null`, and `undefined` are class-value mode through `cx(...)` semantics. This is the migration path for existing Mincho class values: `const styleA = css(...); <div css={styleA} />`.
+- Inline object expressions are CSS-rule mode through `css(...)`, so `<div css={{ color: "red" }} />` extracts a Mincho CSS rule. Inline object class dictionaries are not supported in this position; assign a `ClassValue` to an identifier, call, member expression, conditional, or literal value instead.
+- Inline array expressions are also CSS-rule mode through `css([...])`, so `<div css={[baseClass, { color: "red" }]} />` composes class names and CSS rule objects through Mincho's `ComplexCSSRule` path.
+- Identifiers, calls, member expressions, conditionals, strings, numbers, booleans, `null`, and `undefined` are class-value mode through `cx(...)` semantics. This is the migration path for existing Mincho class values: `const styleA = css(...); <div css={styleA} />`.
+- Class-value arrays must be explicit, for example `<div css={cx(["base", active && "active"])} />`, or assigned to an identifier before being passed to `css`.
 - Strings are class values, not raw CSS declarations. `css="base"` means `cx("base")`, not a serialized CSS body.
 - Function values are unsupported in compile-away mode.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -64,17 +64,16 @@ With `jsxCssProp: true`, supported values are lowered to either the existing Min
 
 ### v2 Value Semantics
 
-The scoped React JSX types define the `css` prop value as `ComplexCSSRule | ClassValue`.
+The scoped React JSX types define the `css` prop value as `ComplexCSSRule | ClassPrimitive`, not the full recursive `ClassValue` type. The primitive side reuses the existing exported `ClassPrimitive` that backs `cx(...)`; React does not duplicate it with a JSX-only union. Object and array syntax belongs to CSS-rule and composition semantics.
 
 - Inline object expressions are CSS-rule mode through `css(...)`, so `<div css={{ color: "red" }} />` extracts a Mincho CSS rule. Transparent direct wrappers keep that mode, including `<div css={{ color: "red" }!} />`, `<div css={{ color: "red" } as const} />`, `<div css={{ color: "red" } satisfies ComplexCSSRule} />`, and `<div css={({ color: "red" })} />`.
-- Inline array expressions are also CSS-rule mode through `css([...])`, so `<div css={[baseClass, { color: "red" }]} />` composes class names and CSS rule objects through Mincho's `ComplexCSSRule` path. Transparent direct array wrappers are supported too, for example `<div css={[{ color: "red" }] as const} />` and `<div css={([{ color: "red" }])} />`.
-- All dynamic class values lower through `cx(...)`. This includes identifiers, members, calls, conditionals, logicals, non-string literals, template literals, and explicit `cx(...)` calls. This is the migration path for existing Mincho class values: `const styleA = css(...); <div css={styleA} />`.
-- Class-value arrays must be explicit, for example `<div css={cx(["base", active && "active"])} />`, or assigned to an identifier before being passed to `css`.
 - Strings are class values, not raw CSS declarations. Bare string-literal class values such as `<div css="base" />` and `<div css={"base"} />` lower directly to `className="base"` without `cx(...)` when no explicit `className` or spread-derived `className` must be merged.
+- Dynamic primitive class values lower through `cx(...)`. This includes identifiers, members, calls, conditionals, logicals, non-string literals, and template literals. This is the migration path for existing Mincho class values: `const styleA = css(...); <div css={styleA} />`.
 - If an explicit `className` or pre-css spread aggregate contributes an existing class, string-literal class values still merge through `cx(existing, cssValue)` with the existing class first.
+- Class dictionaries require explicit `cx(...)`, for example `<div css={cx({ active: condition })} />`. Explicit `css={cx(...)}` remains a class-value escape hatch and is not unwrapped by the JSX transform.
 - Function values are unsupported in compile-away mode.
 
-Supported expression-valued `css` props are class values and lower through `cx(...)`:
+Supported expression-valued primitive `css` props lower through `cx(...)`:
 
 ```tsx
 <div css={condition ? "panel active" : "panel"} />
@@ -84,7 +83,55 @@ Supported expression-valued `css` props are class values and lower through `cx(.
 <div css={getClassName()} />
 ```
 
-First-level static CSS-rule branches are also supported. Mincho lowers each object or array branch with the same CSS-rule extraction path used for direct `css` rules, then composes the generated class names. It does not call `css(condition ? ...)` and does not generate CSS at runtime.
+Static JSX `css` arrays stay on the `css([...])` composition path. They are static `ComplexCSSRule` composition arrays, not recursive `ClassValue` arrays, and they do not lower to `cx(...)` just because they contain string items.
+
+```tsx
+<div css={["base", "active"]} />
+<div css={["base", ""]} />
+<div css={["base", { color: "red" }]} />
+```
+
+These are equivalent to `css(["base", "active"])`, `css(["base", ""])`, and `css(["base", { color: "red" }])` static composition.
+
+First-level dynamic primitive array branches lower through one `cx(...)` merge. Primitive branches pass through as arguments, so the empty string stays present as a `ClassPrimitive` value in dynamic arrays.
+
+```tsx
+<div css={["base", condition && "active"]} />
+<div css={["base", providedClass || "fallback"]} />
+<div css={["base", maybeClass ?? "fallback"]} />
+<div css={["base", activeClass]} />
+<div css={["base", "", activeClass]} />
+```
+
+`<div css={["base", "", activeClass]} />` lowers through `cx(...)` with `""` preserved as a `ClassPrimitive` argument, equivalent to `cx("base", "", activeClass)`. Non-string `ClassPrimitive` literals in arrays also lower through `cx(...)`, not static composition:
+
+```tsx
+<div css={["base", false]} />
+<div css={["base", true]} />
+<div css={["base", null]} />
+<div css={["base", undefined]} />
+<div css={["base", 0]} />
+<div css={["base", 1]} />
+<div css={["base", 0n]} />
+<div css={["base", 1n]} />
+```
+
+First-level dynamic object and array CSS-rule branches are extracted at build time, then merged or selected with `cx(...)`. Mincho extracts the static rule branch to a generated class and keeps primitive branches as written.
+
+```tsx
+<div css={["base", condition && { color: "red" }]} />
+<div css={["base", providedClass || { color: "red" }]} />
+<div css={["base", maybeClass ?? { color: "red" }]} />
+<div css={["base", condition ? { color: "red" } : "inactive"]} />
+<div css={["base", condition ? "active" : { color: "blue" }]} />
+<div css={["base", condition && [{ color: "red" }]]} />
+<div css={["base", condition && ["active", { color: "red" }]]} />
+<div css={["base", { color: "red" }, activeClass]} />
+```
+
+The first example lowers like `cx("base", condition && generatedClass)`. Direct static CSS-rule items in otherwise dynamic arrays use the same extraction path, so `<div css={["base", { color: "red" }, activeClass]} />` lowers like `cx("base", generatedClass, activeClass)`.
+
+First-level CSS-rule branches outside arrays are also supported. Mincho lowers each object or array branch with the same CSS-rule extraction path used for direct `css` rules, then composes the generated class names. It does not call `css(condition ? ...)` and does not generate CSS at runtime.
 
 ```tsx
 <div css={condition ? { color: "red" } : { color: "blue" }} />
@@ -123,9 +170,12 @@ Static-left `&&` object and array rules are truthy guards only. The left rule is
 <div css={{ color: "red" } && { color: "blue" }} />
 ```
 
-The static-rule support is first-level only. Nested, chained, permutation-style, and sequence-expression object/array CSS-rule branches remain unsupported:
+The static-rule support is first-level only. Nested dynamic arrays, array spreads, chained branches, permutation-style branches, and sequence-expression object/array CSS-rule branches remain unsupported:
 
 ```tsx
+<div css={["base", ["nested", condition && { color: "red" }]]} />
+<div css={["base", condition && ["active", nested && { color: "red" }]]} />
+<div css={["base", ...classes]} />
 <div css={outer ? inner ? { color: "red" } : { color: "blue" } : styleA} />
 <div css={condition && flag && { color: "red" }} />
 <div css={(condition && flag) || { color: "red" }} />
@@ -189,6 +239,8 @@ When `jsxCssProp: true` is enabled, unsupported v2 cases fail during the transfo
 | Explicit `key` or `ref` on a spread css-prop element | `Mincho JSX css prop does not support key/ref on spread elements in compile-away mode` |
 | Shorthand `css` | `Mincho JSX css prop requires an expression value` |
 | Function value | `Mincho JSX css prop does not support function values in compile-away mode` |
+| Spread element inside a `css` array | `Mincho JSX css prop array values do not support spread elements in compile-away mode` |
+| Nested dynamic array branch inside a `css` array | `Mincho JSX css prop array branch extraction only supports first-level dynamic branches` |
 | Nested, chained, sequence, unsupported logical, or dynamically resolved object/array CSS-rule value | `Mincho JSX css prop does not support conditional, logical, or wrapped object/array CSS rule values in compile-away mode` |
 | Duplicate `css` | `Mincho JSX css prop must appear only once` |
 | Duplicate `className` | `Mincho JSX css prop cannot merge duplicate className attributes` |

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -41,48 +41,80 @@ export default defineConfig({
 ```tsx
 import { css } from "@mincho-js/css";
 
-const base = css({
+const styleA = css({
   display: "block"
 });
 
+function Panel(props: { className?: string; label: string }) {
+  return <section className={props.className}>{props.label}</section>;
+}
+
 export function App() {
-  return <div className={base} css={{ color: "red" }} />;
+  return (
+    <>
+      <div css={{ color: "red" }} />
+      <div css={styleA} />
+      <Panel css={styleA} label="ClassName forwarding component" />
+    </>
+  );
 }
 ```
 
-With `jsxCssProp: true`, supported intrinsic elements are lowered to the existing Mincho `css(...)` extraction path. If `className` is present, merge order is the existing `className` first and the generated css class second, equivalent to `cx(existingClassName, css(style))`.
+With `jsxCssProp: true`, supported values are lowered to either the existing Mincho `css(...)` extraction path or `cx(...)` class-value merging. If `className` is present, merge order is the existing `className` first and the `css` prop class value second, equivalent to `cx(existingClassName, nextCssClassName)`.
 
-### v1 Scope
+### v2 Value Semantics
 
-- Supported: intrinsic React DOM and SVG elements from Mincho's supported tag list, such as `div`, `button`, and `svg`.
-- Rejected by the transform: custom React components such as `<Button css={{ color: "red" }} />`.
-- Rejected by the transform: JSX member expressions such as `<motion.div css={{ color: "red" }} />`.
-- Rejected by the transform: JSX spreads on an element that also has `css`, such as `<div {...props} css={{ color: "red" }} />`.
-- Rejected by the transform: unsupported custom elements, duplicate `css`, duplicate `className`, shorthand `css`, and non-object direct values.
+The scoped React JSX types define the `css` prop value as `ComplexCSSRule | ClassValue`.
 
-Custom React components are not Mincho css-prop targets in v1. If a custom component needs a prop named `css`, it must be its own independent prop surface outside Mincho css-prop lowering.
+- Inline object expressions are CSS-rule mode through `css(...)`, so `<div css={{ color: "red" }} />` extracts a Mincho CSS rule. Inline object class dictionaries are not supported in this position; assign a `ClassValue` to an identifier, call, member expression, array, conditional, or literal value instead.
+- Identifiers, calls, member expressions, arrays, conditionals, strings, numbers, booleans, `null`, and `undefined` are class-value mode through `cx(...)` semantics. This is the migration path for existing Mincho class values: `const styleA = css(...); <div css={styleA} />`.
+- Strings are class values, not raw CSS declarations. `css="base"` means `cx("base")`, not a serialized CSS body.
+- Function values are unsupported in compile-away mode.
+
+### v2 Targets and Forwarding
+
+The transform accepts JSX identifiers and member-expression components, including intrinsic elements, custom React components, member-expression components such as `<motion.div />`, and custom elements.
+
+Custom components and member-expression components are supported only under a className forwarding contract: their props must accept an arbitrary string-compatible `className`, and the component must forward that `className` to the element that should receive the generated styles. The scoped JSX types add `css` through the same `className` compatibility gate.
+
+User-typed custom elements receive typed `css` only when their React JSX intrinsic props include arbitrary-string-compatible `className`. Transformed custom elements emit `className`, not `class`.
+
+### Spread Support
+
+Spread aggregation has both ordering and context restrictions. Every spread must appear before an explicit `css` prop, and the JSX element must be the direct return argument or a direct expression statement. In that supported shape, the transform aggregates those props, removes any spread-provided `css`, and merges the aggregate `className` before the explicit `css` value.
+
+Nested spread aggregation is unsupported in compile-away mode. This includes fragment-child JSX, expression-bodied arrows, conditional JSX, logical JSX, call arguments, unbraced control-flow consequents, and other nested expression contexts that would require expression-local runtime wrappers.
+
+Spread-after-css is unsupported. Explicit `key` or `ref` on spread css-prop elements is also unsupported because the compile-away aggregation cannot preserve those React-only fields safely.
+
+Spread-only css values are not transformed by Babel. If an own `css` prop reaches the production or development JSX runtime, the runtime own-`css` guard throws the missed-transform diagnostic instead of leaking, stripping, or styling it.
 
 ### Runtime Behavior
 
-`@mincho-js/react/jsx-runtime` is production pass-through to React's automatic JSX runtime. If a `css` prop reaches production runtime, it is passed through unchanged and Mincho does not style it at runtime.
+`@mincho-js/react/jsx-runtime` and `@mincho-js/react/jsx-dev-runtime` are thin wrappers around React's automatic JSX runtimes. They only guard missed transforms for own `css` props.
 
-`@mincho-js/react/jsx-dev-runtime` only guards missed transforms. In development, an own `css` prop that reaches `jsxDEV` throws:
+If an own `css` prop reaches either runtime, Mincho throws:
 
 ```text
 Mincho JSX css prop was not compiled. Enable the Mincho transform with jsxCssProp: true and ensure it runs before React JSX transform.
 ```
 
+There is no Emotion runtime parity. Mincho does not provide an Emotion runtime serializer/cache/style insertion/theme interpolation/full spread parity/post-JSX runtime wrapper behavior for the `css` prop.
+
 ### Transform Errors
 
-When `jsxCssProp: true` is enabled, unsupported v1 cases fail during the transform with explicit diagnostics:
+When `jsxCssProp: true` is enabled, unsupported v2 cases fail during the transform with explicit diagnostics:
 
 | Case | Message |
 | --- | --- |
-| Custom component or member expression | `Mincho JSX css prop only supports intrinsic elements in v1` |
-| Unsupported DOM/SVG tag | `Mincho JSX css prop only supports supported React DOM/SVG tags in v1` |
-| Spread on an element with `css` | `Mincho JSX css prop does not support spreads on elements with css in v1` |
+| Fragment target | `Mincho JSX css prop does not support fragments because fragments cannot receive className` |
+| Namespaced JSX target | `Mincho JSX css prop does not support namespaced JSX elements` |
+| Unsupported JSX target | `Mincho JSX css prop only supports JSX identifiers and member expressions` |
+| Spread after `css` | `Mincho JSX css prop does not support spreads after css in compile-away mode` |
+| Pre-css spread aggregation outside a direct return argument or direct expression statement | `Mincho JSX css prop spread aggregation only supports direct return or expression statement JSX in compile-away mode` |
+| Explicit `key` or `ref` on a spread css-prop element | `Mincho JSX css prop does not support key/ref on spread elements in compile-away mode` |
 | Shorthand `css` | `Mincho JSX css prop requires an expression value` |
-| Raw string, number, boolean, null, or function value | `Mincho JSX css prop expects a Mincho CSS object/expression` |
+| Function value | `Mincho JSX css prop does not support function values in compile-away mode` |
 | Duplicate `css` | `Mincho JSX css prop must appear only once` |
 | Duplicate `className` | `Mincho JSX css prop cannot merge duplicate className attributes` |
 | Shorthand or unsupported `className` value | `Mincho JSX css prop requires className to be a string literal or expression` |

--- a/packages/react/src/jsx-dev-runtime.ts
+++ b/packages/react/src/jsx-dev-runtime.ts
@@ -36,15 +36,10 @@ if (import.meta.vitest) {
 
   describe("Mincho development JSX runtime", () => {
     it("throws when an own css prop survives transform", () => {
+      const props = { css: "base" };
+
       expect(() =>
-        jsxDEV(
-          "div",
-          { css: { color: "red" } },
-          undefined,
-          false,
-          undefined,
-          undefined
-        )
+        jsxDEV("div", props, undefined, false, undefined, undefined)
       ).toThrow(missedTransformErrorMessage);
     });
 

--- a/packages/react/src/jsx-namespace.ts
+++ b/packages/react/src/jsx-namespace.ts
@@ -1,7 +1,18 @@
-import type { ClassValue, ComplexCSSRule } from "@mincho-js/css";
+import type { ClassPrimitive, ComplexCSSRule } from "@mincho-js/css";
 import type { JSX as ReactJSX } from "react";
 
-export type MinchoCssPropValue = ComplexCSSRule | ClassValue;
+type ComplexCSSRuleArrayItem = Extract<ComplexCSSRule, unknown[]>[number];
+type MinchoCssPropFirstLevelArrayItem =
+  | ComplexCSSRuleArrayItem
+  | ClassPrimitive;
+type MinchoCssPropFirstLevelArray =
+  | MinchoCssPropFirstLevelArrayItem[]
+  | readonly MinchoCssPropFirstLevelArrayItem[];
+
+export type MinchoCssPropValue =
+  | ComplexCSSRule
+  | ClassPrimitive
+  | MinchoCssPropFirstLevelArray;
 
 type MinchoCssProp = {
   css?: MinchoCssPropValue;
@@ -41,28 +52,100 @@ if (import.meta.vitest) {
   const { describe, it, assertType, expectTypeOf } = import.meta.vitest;
 
   describe("scoped Mincho JSX namespace", () => {
-    it("defines css values from ComplexCSSRule and ClassValue", () => {
+    it("defines css values from ComplexCSSRule and ClassPrimitive", () => {
       const cssRule: ComplexCSSRule = { color: "red" };
       const condition = true as boolean;
+      const activeClass = "active-class";
+      const styles = { active: "styles-active" };
+      const providedClassName: string = Math.random() > 0.5 ? "base" : "";
       const providedClass: string | undefined =
         Math.random() > 0.5 ? "base" : undefined;
       const maybeClass: string | null = Math.random() > 0.5 ? null : "base";
       const getClassName = () => "base";
+      const emptyClassName: ClassPrimitive = "";
 
+      expectTypeOf<MinchoCssPropValue>().toEqualTypeOf<
+        ComplexCSSRule | ClassPrimitive | MinchoCssPropFirstLevelArray
+      >();
+
+      assertType<ClassPrimitive>(emptyClassName);
       assertType<MinchoCssPropValue>(cssRule);
       assertType<MinchoCssPropValue>("base");
+      assertType<MinchoCssPropValue>(emptyClassName);
       assertType<MinchoCssPropValue>(false);
+      assertType<MinchoCssPropValue>(true);
       assertType<MinchoCssPropValue>(null);
       assertType<MinchoCssPropValue>(undefined);
-      assertType<MinchoCssPropValue>(["base", condition && "active"]);
+      assertType<MinchoCssPropValue>(1);
+      assertType<MinchoCssPropValue>(0);
+      assertType<MinchoCssPropValue>(0n);
+      assertType<MinchoCssPropValue>(1n);
       assertType<MinchoCssPropValue>(condition ? "base" : "fallback");
       assertType<MinchoCssPropValue>(condition && "active");
       assertType<MinchoCssPropValue>(condition || "fallback");
       assertType<MinchoCssPropValue>(maybeClass ?? "fallback");
       assertType<MinchoCssPropValue>(getClassName());
-      assertType<MinchoCssPropValue>({ active: condition });
+
+      // Object literals in JSX css are CSS-rule syntax, not cx class dictionaries.
+      assertType<MinchoCssPropValue>({ color: "red" });
+      assertType<MinchoCssPropValue>({ color: condition ? "red" : "blue" });
+      assertType<MinchoCssPropValue>(["base", "active"]);
+      assertType<MinchoCssPropValue>(["base", ""]);
+      assertType<MinchoCssPropValue>(["base", { color: "red" }]);
+      assertType<MinchoCssPropValue>(["base", false]);
+      assertType<MinchoCssPropValue>(["base", true]);
+      assertType<MinchoCssPropValue>(["base", null]);
+      assertType<MinchoCssPropValue>(["base", undefined]);
+      assertType<MinchoCssPropValue>(["base", 0]);
+      assertType<MinchoCssPropValue>(["base", 1]);
+      assertType<MinchoCssPropValue>(["base", 0n]);
+      assertType<MinchoCssPropValue>(["base", 1n]);
+      assertType<MinchoCssPropValue>(["base", activeClass]);
+      assertType<MinchoCssPropValue>(["base", "", activeClass]);
+      assertType<MinchoCssPropValue>(["base", styles.active]);
+      assertType<MinchoCssPropValue>(["base", getClassName()]);
+      assertType<MinchoCssPropValue>(["base", condition && "active"]);
+      assertType<MinchoCssPropValue>(["base", providedClassName && "active"]);
+      assertType<MinchoCssPropValue>(["base", providedClass || "fallback"]);
+      assertType<MinchoCssPropValue>(["base", maybeClass ?? "fallback"]);
+      assertType<MinchoCssPropValue>([
+        "base",
+        condition ? "active" : "inactive"
+      ]);
+      assertType<MinchoCssPropValue>(["base", { color: "red" }, activeClass]);
+      assertType<MinchoCssPropValue>([
+        "base",
+        providedClass || { color: "red" }
+      ]);
+      assertType<MinchoCssPropValue>(["base", maybeClass ?? { color: "red" }]);
+      assertType<MinchoCssPropValue>([
+        "base",
+        condition ? { color: "red" } : "inactive"
+      ]);
+      assertType<MinchoCssPropValue>([
+        "base",
+        condition ? "active" : { color: "blue" }
+      ]);
+      assertType<MinchoCssPropValue>([
+        "base",
+        condition ? { color: "red" } : { color: "blue" }
+      ]);
+      assertType<MinchoCssPropValue>(condition && { color: "red" });
+      assertType<MinchoCssPropValue>(condition && [{ color: "red" }]);
       assertType<MinchoCssPropValue>(providedClass || { color: "red" });
       assertType<MinchoCssPropValue>(maybeClass ?? [{ color: "red" }]);
+
+      // ClassValue-only object dictionaries with non-CSS keys are rejected.
+      // CSS-shaped objects, for example `{ color: "red" }`, are intentionally
+      // accepted as CSS-rule syntax and cannot be distinguished structurally.
+      // @ts-expect-error Direct class dictionaries are not css prop values.
+      assertType<MinchoCssPropValue>({ active: condition });
+      // @ts-expect-error Direct class dictionaries are not css prop values.
+      assertType<MinchoCssPropValue>({ "is-active": true });
+      // @ts-expect-error Recursive arrays with falsy leaves are ClassValue-only.
+      assertType<MinchoCssPropValue>([["base", false]]);
+      // @ts-expect-error Recursive arrays with numeric leaves are ClassValue-only.
+      assertType<MinchoCssPropValue>([[1]]);
       // @ts-expect-error TypeScript rejects always-truthy object literal logical left operands before Mincho css prop typing.
       // eslint-disable-next-line no-constant-binary-expression -- The constant operand is the TypeScript error under test.
       assertType<MinchoCssPropValue>({ color: "red" } || providedClass);
@@ -77,6 +160,8 @@ if (import.meta.vitest) {
     it("adds css to string-compatible intrinsic className props", () => {
       const cssRule: ComplexCSSRule = { color: "red" };
       const condition = true as boolean;
+      const activeClass = "active-class";
+      const providedClassName: string = Math.random() > 0.5 ? "base" : "";
       const providedClass: string | undefined =
         Math.random() > 0.5 ? "base" : undefined;
       const maybeClass: string | null = Math.random() > 0.5 ? null : "base";
@@ -87,11 +172,103 @@ if (import.meta.vitest) {
       });
 
       assertType<JSX.IntrinsicElements["div"]>({
+        css: ""
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: 1
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
         css: false
       });
 
       assertType<JSX.IntrinsicElements["div"]>({
+        css: true
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: null
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: undefined
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: 0
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: 0n
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: 1n
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: ["base", "active"]
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: ["base", ""]
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: ["base", false]
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: ["base", true]
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: ["base", null]
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: ["base", undefined]
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: ["base", 0]
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: ["base", 1]
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: ["base", 0n]
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: ["base", 1n]
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: ["base", activeClass]
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: ["base", getClassName()]
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
         css: ["base", condition && "active"]
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: ["base", providedClassName && "active"]
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: ["base", condition ? "active" : "inactive"]
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: ["base", providedClass || { color: "red" }]
       });
 
       assertType<JSX.IntrinsicElements["div"]>({
@@ -119,11 +296,24 @@ if (import.meta.vitest) {
       });
 
       assertType<JSX.IntrinsicElements["div"]>({
+        css: condition && [{ color: "red" }]
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: ["base", { color: "red" }, activeClass]
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
         css: providedClass || { color: "red" }
       });
 
       assertType<JSX.IntrinsicElements["div"]>({
         css: maybeClass ?? [{ color: "red" }]
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        // @ts-expect-error Direct class dictionaries are not css prop values.
+        css: { active: condition }
       });
 
       assertType<JSX.IntrinsicElements["div"]>({

--- a/packages/react/src/jsx-namespace.ts
+++ b/packages/react/src/jsx-namespace.ts
@@ -44,6 +44,10 @@ if (import.meta.vitest) {
     it("defines css values from ComplexCSSRule and ClassValue", () => {
       const cssRule: ComplexCSSRule = { color: "red" };
       const condition = true as boolean;
+      const providedClass: string | undefined =
+        Math.random() > 0.5 ? "base" : undefined;
+      const maybeClass: string | null = Math.random() > 0.5 ? null : "base";
+      const getClassName = () => "base";
 
       assertType<MinchoCssPropValue>(cssRule);
       assertType<MinchoCssPropValue>("base");
@@ -51,12 +55,32 @@ if (import.meta.vitest) {
       assertType<MinchoCssPropValue>(null);
       assertType<MinchoCssPropValue>(undefined);
       assertType<MinchoCssPropValue>(["base", condition && "active"]);
+      assertType<MinchoCssPropValue>(condition ? "base" : "fallback");
+      assertType<MinchoCssPropValue>(condition && "active");
+      assertType<MinchoCssPropValue>(condition || "fallback");
+      assertType<MinchoCssPropValue>(maybeClass ?? "fallback");
+      assertType<MinchoCssPropValue>(getClassName());
       assertType<MinchoCssPropValue>({ active: condition });
+      assertType<MinchoCssPropValue>(providedClass || { color: "red" });
+      assertType<MinchoCssPropValue>(maybeClass ?? [{ color: "red" }]);
+      // @ts-expect-error TypeScript rejects always-truthy object literal logical left operands before Mincho css prop typing.
+      // eslint-disable-next-line no-constant-binary-expression -- The constant operand is the TypeScript error under test.
+      assertType<MinchoCssPropValue>({ color: "red" } || providedClass);
+      // @ts-expect-error TypeScript rejects never-nullish object literal nullish left operands before Mincho css prop typing.
+      // eslint-disable-next-line no-constant-binary-expression -- The constant operand is the TypeScript error under test.
+      assertType<MinchoCssPropValue>({ color: "red" } ?? providedClass);
+      // @ts-expect-error TypeScript rejects always-truthy object literal logical left operands before Mincho css prop typing.
+      // eslint-disable-next-line no-constant-binary-expression -- The constant operand is the TypeScript error under test.
+      assertType<MinchoCssPropValue>({ color: "red" } && providedClass);
     });
 
     it("adds css to string-compatible intrinsic className props", () => {
       const cssRule: ComplexCSSRule = { color: "red" };
       const condition = true as boolean;
+      const providedClass: string | undefined =
+        Math.random() > 0.5 ? "base" : undefined;
+      const maybeClass: string | null = Math.random() > 0.5 ? null : "base";
+      const getClassName = () => "base";
 
       assertType<JSX.IntrinsicElements["div"]>({
         css: "base"
@@ -71,7 +95,53 @@ if (import.meta.vitest) {
       });
 
       assertType<JSX.IntrinsicElements["div"]>({
+        css: condition ? "base" : "fallback"
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: condition && "active"
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: condition || "fallback"
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: maybeClass ?? "fallback"
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: getClassName()
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
         css: { color: "red" }
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: providedClass || { color: "red" }
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: maybeClass ?? [{ color: "red" }]
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        // @ts-expect-error TypeScript rejects always-truthy object literal logical left operands before Mincho css prop typing.
+        // eslint-disable-next-line no-constant-binary-expression -- The constant operand is the TypeScript error under test.
+        css: { color: "red" } || providedClass
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        // @ts-expect-error TypeScript rejects never-nullish object literal nullish left operands before Mincho css prop typing.
+        // eslint-disable-next-line no-constant-binary-expression -- The constant operand is the TypeScript error under test.
+        css: { color: "red" } ?? providedClass
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        // @ts-expect-error TypeScript rejects always-truthy object literal logical left operands before Mincho css prop typing.
+        // eslint-disable-next-line no-constant-binary-expression -- The constant operand is the TypeScript error under test.
+        css: { color: "red" } && providedClass
       });
 
       assertType<ReactJSX.IntrinsicElements["div"]>({
@@ -129,7 +199,10 @@ if (import.meta.vitest) {
         Props
       >;
 
+      const condition: boolean = Math.random() > 0.5;
       const functionCss = () => "base";
+      const maybeClass: string | null = Math.random() > 0.5 ? null : "base";
+      const getClassName = () => "base";
 
       assertType<ManagedProps<{ className?: string; label: string }>>({
         css: "base",
@@ -147,6 +220,37 @@ if (import.meta.vitest) {
       >({
         css: { color: "red" },
         label: "Button"
+      });
+
+      assertType<ManagedProps<{ className?: string; label: string }>>({
+        css: condition ? "base" : "fallback",
+        label: "Button"
+      });
+
+      assertType<ManagedProps<{ className?: string; label: string }>>({
+        css: condition && "active",
+        label: "Button"
+      });
+
+      assertType<ManagedProps<{ className?: string; label: string }>>({
+        css: condition || "fallback",
+        label: "Button"
+      });
+
+      assertType<ManagedProps<{ className?: string; label: string }>>({
+        css: maybeClass ?? "fallback",
+        label: "Button"
+      });
+
+      assertType<ManagedProps<{ className?: string; label: string }>>({
+        css: getClassName(),
+        label: "Button"
+      });
+
+      assertType<ManagedProps<{ className?: string; label: string }>>({
+        label: "Button",
+        // @ts-expect-error function-valued css identifiers are not valid css prop values.
+        css: getClassName
       });
 
       assertType<ManagedProps<{ label: string }>>({

--- a/packages/react/src/jsx-namespace.ts
+++ b/packages/react/src/jsx-namespace.ts
@@ -1,15 +1,24 @@
-import type { ComplexCSSRule } from "@mincho-js/css";
+import type { ClassValue, ComplexCSSRule } from "@mincho-js/css";
 import type { JSX as ReactJSX } from "react";
 
-import type { SupportedElements } from "./tags.js";
+export type MinchoCssPropValue = ComplexCSSRule | ClassValue;
 
-type MinchoCSSProp = {
-  css?: ComplexCSSRule;
+type MinchoCssProp = {
+  css?: MinchoCssPropValue;
 };
 
-type MinchoIntrinsicElements = {
-  [Element in SupportedElements]: ReactJSX.IntrinsicElements[Element] &
-    MinchoCSSProp;
+type WithConditionalCSSProp<Props> = "className" extends keyof Props
+  ? string extends NonNullable<Props["className"]>
+    ? Props & MinchoCssProp
+    : Props
+  : Props;
+
+type MinchoIntrinsicElements<
+  IntrinsicElements extends object = ReactJSX.IntrinsicElements
+> = {
+  [Element in keyof IntrinsicElements]: WithConditionalCSSProp<
+    IntrinsicElements[Element]
+  >;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-namespace -- TypeScript scoped JSX runtimes are modeled as exported JSX namespaces.
@@ -19,29 +28,151 @@ export declare namespace JSX {
   type ElementClass = ReactJSX.ElementClass;
   type ElementAttributesProperty = ReactJSX.ElementAttributesProperty;
   type ElementChildrenAttribute = ReactJSX.ElementChildrenAttribute;
-  type LibraryManagedAttributes<Component, Props> =
-    ReactJSX.LibraryManagedAttributes<Component, Props>;
+  type LibraryManagedAttributes<Component, Props> = WithConditionalCSSProp<
+    ReactJSX.LibraryManagedAttributes<Component, Props>
+  >;
   type IntrinsicAttributes = ReactJSX.IntrinsicAttributes;
   type IntrinsicClassAttributes<Element> =
     ReactJSX.IntrinsicClassAttributes<Element>;
-  type IntrinsicElements = Omit<ReactJSX.IntrinsicElements, SupportedElements> &
-    MinchoIntrinsicElements;
+  type IntrinsicElements = MinchoIntrinsicElements;
 }
 
 if (import.meta.vitest) {
   const { describe, it, assertType, expectTypeOf } = import.meta.vitest;
 
   describe("scoped Mincho JSX namespace", () => {
-    it("adds css only to supported intrinsic elements", () => {
+    it("defines css values from ComplexCSSRule and ClassValue", () => {
       const cssRule: ComplexCSSRule = { color: "red" };
+      const condition = true as boolean;
+
+      assertType<MinchoCssPropValue>(cssRule);
+      assertType<MinchoCssPropValue>("base");
+      assertType<MinchoCssPropValue>(false);
+      assertType<MinchoCssPropValue>(null);
+      assertType<MinchoCssPropValue>(undefined);
+      assertType<MinchoCssPropValue>(["base", condition && "active"]);
+      assertType<MinchoCssPropValue>({ active: condition });
+    });
+
+    it("adds css to string-compatible intrinsic className props", () => {
+      const cssRule: ComplexCSSRule = { color: "red" };
+      const condition = true as boolean;
 
       assertType<JSX.IntrinsicElements["div"]>({
-        css: cssRule
+        css: "base"
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: false
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: ["base", condition && "active"]
+      });
+
+      assertType<JSX.IntrinsicElements["div"]>({
+        css: { color: "red" }
       });
 
       assertType<ReactJSX.IntrinsicElements["div"]>({
         // @ts-expect-error React's unscoped intrinsic div props do not include Mincho css.
         css: cssRule
+      });
+    });
+
+    it("uses the same className gate for user-augmented intrinsic props", () => {
+      type UserAugmentedIntrinsicElements = MinchoIntrinsicElements<{
+        "literal-class-element": { className?: "base" };
+        "my-element": { className?: string; id?: string };
+        "number-class-element": { className?: number };
+        "required-class-element": { className: string };
+        "undefined-class-element": { className?: string | undefined };
+        "without-class-element": { id?: string };
+      }>;
+
+      assertType<UserAugmentedIntrinsicElements["my-element"]>({
+        css: "base",
+        id: "root"
+      });
+
+      assertType<UserAugmentedIntrinsicElements["required-class-element"]>({
+        className: "root",
+        css: false
+      });
+
+      assertType<UserAugmentedIntrinsicElements["undefined-class-element"]>({
+        css: { color: "red" }
+      });
+
+      assertType<UserAugmentedIntrinsicElements["without-class-element"]>({
+        // @ts-expect-error intrinsic props without className do not accept css.
+        css: "base"
+      });
+
+      assertType<UserAugmentedIntrinsicElements["number-class-element"]>({
+        className: 1,
+        // @ts-expect-error numeric className props do not accept css.
+        css: "base"
+      });
+
+      assertType<UserAugmentedIntrinsicElements["literal-class-element"]>({
+        className: "base",
+        // @ts-expect-error literal-only className props do not accept css.
+        css: "base"
+      });
+    });
+
+    it("uses the same className gate for custom component props", () => {
+      type Component<Props> = (props: Props) => ReactJSX.Element;
+      type ManagedProps<Props> = JSX.LibraryManagedAttributes<
+        Component<Props>,
+        Props
+      >;
+
+      const functionCss = () => "base";
+
+      assertType<ManagedProps<{ className?: string; label: string }>>({
+        css: "base",
+        label: "Button"
+      });
+
+      assertType<ManagedProps<{ className: string; label: string }>>({
+        className: "root",
+        css: false,
+        label: "Button"
+      });
+
+      assertType<
+        ManagedProps<{ className?: string | undefined; label: string }>
+      >({
+        css: { color: "red" },
+        label: "Button"
+      });
+
+      assertType<ManagedProps<{ label: string }>>({
+        label: "Button",
+        // @ts-expect-error custom components without className do not accept css.
+        css: "base"
+      });
+
+      assertType<ManagedProps<{ className?: number; label: string }>>({
+        className: 1,
+        label: "Button",
+        // @ts-expect-error numeric className props do not accept css.
+        css: "base"
+      });
+
+      assertType<ManagedProps<{ className?: "base"; label: string }>>({
+        className: "base",
+        label: "Button",
+        // @ts-expect-error literal-only className props do not accept css.
+        css: "base"
+      });
+
+      assertType<ManagedProps<{ className?: string; label: string }>>({
+        label: "Button",
+        // @ts-expect-error function-valued css identifiers are not valid css prop values.
+        css: functionCss
       });
     });
 

--- a/packages/react/src/jsx-runtime.ts
+++ b/packages/react/src/jsx-runtime.ts
@@ -1,17 +1,81 @@
-import { Fragment, jsx, jsxs } from "react/jsx-runtime";
+import type { ElementType, Key, ReactElement } from "react";
+import {
+  Fragment,
+  jsx as reactJsx,
+  jsxs as reactJsxs
+} from "react/jsx-runtime";
 
-export { Fragment, jsx, jsxs };
+export { Fragment };
 export type { JSX } from "./jsx-namespace.js";
+
+const missedTransformErrorMessage =
+  "Mincho JSX css prop was not compiled. Enable the Mincho transform with jsxCssProp: true and ensure it runs before React JSX transform.";
+
+export function jsx(
+  type: ElementType,
+  props: unknown,
+  key?: Key
+): ReactElement {
+  throwForOwnCssProp(props);
+
+  return reactJsx(type, props, key);
+}
+
+export function jsxs(
+  type: ElementType,
+  props: unknown,
+  key?: Key
+): ReactElement {
+  throwForOwnCssProp(props);
+
+  return reactJsxs(type, props, key);
+}
+
+function throwForOwnCssProp(props: unknown) {
+  if (hasOwnCssProp(props)) {
+    throw new Error(missedTransformErrorMessage);
+  }
+}
+
+function hasOwnCssProp(props: unknown): boolean {
+  return (
+    typeof props === "object" &&
+    props !== null &&
+    Object.prototype.hasOwnProperty.call(props, "css")
+  );
+}
 
 if (import.meta.vitest) {
   const { describe, it, expect } = import.meta.vitest;
 
   describe("Mincho production JSX runtime", () => {
-    it("passes through surviving css props without styling or throwing", () => {
-      const props = { css: { color: "red" }, id: "root" };
+    it("throws when an own css prop survives transform through jsx", () => {
+      expect(() => jsx("div", { css: "base" }, undefined)).toThrow(
+        missedTransformErrorMessage
+      );
+    });
+
+    it("throws when an own css prop survives transform through jsxs", () => {
+      expect(() =>
+        jsxs("div", { children: ["child"], css: { color: "red" } }, undefined)
+      ).toThrow(missedTransformErrorMessage);
+    });
+
+    it("passes through props without an own css prop", () => {
+      const props = { id: "root" };
 
       expect(() => jsx("div", props, undefined)).not.toThrow();
 
+      const element = jsx("div", props, undefined);
+
+      expect(element.type).toBe("div");
+      expect(element.props).toBe(props);
+    });
+
+    it("does not throw for inherited css props", () => {
+      const props = Object.assign(Object.create({ css: "base" }), {
+        id: "root"
+      });
       const element = jsx("div", props, undefined);
 
       expect(element.type).toBe("div");

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -260,11 +260,24 @@ export function minchoVitePlugin(
             ? _options?.babel
             : { ..._options.babel, jsxCssProp: _options.jsxCssProp };
         const {
-          code,
+          code: transformedCode,
+          jsxCssPropTransformed,
           result: [file, cssExtract]
         } = await babelTransform(id, babelOptions);
 
-        if (!cssExtract || !file) return null;
+        if (!cssExtract || !file) {
+          if (
+            babelOptions?.jsxCssProp === true &&
+            jsxCssPropTransformed === true
+          ) {
+            return {
+              code: transformedCode,
+              map: { mappings: "" }
+            };
+          }
+
+          return null;
+        }
 
         if (config.command === "build" && config.build.watch) {
           this.addWatchFile(file);
@@ -299,7 +312,7 @@ export function minchoVitePlugin(
         });
 
         return {
-          code,
+          code: transformedCode,
           map: { mappings: "" }
         };
       }
@@ -978,13 +991,45 @@ if (import.meta.vitest) {
     `;
   }
 
-  async function createJsxCssPropViteFixture(prefix: string) {
+  function createJsxCssPropV2ClassValueFixtureSource(): string {
+    return `
+      const styleA = "style-a";
+      const styleB = ["style-b"];
+      const spreadProps = {
+        className: "from-spread",
+        css: "leaked-css",
+        id: "root"
+      };
+      const motion = { div: "div" };
+
+      function Button(props) {
+        return <button {...props} />;
+      }
+
+      function App() {
+        return <>
+          <Button css={styleA} />
+          <motion.div css={styleB} />
+        </>;
+      }
+
+      function SpreadApp() {
+        return <div {...spreadProps} css={styleA} />;
+      }
+
+      export { App, SpreadApp };
+    `;
+  }
+
+  async function createJsxCssPropViteFixture(
+    prefix: string,
+    source = createJsxCssPropFixtureSource()
+  ) {
     const cacheRoot = createViteFixtureCacheRoot();
     await fs.promises.mkdir(cacheRoot, { recursive: true });
     const root = await fs.promises.mkdtemp(join(cacheRoot, prefix));
     const srcRoot = join(root, "src");
     const entryPath = join(srcRoot, "entry.tsx");
-    const source = createJsxCssPropFixtureSource();
 
     await fs.promises.mkdir(srcRoot, { recursive: true });
     await fs.promises.writeFile(entryPath, source);
@@ -1090,6 +1135,29 @@ if (import.meta.vitest) {
 
     expect(classNameMergeMatch).not.toBeNull();
     expect(generatedLocalNames).toContain(classNameMergeMatch?.[1]);
+  }
+
+  function expectSourceToContainV2ClassValueCssPropLowering(
+    source: string,
+    cxIdentifier: string
+  ): void {
+    expect(source).toMatch(
+      new RegExp(
+        `<Button className=\\{${escapeRegExp(cxIdentifier)}\\(styleA\\)\\} />`
+      )
+    );
+    expect(source).toMatch(
+      new RegExp(
+        `<motion\\.div className=\\{${escapeRegExp(cxIdentifier)}\\(styleB\\)\\} />`
+      )
+    );
+    expect(source).toContain("css: _minchoCssProp");
+    expect(source).toContain("..._minchoRest");
+    expect(source).toMatch(
+      new RegExp(
+        `className=\\{${escapeRegExp(cxIdentifier)}\\(_minchoClassName, styleA\\)\\}`
+      )
+    );
   }
 
   function extractExportedVariableInitializerFromBuildSource(
@@ -1272,6 +1340,79 @@ if (import.meta.vitest) {
         );
         expectCssSourceToContainClassNames(virtualCss, generatedClassName);
         expect(virtualCss).toContain("color: red;");
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("lowers v2 class-value component and pre-css spread css props before React JSX handling", async () => {
+      const fixture = await createJsxCssPropViteFixture(
+        "jsx-css-prop-v2-class-value-",
+        createJsxCssPropV2ClassValueFixtureSource()
+      );
+
+      try {
+        const babelTransformSpy = await spyOnSourceBabelTransform();
+        const harness = await createViteHarness({
+          configOverrides: {
+            root: fixture.root
+          },
+          pluginOptions: {
+            jsxCssProp: true
+          }
+        });
+        const transformedEntry = extractViteTransformCode(
+          await harness.transform(fixture.entryPath, fixture.source),
+          "Expected v2 class-value css-prop entry transform to return code"
+        );
+        const cxIdentifier = extractCxIdentifierFromSource(transformedEntry);
+
+        expect(babelTransformSpy).toHaveBeenCalledWith(fixture.entryPath, {
+          jsxCssProp: true
+        });
+        expect(transformedEntry).not.toContain(" css=");
+        expect(transformedEntry).not.toContain("css={styleA}");
+        expect(transformedEntry).not.toContain("css={styleB}");
+        expect(transformedEntry).not.toContain("css(styleA)");
+        expect(transformedEntry).not.toContain("_css(styleA)");
+        expectSourceToContainV2ClassValueCssPropLowering(
+          transformedEntry,
+          cxIdentifier
+        );
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("preserves downstream transforms when enabled jsx css prop processing is unused", async () => {
+      const fixture = await createJsxCssPropViteFixture(
+        "jsx-css-prop-unused-",
+        `
+          function App() {
+            return <div className="base" />;
+          }
+
+          export { App };
+        `
+      );
+
+      try {
+        const babelTransformSpy = await spyOnSourceBabelTransform();
+        const harness = await createViteHarness({
+          configOverrides: {
+            root: fixture.root
+          },
+          pluginOptions: {
+            jsxCssProp: true
+          }
+        });
+
+        await expect(
+          harness.transform(fixture.entryPath, fixture.source)
+        ).resolves.toBeNull();
+        expect(babelTransformSpy).toHaveBeenCalledWith(fixture.entryPath, {
+          jsxCssProp: true
+        });
       } finally {
         await fs.promises.rm(fixture.root, { force: true, recursive: true });
       }


### PR DESCRIPTION
## Description

- Add scoped React JSX `css` prop typing and runtime support.
- Lower inline rules, class values, conditional branches, and recursive arrays through Babel.
- Forward the `jsxCssProp` option through integration, Vite, and esbuild.
- Update examples, migration documentation, snapshots, and the changeset.

## Related Issue

N/A

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced JSX `css` prop v2 support across Babel, Vite, ESBuild, and React integration, including class-value lowering and improved `className`-driven behavior.
  - Added conditional TypeScript support so `css` is available only for compatible `className` patterns; exported additional `ClassPrimitive` typing.
- **Bug Fixes**
  - React runtime now throws on an own `css` prop surviving transform (prototype/inherited `css` is unaffected).
  - Improved detection and cleanup of extracted CSS helpers when lowering is unused.
- **Documentation**
  - Updated React documentation to describe v2 semantics, supported operator patterns, and limitations.
- **Tests**
  - Expanded v2 fixtures and runtime/lowering validation across Babel, Vite, and ESBuild.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context

Pre-PR verification:

- `yarn build`: pass
- `yarn check`: pass
- `yarn check:peers`: pass
- `yarn constraints`: pass
- `yarn sync:check`: pass
- `yarn test`: blocked by one integration assertion that expects `_cx("literal-class")` while the transform emits the optimized `className="literal-class"`
- `yarn test:all`: blocked by nine constant-expression lint errors in React type tests

Review blockers:

- Preserve JSX attribute and static-left logical-expression evaluation order.
- Resolve component-owned `css` prop handling consistently between types and Babel lowering.
- Add `@mincho-js/css` to the changeset for the new public `ClassPrimitive` export.

## Checklist

- [x] Changeset and migration documentation updated
- [x] Build succeeds
- [x] Type checks succeed
- [ ] Lint succeeds
- [ ] Tests succeed
