### PR TITLE
Feat: CSS Prop - Add static evaluation foundation

### DIFF
--- a/examples/react-babel/src/App.tsx
+++ b/examples/react-babel/src/App.tsx
@@ -5,6 +5,7 @@ import { styled } from "@mincho-js/react";
 import type { ReactNode } from "react";
 
 import { sharedCardHostClassName } from "./App.css.ts";
+import importedDefaultStyle, { importedNamedStyle } from "./staticStyles";
 
 const styleA = css({
   display: "block",
@@ -86,6 +87,8 @@ function App() {
       <ClassNameForwardingExample css={styleA}>
         Custom component css prop forwarding
       </ClassNameForwardingExample>
+      <div css={importedNamedStyle}>Imported named static css prop</div>
+      <div css={importedDefaultStyle}>Imported default static css prop</div>
       <div
         className={sharedCardHostClassName}
         css={{

--- a/examples/react-babel/src/staticStyles.ts
+++ b/examples/react-babel/src/staticStyles.ts
@@ -1,0 +1,9 @@
+export const importedNamedStyle = {
+  display: "block",
+} as const;
+
+const importedDefaultStyle = {
+  paddingTop: "0",
+} as const;
+
+export default importedDefaultStyle;

--- a/examples/react-swc/src/App.tsx
+++ b/examples/react-swc/src/App.tsx
@@ -3,6 +3,7 @@ import { SharedExampleCard } from "@examples/shared-component";
 import { css } from "@mincho-js/css";
 import { type ReactNode, useState } from "react";
 import reactLogo from "./assets/react.svg";
+import importedDefaultStyle, { importedNamedStyle } from "./staticStyles";
 import viteLogo from "/vite.svg";
 
 const styleA = css({
@@ -51,6 +52,8 @@ function App() {
       <ClassNameForwardingExample css={styleA}>
         Custom component css prop forwarding
       </ClassNameForwardingExample>
+      <div css={importedNamedStyle}>Imported named static css prop</div>
+      <div css={importedDefaultStyle}>Imported default static css prop</div>
       <div
         className={sharedCardContainerClassName}
         css={{

--- a/examples/react-swc/src/staticStyles.ts
+++ b/examples/react-swc/src/staticStyles.ts
@@ -1,0 +1,9 @@
+export const importedNamedStyle = {
+  display: "block",
+} as const;
+
+const importedDefaultStyle = {
+  paddingTop: "var(--react-swc-space-0)",
+} as const;
+
+export default importedDefaultStyle;

--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -35,7 +35,17 @@ export function minchoBabelPlugin(): PluginObj<PluginState> {
 }
 
 export { styledComponentPlugin as minchoStyledComponentPlugin } from "./styled.js";
+export { collectJsxCssPropStaticCssEvalCandidates as internalCollectJsxCssPropStaticCssEvalCandidates } from "./staticCssEval/candidates.js";
+export {
+  createImportedStaticCssEvalModuleRecord as internalCreateImportedStaticCssEvalModuleRecord,
+  createImportedStaticCssEvalProvider as internalCreateImportedStaticCssEvalProvider
+} from "./staticCssEval/importedModules.js";
 export type { PluginOptions } from "./types.js";
+export type {
+  ImportedStaticCssEvalImportResolution as InternalImportedStaticCssEvalImportResolution,
+  ImportedStaticCssEvalLoadedModule as InternalImportedStaticCssEvalLoadedModule,
+  ImportedStaticCssEvalModuleRecord as InternalImportedStaticCssEvalModuleRecord
+} from "./staticCssEval/importedModules.js";
 
 // == Tests ====================================================================
 // Ignore errors when compiling to CommonJS.
@@ -48,7 +58,9 @@ if (import.meta.vitest) {
 
   function babelTransform(
     code: string,
-    pluginOptions: Partial<Pick<PluginOptions, "jsxCssProp">> = {}
+    pluginOptions: Partial<
+      Pick<PluginOptions, "jsxCssProp" | "staticCssEvalProvider">
+    > = {}
   ) {
     const options: PluginOptions = { result: ["", ""], ...pluginOptions };
     const result = transformSync(code, {
@@ -70,6 +82,66 @@ if (import.meta.vitest) {
   ) => Record<string, unknown>;
   type RuntimeCx = (...values: unknown[]) => string;
   type RuntimeCss = (styles: unknown) => string;
+  type StaticCssEvalProvider = NonNullable<
+    PluginOptions["staticCssEvalProvider"]
+  >;
+  type StaticCssEvalProviderResult = ReturnType<
+    StaticCssEvalProvider["getResolvedCssValue"]
+  >;
+  type StaticCssEvalValue = Extract<
+    StaticCssEvalProviderResult,
+    { kind: "resolved" }
+  >["value"];
+
+  function createResolvedStaticCssEvalProvider(
+    values: Record<string, StaticCssEvalValue>
+  ): StaticCssEvalProvider {
+    return {
+      getResolvedCssValue(query): StaticCssEvalProviderResult {
+        const key = query.memberPath?.length
+          ? `${query.bindingName}.${query.memberPath.join(".")}`
+          : (query.bindingName ?? "");
+        const value = values[key];
+
+        if (value === undefined) {
+          return { kind: "not-candidate" };
+        }
+
+        return {
+          kind: "resolved",
+          value,
+          dependencies: ["/provider/styles.ts"]
+        };
+      }
+    };
+  }
+
+  function createUnsupportedReexportStaticCssEvalProvider(): StaticCssEvalProvider {
+    return {
+      getResolvedCssValue(query): StaticCssEvalProviderResult {
+        return {
+          kind: "error",
+          diagnostic: {
+            code: "unsupported-source",
+            message:
+              'Cannot statically evaluate css prop value: export "button" uses unsupported reexport/barrel syntax',
+            reason: "reexport-or-barrel",
+            owner: {
+              file: query.importerId,
+              start: query.expressionStart,
+              end: query.expressionEnd
+            },
+            dependency: { file: "/provider/barrel.ts" },
+            importPath: "./barrel",
+            exportName: "button",
+            memberPath: query.memberPath ?? [],
+            importChain: [query.importerId, "/provider/barrel.ts#button"]
+          },
+          dependencies: ["/provider/barrel.ts"]
+        };
+      }
+    };
+  }
 
   function runJsxCssPropRuntime(
     source: string,
@@ -392,6 +464,520 @@ if (import.meta.vitest) {
       expect(code).toContain("className={_$mincho$$App2}");
     });
 
+    it("lowers same-file const object jsx css prop like an inline object", () => {
+      const inline = babelTransform(
+        `
+        function App() {
+          return <div css={{ color: "red" }} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+      const sameFileConst = babelTransform(
+        `
+        const style = { color: "red" };
+
+        function App() {
+          return <div css={style} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(sameFileConst.code).not.toContain(" css=");
+      expect(sameFileConst.code).toContain("className={_$mincho$$App2}");
+      expect(sameFileConst.code).not.toContain("_cx(style)");
+      expect(sameFileConst.result[1]).toBe(inline.result[1]);
+    });
+
+    it("lowers same-file const member jsx css prop like an inline object", () => {
+      const { result, code } = babelTransform(
+        `
+        const styles = {
+          button: { color: "red" }
+        };
+
+        function App() {
+          return <div css={styles.button} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(code).not.toContain(" css=");
+      expect(code).toContain("className={_$mincho$$App2}");
+      expect(code).not.toContain("_cx(styles.button)");
+      expect(result[1]).toContain("_css({");
+      expect(result[1]).toContain('color: "red"');
+    });
+
+    it("lowers provider-resolved imported css props like inline object and array literals", () => {
+      const inline = babelTransform(
+        `
+        function App() {
+          return <>
+            <div css={{ color: "red" }} />
+            <div css={["base", { color: "blue" }]} />
+          </>;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+      const imported = babelTransform(
+        `
+        import { button, stack } from "./styles";
+
+        function App() {
+          return <>
+            <div css={button} />
+            <div css={stack} />
+          </>;
+        }
+      `,
+        {
+          jsxCssProp: true,
+          staticCssEvalProvider: createResolvedStaticCssEvalProvider({
+            button: { color: "red" },
+            stack: ["base", { color: "blue" }]
+          })
+        }
+      );
+
+      expect(imported.result[1]).toBe(inline.result[1]);
+      expect(imported.code).not.toContain(" css=");
+      expect(imported.code).not.toContain("_cx(button)");
+      expect(imported.code).not.toContain("_cx(stack)");
+      expect(
+        imported.code.match(/className=\{_\$mincho\$\$App\d+\}/g)
+      ).toHaveLength(2);
+    });
+
+    it("merges expression className before provider-resolved css rule class", () => {
+      const { result, code } = babelTransform(
+        `
+        import { button } from "./styles";
+
+        const base = "base";
+
+        function App() {
+          return <div className={base} css={button} />;
+        }
+      `,
+        {
+          jsxCssProp: true,
+          staticCssEvalProvider: createResolvedStaticCssEvalProvider({
+            button: { color: "red" }
+          })
+        }
+      );
+
+      expect(result[1]).toContain("_css({");
+      expect(result[1]).toContain('color: "red"');
+      expect(code).not.toContain(" css=");
+      expect(code).toMatch(/className=\{_cx\(base, _\$mincho\$\$App\d+\)\}/);
+      expect(code).not.toMatch(
+        /className=\{_cx\(_\$mincho\$\$App\d+, base\)\}/
+      );
+      expect(code).not.toContain("_cx(button)");
+    });
+
+    it("preserves provider reexport fallback for whole css values but rejects them inside static rules", () => {
+      const provider = createUnsupportedReexportStaticCssEvalProvider();
+      const wholeExpression = babelTransform(
+        `
+        import { button } from "./barrel";
+
+        function App() {
+          return <div css={button} />;
+        }
+      `,
+        { jsxCssProp: true, staticCssEvalProvider: provider }
+      );
+
+      expect(wholeExpression.result[1]).toBe("");
+      expect(wholeExpression.code).not.toContain(" css=");
+      expect(wholeExpression.code).toContain("className={_cx(button)}");
+      expect(wholeExpression.code).not.toContain("_css(button)");
+
+      expect(() =>
+        babelTransform(
+          `
+          import { button } from "./barrel";
+
+          function App() {
+            return <div css={{ color: button }} />;
+          }
+        `,
+          { jsxCssProp: true, staticCssEvalProvider: provider }
+        )
+      ).toThrow(
+        'Cannot statically evaluate css prop value: export "button" uses unsupported reexport/barrel syntax'
+      );
+    });
+
+    it("respects Babel scope when same-file const css prop bindings shadow", () => {
+      const { result, code } = babelTransform(
+        `
+        const style = { color: "red" };
+
+        function App() {
+          const style = { color: "blue" };
+          return <div css={style} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(code).not.toContain(" css=");
+      expect(code).toContain("className={_$mincho$$App2}");
+      expect(result[1]).toContain('color: "blue"');
+      expect(result[1]).not.toContain('color: "red"');
+    });
+
+    it("preserves dynamic and mutable identifier css props as class values", () => {
+      const { result, code } = babelTransform(
+        `
+        const className = getClassName();
+        let style = { color: "red" };
+
+        function getClassName() {
+          return "dynamic";
+        }
+
+        function App() {
+          return <>
+            <div css={className} />
+            <div css={style} />
+          </>;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(code).not.toContain(" css=");
+      expect(code).toContain("className={_cx(className)}");
+      expect(code).toContain("className={_cx(style)}");
+      expect(code).not.toContain("_css(className)");
+      expect(code).not.toContain("_css(style)");
+      expect(result[1]).not.toContain("_css(");
+    });
+
+    it("rejects mutated same-file const object jsx css prop bindings", () => {
+      expect(() =>
+        babelTransform(
+          `
+          const style = { color: "red" };
+          style.color = "blue";
+
+          function App() {
+            return <div css={style} />;
+          }
+        `,
+          { jsxCssProp: true }
+        )
+      ).toThrow(
+        'Cannot statically evaluate css prop value: same-file binding "style" is mutated'
+      );
+    });
+
+    it("lowers same-file const practical literal grammar like an inline object", () => {
+      const inline = babelTransform(
+        `
+        function App() {
+          return <div css={{
+            color: "red",
+            opacity: -1,
+            zIndex: +2,
+            enabled: true,
+            empty: null,
+            fallbacks: ["red", "blue"],
+            selectors: {
+              "&:hover": {
+                color: "blue"
+              }
+            }
+          }} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+      const sameFileConst = babelTransform(
+        `
+        const style = {
+          color: \`red\`,
+          opacity: -1,
+          zIndex: +2,
+          enabled: true,
+          empty: null,
+          fallbacks: ["red", \`blue\`],
+          selectors: {
+            "&:hover": {
+              color: \`blue\`
+            }
+          }
+        };
+
+        function App() {
+          return <div css={style} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(sameFileConst.code).not.toContain(" css=");
+      expect(sameFileConst.code).toContain("className={_$mincho$$App2}");
+      expect(sameFileConst.code).not.toContain("_cx(style)");
+      expect(sameFileConst.result[1]).toBe(inline.result[1]);
+      expect(sameFileConst.result[1]).toContain('color: "red"');
+      expect(sameFileConst.result[1]).toContain("opacity: -1");
+      expect(sameFileConst.result[1]).toContain("zIndex: +2");
+    });
+
+    it("resolves same-file const object member path grammar", () => {
+      const fixtures = [
+        {
+          expression: "styles.button.primary",
+          inlineCss: `{ color: "blue" }`,
+          expectedColor: 'color: "blue"'
+        },
+        {
+          expression: 'styles["button"]',
+          inlineCss: `{ color: "red", primary: { color: "blue" } }`,
+          expectedColor: 'color: "red"'
+        },
+        {
+          expression: 'styles["button"].primary',
+          inlineCss: `{ color: "blue" }`,
+          expectedColor: 'color: "blue"'
+        }
+      ] as const;
+
+      for (const { expression, inlineCss, expectedColor } of fixtures) {
+        const inline = babelTransform(
+          `
+          function App() {
+            return <div css={${inlineCss}} />;
+          }
+        `,
+          { jsxCssProp: true }
+        );
+        const sameFileConst = babelTransform(
+          `
+          const styles = {
+            button: {
+              color: "red",
+              primary: { color: "blue" }
+            }
+          };
+
+          function App() {
+            return <div css={${expression}} />;
+          }
+        `,
+          { jsxCssProp: true }
+        );
+
+        expect(sameFileConst.code).not.toContain(" css=");
+        expect(sameFileConst.code).toContain("className={_$mincho$$App2}");
+        expect(sameFileConst.code).not.toContain(`_cx(${expression})`);
+        expect(sameFileConst.result[1]).toBe(inline.result[1]);
+        expect(sameFileConst.result[1]).toContain(expectedColor);
+      }
+    });
+
+    it("rejects unsupported same-file static css literal grammar deterministically", () => {
+      const fixtures = [
+        {
+          setup: `const color = "red"; const style = { color };`,
+          expression: "style",
+          reason: "identifier-object-value"
+        },
+        {
+          setup: `const theme = { color: "red" }; const style = { color: theme.color };`,
+          expression: "style",
+          reason: "member-expression-object-value"
+        },
+        {
+          setup: `const color = "red"; const style = { color: \`var(\${color})\` };`,
+          expression: "style",
+          reason: "template-expression"
+        },
+        {
+          setup: `const base = { color: "blue" }; const style = { ...base, color: "red" };`,
+          expression: "style",
+          reason: "object spread"
+        },
+        {
+          setup: `const base = [{ color: "blue" }]; const style = [{ color: "red" }, ...base];`,
+          expression: "style",
+          reason: "array spread"
+        },
+        {
+          setup: `const styles = { button: { color: "red" } };`,
+          expression: "styles?.button",
+          reason: "optional-member-path"
+        },
+        {
+          setup: `const key = "button"; const styles = { button: { color: "red" } };`,
+          expression: "styles[key]",
+          reason: "dynamic-member-path"
+        },
+        {
+          setup: `const styles = [{ color: "red" }];`,
+          expression: "styles[0]",
+          reason: "numeric-member-path"
+        }
+      ] as const;
+
+      for (const { setup, expression, reason } of fixtures) {
+        expect(() =>
+          babelTransform(
+            `
+            ${setup}
+
+            function App() {
+              return <div css={${expression}} />;
+            }
+          `,
+            { jsxCssProp: true }
+          )
+        ).toThrow("Cannot statically evaluate css prop value");
+        expect(() =>
+          babelTransform(
+            `
+            ${setup}
+
+            function App() {
+              return <div css={${expression}} />;
+            }
+          `,
+            { jsxCssProp: true }
+          )
+        ).toThrow(reason);
+      }
+    });
+
+    it("preserves class-value fallback when static css rule candidacy is unproven", () => {
+      const { result, code } = babelTransform(
+        `
+        const key = "root";
+        const styles = { root: "root" };
+        let mutable = { button: { color: "red" } };
+
+        function getClassName() {
+          return "dynamic";
+        }
+
+        function App() {
+          return <>
+            <div css={styles[key]} />
+            <div css={styles?.root} />
+            <div css={styles[0]} />
+            <div css={mutable.button} />
+            <div css={getClassName()} />
+          </>;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(code).not.toContain(" css=");
+      expect(code).toContain("className={_cx(styles[key])}");
+      expect(code).toContain("className={_cx(styles?.root)}");
+      expect(code).toContain("className={_cx(styles[0])}");
+      expect(code).toContain("className={_cx(mutable.button)}");
+      expect(code).toContain("className={_cx(getClassName())}");
+      expect(result[1]).not.toContain("_css(");
+    });
+
+    it("preserves unresolved top-level css prop references as class values", () => {
+      const { result, code } = babelTransform(
+        `
+        function App() {
+          return <>
+            <div css={unknownClassName} />
+            <div css={externalStyles.button} />
+          </>;
+        }
+      `,
+        {
+          jsxCssProp: true,
+          staticCssEvalProvider: createResolvedStaticCssEvalProvider({})
+        }
+      );
+
+      expect(code).not.toContain(" css=");
+      expect(code).toContain("className={_cx(unknownClassName)}");
+      expect(code).toContain("className={_cx(externalStyles.button)}");
+      expect(result[1]).not.toContain("_css(");
+    });
+
+    it("evaluates direct dynamic class-value css prop calls once", () => {
+      const source = `
+        let callCount = 0;
+
+        function getClassName() {
+          callCount += 1;
+          return "dynamic";
+        }
+
+        function App() {
+          return <div css={getClassName()} />;
+        }
+      `;
+      const { result, code } = babelTransform(source, { jsxCssProp: true });
+      const observed = runJsxCssPropRuntime(
+        source,
+        "return { props: App(), callCount };"
+      ) as { props: Record<string, unknown>; callCount: number };
+
+      expect(code).not.toContain(" css=");
+      expect(code).toContain("className={_cx(getClassName())}");
+      expect(code).not.toContain("_css(getClassName())");
+      expect(result[1]).not.toContain("_css(");
+      expect(observed.callCount).toBe(1);
+      expect(observed.props.className).toBe("dynamic");
+      expect("css" in observed.props).toBe(false);
+    });
+
+    it("rejects same-file static css rule member-expression object values", () => {
+      expect(() =>
+        babelTransform(
+          `
+          const theme = { color: "red" };
+          const style = { color: theme.color };
+
+          function App() {
+            return <div css={style} />;
+          }
+        `,
+          { jsxCssProp: true }
+        )
+      ).toThrow(
+        'Cannot statically evaluate css prop value: same-file binding "style" contains unsupported member-expression-object-value: MemberExpression'
+      );
+    });
+
+    it("keeps conditional const object css prop values in class-value mode", () => {
+      const { result, code } = babelTransform(
+        `
+        const condition = true;
+        const style = condition ? { color: "red" } : {};
+
+        function App() {
+          return <div css={style} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(code).not.toContain(" css=");
+      expect(code).toContain("className={_cx(style)}");
+      expect(code).not.toContain("_$mincho$$App");
+      expect(result[1]).not.toContain("_css(");
+      expect(result[1]).not.toContain('color: "red"');
+    });
+
     it("merges string literal className before generated css rule class", () => {
       const { result, code } = babelTransform(
         `
@@ -531,7 +1117,12 @@ if (import.meta.vitest) {
           </>;
         }
       `,
-        { jsxCssProp: true }
+        {
+          jsxCssProp: true,
+          staticCssEvalProvider: createResolvedStaticCssEvalProvider({
+            button: { color: "red" }
+          })
+        }
       );
 
       expect(result).toMatchSnapshot();

--- a/packages/babel/src/jsxCssProp.ts
+++ b/packages/babel/src/jsxCssProp.ts
@@ -1,5 +1,11 @@
 import { types as t } from "@babel/core";
 import type { NodePath } from "@babel/core";
+import { unwrapTransparentCssRuleExpression } from "./staticCssEval/candidates.js";
+import {
+  findUnsupportedImportedStaticCssEvalReferenceDiagnostic,
+  resolveImportedStaticCssEvalExpression
+} from "./staticCssEval/importedModules.js";
+import { resolveSameFileStaticCssEvalExpression } from "./staticCssEval/sameFile.js";
 import type { PluginState, ProgramScope } from "./types.js";
 import { registerImportMethod } from "./utils.js";
 
@@ -59,7 +65,11 @@ export function preprocessJsxCssProp(
 
   path.traverse({
     JSXOpeningElement(openingElementPath) {
-      const normalizedElement = normalizeOpeningElement(openingElementPath);
+      const normalizedElement = normalizeOpeningElement(
+        openingElementPath,
+        path,
+        state
+      );
 
       if (!normalizedElement) {
         return;
@@ -150,7 +160,9 @@ function isUnusedCssModuleHelperImport(
 }
 
 function normalizeOpeningElement(
-  openingElementPath: NodePath<t.JSXOpeningElement>
+  openingElementPath: NodePath<t.JSXOpeningElement>,
+  programPath: NodePath<t.Program>,
+  state: PluginState
 ): {
   cssAttribute: t.JSXAttribute;
   cssExpression: t.Expression;
@@ -207,7 +219,12 @@ function normalizeOpeningElement(
     );
   }
 
-  const cssExpression = getCssExpression(openingElementPath, cssAttribute);
+  const cssExpression = getResolvedCssExpression(
+    openingElementPath,
+    programPath,
+    state,
+    cssAttribute
+  );
   const cssValueClassification = classifyCssPropValue(cssExpression);
 
   if (cssValueClassification === "unsupported-function") {
@@ -243,6 +260,67 @@ function normalizeOpeningElement(
     attributesAfterCss,
     hasSpreadBeforeCss
   };
+}
+
+function getResolvedCssExpression(
+  path: NodePath<t.JSXOpeningElement>,
+  programPath: NodePath<t.Program>,
+  state: PluginState,
+  attribute: t.JSXAttribute
+): t.Expression {
+  const cssExpression = getCssExpression(path, attribute);
+  const ownerFile = getStaticCssEvalOwnerFile(state);
+  const staticCssEvalResult = resolveSameFileStaticCssEvalExpression({
+    expression: cssExpression,
+    ownerFile,
+    programPath,
+    scope: path.scope
+  });
+
+  if (staticCssEvalResult.kind === "error") {
+    throw path.buildCodeFrameError(staticCssEvalResult.diagnostic.message);
+  }
+
+  if (staticCssEvalResult.kind === "resolved") {
+    return staticCssEvalResult.expression;
+  }
+
+  const importedStaticCssEvalResult = resolveImportedStaticCssEvalExpression({
+    expression: cssExpression,
+    ownerFile,
+    provider: state.opts.staticCssEvalProvider,
+    allowUnsupportedSourceFallback: true
+  });
+
+  if (importedStaticCssEvalResult.kind === "error") {
+    throw path.buildCodeFrameError(
+      importedStaticCssEvalResult.diagnostic.message
+    );
+  }
+
+  const resolvedCssExpression =
+    importedStaticCssEvalResult.kind === "resolved"
+      ? importedStaticCssEvalResult.expression
+      : cssExpression;
+
+  const unsupportedImportedReferenceDiagnostic =
+    findUnsupportedImportedStaticCssEvalReferenceDiagnostic({
+      expression: resolvedCssExpression,
+      ownerFile,
+      provider: state.opts.staticCssEvalProvider
+    });
+
+  if (unsupportedImportedReferenceDiagnostic) {
+    throw path.buildCodeFrameError(
+      unsupportedImportedReferenceDiagnostic.message
+    );
+  }
+
+  return resolvedCssExpression;
+}
+
+function getStaticCssEvalOwnerFile(state: PluginState): string {
+  return state.file.opts.filename ?? "<unknown>";
 }
 
 function assertSupportedCssPropElement(
@@ -1226,39 +1304,10 @@ function isUnsupportedDynamicCssRuleValue(
   return false;
 }
 
-type TransparentCssRuleWrapperExpression = t.Expression & {
-  expression: t.Expression;
-};
-
-function unwrapTransparentCssRuleExpression(
-  expression: t.Expression
-): t.Expression {
-  let currentExpression = expression;
-
-  while (isTransparentCssRuleWrapperExpression(currentExpression)) {
-    currentExpression = currentExpression.expression;
-  }
-
-  return currentExpression;
-}
-
 function createStaticStringExpression(
   expression: t.StringLiteral
 ): t.StringLiteral {
   return t.cloneNode(expression);
-}
-
-function isTransparentCssRuleWrapperExpression(
-  expression: t.Expression
-): expression is TransparentCssRuleWrapperExpression {
-  return (
-    expression.type === "TSNonNullExpression" ||
-    expression.type === "TSAsExpression" ||
-    expression.type === "TSSatisfiesExpression" ||
-    expression.type === "ParenthesizedExpression" ||
-    expression.type === "TypeCastExpression" ||
-    expression.type === "TSTypeAssertion"
-  );
 }
 
 function getClassNameExpression(

--- a/packages/babel/src/staticCssEval/ast.ts
+++ b/packages/babel/src/staticCssEval/ast.ts
@@ -1,0 +1,101 @@
+import { types as t } from "@babel/core";
+import type { StaticCssEvalUnsupportedReason } from "./types.js";
+
+export function getStaticObjectMemberValue(
+  expression: t.ObjectExpression,
+  memberName: string
+): t.Expression | null {
+  for (let index = expression.properties.length - 1; index >= 0; index -= 1) {
+    const property = expression.properties[index];
+
+    if (!property || !t.isObjectProperty(property) || property.computed) {
+      return null;
+    }
+
+    if (getStaticObjectPropertyName(property.key) !== memberName) {
+      continue;
+    }
+
+    return t.isExpression(property.value) ? property.value : null;
+  }
+
+  return null;
+}
+
+export function getStaticObjectPropertyName(
+  key: t.ObjectProperty["key"]
+): string | null {
+  if (t.isIdentifier(key)) {
+    return key.name;
+  }
+
+  if (t.isStringLiteral(key)) {
+    return key.value;
+  }
+
+  if (t.isNumericLiteral(key)) {
+    return String(key.value);
+  }
+
+  return null;
+}
+
+export function getStaticMemberPropertyName(
+  expression: t.MemberExpression | t.OptionalMemberExpression
+): string | null {
+  if (!expression.computed && t.isIdentifier(expression.property)) {
+    return expression.property.name;
+  }
+
+  if (expression.computed && t.isStringLiteral(expression.property)) {
+    return expression.property.value;
+  }
+
+  if (expression.computed && t.isNumericLiteral(expression.property)) {
+    return String(expression.property.value);
+  }
+
+  return null;
+}
+
+export function getUnsupportedLiteralReason(
+  expression: t.Expression
+): StaticCssEvalUnsupportedReason {
+  if (t.isIdentifier(expression)) {
+    return "identifier-object-value";
+  }
+
+  if (
+    t.isMemberExpression(expression) ||
+    t.isOptionalMemberExpression(expression)
+  ) {
+    return "member-expression-object-value";
+  }
+
+  if (
+    t.isCallExpression(expression) ||
+    t.isOptionalCallExpression(expression)
+  ) {
+    return "function-or-call";
+  }
+
+  if (
+    t.isConditionalExpression(expression) ||
+    t.isLogicalExpression(expression)
+  ) {
+    return "conditional-or-logical-expression";
+  }
+
+  if (t.isBinaryExpression(expression)) {
+    return "binary-expression";
+  }
+
+  if (
+    t.isTemplateLiteral(expression) ||
+    t.isTaggedTemplateExpression(expression)
+  ) {
+    return "template-expression";
+  }
+
+  return "unsupported-literal";
+}

--- a/packages/babel/src/staticCssEval/boundary.ts
+++ b/packages/babel/src/staticCssEval/boundary.ts
@@ -1,0 +1,379 @@
+import {
+  createStaticCssEvalDiagnostic,
+  type StaticCssEvalDiagnosticContext
+} from "./diagnostics.js";
+import type {
+  StaticCssEvalDependencyKind,
+  StaticCssEvalDependencyMetadata,
+  StaticCssEvalProjectLocalBoundaryState,
+  StaticCssEvalUnsupportedReason
+} from "./types.js";
+
+export interface StaticCssEvalProjectLocalBoundaryDescriptor {
+  rootRealpath: string;
+  resolvedId: string;
+  resolvedRealpath: string;
+  virtual?: boolean;
+  packageExportRealpath?: string | null;
+}
+
+export interface StaticCssEvalProjectLocalBoundaryCheckOptions
+  extends
+    StaticCssEvalProjectLocalBoundaryDescriptor,
+    StaticCssEvalDiagnosticContext {}
+
+export type StaticCssEvalProjectLocalBoundaryResult =
+  | {
+      ok: true;
+      boundary: StaticCssEvalProjectLocalBoundaryState;
+      dependencies: string[];
+    }
+  | {
+      ok: false;
+      boundary: StaticCssEvalProjectLocalBoundaryState;
+      diagnostic: ReturnType<typeof createStaticCssEvalDiagnostic>;
+      dependencies: string[];
+    };
+
+export interface CreateStaticCssEvalDependencyMetadataOptions extends StaticCssEvalProjectLocalBoundaryDescriptor {
+  kind: StaticCssEvalDependencyKind;
+  id?: string;
+  importerId?: string;
+  importPath?: string;
+  sourceHash?: string;
+  version?: string | number;
+}
+
+export function createStaticCssEvalProjectLocalBoundaryState(
+  descriptor: StaticCssEvalProjectLocalBoundaryDescriptor
+): StaticCssEvalProjectLocalBoundaryState {
+  const virtual = isStaticCssEvalVirtualId(
+    descriptor.resolvedId,
+    descriptor.virtual
+  );
+  const packageExportOutsideRoot =
+    descriptor.packageExportRealpath != null &&
+    !isStaticCssEvalPathInsideRoot(
+      descriptor.rootRealpath,
+      descriptor.packageExportRealpath
+    );
+
+  return {
+    rootRealpath: descriptor.rootRealpath,
+    resolvedRealpath: descriptor.resolvedRealpath,
+    insideRoot: isStaticCssEvalPathInsideRoot(
+      descriptor.rootRealpath,
+      descriptor.resolvedRealpath
+    ),
+    insideNodeModules: hasStaticCssEvalNodeModulesSegment(
+      descriptor.resolvedRealpath
+    ),
+    virtual,
+    packageExportOutsideRoot
+  };
+}
+
+export function enforceStaticCssEvalProjectLocalBoundary(
+  options: StaticCssEvalProjectLocalBoundaryCheckOptions
+): StaticCssEvalProjectLocalBoundaryResult {
+  const boundary = createStaticCssEvalProjectLocalBoundaryState(options);
+  const dependencies = boundary.virtual ? [] : [options.resolvedRealpath];
+
+  if (isStaticCssEvalProjectLocalBoundaryAllowed(boundary)) {
+    return { ok: true, boundary, dependencies };
+  }
+
+  const dependency =
+    options.dependency ??
+    (boundary.virtual ? undefined : { file: options.resolvedRealpath });
+  const diagnostic = createStaticCssEvalDiagnostic({
+    code: "failed-project-local-dependency",
+    reason: getStaticCssEvalProjectLocalBoundaryReason(boundary),
+    detail: createStaticCssEvalProjectLocalBoundaryDetail(options, boundary),
+    owner: options.owner,
+    dependency,
+    importPath: options.importPath,
+    exportName: options.exportName,
+    memberPath: options.memberPath,
+    importChain: options.importChain
+  });
+
+  return { ok: false, boundary, diagnostic, dependencies };
+}
+
+export function isStaticCssEvalProjectLocalBoundaryAllowed(
+  boundary: StaticCssEvalProjectLocalBoundaryState
+): boolean {
+  return (
+    boundary.insideRoot &&
+    !boundary.insideNodeModules &&
+    !boundary.virtual &&
+    !boundary.packageExportOutsideRoot
+  );
+}
+
+export function createStaticCssEvalDependencyMetadata(
+  options: CreateStaticCssEvalDependencyMetadataOptions
+): StaticCssEvalDependencyMetadata {
+  const boundary = createStaticCssEvalProjectLocalBoundaryState(options);
+
+  return {
+    kind: options.kind,
+    id: options.id ?? options.resolvedId,
+    realpath: options.resolvedRealpath,
+    ...(options.importerId !== undefined
+      ? { importerId: options.importerId }
+      : {}),
+    ...(options.importPath !== undefined
+      ? { importPath: options.importPath }
+      : {}),
+    ...(options.sourceHash !== undefined
+      ? { sourceHash: options.sourceHash }
+      : {}),
+    ...(options.version !== undefined ? { version: options.version } : {}),
+    projectLocal: isStaticCssEvalProjectLocalBoundaryAllowed(boundary),
+    insideNodeModules: boundary.insideNodeModules,
+    virtual: boundary.virtual
+  };
+}
+
+export function isStaticCssEvalVirtualId(
+  resolvedId: string,
+  virtual?: boolean
+): boolean {
+  return (
+    virtual === true ||
+    resolvedId.startsWith("\0") ||
+    resolvedId.includes("\0") ||
+    resolvedId.startsWith("virtual:") ||
+    resolvedId.includes("__x00__")
+  );
+}
+
+export function isStaticCssEvalPathInsideRoot(
+  rootRealpath: string,
+  resolvedRealpath: string
+): boolean {
+  if (rootRealpath.length === 0 || resolvedRealpath.length === 0) {
+    return false;
+  }
+
+  const normalizedRoot = trimStaticCssEvalTrailingSlash(
+    normalizeStaticCssEvalPath(rootRealpath)
+  );
+  const normalizedResolved = trimStaticCssEvalTrailingSlash(
+    normalizeStaticCssEvalPath(resolvedRealpath)
+  );
+
+  return (
+    normalizedResolved === normalizedRoot ||
+    normalizedResolved.startsWith(`${normalizedRoot}/`)
+  );
+}
+
+export function hasStaticCssEvalNodeModulesSegment(filePath: string): boolean {
+  return normalizeStaticCssEvalPath(filePath)
+    .split("/")
+    .includes("node_modules");
+}
+
+function getStaticCssEvalProjectLocalBoundaryReason(
+  boundary: StaticCssEvalProjectLocalBoundaryState
+): StaticCssEvalUnsupportedReason {
+  if (boundary.virtual) {
+    return "virtual-module";
+  }
+
+  if (boundary.insideNodeModules) {
+    return "node-modules-import";
+  }
+
+  if (boundary.packageExportOutsideRoot || !boundary.insideRoot) {
+    return "not-project-local";
+  }
+
+  return "failed-project-local-dependency";
+}
+
+function createStaticCssEvalProjectLocalBoundaryDetail(
+  options: StaticCssEvalProjectLocalBoundaryDescriptor,
+  boundary: StaticCssEvalProjectLocalBoundaryState
+): string {
+  if (boundary.virtual) {
+    return `dependency is a virtual module (${options.resolvedId})`;
+  }
+
+  if (boundary.insideNodeModules) {
+    return `dependency is inside node_modules (${options.resolvedRealpath})`;
+  }
+
+  if (boundary.packageExportOutsideRoot) {
+    return `package export resolves outside project root (${options.packageExportRealpath} outside ${options.rootRealpath})`;
+  }
+
+  if (!boundary.insideRoot) {
+    return `dependency realpath is outside project root (${options.resolvedRealpath} outside ${options.rootRealpath})`;
+  }
+
+  return `dependency failed project-local boundary checks (${options.resolvedRealpath})`;
+}
+
+function normalizeStaticCssEvalPath(filePath: string): string {
+  return filePath.replace(/\\/g, "/");
+}
+
+function trimStaticCssEvalTrailingSlash(filePath: string): string {
+  return filePath.length > 1 ? filePath.replace(/\/+$/g, "") : filePath;
+}
+
+if (import.meta.vitest) {
+  const { describe, expect, it } = import.meta.vitest;
+
+  const owner = { file: "/project/src/App.tsx", start: 11, end: 18 };
+
+  describe("static css eval project-local boundary", () => {
+    it("accepts real files inside the project root", () => {
+      expect(
+        enforceStaticCssEvalProjectLocalBoundary({
+          owner,
+          rootRealpath: "/project",
+          resolvedId: "/project/src/styles.ts",
+          resolvedRealpath: "/project/src/styles.ts",
+          importPath: "./styles"
+        })
+      ).toEqual({
+        ok: true,
+        boundary: {
+          rootRealpath: "/project",
+          resolvedRealpath: "/project/src/styles.ts",
+          insideRoot: true,
+          insideNodeModules: false,
+          virtual: false,
+          packageExportOutsideRoot: false
+        },
+        dependencies: ["/project/src/styles.ts"]
+      });
+    });
+
+    it("rejects outside-root, node_modules, virtual, and package-export dependencies", () => {
+      expect(
+        enforceStaticCssEvalProjectLocalBoundary({
+          owner,
+          rootRealpath: "/project",
+          resolvedId: "/outside/styles.ts",
+          resolvedRealpath: "/outside/styles.ts",
+          importPath: "../outside"
+        })
+      ).toMatchObject({
+        ok: false,
+        diagnostic: {
+          code: "failed-project-local-dependency",
+          reason: "not-project-local",
+          message:
+            "Cannot statically evaluate css prop value: dependency realpath is outside project root (/outside/styles.ts outside /project)"
+        }
+      });
+      expect(
+        enforceStaticCssEvalProjectLocalBoundary({
+          owner,
+          rootRealpath: "/project",
+          resolvedId: "/project/node_modules/pkg/styles.ts",
+          resolvedRealpath: "/project/node_modules/pkg/styles.ts",
+          importPath: "pkg/styles"
+        })
+      ).toMatchObject({
+        ok: false,
+        diagnostic: {
+          reason: "node-modules-import",
+          message:
+            "Cannot statically evaluate css prop value: dependency is inside node_modules (/project/node_modules/pkg/styles.ts)"
+        }
+      });
+      expect(
+        enforceStaticCssEvalProjectLocalBoundary({
+          owner,
+          rootRealpath: "/project",
+          resolvedId: "\0virtual:mincho",
+          resolvedRealpath: "/project/src/virtual.ts",
+          virtual: true,
+          importPath: "virtual:mincho"
+        })
+      ).toMatchObject({
+        ok: false,
+        diagnostic: {
+          reason: "virtual-module",
+          message:
+            "Cannot statically evaluate css prop value: dependency is a virtual module (\0virtual:mincho)"
+        },
+        dependencies: []
+      });
+      expect(
+        enforceStaticCssEvalProjectLocalBoundary({
+          owner,
+          rootRealpath: "/project",
+          resolvedId: "/outside-pkg/styles.ts",
+          resolvedRealpath: "/outside-pkg/styles.ts",
+          packageExportRealpath: "/outside-pkg/styles.ts",
+          importPath: "pkg/styles"
+        })
+      ).toMatchObject({
+        ok: false,
+        diagnostic: {
+          reason: "not-project-local",
+          message:
+            "Cannot statically evaluate css prop value: package export resolves outside project root (/outside-pkg/styles.ts outside /project)"
+        }
+      });
+    });
+
+    it("classifies dependency metadata through the shared boundary helper", () => {
+      expect(
+        createStaticCssEvalDependencyMetadata({
+          kind: "project-local-import",
+          rootRealpath: "/project",
+          resolvedId: "/project/src/styles.ts",
+          resolvedRealpath: "/project/src/styles.ts",
+          importerId: "/project/src/App.tsx",
+          importPath: "./styles",
+          sourceHash: "sha256:styles",
+          version: 1
+        })
+      ).toEqual({
+        kind: "project-local-import",
+        id: "/project/src/styles.ts",
+        realpath: "/project/src/styles.ts",
+        importerId: "/project/src/App.tsx",
+        importPath: "./styles",
+        sourceHash: "sha256:styles",
+        version: 1,
+        projectLocal: true,
+        insideNodeModules: false,
+        virtual: false
+      });
+    });
+
+    it("uses supplied realpaths so symlink targets outside root are rejected", () => {
+      const result = enforceStaticCssEvalProjectLocalBoundary({
+        owner: { file: "/project/src/App.tsx" },
+        rootRealpath: "/project",
+        resolvedId: "/project/src/symlinked-styles.ts",
+        resolvedRealpath: "/outside-realpath/styles.ts",
+        importPath: "./symlinked-styles"
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        boundary: {
+          insideRoot: false,
+          insideNodeModules: false,
+          virtual: false,
+          packageExportOutsideRoot: false
+        },
+        diagnostic: {
+          code: "failed-project-local-dependency",
+          reason: "not-project-local"
+        }
+      });
+    });
+  });
+}

--- a/packages/babel/src/staticCssEval/candidates.ts
+++ b/packages/babel/src/staticCssEval/candidates.ts
@@ -1,0 +1,429 @@
+import { transformSync, types as t } from "@babel/core";
+import type { NodePath, PluginObj } from "@babel/core";
+import type {
+  StaticCssEvalQuery,
+  StaticCssEvalUnsupportedReason
+} from "./types.js";
+
+const cssAttributeName = "css";
+
+export type StaticCssEvalCandidate = StaticCssEvalQuery;
+
+export interface CollectJsxCssPropStaticCssEvalCandidatesOptions {
+  importerId: string;
+}
+
+export type StaticMemberReference =
+  | SupportedStaticMemberReference
+  | UnsupportedStaticMemberReference;
+
+interface SupportedStaticMemberReference {
+  kind: "supported";
+  bindingName: string;
+  memberPath: string[];
+}
+
+interface UnsupportedStaticMemberReference {
+  kind: "unsupported";
+  bindingName: string;
+  memberPath: string[];
+  reason: StaticCssEvalUnsupportedReason;
+  detail: string;
+  unsupportedPropertyName?: string;
+}
+
+type TransparentCssRuleWrapperExpression = t.Expression & {
+  expression: t.Expression;
+};
+
+export function collectJsxCssPropStaticCssEvalCandidates(
+  path: NodePath<t.Program>,
+  options: CollectJsxCssPropStaticCssEvalCandidatesOptions
+): StaticCssEvalCandidate[] {
+  const candidates: StaticCssEvalCandidate[] = [];
+
+  path.traverse({
+    JSXAttribute(attributePath) {
+      if (!isCssPropAttribute(attributePath.node)) {
+        return;
+      }
+
+      const expression = getJsxExpressionContainerValue(attributePath.node);
+
+      if (!expression) {
+        return;
+      }
+
+      const candidate = createStaticCssEvalCandidate(
+        expression,
+        options.importerId
+      );
+
+      if (candidate) {
+        candidates.push(candidate);
+      }
+    }
+  });
+
+  return candidates;
+}
+
+export function createStaticCssEvalCandidate(
+  expression: t.Expression,
+  importerId: string
+): StaticCssEvalCandidate | null {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+  const range = getExpressionRange(unwrappedExpression);
+  const reference = getStaticCssEvalMemberReference(unwrappedExpression);
+
+  if (!range || !reference || reference.kind !== "supported") {
+    return null;
+  }
+
+  return {
+    importerId,
+    expressionStart: range.start,
+    expressionEnd: range.end,
+    bindingName: reference.bindingName,
+    ...(reference.memberPath.length > 0
+      ? { memberPath: reference.memberPath }
+      : {})
+  };
+}
+
+export function unwrapTransparentCssRuleExpression(
+  expression: t.Expression
+): t.Expression {
+  let currentExpression = expression;
+
+  while (isTransparentCssRuleWrapperExpression(currentExpression)) {
+    currentExpression = currentExpression.expression;
+  }
+
+  return currentExpression;
+}
+
+export function isTransparentCssRuleWrapperExpression(
+  expression: t.Expression
+): expression is TransparentCssRuleWrapperExpression {
+  return (
+    expression.type === "TSNonNullExpression" ||
+    expression.type === "TSAsExpression" ||
+    expression.type === "TSSatisfiesExpression" ||
+    expression.type === "ParenthesizedExpression" ||
+    expression.type === "TypeCastExpression" ||
+    expression.type === "TSTypeAssertion"
+  );
+}
+
+function isCssPropAttribute(attribute: t.JSXAttribute): boolean {
+  return (
+    t.isJSXIdentifier(attribute.name) &&
+    attribute.name.name === cssAttributeName
+  );
+}
+
+function getJsxExpressionContainerValue(
+  attribute: t.JSXAttribute
+): t.Expression | null {
+  if (!t.isJSXExpressionContainer(attribute.value)) {
+    return null;
+  }
+
+  const { expression } = attribute.value;
+
+  if (t.isJSXEmptyExpression(expression)) {
+    return null;
+  }
+
+  return expression;
+}
+
+function getExpressionRange(
+  expression: t.Expression
+): { start: number; end: number } | null {
+  const { start, end } = expression;
+
+  if (typeof start !== "number" || typeof end !== "number") {
+    return null;
+  }
+
+  return { start, end };
+}
+
+export function getStaticCssEvalMemberReference(
+  expression: t.Expression
+): StaticMemberReference | null {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+
+  if (t.isIdentifier(unwrappedExpression)) {
+    return {
+      kind: "supported",
+      bindingName: unwrappedExpression.name,
+      memberPath: []
+    };
+  }
+
+  if (t.isMemberExpression(unwrappedExpression)) {
+    return getMemberExpressionReference(unwrappedExpression);
+  }
+
+  if (t.isOptionalMemberExpression(unwrappedExpression)) {
+    return getOptionalMemberExpressionReference(unwrappedExpression);
+  }
+
+  return null;
+}
+
+function getMemberExpressionReference(
+  expression: t.MemberExpression
+): StaticMemberReference | null {
+  if (t.isSuper(expression.object)) {
+    return null;
+  }
+
+  const objectReference = getStaticCssEvalMemberReference(expression.object);
+
+  if (!objectReference) {
+    return null;
+  }
+
+  if (objectReference.kind === "unsupported") {
+    return objectReference;
+  }
+
+  const propertyName = getStaticMemberPropertyName(expression);
+
+  if (!propertyName) {
+    return createUnsupportedMemberPathReference(objectReference, expression);
+  }
+
+  return {
+    kind: "supported",
+    bindingName: objectReference.bindingName,
+    memberPath: [...objectReference.memberPath, propertyName]
+  };
+}
+
+function getOptionalMemberExpressionReference(
+  expression: t.OptionalMemberExpression
+): StaticMemberReference | null {
+  if (t.isSuper(expression.object)) {
+    return null;
+  }
+
+  const objectReference = getStaticCssEvalMemberReference(expression.object);
+
+  if (!objectReference) {
+    return null;
+  }
+
+  if (objectReference.kind === "unsupported") {
+    return objectReference;
+  }
+
+  return {
+    kind: "unsupported",
+    bindingName: objectReference.bindingName,
+    memberPath: objectReference.memberPath,
+    reason: "optional-member-path",
+    detail: "optional member paths are unsupported"
+  };
+}
+
+function createUnsupportedMemberPathReference(
+  objectReference: SupportedStaticMemberReference,
+  expression: t.MemberExpression
+): UnsupportedStaticMemberReference {
+  if (expression.computed && t.isNumericLiteral(expression.property)) {
+    return {
+      kind: "unsupported",
+      bindingName: objectReference.bindingName,
+      memberPath: objectReference.memberPath,
+      reason: "numeric-member-path",
+      detail: "numeric member paths are unsupported",
+      unsupportedPropertyName: String(expression.property.value)
+    };
+  }
+
+  return {
+    kind: "unsupported",
+    bindingName: objectReference.bindingName,
+    memberPath: objectReference.memberPath,
+    reason: "dynamic-member-path",
+    detail: "dynamic computed member paths are unsupported"
+  };
+}
+
+function getStaticMemberPropertyName(
+  expression: t.MemberExpression
+): string | null {
+  const { computed, property } = expression;
+
+  if (!computed && t.isIdentifier(property)) {
+    return property.name;
+  }
+
+  if (computed && t.isStringLiteral(property)) {
+    return property.value;
+  }
+
+  return null;
+}
+
+if (import.meta.vitest) {
+  const { describe, expect, it } = import.meta.vitest;
+
+  const importerId = "/project/src/App.tsx";
+
+  function collectCandidateFixture(source: string): StaticCssEvalCandidate[] {
+    const candidates: StaticCssEvalCandidate[] = [];
+    const result = transformSync(source, {
+      filename: importerId,
+      plugins: [
+        function collectCandidatesPlugin(): PluginObj {
+          return {
+            visitor: {
+              Program(path) {
+                candidates.push(
+                  ...collectJsxCssPropStaticCssEvalCandidates(path, {
+                    importerId
+                  })
+                );
+              }
+            }
+          };
+        }
+      ],
+      presets: ["@babel/preset-typescript"]
+    });
+
+    if (result === null) {
+      throw new Error("Failed to parse candidate fixture");
+    }
+
+    return candidates;
+  }
+
+  function formatCandidate(
+    source: string,
+    candidate: StaticCssEvalCandidate
+  ): StaticCssEvalCandidate & { expression: string } {
+    return {
+      ...candidate,
+      expression: source.slice(
+        candidate.expressionStart,
+        candidate.expressionEnd
+      )
+    };
+  }
+
+  describe("static css eval candidate collector", () => {
+    it("collects identifier and member JSX css prop candidates", () => {
+      const source = `
+        const style = { color: "red" };
+        const styles = {
+          button: { color: "blue" }
+        };
+
+        function App() {
+          return <>
+            <div css={style} />
+            <Component css={styles.button} />
+            <Component css={styles["button"]} />
+          </>;
+        }
+      `;
+
+      expect(
+        collectCandidateFixture(source).map((candidate) =>
+          formatCandidate(source, candidate)
+        )
+      ).toEqual([
+        {
+          importerId,
+          expressionStart: source.indexOf("style} />"),
+          expressionEnd: source.indexOf("style} />") + "style".length,
+          bindingName: "style",
+          expression: "style"
+        },
+        {
+          importerId,
+          expressionStart: source.indexOf("styles.button"),
+          expressionEnd:
+            source.indexOf("styles.button") + "styles.button".length,
+          bindingName: "styles",
+          memberPath: ["button"],
+          expression: "styles.button"
+        },
+        {
+          importerId,
+          expressionStart: source.indexOf('styles["button"]'),
+          expressionEnd:
+            source.indexOf('styles["button"]') + 'styles["button"]'.length,
+          bindingName: "styles",
+          memberPath: ["button"],
+          expression: 'styles["button"]'
+        }
+      ]);
+    });
+
+    it("collects candidates through transparent TypeScript css prop wrappers", () => {
+      const source = `
+        type ComplexCSSRule = unknown;
+        const style = { color: "red" };
+        const styles = {
+          button: { color: "blue" }
+        };
+
+        function App() {
+          return <>
+            <div css={style as const} />
+            <Component css={styles.button satisfies ComplexCSSRule} />
+          </>;
+        }
+      `;
+
+      expect(
+        collectCandidateFixture(source).map((candidate) =>
+          formatCandidate(source, candidate)
+        )
+      ).toEqual([
+        {
+          importerId,
+          expressionStart: source.indexOf("style as const"),
+          expressionEnd: source.indexOf("style as const") + "style".length,
+          bindingName: "style",
+          expression: "style"
+        },
+        {
+          importerId,
+          expressionStart: source.indexOf("styles.button satisfies"),
+          expressionEnd:
+            source.indexOf("styles.button satisfies") + "styles.button".length,
+          bindingName: "styles",
+          memberPath: ["button"],
+          expression: "styles.button"
+        }
+      ]);
+    });
+
+    it("ignores non-css JSX expressions and unrelated imports", () => {
+      const source = `
+        import { style as cssStyle } from "@mincho-js/css";
+
+        const style = { color: "red" };
+        const styles = {
+          button: { color: "blue" }
+        };
+        const unused = cssStyle;
+
+        function App() {
+          return <div style={style} data-css={styles.button}>{style}</div>;
+        }
+      `;
+
+      expect(collectCandidateFixture(source)).toEqual([]);
+    });
+  });
+}

--- a/packages/babel/src/staticCssEval/cycles.ts
+++ b/packages/babel/src/staticCssEval/cycles.ts
@@ -1,0 +1,277 @@
+import { STATIC_CSS_EVAL_CYCLE_KEY_FIELDS } from "./types.js";
+import {
+  createStaticCssEvalDiagnostic,
+  type StaticCssEvalDiagnosticContext
+} from "./diagnostics.js";
+import type {
+  StaticCssEvalDiagnostic,
+  StaticCssEvalExportName,
+  StaticCssEvalSourceLocation
+} from "./types.js";
+
+export interface StaticCssEvalCycleKeyInput {
+  resolvedId: string;
+  exportName: StaticCssEvalExportName;
+  memberPath?: readonly string[];
+}
+
+export interface StaticCssEvalCycleFrame extends StaticCssEvalCycleKeyInput {
+  importPath?: string;
+  location?: StaticCssEvalSourceLocation;
+}
+
+export type StaticCssEvalCycleCheckResult =
+  | {
+      ok: true;
+      stack: StaticCssEvalCycleFrame[];
+    }
+  | {
+      ok: false;
+      diagnostic: StaticCssEvalDiagnostic;
+      dependencies: string[];
+      cycle: StaticCssEvalCycleFrame[];
+    };
+
+export function createStaticCssEvalCycleKey(
+  input: StaticCssEvalCycleKeyInput
+): string {
+  const cycleIdentity = {
+    resolvedId: input.resolvedId,
+    exportName: input.exportName,
+    memberPath: [...(input.memberPath ?? [])]
+  } satisfies Record<
+    (typeof STATIC_CSS_EVAL_CYCLE_KEY_FIELDS)[number],
+    StaticCssEvalExportName | string | string[]
+  >;
+
+  return JSON.stringify(
+    STATIC_CSS_EVAL_CYCLE_KEY_FIELDS.map((field) => cycleIdentity[field])
+  );
+}
+
+export function enterStaticCssEvalCycleFrame(
+  options: StaticCssEvalDiagnosticContext & {
+    stack: readonly StaticCssEvalCycleFrame[];
+    nextFrame: StaticCssEvalCycleFrame;
+  }
+): StaticCssEvalCycleCheckResult {
+  const cycleStartIndex = findStaticCssEvalCycleStartIndex(
+    options.stack,
+    options.nextFrame
+  );
+
+  if (cycleStartIndex === -1) {
+    return {
+      ok: true,
+      stack: [...options.stack, cloneCycleFrame(options.nextFrame)]
+    };
+  }
+
+  const cycle = [
+    ...options.stack.slice(cycleStartIndex).map(cloneCycleFrame),
+    cloneCycleFrame(options.nextFrame)
+  ];
+  const importChain = cycle.map(formatStaticCssEvalCycleFrame);
+  const dependency =
+    options.nextFrame.location ??
+    options.dependency ??
+    ({
+      file: options.nextFrame.resolvedId
+    } satisfies StaticCssEvalSourceLocation);
+  const diagnostic = createStaticCssEvalDiagnostic({
+    code: "cycle-detected",
+    reason: "runtime-dynamic-value",
+    detail: `cyclic static css reference detected: ${importChain.join(" -> ")}`,
+    owner: options.owner,
+    dependency,
+    importPath: options.nextFrame.importPath ?? options.importPath,
+    exportName: options.nextFrame.exportName,
+    memberPath: options.nextFrame.memberPath,
+    importChain
+  });
+
+  return {
+    ok: false,
+    diagnostic,
+    dependencies: getStaticCssEvalCycleDependencies(cycle, options.owner.file),
+    cycle
+  };
+}
+
+export function formatStaticCssEvalCycleFrame(
+  frame: StaticCssEvalCycleKeyInput
+): string {
+  const exportName = frame.exportName === null ? "<local>" : frame.exportName;
+  const memberPath = frame.memberPath?.length
+    ? `.${frame.memberPath.join(".")}`
+    : "";
+
+  return `${frame.resolvedId}#${exportName}${memberPath}`;
+}
+
+function findStaticCssEvalCycleStartIndex(
+  stack: readonly StaticCssEvalCycleFrame[],
+  nextFrame: StaticCssEvalCycleFrame
+): number {
+  const nextKey = createStaticCssEvalCycleKey(nextFrame);
+
+  return stack.findIndex(
+    (frame) => createStaticCssEvalCycleKey(frame) === nextKey
+  );
+}
+
+function cloneCycleFrame(
+  frame: StaticCssEvalCycleFrame
+): StaticCssEvalCycleFrame {
+  return {
+    resolvedId: frame.resolvedId,
+    exportName: frame.exportName,
+    memberPath: [...(frame.memberPath ?? [])],
+    ...(frame.importPath !== undefined ? { importPath: frame.importPath } : {}),
+    ...(frame.location ? { location: { ...frame.location } } : {})
+  };
+}
+
+function getStaticCssEvalCycleDependencies(
+  cycle: readonly StaticCssEvalCycleFrame[],
+  ownerFile: string
+): string[] {
+  const dependencies = new Set<string>();
+
+  for (const frame of cycle) {
+    if (frame.resolvedId !== ownerFile) {
+      dependencies.add(frame.resolvedId);
+    }
+  }
+
+  return [...dependencies];
+}
+
+if (import.meta.vitest) {
+  const { describe, expect, it } = import.meta.vitest;
+
+  const owner = { file: "/project/src/App.tsx", start: 10, end: 30 };
+
+  describe("static css eval cycles", () => {
+    it("keys cycles by resolved file, export name, and member path only", () => {
+      expect(STATIC_CSS_EVAL_CYCLE_KEY_FIELDS).toEqual([
+        "resolvedId",
+        "exportName",
+        "memberPath"
+      ]);
+      expect(
+        createStaticCssEvalCycleKey({
+          resolvedId: "/project/src/a.ts",
+          exportName: "styles",
+          memberPath: ["button"]
+        })
+      ).toBe(
+        createStaticCssEvalCycleKey({
+          resolvedId: "/project/src/a.ts",
+          exportName: "styles",
+          memberPath: ["button"]
+        })
+      );
+      expect(
+        createStaticCssEvalCycleKey({
+          resolvedId: "/project/src/a.ts",
+          exportName: "styles",
+          memberPath: ["button"]
+        })
+      ).not.toBe(
+        createStaticCssEvalCycleKey({
+          resolvedId: "/project/src/a.ts",
+          exportName: "styles",
+          memberPath: ["card"]
+        })
+      );
+    });
+
+    it("returns a targeted diagnostic with import-chain details for cycles", () => {
+      const stack: StaticCssEvalCycleFrame[] = [
+        {
+          resolvedId: "/project/src/a.ts",
+          exportName: "styles",
+          memberPath: ["button"],
+          importPath: "./a",
+          location: { file: "/project/src/a.ts" }
+        },
+        {
+          resolvedId: "/project/src/b.ts",
+          exportName: "styles",
+          memberPath: ["button"],
+          importPath: "./b",
+          location: { file: "/project/src/b.ts" }
+        }
+      ];
+      const result = enterStaticCssEvalCycleFrame({
+        owner,
+        stack,
+        nextFrame: {
+          resolvedId: "/project/src/a.ts",
+          exportName: "styles",
+          memberPath: ["button"],
+          importPath: "./a",
+          location: { file: "/project/src/a.ts" }
+        }
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.diagnostic).toMatchObject({
+          code: "cycle-detected",
+          reason: "runtime-dynamic-value",
+          owner,
+          dependency: { file: "/project/src/a.ts" },
+          importPath: "./a",
+          exportName: "styles",
+          memberPath: ["button"],
+          importChain: [
+            "/project/src/a.ts#styles.button",
+            "/project/src/b.ts#styles.button",
+            "/project/src/a.ts#styles.button"
+          ]
+        });
+        expect(result.diagnostic.message).toContain("cyclic");
+        expect(result.dependencies).toEqual([
+          "/project/src/a.ts",
+          "/project/src/b.ts"
+        ]);
+      }
+    });
+
+    it("pushes non-cyclic frames and keeps different exports independent", () => {
+      const result = enterStaticCssEvalCycleFrame({
+        owner,
+        stack: [
+          {
+            resolvedId: "/project/src/a.ts",
+            exportName: "styles",
+            memberPath: ["button"]
+          }
+        ],
+        nextFrame: {
+          resolvedId: "/project/src/a.ts",
+          exportName: "tokens",
+          memberPath: ["button"]
+        }
+      });
+
+      expect(result).toEqual({
+        ok: true,
+        stack: [
+          {
+            resolvedId: "/project/src/a.ts",
+            exportName: "styles",
+            memberPath: ["button"]
+          },
+          {
+            resolvedId: "/project/src/a.ts",
+            exportName: "tokens",
+            memberPath: ["button"]
+          }
+        ]
+      });
+    });
+  });
+}

--- a/packages/babel/src/staticCssEval/diagnostics.ts
+++ b/packages/babel/src/staticCssEval/diagnostics.ts
@@ -1,0 +1,127 @@
+import type {
+  StaticCssEvalDiagnostic,
+  StaticCssEvalDiagnosticCode,
+  StaticCssEvalExportName,
+  StaticCssEvalSourceLocation,
+  StaticCssEvalUnsupportedReason
+} from "./types.js";
+
+export const STATIC_CSS_EVAL_DIAGNOSTIC_MESSAGE_PREFIX =
+  "Cannot statically evaluate css prop value";
+
+export interface StaticCssEvalDiagnosticContext {
+  owner: StaticCssEvalSourceLocation;
+  dependency?: StaticCssEvalSourceLocation;
+  importPath?: string;
+  exportName?: StaticCssEvalExportName;
+  memberPath?: readonly string[];
+  importChain?: readonly string[];
+}
+
+export interface CreateStaticCssEvalDiagnosticOptions extends StaticCssEvalDiagnosticContext {
+  code: StaticCssEvalDiagnosticCode;
+  reason: StaticCssEvalUnsupportedReason;
+  detail: string;
+}
+
+export type StaticCssEvalGuardResult =
+  | { ok: true }
+  | {
+      ok: false;
+      diagnostic: StaticCssEvalDiagnostic;
+      dependencies: string[];
+    };
+
+export function createStaticCssEvalDiagnostic(
+  options: CreateStaticCssEvalDiagnosticOptions
+): StaticCssEvalDiagnostic {
+  const diagnostic: StaticCssEvalDiagnostic = {
+    code: options.code,
+    message: formatStaticCssEvalDiagnosticMessage(options.detail),
+    reason: options.reason,
+    owner: cloneSourceLocation(options.owner)
+  };
+
+  if (options.dependency) {
+    diagnostic.dependency = cloneSourceLocation(options.dependency);
+  }
+
+  if (options.importPath !== undefined) {
+    diagnostic.importPath = options.importPath;
+  }
+
+  if (options.exportName !== undefined) {
+    diagnostic.exportName = options.exportName;
+  }
+
+  if (options.memberPath) {
+    diagnostic.memberPath = [...options.memberPath];
+  }
+
+  if (options.importChain) {
+    diagnostic.importChain = [...options.importChain];
+  }
+
+  return diagnostic;
+}
+
+export function formatStaticCssEvalDiagnosticMessage(detail: string): string {
+  return `${STATIC_CSS_EVAL_DIAGNOSTIC_MESSAGE_PREFIX}: ${detail}`;
+}
+
+export function getStaticCssEvalDiagnosticDependencies(
+  diagnostic: StaticCssEvalDiagnostic
+): string[] {
+  const dependencies = new Set<string>();
+
+  if (diagnostic.dependency) {
+    dependencies.add(diagnostic.dependency.file);
+  }
+
+  return [...dependencies];
+}
+
+function cloneSourceLocation(
+  location: StaticCssEvalSourceLocation
+): StaticCssEvalSourceLocation {
+  return { ...location };
+}
+
+if (import.meta.vitest) {
+  const { describe, expect, it } = import.meta.vitest;
+
+  describe("static css eval diagnostics", () => {
+    it("creates deterministic css prop diagnostics with cloned metadata", () => {
+      const owner = { file: "/project/src/App.tsx", start: 10, end: 20 };
+      const diagnostic = createStaticCssEvalDiagnostic({
+        code: "unsupported-source",
+        reason: "not-project-local",
+        detail: "dependency is outside the project root",
+        owner,
+        dependency: { file: "/outside/style.ts" },
+        importPath: "pkg/style",
+        exportName: "button",
+        memberPath: ["root"],
+        importChain: ["/project/src/App.tsx", "/outside/style.ts#button.root"]
+      });
+
+      owner.file = "/mutated.tsx";
+
+      expect(diagnostic).toEqual({
+        code: "unsupported-source",
+        message:
+          "Cannot statically evaluate css prop value: dependency is outside the project root",
+        reason: "not-project-local",
+        owner: { file: "/project/src/App.tsx", start: 10, end: 20 },
+        dependency: { file: "/outside/style.ts" },
+        importPath: "pkg/style",
+        exportName: "button",
+        memberPath: ["root"],
+        importChain: ["/project/src/App.tsx", "/outside/style.ts#button.root"]
+      });
+      expect(getStaticCssEvalDiagnosticDependencies(diagnostic)).toEqual([
+        "/outside/style.ts"
+      ]);
+    });
+  });
+}

--- a/packages/babel/src/staticCssEval/importedModules.ts
+++ b/packages/babel/src/staticCssEval/importedModules.ts
@@ -1,0 +1,1506 @@
+import { transformSync, types as t } from "@babel/core";
+import type { NodePath, PluginObj } from "@babel/core";
+import {
+  getStaticObjectMemberValue,
+  getStaticObjectPropertyName,
+  getUnsupportedLiteralReason
+} from "./ast.js";
+import {
+  createStaticCssEvalCandidate,
+  unwrapTransparentCssRuleExpression
+} from "./candidates.js";
+import { createStaticCssEvalDiagnostic } from "./diagnostics.js";
+import {
+  enforceStaticCssEvalLiteralNodeCount,
+  enforceStaticCssEvalObjectArrayRecursionDepth,
+  enforceStaticCssEvalSourceSize
+} from "./limits.js";
+import {
+  getStaticCssEvalConstBindingInitExpression,
+  hasStaticCssEvalBindingMutation
+} from "./sameFile.js";
+import type {
+  StaticCssEvalDiagnostic,
+  StaticCssEvalExportName,
+  StaticCssEvalProvider,
+  StaticCssEvalQuery,
+  StaticCssEvalResult,
+  StaticCssEvalSourceLocation,
+  StaticCssEvalUnsupportedReason,
+  StaticCssLiteral,
+  StaticCssEvalModuleRecord
+} from "./types.js";
+
+export type ImportedStaticCssEvalImportBinding =
+  | {
+      kind: "default";
+      localName: string;
+      importPath: string;
+      importedName: "default";
+    }
+  | {
+      kind: "named";
+      localName: string;
+      importPath: string;
+      importedName: string;
+    }
+  | {
+      kind: "namespace";
+      localName: string;
+      importPath: string;
+    };
+
+export type ImportedStaticCssEvalExportBinding =
+  | {
+      kind: "local";
+      exportName: StaticCssEvalExportName;
+      localName: string;
+    }
+  | {
+      kind: "expression";
+      exportName: StaticCssEvalExportName;
+      expression: t.Expression;
+    }
+  | {
+      kind: "unsupported";
+      exportName: StaticCssEvalExportName;
+      reason: StaticCssEvalUnsupportedReason;
+      detail: string;
+    };
+
+type ImportedStaticCssEvalResolutionResult =
+  | { kind: "not-candidate" }
+  | { kind: "resolved"; value: StaticCssLiteral }
+  | { kind: "error"; diagnostic: StaticCssEvalDiagnostic };
+
+interface ImportedStaticCssEvalContext {
+  owner: StaticCssEvalSourceLocation;
+  dependency: StaticCssEvalSourceLocation;
+  importPath: string;
+  exportName: StaticCssEvalExportName;
+  memberPath: string[];
+}
+
+interface StaticCssLiteralValidationState {
+  count: number;
+}
+
+export interface ImportedStaticCssEvalLoadedModule {
+  id: string;
+  source: string;
+  realpath?: string;
+  sourceHash?: string;
+  version?: string | number;
+}
+
+export interface ImportedStaticCssEvalImportResolution {
+  importerId: string;
+  importPath: string;
+  resolvedId: string;
+}
+
+export interface ImportedStaticCssEvalModuleRecord extends StaticCssEvalModuleRecord {
+  source: string;
+  imports: ReadonlyMap<string, ImportedStaticCssEvalImportBinding>;
+  exports: ReadonlyMap<
+    StaticCssEvalExportName,
+    ImportedStaticCssEvalExportBinding
+  >;
+  exportAllReexportSources: readonly string[];
+  programPath: NodePath<t.Program>;
+}
+
+export interface CreateImportedStaticCssEvalProviderOptions {
+  modules: readonly ImportedStaticCssEvalLoadedModule[];
+  importResolutions: readonly ImportedStaticCssEvalImportResolution[];
+  moduleRecords?: readonly ImportedStaticCssEvalModuleRecord[];
+}
+
+export type ResolveImportedStaticCssEvalExpressionResult =
+  | { kind: "not-candidate" }
+  | { kind: "resolved"; expression: t.ObjectExpression | t.ArrayExpression }
+  | { kind: "error"; diagnostic: StaticCssEvalDiagnostic };
+
+const importResolutionKeySeparator = "\0";
+
+export function createImportedStaticCssEvalProvider(
+  options: CreateImportedStaticCssEvalProviderOptions
+): StaticCssEvalProvider {
+  const resolver = new ImportedStaticCssEvalResolver(options);
+
+  return {
+    getResolvedCssValue(query) {
+      return resolver.resolve(query);
+    }
+  };
+}
+
+export function createImportedStaticCssEvalModuleRecord(
+  loadedModule: ImportedStaticCssEvalLoadedModule
+): ImportedStaticCssEvalModuleRecord {
+  const programPathRef: { current?: NodePath<t.Program> } = {};
+  const isTypeScript = /\.[cm]?tsx?$/.test(loadedModule.id);
+  const isJsx = /\.[jt]sx$/.test(loadedModule.id);
+  const captureProgramPathPlugin: PluginObj = {
+    visitor: {
+      Program(path: NodePath<t.Program>) {
+        programPathRef.current = path;
+        path.stop();
+      }
+    }
+  };
+
+  transformSync(loadedModule.source, {
+    filename: loadedModule.id,
+    ast: true,
+    code: false,
+    sourceType: "module",
+    configFile: false,
+    babelrc: false,
+    parserOpts: {
+      plugins: [
+        ...(isJsx ? (["jsx"] as const) : []),
+        ...(isTypeScript ? (["typescript"] as const) : [])
+      ]
+    },
+    plugins: [captureProgramPathPlugin]
+  });
+
+  const capturedProgramPath = programPathRef.current;
+
+  if (!capturedProgramPath) {
+    throw new Error(
+      `Failed to create static css module scope ${loadedModule.id}`
+    );
+  }
+
+  const imports = new Map<string, ImportedStaticCssEvalImportBinding>();
+  const exports = new Map<
+    StaticCssEvalExportName,
+    ImportedStaticCssEvalExportBinding
+  >();
+  const exportAllReexportSources: string[] = [];
+
+  for (const statement of capturedProgramPath.node.body) {
+    collectModuleImportBindings(statement, imports);
+    collectModuleExportBindings(statement, exports, exportAllReexportSources);
+  }
+
+  return {
+    id: loadedModule.id,
+    realpath: loadedModule.realpath ?? loadedModule.id,
+    sourceHash:
+      loadedModule.sourceHash ?? `inline:${loadedModule.source.length}`,
+    ...(loadedModule.version !== undefined
+      ? { version: loadedModule.version }
+      : {}),
+    dependencies: [],
+    source: loadedModule.source,
+    imports,
+    exports,
+    exportAllReexportSources,
+    programPath: capturedProgramPath
+  };
+}
+
+export function resolveImportedStaticCssEvalExpression(options: {
+  expression: t.Expression;
+  ownerFile: string;
+  provider?: StaticCssEvalProvider;
+  allowUnsupportedSourceFallback?: boolean;
+}): ResolveImportedStaticCssEvalExpressionResult {
+  if (!options.provider) {
+    return { kind: "not-candidate" };
+  }
+
+  const candidate = createStaticCssEvalCandidate(
+    options.expression,
+    options.ownerFile
+  );
+
+  if (!candidate?.bindingName) {
+    return { kind: "not-candidate" };
+  }
+
+  const result = options.provider.getResolvedCssValue(candidate);
+
+  if (result.kind === "not-candidate") {
+    return { kind: "not-candidate" };
+  }
+
+  if (result.kind === "error") {
+    if (
+      options.allowUnsupportedSourceFallback === true &&
+      result.diagnostic.reason === "reexport-or-barrel"
+    ) {
+      return { kind: "not-candidate" };
+    }
+
+    return { kind: "error", diagnostic: result.diagnostic };
+  }
+
+  if (!isStaticCssRuleLiteralValue(result.value)) {
+    return { kind: "not-candidate" };
+  }
+
+  const expression = createStaticCssLiteralExpression(result.value);
+
+  return t.isObjectExpression(expression) || t.isArrayExpression(expression)
+    ? { kind: "resolved", expression }
+    : { kind: "not-candidate" };
+}
+
+export function findUnsupportedImportedStaticCssEvalReferenceDiagnostic(options: {
+  expression: t.Expression;
+  ownerFile: string;
+  provider?: StaticCssEvalProvider;
+}): StaticCssEvalDiagnostic | null {
+  const { provider } = options;
+
+  if (!provider) {
+    return null;
+  }
+
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(
+    options.expression
+  );
+
+  if (t.isObjectExpression(unwrappedExpression)) {
+    return findUnsupportedImportedObjectReferenceDiagnostic(
+      unwrappedExpression,
+      { ownerFile: options.ownerFile, provider }
+    );
+  }
+
+  if (t.isArrayExpression(unwrappedExpression)) {
+    return findUnsupportedImportedArrayReferenceDiagnostic(
+      unwrappedExpression,
+      { ownerFile: options.ownerFile, provider }
+    );
+  }
+
+  return null;
+}
+
+export function createStaticCssLiteralExpression(
+  value: StaticCssLiteral
+): t.Expression {
+  if (Array.isArray(value)) {
+    return t.arrayExpression(value.map(createStaticCssLiteralExpression));
+  }
+
+  if (value && typeof value === "object") {
+    return t.objectExpression(
+      Object.entries(value).map(([key, propertyValue]) =>
+        t.objectProperty(
+          t.isValidIdentifier(key) ? t.identifier(key) : t.stringLiteral(key),
+          createStaticCssLiteralExpression(propertyValue)
+        )
+      )
+    );
+  }
+
+  if (typeof value === "string") {
+    return t.stringLiteral(value);
+  }
+
+  if (typeof value === "number") {
+    return t.numericLiteral(value);
+  }
+
+  if (typeof value === "boolean") {
+    return t.booleanLiteral(value);
+  }
+
+  return t.nullLiteral();
+}
+
+class ImportedStaticCssEvalResolver {
+  readonly #modules = new Map<string, ImportedStaticCssEvalLoadedModule>();
+  readonly #records = new Map<string, ImportedStaticCssEvalModuleRecord>();
+  readonly #importResolutions = new Map<string, string>();
+
+  constructor(options: CreateImportedStaticCssEvalProviderOptions) {
+    for (const loadedModule of options.modules) {
+      this.#modules.set(loadedModule.id, loadedModule);
+    }
+
+    for (const moduleRecord of options.moduleRecords ?? []) {
+      this.#records.set(moduleRecord.id, moduleRecord);
+    }
+
+    for (const resolution of options.importResolutions) {
+      this.#importResolutions.set(
+        createImportResolutionKey(resolution.importerId, resolution.importPath),
+        resolution.resolvedId
+      );
+    }
+  }
+
+  resolve(query: StaticCssEvalQuery): StaticCssEvalResult {
+    if (!query.bindingName) {
+      return { kind: "not-candidate" };
+    }
+
+    const ownerRecord = this.#getModuleRecord(query.importerId);
+
+    if (!ownerRecord) {
+      return { kind: "not-candidate" };
+    }
+
+    const importBinding = ownerRecord.imports.get(query.bindingName);
+
+    if (!importBinding || importBinding.kind === "namespace") {
+      return { kind: "not-candidate" };
+    }
+
+    const owner = createQueryOwnerLocation(query);
+    const resolvedId = this.#resolveImport(
+      query.importerId,
+      importBinding.importPath
+    );
+
+    if (!resolvedId) {
+      const diagnostic = createImportedStaticCssEvalDiagnostic({
+        owner,
+        dependency: { file: importBinding.importPath },
+        importPath: importBinding.importPath,
+        exportName: importBinding.importedName,
+        memberPath: query.memberPath ?? [],
+        code: "failed-project-local-dependency",
+        reason: "failed-project-local-dependency",
+        detail: `failed to resolve project-local dependency ${importBinding.importPath}`
+      });
+
+      return {
+        kind: "error",
+        diagnostic,
+        dependencies: []
+      };
+    }
+
+    const dependency = { file: resolvedId };
+    const loadedModule = this.#modules.get(resolvedId);
+
+    if (!loadedModule) {
+      const diagnostic = createImportedStaticCssEvalDiagnostic({
+        owner,
+        dependency,
+        importPath: importBinding.importPath,
+        exportName: importBinding.importedName,
+        memberPath: query.memberPath ?? [],
+        code: "failed-project-local-dependency",
+        reason: "failed-project-local-dependency",
+        detail: `failed to load project-local dependency ${resolvedId}`
+      });
+
+      return {
+        kind: "error",
+        diagnostic,
+        dependencies: [resolvedId]
+      };
+    }
+
+    const sourceSizeResult = enforceStaticCssEvalSourceSize({
+      owner,
+      dependency,
+      importPath: importBinding.importPath,
+      exportName: importBinding.importedName,
+      memberPath: query.memberPath,
+      source: loadedModule.source
+    });
+
+    if (!sourceSizeResult.ok) {
+      return {
+        kind: "error",
+        diagnostic: sourceSizeResult.diagnostic,
+        dependencies: [resolvedId]
+      };
+    }
+
+    const dependencyRecord = this.#getModuleRecord(resolvedId);
+
+    if (!dependencyRecord) {
+      const diagnostic = createImportedStaticCssEvalDiagnostic({
+        owner,
+        dependency,
+        importPath: importBinding.importPath,
+        exportName: importBinding.importedName,
+        memberPath: query.memberPath ?? [],
+        code: "failed-project-local-dependency",
+        reason: "failed-project-local-dependency",
+        detail: `failed to parse project-local dependency ${resolvedId}`
+      });
+
+      return {
+        kind: "error",
+        diagnostic,
+        dependencies: [resolvedId]
+      };
+    }
+
+    const context: ImportedStaticCssEvalContext = {
+      owner,
+      dependency,
+      importPath: importBinding.importPath,
+      exportName: importBinding.importedName,
+      memberPath: [...(query.memberPath ?? [])]
+    };
+    const result = resolveImportedModuleExport(dependencyRecord, context);
+
+    if (result.kind === "not-candidate") {
+      return { kind: "not-candidate" };
+    }
+
+    if (result.kind === "error") {
+      return {
+        kind: "error",
+        diagnostic: result.diagnostic,
+        dependencies: [resolvedId]
+      };
+    }
+
+    return {
+      kind: "resolved",
+      value: result.value,
+      dependencies: [resolvedId]
+    };
+  }
+
+  #resolveImport(importerId: string, importPath: string): string | null {
+    return (
+      this.#importResolutions.get(
+        createImportResolutionKey(importerId, importPath)
+      ) ?? (this.#modules.has(importPath) ? importPath : null)
+    );
+  }
+
+  #getModuleRecord(id: string): ImportedStaticCssEvalModuleRecord | null {
+    const cachedRecord = this.#records.get(id);
+
+    if (cachedRecord) {
+      return cachedRecord;
+    }
+
+    const loadedModule = this.#modules.get(id);
+
+    if (!loadedModule) {
+      return null;
+    }
+
+    try {
+      const record = createImportedStaticCssEvalModuleRecord(loadedModule);
+      this.#records.set(id, record);
+      return record;
+    } catch {
+      return null;
+    }
+  }
+}
+
+function collectModuleImportBindings(
+  statement: t.Statement,
+  imports: Map<string, ImportedStaticCssEvalImportBinding>
+): void {
+  if (!t.isImportDeclaration(statement) || statement.importKind === "type") {
+    return;
+  }
+
+  const importPath = statement.source.value;
+
+  for (const specifier of statement.specifiers) {
+    if (t.isImportDefaultSpecifier(specifier)) {
+      imports.set(specifier.local.name, {
+        kind: "default",
+        localName: specifier.local.name,
+        importPath,
+        importedName: "default"
+      });
+      continue;
+    }
+
+    if (t.isImportSpecifier(specifier) && specifier.importKind !== "type") {
+      const importedName = getModuleStringName(specifier.imported);
+
+      if (importedName) {
+        imports.set(specifier.local.name, {
+          kind: "named",
+          localName: specifier.local.name,
+          importPath,
+          importedName
+        });
+      }
+      continue;
+    }
+
+    if (t.isImportNamespaceSpecifier(specifier)) {
+      imports.set(specifier.local.name, {
+        kind: "namespace",
+        localName: specifier.local.name,
+        importPath
+      });
+    }
+  }
+}
+
+function collectModuleExportBindings(
+  statement: t.Statement,
+  exports: Map<StaticCssEvalExportName, ImportedStaticCssEvalExportBinding>,
+  exportAllReexportSources: string[]
+): void {
+  if (t.isExportAllDeclaration(statement)) {
+    exportAllReexportSources.push(statement.source.value);
+    return;
+  }
+
+  if (t.isExportDefaultDeclaration(statement)) {
+    collectDefaultExportBinding(statement, exports);
+    return;
+  }
+
+  if (
+    !t.isExportNamedDeclaration(statement) ||
+    statement.exportKind === "type"
+  ) {
+    return;
+  }
+
+  if (statement.source) {
+    collectReexportBindings(statement, exports);
+    return;
+  }
+
+  if (statement.declaration) {
+    collectDeclaredExportBindings(statement.declaration, exports);
+    return;
+  }
+
+  for (const specifier of statement.specifiers) {
+    if (!t.isExportSpecifier(specifier) || specifier.exportKind === "type") {
+      continue;
+    }
+
+    const localName = getModuleStringName(specifier.local);
+    const exportName = getModuleStringName(specifier.exported);
+
+    if (localName && exportName) {
+      exports.set(exportName, {
+        kind: "local",
+        exportName,
+        localName
+      });
+    }
+  }
+}
+
+function collectDefaultExportBinding(
+  statement: t.ExportDefaultDeclaration,
+  exports: Map<StaticCssEvalExportName, ImportedStaticCssEvalExportBinding>
+): void {
+  const { declaration } = statement;
+
+  if (t.isIdentifier(declaration)) {
+    exports.set("default", {
+      kind: "local",
+      exportName: "default",
+      localName: declaration.name
+    });
+    return;
+  }
+
+  if (t.isExpression(declaration)) {
+    exports.set("default", {
+      kind: "expression",
+      exportName: "default",
+      expression: declaration
+    });
+    return;
+  }
+
+  exports.set("default", {
+    kind: "unsupported",
+    exportName: "default",
+    reason: "function-or-call",
+    detail: "default export declaration is not a static expression"
+  });
+}
+
+function collectReexportBindings(
+  statement: t.ExportNamedDeclaration,
+  exports: Map<StaticCssEvalExportName, ImportedStaticCssEvalExportBinding>
+): void {
+  for (const specifier of statement.specifiers) {
+    if (t.isExportSpecifier(specifier)) {
+      const exportName = getModuleStringName(specifier.exported);
+
+      if (exportName) {
+        exports.set(exportName, {
+          kind: "unsupported",
+          exportName,
+          reason: "reexport-or-barrel",
+          detail: `export "${exportName}" uses unsupported reexport/barrel syntax`
+        });
+      }
+      continue;
+    }
+
+    if (t.isExportNamespaceSpecifier(specifier)) {
+      const exportName = getModuleStringName(specifier.exported);
+
+      if (exportName) {
+        exports.set(exportName, {
+          kind: "unsupported",
+          exportName,
+          reason: "reexport-or-barrel",
+          detail: `export "${exportName}" uses unsupported reexport/barrel syntax`
+        });
+      }
+    }
+  }
+}
+
+function collectDeclaredExportBindings(
+  declaration: t.Declaration,
+  exports: Map<StaticCssEvalExportName, ImportedStaticCssEvalExportBinding>
+): void {
+  if (t.isVariableDeclaration(declaration)) {
+    for (const declarator of declaration.declarations) {
+      if (!t.isIdentifier(declarator.id)) {
+        continue;
+      }
+
+      if (declaration.kind !== "const") {
+        exports.set(declarator.id.name, {
+          kind: "unsupported",
+          exportName: declarator.id.name,
+          reason: "let-or-var-binding",
+          detail: `export "${declarator.id.name}" is not a const binding`
+        });
+        continue;
+      }
+
+      exports.set(declarator.id.name, {
+        kind: "local",
+        exportName: declarator.id.name,
+        localName: declarator.id.name
+      });
+    }
+    return;
+  }
+
+  if (
+    (t.isFunctionDeclaration(declaration) ||
+      t.isClassDeclaration(declaration)) &&
+    declaration.id
+  ) {
+    exports.set(declaration.id.name, {
+      kind: "unsupported",
+      exportName: declaration.id.name,
+      reason: "function-or-call",
+      detail: `export "${declaration.id.name}" is not a static const literal`
+    });
+  }
+}
+
+function resolveImportedModuleExport(
+  record: ImportedStaticCssEvalModuleRecord,
+  context: ImportedStaticCssEvalContext
+): ImportedStaticCssEvalResolutionResult {
+  const exportBinding = record.exports.get(context.exportName);
+
+  if (!exportBinding) {
+    if (record.exportAllReexportSources.length > 0) {
+      return {
+        kind: "error",
+        diagnostic: createImportedStaticCssEvalDiagnostic({
+          ...context,
+          code: "unsupported-source",
+          reason: "reexport-or-barrel",
+          detail: `export "${formatExportName(
+            context.exportName
+          )}" may come from unsupported export * barrel syntax`
+        })
+      };
+    }
+
+    return { kind: "not-candidate" };
+  }
+
+  if (exportBinding.kind === "unsupported") {
+    return {
+      kind: "error",
+      diagnostic: createImportedStaticCssEvalDiagnostic({
+        ...context,
+        code:
+          exportBinding.reason === "reexport-or-barrel"
+            ? "unsupported-source"
+            : "unsupported-syntax",
+        reason: exportBinding.reason,
+        detail: exportBinding.detail
+      })
+    };
+  }
+
+  const localName =
+    exportBinding.kind === "local" ? exportBinding.localName : null;
+  const expression =
+    exportBinding.kind === "expression"
+      ? exportBinding.expression
+      : getLocalConstBindingExpression(record, exportBinding.localName);
+
+  if (!expression) {
+    return { kind: "not-candidate" };
+  }
+
+  const memberExpression = resolveStaticObjectMemberPath(
+    expression,
+    context.memberPath
+  );
+
+  if (
+    !memberExpression ||
+    !isStaticCssRuleLiteralExpression(memberExpression)
+  ) {
+    return { kind: "not-candidate" };
+  }
+
+  if (localName && hasImportedStaticCssBindingMutation(record, localName)) {
+    return {
+      kind: "error",
+      diagnostic: createImportedStaticCssEvalDiagnostic({
+        ...context,
+        code: "mutation-detected",
+        reason: "mutated-binding",
+        detail: `imported binding "${localName}" from "${context.importPath}" is mutated`
+      })
+    };
+  }
+
+  const literalResult = evaluateStaticCssLiteralExpression(
+    memberExpression,
+    context,
+    { count: 0 },
+    1
+  );
+
+  if (literalResult.kind === "error") {
+    return literalResult;
+  }
+
+  return {
+    kind: "resolved",
+    value: literalResult.value
+  };
+}
+
+function getLocalConstBindingExpression(
+  record: ImportedStaticCssEvalModuleRecord,
+  localName: string
+): t.Expression | null {
+  const binding = record.programPath.scope.getBinding(localName);
+
+  return binding ? getStaticCssEvalConstBindingInitExpression(binding) : null;
+}
+
+function hasImportedStaticCssBindingMutation(
+  record: ImportedStaticCssEvalModuleRecord,
+  localName: string
+): boolean {
+  const binding = record.programPath.scope.getBinding(localName);
+
+  return binding
+    ? hasStaticCssEvalBindingMutation(record.programPath, binding)
+    : false;
+}
+
+function resolveStaticObjectMemberPath(
+  expression: t.Expression,
+  memberPath: readonly string[]
+): t.Expression | null {
+  let currentExpression: t.Expression | null =
+    unwrapTransparentCssRuleExpression(expression);
+
+  for (const memberName of memberPath) {
+    if (!currentExpression) {
+      return null;
+    }
+
+    const unwrappedExpression =
+      unwrapTransparentCssRuleExpression(currentExpression);
+
+    if (!t.isObjectExpression(unwrappedExpression)) {
+      return null;
+    }
+
+    currentExpression = getStaticObjectMemberValue(
+      unwrappedExpression,
+      memberName
+    );
+  }
+
+  return currentExpression
+    ? unwrapTransparentCssRuleExpression(currentExpression)
+    : null;
+}
+
+function evaluateStaticCssLiteralExpression(
+  expression: t.Expression,
+  context: ImportedStaticCssEvalContext,
+  state: StaticCssLiteralValidationState,
+  depth: number
+):
+  | { kind: "resolved"; value: StaticCssLiteral }
+  | { kind: "error"; diagnostic: StaticCssEvalDiagnostic } {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+  state.count += 1;
+
+  const countResult = enforceImportedStaticCssEvalLiteralCount(context, state);
+
+  if (countResult) {
+    return { kind: "error", diagnostic: countResult };
+  }
+
+  if (t.isObjectExpression(unwrappedExpression)) {
+    const depthResult = enforceImportedStaticCssEvalDepth(context, depth);
+
+    if (depthResult) {
+      return { kind: "error", diagnostic: depthResult };
+    }
+
+    return evaluateStaticCssObjectExpression(
+      unwrappedExpression,
+      context,
+      state,
+      depth
+    );
+  }
+
+  if (t.isArrayExpression(unwrappedExpression)) {
+    const depthResult = enforceImportedStaticCssEvalDepth(context, depth);
+
+    if (depthResult) {
+      return { kind: "error", diagnostic: depthResult };
+    }
+
+    return evaluateStaticCssArrayExpression(
+      unwrappedExpression,
+      context,
+      state,
+      depth
+    );
+  }
+
+  if (t.isStringLiteral(unwrappedExpression)) {
+    return { kind: "resolved", value: unwrappedExpression.value };
+  }
+
+  if (t.isNumericLiteral(unwrappedExpression)) {
+    return { kind: "resolved", value: unwrappedExpression.value };
+  }
+
+  if (t.isBooleanLiteral(unwrappedExpression)) {
+    return { kind: "resolved", value: unwrappedExpression.value };
+  }
+
+  if (t.isNullLiteral(unwrappedExpression)) {
+    return { kind: "resolved", value: null };
+  }
+
+  if (
+    t.isUnaryExpression(unwrappedExpression) &&
+    (unwrappedExpression.operator === "+" ||
+      unwrappedExpression.operator === "-") &&
+    t.isNumericLiteral(unwrappedExpression.argument)
+  ) {
+    return {
+      kind: "resolved",
+      value:
+        unwrappedExpression.operator === "-"
+          ? -unwrappedExpression.argument.value
+          : unwrappedExpression.argument.value
+    };
+  }
+
+  if (
+    t.isTemplateLiteral(unwrappedExpression) &&
+    unwrappedExpression.expressions.length === 0
+  ) {
+    const [quasi] = unwrappedExpression.quasis;
+    return {
+      kind: "resolved",
+      value: quasi?.value.cooked ?? quasi?.value.raw ?? ""
+    };
+  }
+
+  return {
+    kind: "error",
+    diagnostic: createImportedStaticCssEvalDiagnostic({
+      ...context,
+      code: "unsupported-syntax",
+      reason: getUnsupportedLiteralReason(unwrappedExpression),
+      detail: `imported export "${formatExportName(
+        context.exportName
+      )}" contains unsupported ${unwrappedExpression.type}`
+    })
+  };
+}
+
+function evaluateStaticCssObjectExpression(
+  expression: t.ObjectExpression,
+  context: ImportedStaticCssEvalContext,
+  state: StaticCssLiteralValidationState,
+  depth: number
+):
+  | { kind: "resolved"; value: StaticCssLiteral }
+  | { kind: "error"; diagnostic: StaticCssEvalDiagnostic } {
+  const value: Record<string, StaticCssLiteral> = {};
+
+  for (const property of expression.properties) {
+    if (t.isSpreadElement(property)) {
+      return createStaticCssLiteralError(
+        context,
+        "object-or-array-spread",
+        `imported export "${formatExportName(
+          context.exportName
+        )}" contains an object spread`
+      );
+    }
+
+    if (!t.isObjectProperty(property)) {
+      return createStaticCssLiteralError(
+        context,
+        "function-or-call",
+        `imported export "${formatExportName(
+          context.exportName
+        )}" contains an object method`
+      );
+    }
+
+    if (property.computed) {
+      return createStaticCssLiteralError(
+        context,
+        "computed-object-key",
+        `imported export "${formatExportName(
+          context.exportName
+        )}" contains a computed object key`
+      );
+    }
+
+    if (!t.isExpression(property.value)) {
+      return createStaticCssLiteralError(
+        context,
+        "unsupported-literal",
+        `imported export "${formatExportName(
+          context.exportName
+        )}" contains a non-expression object value`
+      );
+    }
+
+    const propertyName = getStaticObjectPropertyName(property.key);
+
+    if (!propertyName) {
+      return createStaticCssLiteralError(
+        context,
+        "unsupported-literal",
+        `imported export "${formatExportName(
+          context.exportName
+        )}" contains an unsupported object key`
+      );
+    }
+
+    const propertyResult = evaluateStaticCssLiteralExpression(
+      property.value,
+      context,
+      state,
+      depth + 1
+    );
+
+    if (propertyResult.kind === "error") {
+      return propertyResult;
+    }
+
+    value[propertyName] = propertyResult.value;
+  }
+
+  return { kind: "resolved", value };
+}
+
+function evaluateStaticCssArrayExpression(
+  expression: t.ArrayExpression,
+  context: ImportedStaticCssEvalContext,
+  state: StaticCssLiteralValidationState,
+  depth: number
+):
+  | { kind: "resolved"; value: StaticCssLiteral }
+  | { kind: "error"; diagnostic: StaticCssEvalDiagnostic } {
+  const value: StaticCssLiteral[] = [];
+
+  for (const element of expression.elements) {
+    if (!element) {
+      return createStaticCssLiteralError(
+        context,
+        "unsupported-literal",
+        `imported export "${formatExportName(
+          context.exportName
+        )}" contains an array hole`
+      );
+    }
+
+    if (t.isSpreadElement(element)) {
+      return createStaticCssLiteralError(
+        context,
+        "object-or-array-spread",
+        `imported export "${formatExportName(
+          context.exportName
+        )}" contains an array spread`
+      );
+    }
+
+    const elementResult = evaluateStaticCssLiteralExpression(
+      element,
+      context,
+      state,
+      depth + 1
+    );
+
+    if (elementResult.kind === "error") {
+      return elementResult;
+    }
+
+    value.push(elementResult.value);
+  }
+
+  return { kind: "resolved", value };
+}
+
+function findUnsupportedImportedObjectReferenceDiagnostic(
+  expression: t.ObjectExpression,
+  options: {
+    ownerFile: string;
+    provider: StaticCssEvalProvider;
+  }
+): StaticCssEvalDiagnostic | null {
+  for (const property of expression.properties) {
+    if (!t.isObjectProperty(property) || !t.isExpression(property.value)) {
+      continue;
+    }
+
+    const diagnostic = findUnsupportedImportedExpressionReferenceDiagnostic(
+      property.value,
+      options
+    );
+
+    if (diagnostic) {
+      return diagnostic;
+    }
+  }
+
+  return null;
+}
+
+function findUnsupportedImportedArrayReferenceDiagnostic(
+  expression: t.ArrayExpression,
+  options: {
+    ownerFile: string;
+    provider: StaticCssEvalProvider;
+  }
+): StaticCssEvalDiagnostic | null {
+  for (const element of expression.elements) {
+    if (!element || t.isSpreadElement(element)) {
+      continue;
+    }
+
+    const diagnostic = findUnsupportedImportedExpressionReferenceDiagnostic(
+      element,
+      options
+    );
+
+    if (diagnostic) {
+      return diagnostic;
+    }
+  }
+
+  return null;
+}
+
+function findUnsupportedImportedExpressionReferenceDiagnostic(
+  expression: t.Expression,
+  options: {
+    ownerFile: string;
+    provider: StaticCssEvalProvider;
+  }
+): StaticCssEvalDiagnostic | null {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+  const candidate = createStaticCssEvalCandidate(
+    unwrappedExpression,
+    options.ownerFile
+  );
+
+  if (candidate?.bindingName) {
+    const result = options.provider.getResolvedCssValue(candidate);
+
+    if (result.kind === "error") {
+      return result.diagnostic;
+    }
+  }
+
+  if (t.isObjectExpression(unwrappedExpression)) {
+    return findUnsupportedImportedObjectReferenceDiagnostic(
+      unwrappedExpression,
+      options
+    );
+  }
+
+  if (t.isArrayExpression(unwrappedExpression)) {
+    return findUnsupportedImportedArrayReferenceDiagnostic(
+      unwrappedExpression,
+      options
+    );
+  }
+
+  return null;
+}
+
+function enforceImportedStaticCssEvalDepth(
+  context: ImportedStaticCssEvalContext,
+  depth: number
+): StaticCssEvalDiagnostic | null {
+  const result = enforceStaticCssEvalObjectArrayRecursionDepth({
+    owner: context.owner,
+    dependency: context.dependency,
+    importPath: context.importPath,
+    exportName: context.exportName,
+    memberPath: context.memberPath,
+    recursionDepth: depth
+  });
+
+  return result.ok ? null : result.diagnostic;
+}
+
+function enforceImportedStaticCssEvalLiteralCount(
+  context: ImportedStaticCssEvalContext,
+  state: StaticCssLiteralValidationState
+): StaticCssEvalDiagnostic | null {
+  const result = enforceStaticCssEvalLiteralNodeCount({
+    owner: context.owner,
+    dependency: context.dependency,
+    importPath: context.importPath,
+    exportName: context.exportName,
+    memberPath: context.memberPath,
+    literalNodeCount: state.count
+  });
+
+  return result.ok ? null : result.diagnostic;
+}
+
+function createStaticCssLiteralError(
+  context: ImportedStaticCssEvalContext,
+  reason: StaticCssEvalUnsupportedReason,
+  detail: string
+): { kind: "error"; diagnostic: StaticCssEvalDiagnostic } {
+  return {
+    kind: "error",
+    diagnostic: createImportedStaticCssEvalDiagnostic({
+      ...context,
+      code: "unsupported-syntax",
+      reason,
+      detail
+    })
+  };
+}
+
+function createImportedStaticCssEvalDiagnostic(
+  options: ImportedStaticCssEvalContext & {
+    code: StaticCssEvalDiagnostic["code"];
+    reason: StaticCssEvalUnsupportedReason;
+    detail: string;
+  }
+): StaticCssEvalDiagnostic {
+  return createStaticCssEvalDiagnostic({
+    code: options.code,
+    reason: options.reason,
+    detail: options.detail,
+    owner: options.owner,
+    dependency: options.dependency,
+    importPath: options.importPath,
+    exportName: options.exportName,
+    memberPath: options.memberPath,
+    importChain: [
+      options.owner.file,
+      `${options.dependency.file}#${formatExportName(options.exportName)}${
+        options.memberPath.length > 0 ? `.${options.memberPath.join(".")}` : ""
+      }`
+    ]
+  });
+}
+
+function createQueryOwnerLocation(
+  query: StaticCssEvalQuery
+): StaticCssEvalSourceLocation {
+  return {
+    file: query.importerId,
+    start: query.expressionStart,
+    end: query.expressionEnd
+  };
+}
+
+function getModuleStringName(
+  node: t.Identifier | t.StringLiteral
+): string | null {
+  if (t.isIdentifier(node)) {
+    return node.name;
+  }
+
+  if (t.isStringLiteral(node)) {
+    return node.value;
+  }
+
+  return null;
+}
+
+function isStaticCssRuleLiteralExpression(
+  expression: t.Expression
+): expression is t.ObjectExpression | t.ArrayExpression {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+
+  return (
+    t.isObjectExpression(unwrappedExpression) ||
+    t.isArrayExpression(unwrappedExpression)
+  );
+}
+
+function isStaticCssRuleLiteralValue(
+  value: StaticCssLiteral
+): value is StaticCssLiteral[] | { [key: string]: StaticCssLiteral } {
+  return value !== null && typeof value === "object";
+}
+
+function formatExportName(exportName: StaticCssEvalExportName): string {
+  return exportName === null ? "<local>" : exportName;
+}
+
+function createImportResolutionKey(
+  importerId: string,
+  importPath: string
+): string {
+  return `${importerId}${importResolutionKeySeparator}${importPath}`;
+}
+
+if (import.meta.vitest) {
+  const { describe, expect, it } = import.meta.vitest;
+
+  const ownerId = "/project/src/App.tsx";
+  const stylesId = "/project/src/styles.ts";
+  const barrelId = "/project/src/barrel.ts";
+
+  function createProvider(
+    stylesSource: string,
+    ownerSource = `import { button } from "./styles"; <div css={button} />;`,
+    barrelSource = `export { button } from "./styles";`
+  ): StaticCssEvalProvider {
+    return createImportedStaticCssEvalProvider({
+      modules: [
+        { id: ownerId, source: ownerSource },
+        { id: stylesId, source: stylesSource },
+        {
+          id: barrelId,
+          source: barrelSource
+        }
+      ],
+      importResolutions: [
+        { importerId: ownerId, importPath: "./styles", resolvedId: stylesId },
+        { importerId: ownerId, importPath: "./barrel", resolvedId: barrelId }
+      ]
+    });
+  }
+
+  function resolveFixture(
+    provider: StaticCssEvalProvider,
+    bindingName: string,
+    memberPath: string[] = []
+  ): StaticCssEvalResult {
+    return provider.getResolvedCssValue({
+      importerId: ownerId,
+      expressionStart: 0,
+      expressionEnd: bindingName.length,
+      bindingName,
+      ...(memberPath.length > 0 ? { memberPath } : {})
+    });
+  }
+
+  describe("imported static css eval module records", () => {
+    it("matches parser plugins to the loaded module extension", () => {
+      expect(() =>
+        createImportedStaticCssEvalModuleRecord({
+          id: "/project/src/styles.ts",
+          source: `export const value = <number>1;`
+        })
+      ).not.toThrow();
+
+      expect(() =>
+        createImportedStaticCssEvalModuleRecord({
+          id: "/project/src/styles.js",
+          source: `export const value: number = 1;`
+        })
+      ).toThrow();
+
+      expect(() =>
+        createImportedStaticCssEvalModuleRecord({
+          id: "/project/src/styles.jsx",
+          source: `export const value = <div />;`
+        })
+      ).not.toThrow();
+    });
+
+    it("resolves named, aliased, default object, default const, and same-module export aliases", () => {
+      expect(
+        resolveFixture(
+          createProvider(`export const button = { color: "red" } as const;`),
+          "button"
+        )
+      ).toMatchObject({
+        kind: "resolved",
+        value: { color: "red" },
+        dependencies: [stylesId]
+      });
+
+      expect(
+        resolveFixture(
+          createProvider(
+            `export const button = { color: "red" } as const;`,
+            `import { button as buttonStyle } from "./styles"; <div css={buttonStyle} />;`
+          ),
+          "buttonStyle"
+        )
+      ).toMatchObject({
+        kind: "resolved",
+        value: { color: "red" }
+      });
+
+      expect(
+        resolveFixture(
+          createProvider(
+            `export default { color: "blue" } as const;`,
+            `import styles from "./styles"; <div css={styles} />;`
+          ),
+          "styles"
+        )
+      ).toMatchObject({
+        kind: "resolved",
+        value: { color: "blue" }
+      });
+
+      expect(
+        resolveFixture(
+          createProvider(
+            `const button = { color: "green" } as const; export default button;`,
+            `import styles from "./styles"; <div css={styles} />;`
+          ),
+          "styles"
+        )
+      ).toMatchObject({
+        kind: "resolved",
+        value: { color: "green" }
+      });
+
+      expect(
+        resolveFixture(
+          createProvider(
+            `const x = { color: "orange" } as const; export { x as y };`,
+            `import { y } from "./styles"; <div css={y} />;`
+          ),
+          "y"
+        )
+      ).toMatchObject({
+        kind: "resolved",
+        value: { color: "orange" }
+      });
+    });
+
+    it("resolves nested member paths over imported static objects", () => {
+      expect(
+        resolveFixture(
+          createProvider(
+            `export const styles = { button: { primary: { color: "red" } } } as const;`,
+            `import { styles } from "./styles"; <div css={styles.button.primary} />;`
+          ),
+          "styles",
+          ["button", "primary"]
+        )
+      ).toMatchObject({
+        kind: "resolved",
+        value: { color: "red" }
+      });
+    });
+
+    it("rejects reexports and exported const mutations deterministically", () => {
+      expect(
+        resolveFixture(
+          createProvider(
+            `export const button = { color: "red" } as const;`,
+            `import { button } from "./barrel"; <div css={button} />;`
+          ),
+          "button"
+        )
+      ).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          code: "unsupported-source",
+          reason: "reexport-or-barrel"
+        },
+        dependencies: [barrelId]
+      });
+
+      expect(
+        resolveFixture(
+          createProvider(
+            `export const button = { color: "red" } as const;`,
+            `import { button } from "./barrel"; <div css={button} />;`,
+            `export * from "./styles";`
+          ),
+          "button"
+        )
+      ).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          code: "unsupported-source",
+          reason: "reexport-or-barrel"
+        },
+        dependencies: [barrelId]
+      });
+
+      expect(
+        resolveFixture(
+          createProvider(
+            `export const button = { color: "red" } as const; button.color = "blue";`
+          ),
+          "button"
+        )
+      ).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          code: "mutation-detected",
+          reason: "mutated-binding"
+        },
+        dependencies: [stylesId]
+      });
+
+      expect(
+        resolveFixture(
+          createProvider(
+            `export const buttons = [{ color: "red" }] as const; buttons.push({ color: "blue" });`,
+            `import { buttons } from "./styles"; <div css={buttons} />;`
+          ),
+          "buttons"
+        )
+      ).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          code: "mutation-detected",
+          reason: "mutated-binding"
+        },
+        dependencies: [stylesId]
+      });
+    });
+  });
+}

--- a/packages/babel/src/staticCssEval/limits.ts
+++ b/packages/babel/src/staticCssEval/limits.ts
@@ -1,0 +1,282 @@
+import {
+  STATIC_CSS_EVAL_LIMITS,
+  type StaticCssEvalUnsupportedReason
+} from "./types.js";
+import {
+  createStaticCssEvalDiagnostic,
+  getStaticCssEvalDiagnosticDependencies,
+  type StaticCssEvalDiagnosticContext,
+  type StaticCssEvalGuardResult
+} from "./diagnostics.js";
+
+export type StaticCssEvalLimitName = keyof typeof STATIC_CSS_EVAL_LIMITS;
+
+export interface StaticCssEvalLimitCheckOptions extends StaticCssEvalDiagnosticContext {
+  actual: number;
+  limitName: StaticCssEvalLimitName;
+}
+
+const staticCssEvalLimitLabels = {
+  maxImportDepth: "max import depth",
+  maxEvaluatedModulesPerOwner: "max evaluated modules per owner",
+  maxLoadedDependencySourceBytes: "max loaded dependency source size",
+  maxObjectArrayRecursionDepth: "max object/array recursion depth",
+  maxStaticLiteralNodeCount: "max static literal node count"
+} as const satisfies Record<StaticCssEvalLimitName, string>;
+
+const staticCssEvalLimitUnits = {
+  maxImportDepth: "levels",
+  maxEvaluatedModulesPerOwner: "modules",
+  maxLoadedDependencySourceBytes: "bytes",
+  maxObjectArrayRecursionDepth: "levels",
+  maxStaticLiteralNodeCount: "nodes"
+} as const satisfies Record<StaticCssEvalLimitName, string>;
+
+const staticCssEvalLimitReasons = {
+  maxImportDepth: "failed-project-local-dependency",
+  maxEvaluatedModulesPerOwner: "failed-project-local-dependency",
+  maxLoadedDependencySourceBytes: "failed-project-local-dependency",
+  maxObjectArrayRecursionDepth: "unsupported-literal",
+  maxStaticLiteralNodeCount: "unsupported-literal"
+} as const satisfies Record<
+  StaticCssEvalLimitName,
+  StaticCssEvalUnsupportedReason
+>;
+
+export function enforceStaticCssEvalLimit(
+  options: StaticCssEvalLimitCheckOptions
+): StaticCssEvalGuardResult {
+  const limit = STATIC_CSS_EVAL_LIMITS[options.limitName];
+
+  if (options.actual <= limit) {
+    return { ok: true };
+  }
+
+  const unit = staticCssEvalLimitUnits[options.limitName];
+  const diagnostic = createStaticCssEvalDiagnostic({
+    code: "limit-exceeded",
+    reason: staticCssEvalLimitReasons[options.limitName],
+    detail: `${staticCssEvalLimitLabels[options.limitName]} exceeded (${options.actual} ${unit} > ${limit} ${unit})`,
+    owner: options.owner,
+    dependency: options.dependency,
+    importPath: options.importPath,
+    exportName: options.exportName,
+    memberPath: options.memberPath,
+    importChain: options.importChain
+  });
+
+  return {
+    ok: false,
+    diagnostic,
+    dependencies: getStaticCssEvalDiagnosticDependencies(diagnostic)
+  };
+}
+
+export function enforceStaticCssEvalImportDepth(
+  options: Omit<StaticCssEvalLimitCheckOptions, "actual" | "limitName"> & {
+    importDepth: number;
+  }
+): StaticCssEvalGuardResult {
+  const { importDepth, ...context } = options;
+
+  return enforceStaticCssEvalLimit({
+    ...context,
+    actual: importDepth,
+    limitName: "maxImportDepth"
+  });
+}
+
+export function enforceStaticCssEvalModuleCount(
+  options: Omit<StaticCssEvalLimitCheckOptions, "actual" | "limitName"> & {
+    evaluatedModuleCount: number;
+  }
+): StaticCssEvalGuardResult {
+  const { evaluatedModuleCount, ...context } = options;
+
+  return enforceStaticCssEvalLimit({
+    ...context,
+    actual: evaluatedModuleCount,
+    limitName: "maxEvaluatedModulesPerOwner"
+  });
+}
+
+export function enforceStaticCssEvalSourceSize(
+  options: Omit<StaticCssEvalLimitCheckOptions, "actual" | "limitName"> & {
+    source: string;
+  }
+): StaticCssEvalGuardResult {
+  const { source, ...context } = options;
+
+  return enforceStaticCssEvalSourceByteLength({
+    ...context,
+    byteLength: getStaticCssEvalSourceByteLength(source)
+  });
+}
+
+export function enforceStaticCssEvalSourceByteLength(
+  options: Omit<StaticCssEvalLimitCheckOptions, "actual" | "limitName"> & {
+    byteLength: number;
+  }
+): StaticCssEvalGuardResult {
+  const { byteLength, ...context } = options;
+
+  return enforceStaticCssEvalLimit({
+    ...context,
+    actual: byteLength,
+    limitName: "maxLoadedDependencySourceBytes"
+  });
+}
+
+export function enforceStaticCssEvalObjectArrayRecursionDepth(
+  options: Omit<StaticCssEvalLimitCheckOptions, "actual" | "limitName"> & {
+    recursionDepth: number;
+  }
+): StaticCssEvalGuardResult {
+  const { recursionDepth, ...context } = options;
+
+  return enforceStaticCssEvalLimit({
+    ...context,
+    actual: recursionDepth,
+    limitName: "maxObjectArrayRecursionDepth"
+  });
+}
+
+export function enforceStaticCssEvalLiteralNodeCount(
+  options: Omit<StaticCssEvalLimitCheckOptions, "actual" | "limitName"> & {
+    literalNodeCount: number;
+  }
+): StaticCssEvalGuardResult {
+  const { literalNodeCount, ...context } = options;
+
+  return enforceStaticCssEvalLimit({
+    ...context,
+    actual: literalNodeCount,
+    limitName: "maxStaticLiteralNodeCount"
+  });
+}
+
+export function getStaticCssEvalSourceByteLength(source: string): number {
+  return new TextEncoder().encode(source).byteLength;
+}
+
+if (import.meta.vitest) {
+  const { describe, expect, it } = import.meta.vitest;
+
+  const owner = { file: "/project/src/App.tsx", start: 42, end: 55 };
+  const dependency = { file: "/project/src/styles.ts" };
+
+  describe("static css eval limits", () => {
+    it("rejects loaded dependency source over the shared 1 MB limit", () => {
+      expect(
+        enforceStaticCssEvalSourceSize({
+          owner,
+          dependency,
+          source: "a".repeat(
+            STATIC_CSS_EVAL_LIMITS.maxLoadedDependencySourceBytes
+          )
+        })
+      ).toEqual({ ok: true });
+
+      const result = enforceStaticCssEvalSourceSize({
+        owner,
+        dependency,
+        importPath: "./styles",
+        exportName: "button",
+        memberPath: ["root"],
+        source: "a".repeat(
+          STATIC_CSS_EVAL_LIMITS.maxLoadedDependencySourceBytes + 1
+        )
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.diagnostic).toMatchObject({
+          code: "limit-exceeded",
+          reason: "failed-project-local-dependency",
+          owner,
+          dependency,
+          importPath: "./styles",
+          exportName: "button",
+          memberPath: ["root"]
+        });
+        expect(result.diagnostic.message).toBe(
+          "Cannot statically evaluate css prop value: max loaded dependency source size exceeded (1048577 bytes > 1048576 bytes)"
+        );
+        expect(result.dependencies).toEqual(["/project/src/styles.ts"]);
+      }
+    });
+
+    it("enforces import depth and module count from shared constants", () => {
+      expect(
+        enforceStaticCssEvalImportDepth({
+          owner,
+          dependency,
+          importDepth: STATIC_CSS_EVAL_LIMITS.maxImportDepth
+        })
+      ).toEqual({ ok: true });
+      expect(
+        enforceStaticCssEvalImportDepth({
+          owner,
+          dependency,
+          importDepth: STATIC_CSS_EVAL_LIMITS.maxImportDepth + 1
+        })
+      ).toMatchObject({
+        ok: false,
+        diagnostic: {
+          code: "limit-exceeded",
+          reason: "failed-project-local-dependency",
+          message:
+            "Cannot statically evaluate css prop value: max import depth exceeded (11 levels > 10 levels)"
+        }
+      });
+      expect(
+        enforceStaticCssEvalModuleCount({
+          owner,
+          dependency,
+          evaluatedModuleCount:
+            STATIC_CSS_EVAL_LIMITS.maxEvaluatedModulesPerOwner + 1
+        })
+      ).toMatchObject({
+        ok: false,
+        diagnostic: {
+          message:
+            "Cannot statically evaluate css prop value: max evaluated modules per owner exceeded (101 modules > 100 modules)"
+        }
+      });
+    });
+
+    it("enforces recursion depth and literal node count from shared constants", () => {
+      expect(
+        enforceStaticCssEvalObjectArrayRecursionDepth({
+          owner,
+          dependency,
+          recursionDepth:
+            STATIC_CSS_EVAL_LIMITS.maxObjectArrayRecursionDepth + 1
+        })
+      ).toMatchObject({
+        ok: false,
+        diagnostic: {
+          code: "limit-exceeded",
+          reason: "unsupported-literal",
+          message:
+            "Cannot statically evaluate css prop value: max object/array recursion depth exceeded (51 levels > 50 levels)"
+        }
+      });
+      expect(
+        enforceStaticCssEvalLiteralNodeCount({
+          owner,
+          dependency,
+          literalNodeCount: STATIC_CSS_EVAL_LIMITS.maxStaticLiteralNodeCount + 1
+        })
+      ).toMatchObject({
+        ok: false,
+        diagnostic: {
+          code: "limit-exceeded",
+          reason: "unsupported-literal",
+          message:
+            "Cannot statically evaluate css prop value: max static literal node count exceeded (10001 nodes > 10000 nodes)"
+        }
+      });
+    });
+  });
+}

--- a/packages/babel/src/staticCssEval/sameFile.ts
+++ b/packages/babel/src/staticCssEval/sameFile.ts
@@ -1,0 +1,804 @@
+import { types as t } from "@babel/core";
+import type { NodePath } from "@babel/core";
+import type { Binding, Scope } from "@babel/traverse";
+import {
+  getStaticMemberPropertyName,
+  getStaticObjectMemberValue,
+  getUnsupportedLiteralReason
+} from "./ast.js";
+import {
+  getStaticCssEvalMemberReference,
+  unwrapTransparentCssRuleExpression
+} from "./candidates.js";
+import type { StaticMemberReference } from "./candidates.js";
+import { createStaticCssEvalDiagnostic } from "./diagnostics.js";
+import {
+  enforceStaticCssEvalLiteralNodeCount,
+  enforceStaticCssEvalObjectArrayRecursionDepth
+} from "./limits.js";
+import type {
+  StaticCssEvalDiagnostic,
+  StaticCssEvalSourceLocation,
+  StaticCssEvalUnsupportedReason
+} from "./types.js";
+
+export type SameFileStaticCssEvalResult =
+  | { kind: "not-candidate" }
+  | {
+      kind: "resolved";
+      expression: t.ObjectExpression | t.ArrayExpression;
+    }
+  | {
+      kind: "error";
+      diagnostic: StaticCssEvalDiagnostic;
+    };
+
+export interface ResolveSameFileStaticCssEvalOptions {
+  expression: t.Expression;
+  ownerFile: string;
+  programPath: NodePath<t.Program>;
+  scope: Scope;
+}
+
+interface SameFileStaticCssEvalContext {
+  binding: Binding;
+  bindingName: string;
+  memberPath: string[];
+  owner: StaticCssEvalSourceLocation;
+}
+
+interface LiteralValidationState {
+  count: number;
+}
+
+const arrayMutationMethods = new Set([
+  "copyWithin",
+  "fill",
+  "pop",
+  "push",
+  "reverse",
+  "shift",
+  "sort",
+  "splice",
+  "unshift"
+]);
+
+const objectMutationMethods = new Set([
+  "assign",
+  "defineProperties",
+  "defineProperty",
+  "setPrototypeOf"
+]);
+
+export function resolveSameFileStaticCssEvalExpression(
+  options: ResolveSameFileStaticCssEvalOptions
+): SameFileStaticCssEvalResult {
+  const reference = getStaticCssEvalMemberReference(options.expression);
+  const expressionRange = getExpressionRange(
+    unwrapTransparentCssRuleExpression(options.expression)
+  );
+
+  if (!reference || !expressionRange) {
+    return { kind: "not-candidate" };
+  }
+
+  const binding = options.scope.getBinding(reference.bindingName);
+
+  if (!binding) {
+    return { kind: "not-candidate" };
+  }
+
+  const init = getStaticCssEvalConstBindingInitExpression(binding);
+
+  if (!init) {
+    return { kind: "not-candidate" };
+  }
+
+  const memberPath = reference.memberPath;
+  const context: SameFileStaticCssEvalContext = {
+    binding,
+    bindingName: reference.bindingName,
+    memberPath,
+    owner: {
+      file: options.ownerFile,
+      start: expressionRange.start,
+      end: expressionRange.end
+    }
+  };
+
+  if (reference.kind === "unsupported") {
+    const unsupportedMemberPathDiagnostic =
+      createUnsupportedMemberPathDiagnostic(init, reference, context);
+
+    if (!unsupportedMemberPathDiagnostic) {
+      return { kind: "not-candidate" };
+    }
+
+    if (hasStaticCssEvalBindingMutation(options.programPath, binding)) {
+      return {
+        kind: "error",
+        diagnostic: createSameFileStaticCssEvalDiagnostic(
+          context,
+          "mutation-detected",
+          "mutated-binding",
+          `same-file binding "${reference.bindingName}" is mutated`
+        )
+      };
+    }
+
+    return {
+      kind: "error",
+      diagnostic: unsupportedMemberPathDiagnostic
+    };
+  }
+
+  const resolvedExpression = resolveStaticMemberPath(init, memberPath);
+
+  if (!resolvedExpression || !isStaticCssRuleLiteral(resolvedExpression)) {
+    return { kind: "not-candidate" };
+  }
+
+  if (hasStaticCssEvalBindingMutation(options.programPath, binding)) {
+    return {
+      kind: "error",
+      diagnostic: createSameFileStaticCssEvalDiagnostic(
+        context,
+        "mutation-detected",
+        "mutated-binding",
+        `same-file binding "${reference.bindingName}" is mutated`
+      )
+    };
+  }
+
+  const validationDiagnostic = validateStaticCssLiteralExpression(
+    resolvedExpression,
+    context,
+    { count: 0 },
+    1
+  );
+
+  if (validationDiagnostic) {
+    return { kind: "error", diagnostic: validationDiagnostic };
+  }
+
+  return {
+    kind: "resolved",
+    expression: normalizeStaticCssLiteralExpression(resolvedExpression)
+  };
+}
+
+function getExpressionRange(
+  expression: t.Expression
+): { start: number; end: number } | null {
+  const { start, end } = expression;
+
+  if (typeof start !== "number" || typeof end !== "number") {
+    return null;
+  }
+
+  return { start, end };
+}
+
+export function getStaticCssEvalConstBindingInitExpression(
+  binding: Binding
+): t.Expression | null {
+  const bindingPath = binding.path;
+
+  if (!bindingPath.isVariableDeclarator()) {
+    return null;
+  }
+
+  if (!t.isIdentifier(bindingPath.node.id)) {
+    return null;
+  }
+
+  if (!bindingPath.parentPath.isVariableDeclaration({ kind: "const" })) {
+    return null;
+  }
+
+  const initPath = bindingPath.get("init");
+
+  if (!initPath.node || !initPath.isExpression()) {
+    return null;
+  }
+
+  return initPath.node;
+}
+
+function resolveStaticMemberPath(
+  expression: t.Expression,
+  memberPath: readonly string[]
+): t.Expression | null {
+  let currentExpression: t.Expression | null =
+    unwrapTransparentCssRuleExpression(expression);
+
+  for (const memberName of memberPath) {
+    if (!currentExpression) {
+      return null;
+    }
+
+    const unwrappedExpression =
+      unwrapTransparentCssRuleExpression(currentExpression);
+
+    if (t.isObjectExpression(unwrappedExpression)) {
+      currentExpression = getStaticObjectMemberValue(
+        unwrappedExpression,
+        memberName
+      );
+      continue;
+    }
+
+    return null;
+  }
+
+  return currentExpression
+    ? unwrapTransparentCssRuleExpression(currentExpression)
+    : null;
+}
+
+function getStaticArrayMemberValue(
+  expression: t.ArrayExpression,
+  memberName: string
+): t.Expression | null {
+  if (!/^\d+$/.test(memberName)) {
+    return null;
+  }
+
+  const element = expression.elements[Number(memberName)];
+
+  return element && t.isExpression(element) ? element : null;
+}
+
+function isStaticCssRuleLiteral(
+  expression: t.Expression
+): expression is t.ObjectExpression | t.ArrayExpression {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+  return (
+    t.isObjectExpression(unwrappedExpression) ||
+    t.isArrayExpression(unwrappedExpression)
+  );
+}
+
+function createUnsupportedMemberPathDiagnostic(
+  expression: t.Expression,
+  reference: Extract<StaticMemberReference, { kind: "unsupported" }>,
+  context: SameFileStaticCssEvalContext
+): StaticCssEvalDiagnostic | null {
+  const baseExpression = resolveStaticMemberPath(
+    expression,
+    reference.memberPath
+  );
+
+  if (
+    !baseExpression ||
+    !isProvenStaticCssRuleMemberTarget(
+      baseExpression,
+      reference.unsupportedPropertyName
+    )
+  ) {
+    return null;
+  }
+
+  return createSameFileStaticCssEvalDiagnostic(
+    context,
+    "unsupported-syntax",
+    reference.reason,
+    `same-file binding "${context.bindingName}" contains unsupported ${reference.reason}: ${reference.detail}`
+  );
+}
+
+function isProvenStaticCssRuleMemberTarget(
+  expression: t.Expression,
+  unsupportedPropertyName?: string
+): boolean {
+  if (unsupportedPropertyName !== undefined) {
+    const value = getStaticMemberValueForUnsupportedProperty(
+      expression,
+      unsupportedPropertyName
+    );
+
+    return Boolean(value && isStaticCssRuleLiteral(value));
+  }
+
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+
+  if (t.isObjectExpression(unwrappedExpression)) {
+    return hasOnlyStaticCssRuleObjectValues(unwrappedExpression);
+  }
+
+  if (t.isArrayExpression(unwrappedExpression)) {
+    return hasOnlyStaticCssRuleArrayValues(unwrappedExpression);
+  }
+
+  return false;
+}
+
+function getStaticMemberValueForUnsupportedProperty(
+  expression: t.Expression,
+  memberName: string
+): t.Expression | null {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+
+  if (t.isObjectExpression(unwrappedExpression)) {
+    return getStaticObjectMemberValue(unwrappedExpression, memberName);
+  }
+
+  if (t.isArrayExpression(unwrappedExpression)) {
+    return getStaticArrayMemberValue(unwrappedExpression, memberName);
+  }
+
+  return null;
+}
+
+function hasOnlyStaticCssRuleObjectValues(
+  expression: t.ObjectExpression
+): boolean {
+  if (expression.properties.length === 0) {
+    return false;
+  }
+
+  return expression.properties.every((property) => {
+    if (!t.isObjectProperty(property) || property.computed) {
+      return false;
+    }
+
+    return (
+      t.isExpression(property.value) && isStaticCssRuleLiteral(property.value)
+    );
+  });
+}
+
+function hasOnlyStaticCssRuleArrayValues(
+  expression: t.ArrayExpression
+): boolean {
+  if (expression.elements.length === 0) {
+    return false;
+  }
+
+  return expression.elements.every((element) => {
+    return Boolean(
+      element && !t.isSpreadElement(element) && isStaticCssRuleLiteral(element)
+    );
+  });
+}
+
+export function hasStaticCssEvalBindingMutation(
+  programPath: NodePath<t.Program>,
+  binding: Binding
+): boolean {
+  if (binding.constantViolations.length > 0) {
+    return true;
+  }
+
+  let mutated = false;
+
+  programPath.traverse({
+    AssignmentExpression(path) {
+      if (pathTouchesBinding(path.get("left"), binding)) {
+        mutated = true;
+        path.stop();
+      }
+    },
+    CallExpression(path) {
+      if (isMutatingCallExpression(path, binding)) {
+        mutated = true;
+        path.stop();
+      }
+    },
+    UnaryExpression(path) {
+      if (
+        path.node.operator === "delete" &&
+        pathTouchesBinding(path.get("argument"), binding)
+      ) {
+        mutated = true;
+        path.stop();
+      }
+    },
+    UpdateExpression(path) {
+      if (pathTouchesBinding(path.get("argument"), binding)) {
+        mutated = true;
+        path.stop();
+      }
+    }
+  });
+
+  return mutated;
+}
+
+function isMutatingCallExpression(
+  path: NodePath<t.CallExpression>,
+  binding: Binding
+): boolean {
+  const calleePath = path.get("callee");
+
+  if (calleePath.isMemberExpression()) {
+    const methodName = getStaticMemberPropertyName(calleePath.node);
+
+    if (
+      methodName &&
+      arrayMutationMethods.has(methodName) &&
+      pathTouchesBinding(calleePath.get("object"), binding)
+    ) {
+      return true;
+    }
+
+    if (isObjectMutationCall(calleePath, methodName)) {
+      const firstArgument = path.get("arguments.0");
+      return Boolean(
+        firstArgument?.node && pathTouchesBinding(firstArgument, binding)
+      );
+    }
+  }
+
+  return false;
+}
+
+function isObjectMutationCall(
+  calleePath: NodePath<t.MemberExpression>,
+  methodName: string | null
+): boolean {
+  if (!methodName || !objectMutationMethods.has(methodName)) {
+    return false;
+  }
+
+  const objectPath = calleePath.get("object");
+  return objectPath.isIdentifier({ name: "Object" });
+}
+
+function pathTouchesBinding(
+  path: NodePath<t.Node | null>,
+  binding: Binding
+): boolean {
+  if (!path.node) {
+    return false;
+  }
+
+  if (path.isIdentifier()) {
+    return path.scope.getBinding(path.node.name) === binding;
+  }
+
+  if (path.isMemberExpression()) {
+    return pathTouchesBinding(path.get("object") as NodePath<t.Node>, binding);
+  }
+
+  if (path.isArrayPattern()) {
+    return path.get("elements").some((elementPath) => {
+      return Boolean(
+        elementPath.node &&
+        pathTouchesBinding(elementPath as NodePath<t.Node>, binding)
+      );
+    });
+  }
+
+  if (path.isObjectPattern()) {
+    return path.get("properties").some((propertyPath) => {
+      if (propertyPath.isObjectProperty()) {
+        return pathTouchesBinding(propertyPath.get("value"), binding);
+      }
+
+      if (propertyPath.isRestElement()) {
+        return pathTouchesBinding(propertyPath.get("argument"), binding);
+      }
+
+      return false;
+    });
+  }
+
+  if (path.isRestElement()) {
+    return pathTouchesBinding(
+      path.get("argument") as NodePath<t.Node>,
+      binding
+    );
+  }
+
+  if (path.isTSNonNullExpression()) {
+    return pathTouchesBinding(
+      path.get("expression") as NodePath<t.Node>,
+      binding
+    );
+  }
+
+  if (path.isTSAsExpression()) {
+    return pathTouchesBinding(
+      path.get("expression") as NodePath<t.Node>,
+      binding
+    );
+  }
+
+  if (path.isTSSatisfiesExpression()) {
+    return pathTouchesBinding(
+      path.get("expression") as NodePath<t.Node>,
+      binding
+    );
+  }
+
+  if (path.isParenthesizedExpression()) {
+    return pathTouchesBinding(
+      path.get("expression") as NodePath<t.Node>,
+      binding
+    );
+  }
+
+  return false;
+}
+
+function validateStaticCssLiteralExpression(
+  expression: t.Expression,
+  context: SameFileStaticCssEvalContext,
+  state: LiteralValidationState,
+  depth: number
+): StaticCssEvalDiagnostic | null {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+  state.count += 1;
+
+  const countResult = enforceStaticCssEvalLiteralNodeCount({
+    owner: context.owner,
+    memberPath: context.memberPath,
+    literalNodeCount: state.count
+  });
+
+  if (!countResult.ok) {
+    return countResult.diagnostic;
+  }
+
+  if (t.isObjectExpression(unwrappedExpression)) {
+    const depthResult = enforceStaticCssEvalObjectArrayRecursionDepth({
+      owner: context.owner,
+      memberPath: context.memberPath,
+      recursionDepth: depth
+    });
+
+    if (!depthResult.ok) {
+      return depthResult.diagnostic;
+    }
+
+    return validateStaticCssObjectExpression(
+      unwrappedExpression,
+      context,
+      state,
+      depth
+    );
+  }
+
+  if (t.isArrayExpression(unwrappedExpression)) {
+    const depthResult = enforceStaticCssEvalObjectArrayRecursionDepth({
+      owner: context.owner,
+      memberPath: context.memberPath,
+      recursionDepth: depth
+    });
+
+    if (!depthResult.ok) {
+      return depthResult.diagnostic;
+    }
+
+    return validateStaticCssArrayExpression(
+      unwrappedExpression,
+      context,
+      state,
+      depth
+    );
+  }
+
+  if (isSupportedStaticCssPrimitiveLiteral(unwrappedExpression)) {
+    return null;
+  }
+
+  return createUnsupportedLiteralDiagnostic(context, unwrappedExpression);
+}
+
+function validateStaticCssObjectExpression(
+  expression: t.ObjectExpression,
+  context: SameFileStaticCssEvalContext,
+  state: LiteralValidationState,
+  depth: number
+): StaticCssEvalDiagnostic | null {
+  for (const property of expression.properties) {
+    if (t.isSpreadElement(property)) {
+      return createSameFileStaticCssEvalDiagnostic(
+        context,
+        "unsupported-syntax",
+        "object-or-array-spread",
+        `same-file binding "${context.bindingName}" contains an object spread`
+      );
+    }
+
+    if (!t.isObjectProperty(property)) {
+      return createSameFileStaticCssEvalDiagnostic(
+        context,
+        "unsupported-syntax",
+        "function-or-call",
+        `same-file binding "${context.bindingName}" contains an object method`
+      );
+    }
+
+    if (property.computed) {
+      return createSameFileStaticCssEvalDiagnostic(
+        context,
+        "unsupported-syntax",
+        "computed-object-key",
+        `same-file binding "${context.bindingName}" contains a computed object key`
+      );
+    }
+
+    if (!t.isExpression(property.value)) {
+      return createSameFileStaticCssEvalDiagnostic(
+        context,
+        "unsupported-syntax",
+        "unsupported-literal",
+        `same-file binding "${context.bindingName}" contains a non-expression object value`
+      );
+    }
+
+    const diagnostic = validateStaticCssLiteralExpression(
+      property.value,
+      context,
+      state,
+      depth + 1
+    );
+
+    if (diagnostic) {
+      return diagnostic;
+    }
+  }
+
+  return null;
+}
+
+function validateStaticCssArrayExpression(
+  expression: t.ArrayExpression,
+  context: SameFileStaticCssEvalContext,
+  state: LiteralValidationState,
+  depth: number
+): StaticCssEvalDiagnostic | null {
+  for (const element of expression.elements) {
+    if (!element) {
+      return createSameFileStaticCssEvalDiagnostic(
+        context,
+        "unsupported-syntax",
+        "unsupported-literal",
+        `same-file binding "${context.bindingName}" contains an array hole`
+      );
+    }
+
+    if (t.isSpreadElement(element)) {
+      return createSameFileStaticCssEvalDiagnostic(
+        context,
+        "unsupported-syntax",
+        "object-or-array-spread",
+        `same-file binding "${context.bindingName}" contains an array spread`
+      );
+    }
+
+    const diagnostic = validateStaticCssLiteralExpression(
+      element,
+      context,
+      state,
+      depth + 1
+    );
+
+    if (diagnostic) {
+      return diagnostic;
+    }
+  }
+
+  return null;
+}
+
+function isSupportedStaticCssPrimitiveLiteral(
+  expression: t.Expression
+): boolean {
+  return (
+    t.isStringLiteral(expression) ||
+    t.isNumericLiteral(expression) ||
+    t.isBooleanLiteral(expression) ||
+    t.isNullLiteral(expression) ||
+    isUnaryNumericLiteral(expression) ||
+    isNoExpressionTemplateLiteral(expression)
+  );
+}
+
+function isUnaryNumericLiteral(
+  expression: t.Expression
+): expression is t.UnaryExpression & { argument: t.NumericLiteral } {
+  return (
+    t.isUnaryExpression(expression) &&
+    (expression.operator === "+" || expression.operator === "-") &&
+    t.isNumericLiteral(expression.argument)
+  );
+}
+
+function isNoExpressionTemplateLiteral(
+  expression: t.Expression
+): expression is t.TemplateLiteral {
+  return t.isTemplateLiteral(expression) && expression.expressions.length === 0;
+}
+
+function normalizeStaticCssLiteralExpression(
+  expression: t.ObjectExpression | t.ArrayExpression
+): t.ObjectExpression | t.ArrayExpression {
+  const normalizedExpression = normalizeStaticCssLiteralValue(expression);
+
+  if (
+    !t.isObjectExpression(normalizedExpression) &&
+    !t.isArrayExpression(normalizedExpression)
+  ) {
+    throw new Error(
+      "Expected normalized static css literal to remain object/array"
+    );
+  }
+
+  return normalizedExpression;
+}
+
+function normalizeStaticCssLiteralValue(
+  expression: t.Expression
+): t.Expression {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+
+  if (t.isObjectExpression(unwrappedExpression)) {
+    return t.objectExpression(
+      unwrappedExpression.properties.map((property) => {
+        const nextProperty = t.cloneNode(property);
+
+        if (
+          t.isObjectProperty(nextProperty) &&
+          t.isExpression(nextProperty.value)
+        ) {
+          nextProperty.value = normalizeStaticCssLiteralValue(
+            nextProperty.value
+          );
+        }
+
+        return nextProperty;
+      })
+    );
+  }
+
+  if (t.isArrayExpression(unwrappedExpression)) {
+    return t.arrayExpression(
+      unwrappedExpression.elements.map((element) => {
+        if (!element || t.isSpreadElement(element)) {
+          return element ? t.cloneNode(element) : null;
+        }
+
+        return normalizeStaticCssLiteralValue(element);
+      })
+    );
+  }
+
+  if (isNoExpressionTemplateLiteral(unwrappedExpression)) {
+    const [quasi] = unwrappedExpression.quasis;
+    return t.stringLiteral(quasi?.value.cooked ?? quasi?.value.raw ?? "");
+  }
+
+  return t.cloneNode(unwrappedExpression);
+}
+
+function createUnsupportedLiteralDiagnostic(
+  context: SameFileStaticCssEvalContext,
+  expression: t.Expression
+): StaticCssEvalDiagnostic {
+  const reason = getUnsupportedLiteralReason(expression);
+
+  return createSameFileStaticCssEvalDiagnostic(
+    context,
+    "unsupported-syntax",
+    reason,
+    `same-file binding "${context.bindingName}" contains unsupported ${reason}: ${expression.type}`
+  );
+}
+
+function createSameFileStaticCssEvalDiagnostic(
+  context: SameFileStaticCssEvalContext,
+  code: StaticCssEvalDiagnostic["code"],
+  reason: StaticCssEvalUnsupportedReason,
+  detail: string
+): StaticCssEvalDiagnostic {
+  return createStaticCssEvalDiagnostic({
+    code,
+    reason,
+    detail,
+    owner: context.owner,
+    ...(context.memberPath.length > 0 ? { memberPath: context.memberPath } : {})
+  });
+}

--- a/packages/babel/src/staticCssEval/types.ts
+++ b/packages/babel/src/staticCssEval/types.ts
@@ -1,0 +1,430 @@
+export interface StaticCssEvalProvider {
+  getResolvedCssValue(query: StaticCssEvalQuery): StaticCssEvalResult;
+}
+
+export interface StaticCssEvalQuery {
+  importerId: string;
+  expressionStart: number;
+  expressionEnd: number;
+  bindingName?: string;
+  memberPath?: string[];
+}
+
+export type StaticCssEvalResult =
+  | { kind: "not-candidate" }
+  | {
+      kind: "resolved";
+      value: StaticCssLiteral;
+      dependencies: string[];
+    }
+  | {
+      kind: "error";
+      diagnostic: StaticCssEvalDiagnostic;
+      dependencies: string[];
+    };
+
+export type StaticCssLiteral =
+  | string
+  | number
+  | boolean
+  | null
+  | StaticCssLiteral[]
+  | { [key: string]: StaticCssLiteral };
+
+export type StaticCssEvalExportName = "default" | string | null;
+
+export interface StaticCssEvalSourceLocation {
+  file: string;
+  line?: number;
+  column?: number;
+  start?: number;
+  end?: number;
+}
+
+export const STATIC_CSS_EVAL_DIAGNOSTIC_CODES = [
+  "unsupported-syntax",
+  "unsupported-source",
+  "mutation-detected",
+  "cycle-detected",
+  "limit-exceeded",
+  "failed-project-local-dependency"
+] as const;
+
+export type StaticCssEvalDiagnosticCode =
+  (typeof STATIC_CSS_EVAL_DIAGNOSTIC_CODES)[number];
+
+export const STATIC_CSS_EVAL_UNSUPPORTED_REASONS = [
+  "let-or-var-binding",
+  "mutated-binding",
+  "namespace-import",
+  "reexport-or-barrel",
+  "commonjs-require",
+  "node-modules-import",
+  "virtual-module",
+  "function-or-call",
+  "runtime-dynamic-value",
+  "computed-object-key",
+  "object-or-array-spread",
+  "conditional-or-logical-expression",
+  "binary-expression",
+  "template-expression",
+  "identifier-object-value",
+  "member-expression-object-value",
+  "dynamic-member-path",
+  "numeric-member-path",
+  "optional-member-path",
+  "unsupported-literal",
+  "not-project-local",
+  "failed-project-local-dependency"
+] as const;
+
+export type StaticCssEvalUnsupportedReason =
+  (typeof STATIC_CSS_EVAL_UNSUPPORTED_REASONS)[number];
+
+export interface StaticCssEvalDiagnostic {
+  code: StaticCssEvalDiagnosticCode;
+  message: string;
+  reason: StaticCssEvalUnsupportedReason;
+  owner: StaticCssEvalSourceLocation;
+  dependency?: StaticCssEvalSourceLocation;
+  importPath?: string;
+  exportName?: StaticCssEvalExportName;
+  memberPath?: string[];
+  importChain?: string[];
+}
+
+export type StaticCssEvalDependencyKind = "owner" | "project-local-import";
+
+export interface StaticCssEvalDependencyMetadata {
+  kind: StaticCssEvalDependencyKind;
+  id: string;
+  realpath: string;
+  importerId?: string;
+  importPath?: string;
+  sourceHash?: string;
+  version?: string | number;
+  projectLocal: boolean;
+  insideNodeModules: boolean;
+  virtual: boolean;
+}
+
+export interface StaticCssEvalModuleRecord {
+  id: string;
+  realpath: string;
+  sourceHash: string;
+  version?: string | number;
+  dependencies: StaticCssEvalDependencyMetadata[];
+}
+
+export interface StaticCssEvalDependencyMaps {
+  ownerToDependencies: ReadonlyMap<string, string[]>;
+  dependencyToOwners: ReadonlyMap<string, string[]>;
+  resolvedModuleCache: ReadonlyMap<string, StaticCssEvalModuleRecord>;
+}
+
+export interface StaticCssEvalProjectLocalBoundaryState {
+  rootRealpath: string;
+  resolvedRealpath: string;
+  insideRoot: boolean;
+  insideNodeModules: boolean;
+  virtual: boolean;
+  packageExportOutsideRoot: boolean;
+}
+
+export interface StaticCssEvalParserOptionsKey {
+  plugins: string[];
+  sourceType: "module" | "script" | "unambiguous";
+  jsx: boolean;
+  typescript: boolean;
+}
+
+export interface StaticCssEvalCacheKey {
+  resolvedId: string;
+  sourceHash: string;
+  sourceVersion?: string | number;
+  parserOptions: StaticCssEvalParserOptionsKey;
+  exportName: StaticCssEvalExportName;
+  memberPath: string[];
+  projectLocalBoundary: StaticCssEvalProjectLocalBoundaryState;
+}
+
+export const STATIC_CSS_EVAL_LIMITS = {
+  maxImportDepth: 10,
+  maxEvaluatedModulesPerOwner: 100,
+  maxLoadedDependencySourceBytes: 1024 * 1024,
+  maxObjectArrayRecursionDepth: 50,
+  maxStaticLiteralNodeCount: 10_000
+} as const;
+
+export const STATIC_CSS_EVAL_CYCLE_KEY_FIELDS = [
+  "resolvedId",
+  "exportName",
+  "memberPath"
+] as const satisfies readonly (keyof StaticCssEvalCacheKey)[];
+
+export const STATIC_CSS_EVAL_GUARDRAILS = [
+  "project-local-files-only",
+  "no-module-execution",
+  "no-node-vm-eval-dynamic-import",
+  "no-bundler-runtime-evaluation",
+  "no-reexports-or-barrels-v1",
+  "no-namespace-imports-v1",
+  "no-node-modules-or-virtual-modules-v1",
+  "async-prepass-sync-babel-boundary"
+] as const;
+
+export type StaticCssEvalSupportStatus =
+  | "preserved"
+  | "supported"
+  | "unsupported";
+
+export interface StaticCssEvalSupportMatrixEntry {
+  construct: string;
+  behavior: string;
+  status: StaticCssEvalSupportStatus;
+}
+
+export const STATIC_CSS_EVAL_SUPPORT_MATRIX = [
+  {
+    construct: "Direct object/array in `css={...}`",
+    behavior: "Existing behavior preserved",
+    status: "preserved"
+  },
+  {
+    construct: "Same-file top-level `const` object/array",
+    behavior: "Supported",
+    status: "supported"
+  },
+  {
+    construct: "Same-file lexical `const` inside component/function",
+    behavior: "Supported if Babel scope resolves it and no reassignment exists",
+    status: "supported"
+  },
+  {
+    construct: "`let` / `var`",
+    behavior: "Unsupported as static css-rule candidates",
+    status: "unsupported"
+  },
+  {
+    construct: "`const style = {...}; style.color = ...`",
+    behavior:
+      "Unsupported; deterministic mutation diagnostic in css-rule candidate mode",
+    status: "unsupported"
+  },
+  {
+    construct: "`const styles = []; styles.push(...)`",
+    behavior:
+      "Unsupported; deterministic mutation diagnostic in css-rule candidate mode",
+    status: "unsupported"
+  },
+  {
+    construct: "Shadowed bindings",
+    behavior: "Must respect Babel scope; local binding wins",
+    status: "supported"
+  },
+  {
+    construct: '`import { x } from "./style"`',
+    behavior: "Supported for project-local ESM source",
+    status: "supported"
+  },
+  {
+    construct: '`import { x as y } from "./style"`',
+    behavior: "Supported",
+    status: "supported"
+  },
+  {
+    construct: '`import x from "./style"`',
+    behavior: "Supported when default export resolves to supported literal",
+    status: "supported"
+  },
+  {
+    construct: "`export const x = {...}`",
+    behavior: "Supported",
+    status: "supported"
+  },
+  {
+    construct: "`const x = {...}; export { x }`",
+    behavior: "Supported within same module only",
+    status: "supported"
+  },
+  {
+    construct: "`export { x as y }` in same module",
+    behavior: "Supported",
+    status: "supported"
+  },
+  {
+    construct: "`export default {...}`",
+    behavior: "Supported",
+    status: "supported"
+  },
+  {
+    construct: "`const x = {...}; export default x`",
+    behavior: "Supported",
+    status: "supported"
+  },
+  {
+    construct: 'Reexports / barrels (`export { x } from "./x"`, `export *`)',
+    behavior: "Unsupported",
+    status: "unsupported"
+  },
+  {
+    construct: "Namespace imports (`import * as styles`)",
+    behavior: "Unsupported",
+    status: "unsupported"
+  },
+  {
+    construct: "CommonJS / `require()`",
+    behavior: "Unsupported",
+    status: "unsupported"
+  },
+  {
+    construct: "`node_modules` imports",
+    behavior: "Unsupported; preserve class-value or error per candidate policy",
+    status: "unsupported"
+  },
+  {
+    construct: "Virtual modules",
+    behavior: "Unsupported",
+    status: "unsupported"
+  },
+  {
+    construct: "Calls / mixins / functions",
+    behavior: "Unsupported",
+    status: "unsupported"
+  },
+  {
+    construct: "Runtime dynamic values",
+    behavior: "Unsupported in css-rule contexts",
+    status: "unsupported"
+  },
+  {
+    construct: "Template literal without expressions",
+    behavior: "Supported as string literal",
+    status: "supported"
+  },
+  {
+    construct: "Template literal with expressions",
+    behavior: "Unsupported",
+    status: "unsupported"
+  },
+  {
+    construct: "TS `as const` / `satisfies` wrappers",
+    behavior:
+      "Supported as transparent wrappers when already accepted by current unwrapping rules",
+    status: "supported"
+  },
+  {
+    construct: "Computed object keys",
+    behavior: "Unsupported",
+    status: "unsupported"
+  },
+  {
+    construct: "Object spread / array spread",
+    behavior: "Unsupported",
+    status: "unsupported"
+  },
+  {
+    construct: "Conditional/logical expressions as static values",
+    behavior:
+      "Unsupported for imported/static evaluation; existing direct css prop branch semantics remain separate",
+    status: "unsupported"
+  },
+  {
+    construct: "Binary expressions / string concatenation",
+    behavior: "Unsupported",
+    status: "unsupported"
+  },
+  {
+    construct: "BigInt / RegExp / Date / Symbol / `NaN` / `Infinity`",
+    behavior: "Unsupported",
+    status: "unsupported"
+  }
+] as const satisfies readonly StaticCssEvalSupportMatrixEntry[];
+
+if (import.meta.vitest) {
+  const { describe, expect, it } = import.meta.vitest;
+
+  describe("static css evaluator contracts", () => {
+    it("encodes v1 static evaluator limits and guardrails", () => {
+      expect(STATIC_CSS_EVAL_LIMITS).toEqual({
+        maxImportDepth: 10,
+        maxEvaluatedModulesPerOwner: 100,
+        maxLoadedDependencySourceBytes: 1024 * 1024,
+        maxObjectArrayRecursionDepth: 50,
+        maxStaticLiteralNodeCount: 10_000
+      });
+      expect(STATIC_CSS_EVAL_GUARDRAILS).toContain("no-module-execution");
+      expect(STATIC_CSS_EVAL_GUARDRAILS).toContain(
+        "async-prepass-sync-babel-boundary"
+      );
+    });
+
+    it("keeps the v1 support matrix testable", () => {
+      expect(
+        STATIC_CSS_EVAL_SUPPORT_MATRIX.find(
+          ({ construct }) =>
+            construct === "Namespace imports (`import * as styles`)"
+        )?.status
+      ).toBe("unsupported");
+      expect(
+        STATIC_CSS_EVAL_SUPPORT_MATRIX.find(
+          ({ construct }) => construct === '`import x from "./style"`'
+        )?.status
+      ).toBe("supported");
+      expect(STATIC_CSS_EVAL_SUPPORT_MATRIX).toHaveLength(30);
+    });
+
+    it("accepts synchronous provider and cache key contracts", () => {
+      const provider: StaticCssEvalProvider = {
+        getResolvedCssValue(query) {
+          expect(query).toMatchObject({
+            importerId: "/project/src/App.tsx",
+            bindingName: "styles",
+            memberPath: ["button"]
+          });
+
+          return {
+            kind: "resolved",
+            value: { color: "red" },
+            dependencies: ["/project/src/styles.ts"]
+          };
+        }
+      };
+      const cacheKey: StaticCssEvalCacheKey = {
+        resolvedId: "/project/src/styles.ts",
+        sourceHash: "sha256:source",
+        parserOptions: {
+          plugins: ["jsx", "typescript"],
+          sourceType: "module",
+          jsx: true,
+          typescript: true
+        },
+        exportName: "default",
+        memberPath: ["button"],
+        projectLocalBoundary: {
+          rootRealpath: "/project",
+          resolvedRealpath: "/project/src/styles.ts",
+          insideRoot: true,
+          insideNodeModules: false,
+          virtual: false,
+          packageExportOutsideRoot: false
+        }
+      };
+
+      expect(cacheKey.projectLocalBoundary.insideRoot).toBe(true);
+      expect(
+        provider.getResolvedCssValue({
+          importerId: "/project/src/App.tsx",
+          expressionStart: 42,
+          expressionEnd: 55,
+          bindingName: "styles",
+          memberPath: ["button"]
+        })
+      ).toEqual({
+        kind: "resolved",
+        value: { color: "red" },
+        dependencies: ["/project/src/styles.ts"]
+      });
+    });
+  });
+}

--- a/packages/babel/src/types.ts
+++ b/packages/babel/src/types.ts
@@ -1,10 +1,13 @@
 import type { NodePath, PluginPass, types as t } from "@babel/core";
 import type { Scope } from "@babel/traverse";
+import type { StaticCssEvalProvider } from "./staticCssEval/types.js";
 
 export interface PluginOptions {
   result: [string, string];
   jsxCssProp?: boolean;
   jsxCssPropTransformed?: boolean;
+  /** @internal Prepared sync provider supplied by bundler prepasses only. */
+  staticCssEvalProvider?: StaticCssEvalProvider;
 }
 
 export interface PluginState extends PluginPass {

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -1,16 +1,53 @@
 import * as fs from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve as resolvePath } from "node:path";
 import { vanillaExtractPlugin } from "@vanilla-extract/esbuild-plugin";
-import { type Plugin as EsbuildPlugin } from "esbuild";
+import {
+  type Plugin as EsbuildPlugin,
+  type PluginBuild,
+  type ResolveResult
+} from "esbuild";
 import {
   type BabelOptions,
   babelTransform,
   compile,
+  createStaticCssEvalSourceHash as createSharedStaticCssEvalSourceHash,
+  createUnsupportedStaticCssEvalResolution as createSharedUnsupportedStaticCssEvalResolution,
+  getExistingRealpath as getSharedExistingRealpath,
+  getRealpathOrResolvedPath as getSharedRealpathOrResolvedPath,
+  hasNodeModulesSegment as sharedHasNodeModulesSegment,
+  isPathInsideRoot as sharedIsPathInsideRoot,
+  isProjectLocalImportPath as sharedIsProjectLocalImportPath,
+  isUnsupportedStaticCssEvalResolutionId as sharedIsUnsupportedStaticCssEvalResolutionId,
+  isVirtualStaticCssEvalId as sharedIsVirtualStaticCssEvalId,
   processDefineRulesPresetRegistryFile,
   runDefineRulesPresetRegistryStep
 } from "@mincho-js/integration";
 
 type ScriptLoader = "js" | "jsx" | "ts" | "tsx";
+
+type MaybePromise<T> = T | Promise<T>;
+
+interface StaticCssEvalSourceResolution {
+  id: string;
+  realpath?: string;
+  sourceHash?: string;
+  version?: string | number;
+}
+
+interface StaticCssEvalLoadedSource {
+  source: string;
+  realpath?: string;
+  sourceHash?: string;
+  version?: string | number;
+}
+
+interface StaticCssEvalSourceProvider {
+  resolve(
+    importerId: string,
+    importPath: string
+  ): MaybePromise<StaticCssEvalSourceResolution | null>;
+  load(id: string): MaybePromise<StaticCssEvalLoadedSource | null>;
+}
 
 const integrationHelpers = {
   babelTransform,
@@ -21,11 +58,363 @@ const integrationHelpers = {
 
 type MinchoBabelOptions = BabelOptions & { jsxCssProp?: boolean };
 
+type MinchoBabelOptionsWithStaticCssEval = MinchoBabelOptions & {
+  staticCssEvalSourceProvider?: StaticCssEvalSourceProvider;
+};
+
+type BabelTransformResult = Awaited<ReturnType<typeof babelTransform>> & {
+  staticCssEval?: {
+    dependencyFiles: string[];
+  };
+};
+
+type StaticCssEvalResolutionCache = Map<
+  string,
+  StaticCssEvalSourceResolution | null
+>;
+
+type StaticCssEvalLoadedSourceCache = Map<
+  string,
+  StaticCssEvalLoadedSource | null
+>;
+
 function getScriptLoader(path: string): ScriptLoader {
   if (/\.tsx$/i.test(path)) return "tsx";
   if (/\.ts$/i.test(path)) return "ts";
   if (/\.jsx$/i.test(path)) return "jsx";
   return "js";
+}
+
+function createEsbuildStaticCssEvalSourceProvider(options: {
+  build: PluginBuild;
+  ownerId: string;
+  ownerSource: string;
+  rootRealpath: Promise<string>;
+  resolutionCache: StaticCssEvalResolutionCache;
+  loadedSourceCache: StaticCssEvalLoadedSourceCache;
+}): StaticCssEvalSourceProvider {
+  const ownerId = normalizeStaticCssEvalFileId(options.ownerId);
+
+  return {
+    async resolve(importerId: string, importPath: string) {
+      const cacheKey = `${normalizeStaticCssEvalFileId(importerId)}\0${importPath}`;
+
+      if (options.resolutionCache.has(cacheKey)) {
+        return options.resolutionCache.get(cacheKey) ?? null;
+      }
+
+      const resolution = await resolveEsbuildStaticCssEvalImport({
+        build: options.build,
+        importerId,
+        importPath,
+        rootRealpath: options.rootRealpath
+      });
+
+      options.resolutionCache.set(cacheKey, resolution);
+      return resolution;
+    },
+    async load(id: string) {
+      const cacheKey = normalizeStaticCssEvalFileId(id);
+
+      if (options.loadedSourceCache.has(cacheKey)) {
+        return options.loadedSourceCache.get(cacheKey) ?? null;
+      }
+
+      const loadedSource = await loadEsbuildStaticCssEvalSource({
+        id,
+        ownerId,
+        ownerSource: options.ownerSource,
+        rootRealpath: options.rootRealpath
+      });
+
+      options.loadedSourceCache.set(cacheKey, loadedSource);
+      return loadedSource;
+    }
+  };
+}
+
+async function resolveEsbuildStaticCssEvalImport(options: {
+  build: PluginBuild;
+  importerId: string;
+  importPath: string;
+  rootRealpath: Promise<string>;
+}): Promise<StaticCssEvalSourceResolution | null> {
+  if (!isProjectLocalImportPath(options.importPath)) {
+    return createUnsupportedStaticCssEvalResolution(options.importPath);
+  }
+
+  const resolved = await resolveEsbuildImport(
+    options.build,
+    options.importerId,
+    options.importPath
+  );
+
+  if (resolved == null) {
+    return null;
+  }
+
+  if (
+    resolved.external ||
+    (resolved.namespace !== "" && resolved.namespace !== "file") ||
+    isVirtualStaticCssEvalId(resolved.path)
+  ) {
+    return createUnsupportedStaticCssEvalResolution(options.importPath);
+  }
+
+  const resolvedId = normalizeStaticCssEvalFileId(resolved.path);
+  const resolvedRealpath = await getExistingRealpath(resolvedId);
+
+  if (!resolvedRealpath) {
+    return null;
+  }
+
+  const rootRealpath = await options.rootRealpath;
+
+  if (
+    hasNodeModulesSegment(resolvedRealpath) ||
+    !isPathInsideRoot(rootRealpath, resolvedRealpath)
+  ) {
+    return createUnsupportedStaticCssEvalResolution(options.importPath);
+  }
+
+  let stat: fs.Stats;
+
+  try {
+    stat = await fs.promises.stat(resolvedRealpath);
+  } catch (error) {
+    if (isMissingFileSystemEntryError(error)) {
+      return null;
+    }
+
+    throw error;
+  }
+
+  return {
+    id: resolvedRealpath,
+    realpath: resolvedRealpath,
+    sourceHash: createStaticCssEvalSourceHash(stat),
+    version: stat.mtimeMs
+  };
+}
+
+async function resolveEsbuildImport(
+  build: PluginBuild,
+  importerId: string,
+  importPath: string
+): Promise<ResolveResult | null> {
+  if (typeof build.resolve === "function") {
+    const resolved = await build.resolve(importPath, {
+      importer: importerId,
+      kind: "import-statement",
+      resolveDir: dirname(importerId)
+    });
+
+    if (resolved.errors.length > 0 || resolved.path === "") {
+      return null;
+    }
+
+    return resolved;
+  }
+
+  const resolvedPath = resolveStaticCssEvalImportFromFileSystem(
+    importerId,
+    importPath
+  );
+
+  return resolvedPath ? createStaticCssEvalResolveResult(resolvedPath) : null;
+}
+
+async function loadEsbuildStaticCssEvalSource(options: {
+  id: string;
+  ownerId: string;
+  ownerSource: string;
+  rootRealpath: Promise<string>;
+}): Promise<StaticCssEvalLoadedSource | null> {
+  const fileId = normalizeStaticCssEvalFileId(options.id);
+
+  if (fileId === options.ownerId) {
+    const ownerRealpath = await getExistingRealpath(fileId);
+
+    return {
+      source: options.ownerSource,
+      ...(ownerRealpath ? { realpath: ownerRealpath } : {})
+    };
+  }
+
+  if (isUnsupportedStaticCssEvalResolutionId(options.id)) {
+    return { source: "export {};" };
+  }
+
+  if (isVirtualStaticCssEvalId(options.id) || hasNodeModulesSegment(fileId)) {
+    return null;
+  }
+
+  const realpath = await getExistingRealpath(fileId);
+  const rootRealpath = await options.rootRealpath;
+
+  if (
+    !realpath ||
+    hasNodeModulesSegment(realpath) ||
+    !isPathInsideRoot(rootRealpath, realpath)
+  ) {
+    return null;
+  }
+
+  let source: string;
+  let stat: fs.Stats;
+
+  try {
+    [source, stat] = await Promise.all([
+      fs.promises.readFile(realpath, "utf8"),
+      fs.promises.stat(realpath)
+    ]);
+  } catch (error) {
+    if (isMissingFileSystemEntryError(error)) {
+      return null;
+    }
+
+    throw error;
+  }
+
+  return {
+    source,
+    realpath,
+    sourceHash: createStaticCssEvalSourceHash(stat),
+    version: stat.mtimeMs
+  };
+}
+
+function createUnsupportedStaticCssEvalResolution(
+  importPath: string
+): StaticCssEvalSourceResolution {
+  return createSharedUnsupportedStaticCssEvalResolution(importPath);
+}
+
+function isUnsupportedStaticCssEvalResolutionId(id: string): boolean {
+  return sharedIsUnsupportedStaticCssEvalResolutionId(id);
+}
+
+function normalizeStaticCssEvalFileId(id: string): string {
+  return stripStaticCssEvalRequestQuery(id).replace(/\\/g, "/");
+}
+
+function stripStaticCssEvalRequestQuery(id: string): string {
+  const queryIndex = id.search(/[?#]/);
+  return queryIndex === -1 ? id : id.slice(0, queryIndex);
+}
+
+function isProjectLocalImportPath(importPath: string): boolean {
+  return sharedIsProjectLocalImportPath(importPath);
+}
+
+function isVirtualStaticCssEvalId(id: string): boolean {
+  return sharedIsVirtualStaticCssEvalId(id);
+}
+
+function hasNodeModulesSegment(filePath: string): boolean {
+  return sharedHasNodeModulesSegment(filePath, normalizeStaticCssEvalFileId);
+}
+
+function isPathInsideRoot(rootPath: string, filePath: string): boolean {
+  return sharedIsPathInsideRoot(
+    rootPath,
+    filePath,
+    normalizeStaticCssEvalFileId
+  );
+}
+
+async function getRealpathOrResolvedPath(filePath: string): Promise<string> {
+  return getSharedRealpathOrResolvedPath(filePath, {
+    normalizeFilePath: normalizeStaticCssEvalFileId,
+    resolvePath
+  });
+}
+
+async function getExistingRealpath(filePath: string): Promise<string | null> {
+  return getSharedExistingRealpath(filePath, normalizeStaticCssEvalFileId);
+}
+
+function createStaticCssEvalSourceHash(stat: fs.Stats): string {
+  return createSharedStaticCssEvalSourceHash(stat);
+}
+
+function isMissingFileSystemEntryError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error.code === "ENOENT" || error.code === "ENOTDIR")
+  );
+}
+
+function getWatchableStaticCssEvalDependencyFiles(
+  rootRealpath: string,
+  dependencyFiles: readonly string[] | undefined
+): string[] {
+  const watchFiles = new Set<string>();
+
+  for (const dependencyFile of dependencyFiles ?? []) {
+    const fileId = normalizeStaticCssEvalFileId(dependencyFile);
+
+    if (
+      isVirtualStaticCssEvalId(fileId) ||
+      hasNodeModulesSegment(fileId) ||
+      !isPathInsideRoot(rootRealpath, fileId)
+    ) {
+      continue;
+    }
+
+    watchFiles.add(fileId);
+  }
+
+  return [...watchFiles];
+}
+
+function resolveStaticCssEvalImportFromFileSystem(
+  importerId: string,
+  importPath: string
+): string | null {
+  if (
+    !isProjectLocalImportPath(importPath) ||
+    isVirtualStaticCssEvalId(importPath)
+  ) {
+    return null;
+  }
+
+  const basePath = importPath.startsWith("/")
+    ? importPath
+    : resolvePath(dirname(importerId), importPath);
+  const candidates = [
+    basePath,
+    `${basePath}.ts`,
+    `${basePath}.tsx`,
+    `${basePath}.js`,
+    `${basePath}.jsx`,
+    join(basePath, "index.ts"),
+    join(basePath, "index.tsx"),
+    join(basePath, "index.js"),
+    join(basePath, "index.jsx")
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function createStaticCssEvalResolveResult(path: string): ResolveResult {
+  return {
+    errors: [],
+    warnings: [],
+    path,
+    external: false,
+    sideEffects: true,
+    namespace: "file",
+    suffix: "",
+    pluginData: undefined
+  };
 }
 
 interface MinchoEsbuildPluginOptions {
@@ -56,10 +445,19 @@ export function minchoEsbuildPlugin({
     setup(build) {
       const resolvers = new Map<string, string>();
       const resolverCache = new Map<string, string>();
+      const staticCssEvalResolutionCache: StaticCssEvalResolutionCache =
+        new Map();
+      const staticCssEvalLoadedSourceCache: StaticCssEvalLoadedSourceCache =
+        new Map();
+      const rootRealpath = getRealpathOrResolvedPath(
+        build.initialOptions.absWorkingDir ?? process.cwd()
+      );
 
       build.onEnd(() => {
         resolvers.clear();
         resolverCache.clear();
+        staticCssEvalResolutionCache.clear();
+        staticCssEvalLoadedSourceCache.clear();
       });
 
       build.onResolve({ filter: /^extracted_(.*)\.css\.ts$/ }, async (args) => {
@@ -138,10 +536,31 @@ export function minchoEsbuildPlugin({
 
         const babelOptions: MinchoBabelOptions | undefined =
           jsxCssProp === undefined ? undefined : { jsxCssProp };
+        const transformBabelOptions:
+          | MinchoBabelOptionsWithStaticCssEval
+          | undefined =
+          babelOptions?.jsxCssProp === true
+            ? {
+                ...babelOptions,
+                staticCssEvalSourceProvider:
+                  createEsbuildStaticCssEvalSourceProvider({
+                    build,
+                    ownerId: args.path,
+                    ownerSource: await fs.promises.readFile(args.path, "utf8"),
+                    rootRealpath,
+                    resolutionCache: staticCssEvalResolutionCache,
+                    loadedSourceCache: staticCssEvalLoadedSourceCache
+                  })
+              }
+            : babelOptions;
         const {
           code,
-          result: [file, cssExtract]
-        } = await integrationHelpers.babelTransform(args.path, babelOptions);
+          result: [file, cssExtract],
+          staticCssEval
+        } = (await integrationHelpers.babelTransform(
+          args.path,
+          transformBabelOptions
+        )) as BabelTransformResult;
 
         // the extracted code and original are the same -> no css extracted
         if (file && cssExtract && cssExtract != code) {
@@ -154,7 +573,11 @@ export function minchoEsbuildPlugin({
           loader: getScriptLoader(args.path),
           pluginData: {
             mainFilePath: args.path
-          }
+          },
+          watchFiles: getWatchableStaticCssEvalDependencyFiles(
+            await rootRealpath,
+            staticCssEval?.dependencyFiles
+          )
         };
       });
     }
@@ -307,12 +730,14 @@ if (import.meta.vitest) {
     absWorkingDir = "/workspace",
     esbuild,
     minify = false,
-    plugin = minchoEsbuildPlugin()
+    plugin = minchoEsbuildPlugin(),
+    resolve: resolveImport
   }: {
     absWorkingDir?: string;
     esbuild?: TestEsbuildApi;
     minify?: boolean;
     plugin?: EsbuildPlugin;
+    resolve?: PluginBuild["resolve"];
   } = {}) {
     let extractedCssResolveCallback: ResolveCallback | undefined;
     let extractedCssLoadCallback: LoadCallback | undefined;
@@ -324,6 +749,30 @@ if (import.meta.vitest) {
       initialOptions: {
         absWorkingDir,
         minify
+      },
+      async resolve(path: string, options?: { importer?: string }) {
+        if (resolveImport) {
+          return resolveImport(path, options);
+        }
+
+        const importer = options?.importer ?? join(absWorkingDir, "entry.ts");
+        const resolvedPath = resolveStaticCssEvalImportFromFileSystem(
+          importer,
+          path
+        );
+
+        return resolvedPath
+          ? createStaticCssEvalResolveResult(resolvedPath)
+          : {
+              errors: [],
+              warnings: [],
+              path: "",
+              external: false,
+              sideEffects: true,
+              namespace: "",
+              suffix: "",
+              pluginData: undefined
+            };
       },
       onResolve(_options: { filter: RegExp }, callback: ResolveCallback): void {
         extractedCssResolveCallback = callback;
@@ -614,6 +1063,104 @@ if (import.meta.vitest) {
       root,
       source
     };
+  }
+
+  function createImportedCssPropEntrySource(
+    importPath = "./styles",
+    cssExpression = "button"
+  ): string {
+    return `
+      import { button } from "${importPath}";
+
+      function App() {
+        return <div css={${cssExpression}} />;
+      }
+
+      export { App };
+    `;
+  }
+
+  function createImportedCssPropStaticRuleEntrySource(
+    importPath = "./styles",
+    importedName = "button"
+  ): string {
+    return `
+      import { ${importedName} } from "${importPath}";
+
+      function App() {
+        return <div css={{ color: ${importedName} }} />;
+      }
+
+      export { App };
+    `;
+  }
+
+  function createImportedStyleSource(color: string): string {
+    return `export const button = { color: "${color}" } as const;`;
+  }
+
+  async function createImportedCssPropEsbuildFixture(
+    prefix: string,
+    options: {
+      entrySource?: string;
+      styleSource?: string;
+    } = {}
+  ) {
+    const cacheRoot = join(process.cwd(), "packages/esbuild/.cache");
+    await fs.promises.mkdir(cacheRoot, { recursive: true });
+    const root = await fs.promises.mkdtemp(join(cacheRoot, prefix));
+    const srcRoot = join(root, "src");
+    const entryPath = join(srcRoot, "entry.tsx");
+    const stylesPath = join(srcRoot, "styles.ts");
+    const entrySource =
+      options.entrySource ?? createImportedCssPropEntrySource();
+    const styleSource = options.styleSource ?? createImportedStyleSource("red");
+
+    await fs.promises.mkdir(srcRoot, { recursive: true });
+    await fs.promises.writeFile(entryPath, entrySource, "utf8");
+    await fs.promises.writeFile(stylesPath, styleSource, "utf8");
+
+    return {
+      entryPath,
+      entrySource,
+      root,
+      srcRoot,
+      stylesPath,
+      styleSource
+    };
+  }
+
+  function collectEsbuildOutputTexts(result: {
+    outputFiles?: Array<{ path: string; text: string }>;
+  }): {
+    all: string;
+    css: string;
+    js: string;
+  } {
+    const outputFiles = result.outputFiles ?? [];
+    const js = outputFiles
+      .filter((outputFile) => /\.(?:mjs|js)$/.test(outputFile.path))
+      .map((outputFile) => outputFile.text)
+      .join("\n");
+    const css = outputFiles
+      .filter((outputFile) => outputFile.path.endsWith(".css"))
+      .map((outputFile) => outputFile.text)
+      .join("\n");
+
+    return {
+      all: outputFiles.map((outputFile) => outputFile.text).join("\n"),
+      css,
+      js
+    };
+  }
+
+  function expectCssPropBuildOutputToContainColor(
+    output: { all: string; css: string; js: string },
+    color: string
+  ): void {
+    expect(output.css).toContain(`color: ${color};`);
+    expect(output.js).not.toContain(" css=");
+    expect(output.js).not.toContain("css={");
   }
 
   function createRealRegistryBuildEntrySource(
@@ -919,11 +1466,8 @@ if (import.meta.vitest) {
         `<Button className=\\{${escapeRegExp(cxIdentifier)}\\(styleA\\)\\} />`
       )
     );
-    expect(source).toMatch(
-      new RegExp(
-        `<motion\\.div className=\\{${escapeRegExp(cxIdentifier)}\\(styleB\\)\\} />`
-      )
-    );
+    expect(source).toMatch(/<motion\.div className=\{[A-Za-z_$][\w$]*\} \/>/);
+    expect(source).not.toContain(`${cxIdentifier}(styleB)`);
     expect(source).toContain("css: _minchoCssProp");
     expect(source).toContain("..._minchoRest");
     expect(source).toMatch(
@@ -946,6 +1490,22 @@ if (import.meta.vitest) {
       resolve,
       reject
     };
+  }
+
+  async function spyOnSourceBabelTransform() {
+    const sourceIntegrationUrl = new URL(
+      "../../integration/src/babel" + ".ts",
+      import.meta.url
+    ).href;
+    const sourceIntegrationModule = (await import(
+      /* @vite-ignore */ sourceIntegrationUrl
+    )) as {
+      babelTransform: typeof babelTransform;
+    };
+
+    return vi
+      .spyOn(integrationHelpers, "babelTransform")
+      .mockImplementation(sourceIntegrationModule.babelTransform);
   }
 
   async function loadExtractedCssFromEntry(
@@ -977,12 +1537,30 @@ if (import.meta.vitest) {
     vi.restoreAllMocks();
   });
 
+  it("resolves directory imports to index files", async () => {
+    const { entryPath, root } = await createJsxCssPropFixture(
+      "static-css-resolve-directory-"
+    );
+    const directoryPath = join(root, "src", "styles");
+    const indexPath = join(directoryPath, "index.ts");
+    await fs.promises.mkdir(directoryPath);
+    await fs.promises.writeFile(indexPath, "export const button = {};", "utf8");
+
+    try {
+      expect(
+        resolveStaticCssEvalImportFromFileSystem(entryPath, "./styles")
+      ).toBe(indexPath);
+    } finally {
+      await fs.promises.rm(root, { force: true, recursive: true });
+    }
+  });
+
   describe("minchoEsbuildPlugin", () => {
     it("loads a TSX fixture with jsxCssProp enabled and registers extracted css sidecar content", async () => {
       const { entryPath, root } = await createJsxCssPropFixture(
         "jsx-css-prop-enabled-"
       );
-      const babelTransformSpy = vi.spyOn(integrationHelpers, "babelTransform");
+      const babelTransformSpy = await spyOnSourceBabelTransform();
       const compileSpy = vi
         .spyOn(integrationHelpers, "compile")
         .mockResolvedValue({
@@ -1012,9 +1590,13 @@ if (import.meta.vitest) {
             scriptLoadResult.contents
           );
 
-        expect(babelTransformSpy).toHaveBeenCalledWith(entryPath, {
-          jsxCssProp: true
-        });
+        expect(babelTransformSpy).toHaveBeenCalledWith(
+          entryPath,
+          expect.objectContaining({
+            jsxCssProp: true,
+            staticCssEvalSourceProvider: expect.any(Object)
+          })
+        );
         expect(scriptLoadResult.loader).toBe("tsx");
         expect(scriptLoadResult.contents).not.toContain(" css=");
         expect(scriptLoadResult.contents).not.toContain("css={{");
@@ -1069,7 +1651,7 @@ if (import.meta.vitest) {
         "jsx-css-prop-v2-class-value-",
         createJsxCssPropV2ClassValueFixtureSource()
       );
-      const babelTransformSpy = vi.spyOn(integrationHelpers, "babelTransform");
+      const babelTransformSpy = await spyOnSourceBabelTransform();
 
       try {
         const harness = createBuildHarness({
@@ -1087,9 +1669,13 @@ if (import.meta.vitest) {
           pluginData: scriptLoadResult.pluginData
         });
 
-        expect(babelTransformSpy).toHaveBeenCalledWith(entryPath, {
-          jsxCssProp: true
-        });
+        expect(babelTransformSpy).toHaveBeenCalledWith(
+          entryPath,
+          expect.objectContaining({
+            jsxCssProp: true,
+            staticCssEvalSourceProvider: expect.any(Object)
+          })
+        );
         expect(scriptLoadResult.loader).toBe("tsx");
         expect(scriptLoadResult.contents).not.toContain(" css=");
         expect(scriptLoadResult.contents).not.toContain("css={styleA}");
@@ -1112,7 +1698,7 @@ if (import.meta.vitest) {
         createJsxCssPropV2ClassValueFixtureSource()
       );
       const minchoPlugin = minchoEsbuildPlugins({ jsxCssProp: true })[0];
-      const babelTransformSpy = vi.spyOn(integrationHelpers, "babelTransform");
+      const babelTransformSpy = await spyOnSourceBabelTransform();
 
       if (minchoPlugin == null) {
         throw new Error(
@@ -1129,9 +1715,13 @@ if (import.meta.vitest) {
           scriptLoadResult.contents
         );
 
-        expect(babelTransformSpy).toHaveBeenCalledWith(entryPath, {
-          jsxCssProp: true
-        });
+        expect(babelTransformSpy).toHaveBeenCalledWith(
+          entryPath,
+          expect.objectContaining({
+            jsxCssProp: true,
+            staticCssEvalSourceProvider: expect.any(Object)
+          })
+        );
         expect(scriptLoadResult.contents).not.toContain(" css=");
         expectSourceToContainV2ClassValueCssPropLowering(
           scriptLoadResult.contents,
@@ -1141,6 +1731,278 @@ if (import.meta.vitest) {
         await fs.promises.rm(root, { force: true, recursive: true });
       }
     });
+
+    it("refreshes imported static css prop dependencies across esbuild rebuilds without stale CSS", async () => {
+      const realEsbuild = await import("esbuild");
+      const fixture = await createImportedCssPropEsbuildFixture(
+        "jsx-css-prop-imported-rebuild-"
+      );
+      await spyOnSourceBabelTransform();
+      const context = await realEsbuild.context({
+        absWorkingDir: fixture.root,
+        bundle: true,
+        entryPoints: [fixture.entryPath],
+        external: ["@mincho-js/css"],
+        format: "esm",
+        minify: false,
+        outdir: join(fixture.root, "dist"),
+        plugins: minchoEsbuildPlugins({ jsxCssProp: true }),
+        write: false
+      });
+
+      try {
+        const redOutput = collectEsbuildOutputTexts(await context.rebuild());
+
+        expectCssPropBuildOutputToContainColor(redOutput, "red");
+        expect(redOutput.all).not.toContain("color: blue");
+
+        await fs.promises.writeFile(
+          fixture.stylesPath,
+          createImportedStyleSource("blue"),
+          "utf8"
+        );
+
+        const blueOutput = collectEsbuildOutputTexts(await context.rebuild());
+
+        expectCssPropBuildOutputToContainColor(blueOutput, "blue");
+        expect(blueOutput.all).not.toContain("color: red");
+      } finally {
+        await context.dispose();
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    }, 20000);
+
+    it("scopes imported static css eval source caches to independent esbuild build contexts", async () => {
+      const realEsbuild = await import("esbuild");
+      const redFixture = await createImportedCssPropEsbuildFixture(
+        "jsx-css-prop-cache-scope-red-",
+        { styleSource: createImportedStyleSource("red") }
+      );
+      const blueFixture = await createImportedCssPropEsbuildFixture(
+        "jsx-css-prop-cache-scope-blue-",
+        { styleSource: createImportedStyleSource("blue") }
+      );
+      await spyOnSourceBabelTransform();
+      const sharedMinchoPlugin = minchoEsbuildPlugin({ jsxCssProp: true });
+      const redContext = await realEsbuild.context({
+        absWorkingDir: redFixture.root,
+        bundle: true,
+        entryPoints: [redFixture.entryPath],
+        external: ["@mincho-js/css"],
+        format: "esm",
+        minify: false,
+        outdir: join(redFixture.root, "dist"),
+        plugins: [sharedMinchoPlugin, vanillaExtractPlugin()],
+        write: false
+      });
+      const blueContext = await realEsbuild.context({
+        absWorkingDir: blueFixture.root,
+        bundle: true,
+        entryPoints: [blueFixture.entryPath],
+        external: ["@mincho-js/css"],
+        format: "esm",
+        minify: false,
+        outdir: join(blueFixture.root, "dist"),
+        plugins: [sharedMinchoPlugin, vanillaExtractPlugin()],
+        write: false
+      });
+
+      try {
+        const redOutput = collectEsbuildOutputTexts(await redContext.rebuild());
+        const blueOutput = collectEsbuildOutputTexts(
+          await blueContext.rebuild()
+        );
+
+        expectCssPropBuildOutputToContainColor(redOutput, "red");
+        expect(redOutput.all).not.toContain("color: blue");
+        expectCssPropBuildOutputToContainColor(blueOutput, "blue");
+        expect(blueOutput.all).not.toContain("color: red");
+      } finally {
+        await Promise.all([redContext.dispose(), blueContext.dispose()]);
+        await Promise.all([
+          fs.promises.rm(redFixture.root, { force: true, recursive: true }),
+          fs.promises.rm(blueFixture.root, { force: true, recursive: true })
+        ]);
+      }
+    }, 20000);
+
+    it("refuses virtual, package, and node_modules static css evaluation at esbuild boundaries", async () => {
+      const fallbackFixture = await createJsxCssPropFixture(
+        "jsx-css-prop-esbuild-boundary-fallback-",
+        `
+          import { button as virtualButton } from "virtual:styles";
+          import { button as packageButton } from "pkg/styles";
+          import { button as nodeModuleButton } from "./node_modules/pkg/styles";
+
+          function App() {
+            return <>
+              <div css={virtualButton} />
+              <div css={packageButton} />
+              <div css={nodeModuleButton} />
+            </>;
+          }
+        `
+      );
+      const staticRuleFixture = await createJsxCssPropFixture(
+        "jsx-css-prop-esbuild-boundary-static-rule-",
+        createImportedCssPropStaticRuleEntrySource(
+          "./node_modules/pkg/styles",
+          "button"
+        )
+      );
+      await spyOnSourceBabelTransform();
+
+      try {
+        await Promise.all([
+          fs.promises.mkdir(
+            join(fallbackFixture.root, "src/node_modules/pkg"),
+            { recursive: true }
+          ),
+          fs.promises.mkdir(
+            join(staticRuleFixture.root, "src/node_modules/pkg"),
+            { recursive: true }
+          )
+        ]);
+        await Promise.all([
+          fs.promises.writeFile(
+            join(fallbackFixture.root, "src/node_modules/pkg/styles.ts"),
+            createImportedStyleSource("red"),
+            "utf8"
+          ),
+          fs.promises.writeFile(
+            join(staticRuleFixture.root, "src/node_modules/pkg/styles.ts"),
+            createImportedStyleSource("red"),
+            "utf8"
+          )
+        ]);
+
+        const fallbackHarness = createBuildHarness({
+          absWorkingDir: fallbackFixture.root,
+          plugin: minchoEsbuildPlugin({ jsxCssProp: true })
+        });
+        const fallbackResult = (await fallbackHarness.loadScript({
+          path: fallbackFixture.entryPath
+        })) as ScriptLoadResult;
+        const cxIdentifier = extractCxIdentifierFromSource(
+          fallbackResult.contents
+        );
+
+        expect(fallbackResult.contents).not.toContain("extracted_");
+        for (const localName of [
+          "virtualButton",
+          "packageButton",
+          "nodeModuleButton"
+        ]) {
+          expect(fallbackResult.contents).toMatch(
+            new RegExp(
+              `className=\\{${escapeRegExp(cxIdentifier)}\\(${localName}\\)\\}`
+            )
+          );
+        }
+
+        const staticRuleHarness = createBuildHarness({
+          absWorkingDir: staticRuleFixture.root,
+          plugin: minchoEsbuildPlugin({ jsxCssProp: true })
+        });
+
+        await expect(
+          staticRuleHarness.loadScript({ path: staticRuleFixture.entryPath })
+        ).rejects.toThrow("Cannot statically evaluate css prop value");
+      } finally {
+        await Promise.all([
+          fs.promises.rm(fallbackFixture.root, {
+            force: true,
+            recursive: true
+          }),
+          fs.promises.rm(staticRuleFixture.root, {
+            force: true,
+            recursive: true
+          })
+        ]);
+      }
+    });
+
+    it("returns null when a resolved static css dependency disappears before stat", async () => {
+      const fixture = await createImportedCssPropEsbuildFixture(
+        "jsx-css-prop-esbuild-disappeared-before-stat-"
+      );
+      const originalStat = fs.promises.stat.bind(fs.promises);
+      const targetRealpath = normalizeStaticCssEvalFileId(
+        await fs.promises.realpath(fixture.stylesPath)
+      );
+      const statSpy = vi
+        .spyOn(fs.promises, "stat")
+        .mockImplementation(
+          async (...args: Parameters<typeof fs.promises.stat>) => {
+            const [path] = args;
+
+            if (String(path).replace(/\\/g, "/") === targetRealpath) {
+              const missingError = new Error(
+                `ENOENT: ${targetRealpath}`
+              ) as Error & {
+                code?: string;
+              };
+              missingError.code = "ENOENT";
+              throw missingError;
+            }
+
+            return originalStat(...args);
+          }
+        );
+
+      try {
+        const resolution = await resolveEsbuildStaticCssEvalImport({
+          build: {
+            resolve: vi
+              .fn()
+              .mockResolvedValue(
+                createStaticCssEvalResolveResult(fixture.stylesPath)
+              )
+          } as PluginBuild,
+          importerId: fixture.entryPath,
+          importPath: "./styles",
+          rootRealpath: getRealpathOrResolvedPath(fixture.root)
+        });
+
+        expect(resolution).toBeNull();
+      } finally {
+        statSpy.mockRestore();
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("retransforms owners and drops stale CSS when an imported static dependency is deleted", async () => {
+      const realEsbuild = await import("esbuild");
+      const fixture = await createImportedCssPropEsbuildFixture(
+        "jsx-css-prop-imported-deleted-dependency-"
+      );
+      await spyOnSourceBabelTransform();
+      const context = await realEsbuild.context({
+        absWorkingDir: fixture.root,
+        bundle: true,
+        entryPoints: [fixture.entryPath],
+        external: ["@mincho-js/css"],
+        format: "esm",
+        minify: false,
+        outdir: join(fixture.root, "dist"),
+        plugins: minchoEsbuildPlugins({ jsxCssProp: true }),
+        write: false
+      });
+
+      try {
+        const redOutput = collectEsbuildOutputTexts(await context.rebuild());
+
+        expectCssPropBuildOutputToContainColor(redOutput, "red");
+
+        await fs.promises.rm(fixture.stylesPath, { force: true });
+        await expect(context.rebuild()).rejects.toThrow(
+          "Cannot statically evaluate css prop value: failed to resolve project-local dependency ./styles"
+        );
+      } finally {
+        await context.dispose();
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    }, 20000);
 
     it("leaves TSX css prop unchanged when jsxCssProp is omitted or false", async () => {
       const fixtureCases = [

--- a/packages/integration/src/babel.ts
+++ b/packages/integration/src/babel.ts
@@ -1,9 +1,52 @@
 import { type TransformOptions, transformFileAsync } from "@babel/core";
 import {
+  internalCollectJsxCssPropStaticCssEvalCandidates as collectJsxCssPropStaticCssEvalCandidates,
+  internalCreateImportedStaticCssEvalModuleRecord as createImportedStaticCssEvalModuleRecord,
+  internalCreateImportedStaticCssEvalProvider as createImportedStaticCssEvalProvider,
+  type InternalImportedStaticCssEvalImportResolution as ImportedStaticCssEvalImportResolution,
+  type InternalImportedStaticCssEvalLoadedModule as ImportedStaticCssEvalLoadedModule,
+  type InternalImportedStaticCssEvalModuleRecord as ImportedStaticCssEvalModuleRecord,
   type PluginOptions,
   minchoBabelPlugin,
   minchoStyledComponentPlugin
 } from "@mincho-js/babel";
+
+type MaybePromise<T> = T | Promise<T>;
+
+export interface StaticCssEvalSourceResolution {
+  id: string;
+  realpath?: string;
+  sourceHash?: string;
+  version?: string | number;
+}
+
+export interface StaticCssEvalLoadedSource {
+  source: string;
+  realpath?: string;
+  sourceHash?: string;
+  version?: string | number;
+}
+
+/** @internal Async owner/dependency source provider for bundler prepasses. */
+export interface StaticCssEvalSourceProvider {
+  resolve(
+    importerId: string,
+    importPath: string
+  ): MaybePromise<StaticCssEvalSourceResolution | null>;
+  load(id: string): MaybePromise<StaticCssEvalLoadedSource | null>;
+}
+
+export interface StaticCssEvalPrepassResult {
+  dependencyFiles: string[];
+  ownerToDependencies: ReadonlyMap<string, string[]>;
+  dependencyToOwners: ReadonlyMap<string, string[]>;
+  resolvedModuleCache: ReadonlyMap<string, ImportedStaticCssEvalModuleRecord>;
+}
+
+interface PreparedStaticCssEvalPrepass {
+  provider: NonNullable<PluginOptions["staticCssEvalProvider"]>;
+  result: StaticCssEvalPrepassResult;
+}
 
 export type BabelOptions = Omit<
   TransformOptions,
@@ -15,22 +58,40 @@ export type BabelOptions = Omit<
   | "inputSourceMap"
 > & {
   jsxCssProp?: boolean;
+  staticCssEvalProvider?: PluginOptions["staticCssEvalProvider"];
+  /** @internal Async source provider used to prepare imported css eval data. */
+  staticCssEvalSourceProvider?: StaticCssEvalSourceProvider;
 };
 
 export type BabelTransformResult = {
   code: string;
   readonly jsxCssPropTransformed?: boolean;
   result: [string, string];
+  readonly staticCssEval?: StaticCssEvalPrepassResult;
 };
 
 export async function babelTransform(
   path: string,
   babel: BabelOptions = {}
 ): Promise<BabelTransformResult> {
-  const { jsxCssProp = false, ...babelCoreOptions } = babel;
-  const options: PluginOptions & { jsxCssProp?: boolean } = {
+  const {
+    jsxCssProp = false,
+    staticCssEvalProvider,
+    staticCssEvalSourceProvider,
+    ...babelCoreOptions
+  } = babel;
+  const staticCssEvalPrepass =
+    jsxCssProp === true && staticCssEvalSourceProvider
+      ? await createStaticCssEvalPrepass(path, staticCssEvalSourceProvider)
+      : undefined;
+  const preparedStaticCssEvalProvider =
+    staticCssEvalProvider ?? staticCssEvalPrepass?.provider;
+  const options: PluginOptions & {
+    jsxCssProp?: boolean;
+  } = {
     result: ["", ""],
-    jsxCssProp
+    jsxCssProp,
+    staticCssEvalProvider: preparedStaticCssEvalProvider
   };
   const result = await transformFileAsync(path, {
     ...babelCoreOptions,
@@ -57,8 +118,160 @@ export async function babelTransform(
   return {
     result: options.result,
     code: result.code,
-    jsxCssPropTransformed: options.jsxCssPropTransformed === true
+    jsxCssPropTransformed: options.jsxCssPropTransformed === true,
+    ...(staticCssEvalPrepass
+      ? { staticCssEval: staticCssEvalPrepass.result }
+      : {})
   };
+}
+
+async function createStaticCssEvalPrepass(
+  ownerId: string,
+  sourceProvider: StaticCssEvalSourceProvider
+): Promise<PreparedStaticCssEvalPrepass> {
+  const ownerSource = await sourceProvider.load(ownerId);
+
+  if (!ownerSource) {
+    throw new Error(`Failed to load static css eval owner source ${ownerId}`);
+  }
+
+  const ownerModule = createLoadedModule(ownerId, ownerSource);
+  const ownerRecord = createImportedStaticCssEvalModuleRecord(ownerModule);
+  const candidates = collectJsxCssPropStaticCssEvalCandidates(
+    ownerRecord.programPath,
+    { importerId: ownerId }
+  );
+  const loadedModules: ImportedStaticCssEvalLoadedModule[] = [ownerModule];
+  const importResolutions: ImportedStaticCssEvalImportResolution[] = [];
+  const resolvedModuleCache = new Map<
+    string,
+    ImportedStaticCssEvalModuleRecord
+  >([[ownerRecord.id, ownerRecord]]);
+  const ownerDependencies: string[] = [];
+  const dependencyToOwners = new Map<string, string[]>();
+  const resolvedImports = new Map<
+    string,
+    StaticCssEvalSourceResolution | null
+  >();
+  const loadedDependencyIds = new Set<string>([ownerId]);
+
+  for (const candidate of candidates) {
+    const importBinding = candidate.bindingName
+      ? ownerRecord.imports.get(candidate.bindingName)
+      : undefined;
+
+    if (!importBinding || importBinding.kind === "namespace") {
+      continue;
+    }
+
+    const importPath = importBinding.importPath;
+    let resolution = resolvedImports.get(importPath);
+
+    if (!resolvedImports.has(importPath)) {
+      resolution = await sourceProvider.resolve(ownerId, importPath);
+      resolvedImports.set(importPath, resolution ?? null);
+
+      if (resolution) {
+        importResolutions.push({
+          importerId: ownerId,
+          importPath,
+          resolvedId: resolution.id
+        });
+      }
+    }
+
+    if (!resolution) {
+      continue;
+    }
+
+    addOwnerDependency(
+      ownerDependencies,
+      dependencyToOwners,
+      ownerId,
+      resolution.id
+    );
+
+    if (loadedDependencyIds.has(resolution.id)) {
+      continue;
+    }
+
+    loadedDependencyIds.add(resolution.id);
+    const loadedSource = await sourceProvider.load(resolution.id);
+
+    if (!loadedSource) {
+      continue;
+    }
+
+    const loadedModule = createLoadedModule(
+      resolution.id,
+      loadedSource,
+      resolution
+    );
+
+    try {
+      const moduleRecord =
+        createImportedStaticCssEvalModuleRecord(loadedModule);
+      resolvedModuleCache.set(moduleRecord.id, moduleRecord);
+      loadedModules.push(loadedModule);
+    } catch {
+      continue;
+    }
+  }
+
+  const ownerToDependencies = new Map<string, string[]>([
+    [ownerId, ownerDependencies]
+  ]);
+  const provider = createImportedStaticCssEvalProvider({
+    modules: loadedModules,
+    importResolutions,
+    moduleRecords: [...resolvedModuleCache.values()]
+  });
+
+  return {
+    provider,
+    result: {
+      dependencyFiles: [...ownerDependencies],
+      ownerToDependencies,
+      dependencyToOwners,
+      resolvedModuleCache
+    }
+  };
+}
+
+function createLoadedModule(
+  id: string,
+  loadedSource: StaticCssEvalLoadedSource,
+  resolution?: StaticCssEvalSourceResolution
+): ImportedStaticCssEvalLoadedModule {
+  return {
+    id,
+    source: loadedSource.source,
+    realpath: loadedSource.realpath ?? resolution?.realpath,
+    sourceHash: loadedSource.sourceHash ?? resolution?.sourceHash,
+    version: loadedSource.version ?? resolution?.version
+  };
+}
+
+function addOwnerDependency(
+  ownerDependencies: string[],
+  dependencyToOwners: Map<string, string[]>,
+  ownerId: string,
+  dependencyId: string
+): void {
+  if (!ownerDependencies.includes(dependencyId)) {
+    ownerDependencies.push(dependencyId);
+  }
+
+  const owners = dependencyToOwners.get(dependencyId);
+
+  if (!owners) {
+    dependencyToOwners.set(dependencyId, [ownerId]);
+    return;
+  }
+
+  if (!owners.includes(ownerId)) {
+    owners.push(ownerId);
+  }
 }
 
 // == Tests ====================================================================
@@ -104,6 +317,107 @@ if (import.meta.vitest) {
 
   function escapeRegExp(input: string) {
     return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+
+  type StaticCssEvalProvider = NonNullable<
+    PluginOptions["staticCssEvalProvider"]
+  >;
+  type StaticCssEvalProviderResult = ReturnType<
+    StaticCssEvalProvider["getResolvedCssValue"]
+  >;
+  type StaticCssEvalValue = Extract<
+    StaticCssEvalProviderResult,
+    { kind: "resolved" }
+  >["value"];
+
+  function createResolvedStaticCssEvalProvider(
+    values: Record<string, StaticCssEvalValue>
+  ): StaticCssEvalProvider {
+    return {
+      getResolvedCssValue(query): StaticCssEvalProviderResult {
+        const key = query.memberPath?.length
+          ? `${query.bindingName}.${query.memberPath.join(".")}`
+          : (query.bindingName ?? "");
+        const value = values[key];
+
+        if (value === undefined) {
+          return { kind: "not-candidate" };
+        }
+
+        return {
+          kind: "resolved",
+          value,
+          dependencies: ["/provider/styles.ts"]
+        };
+      }
+    };
+  }
+
+  function createUnsupportedReexportStaticCssEvalProvider(): StaticCssEvalProvider {
+    return {
+      getResolvedCssValue(query): StaticCssEvalProviderResult {
+        return {
+          kind: "error",
+          diagnostic: {
+            code: "unsupported-source",
+            message:
+              'Cannot statically evaluate css prop value: export "button" uses unsupported reexport/barrel syntax',
+            reason: "reexport-or-barrel",
+            owner: {
+              file: query.importerId,
+              start: query.expressionStart,
+              end: query.expressionEnd
+            },
+            dependency: { file: "/provider/barrel.ts" },
+            importPath: "./barrel",
+            exportName: "button",
+            memberPath: query.memberPath ?? [],
+            importChain: [query.importerId, "/provider/barrel.ts#button"]
+          },
+          dependencies: ["/provider/barrel.ts"]
+        };
+      }
+    };
+  }
+
+  interface FakeStaticCssEvalSourceProviderCalls {
+    resolved: Array<{ importerId: string; importPath: string }>;
+    loaded: string[];
+  }
+
+  function createFakeStaticCssEvalSourceProvider(options: {
+    sources: Record<string, string>;
+    resolutions: Record<string, string>;
+  }): {
+    provider: StaticCssEvalSourceProvider;
+    calls: FakeStaticCssEvalSourceProviderCalls;
+  } {
+    const calls: FakeStaticCssEvalSourceProviderCalls = {
+      resolved: [],
+      loaded: []
+    };
+
+    return {
+      calls,
+      provider: {
+        resolve(importerId, importPath) {
+          calls.resolved.push({ importerId, importPath });
+          const resolvedId =
+            options.resolutions[`${importerId}\0${importPath}`];
+
+          return resolvedId ? { id: resolvedId } : null;
+        },
+        load(id) {
+          calls.loaded.push(id);
+
+          if (!Object.prototype.hasOwnProperty.call(options.sources, id)) {
+            return null;
+          }
+
+          return { source: options.sources[id] ?? "" };
+        }
+      }
+    };
   }
 
   describe("babelTransform", () => {
@@ -159,7 +473,44 @@ if (import.meta.vitest) {
       expect(code).not.toContain('color: "red"');
     });
 
-    it("lowers bare string css props directly and dynamic values through cx", async () => {
+    it("preserves direct object and class-value css props without a static source provider", async () => {
+      const fixturePath = await createBabelFixture(
+        `
+          import { css } from "@mincho-js/css";
+
+          const styleA = css({ color: "blue" });
+          const condition = true;
+
+          function App() {
+            return <>
+              <div className="base" css={{ color: "red" }} />
+              <div css={styleA} />
+              <div css={condition ? "active" : "inactive"} />
+            </>;
+          }
+        `,
+        "css-prop-provider-absence"
+      );
+      const transformed = await babelTransform(fixturePath, {
+        jsxCssProp: true
+      });
+      const { result, code } = transformed;
+      const [, sidecarSource] = result;
+      const exportedDeclarations = sidecarSource.match(/export var/g) ?? [];
+
+      expect(transformed.staticCssEval).toBeUndefined();
+      expect(exportedDeclarations).toHaveLength(2);
+      expect(sidecarSource).toContain('color: "blue"');
+      expect(sidecarSource).toContain('color: "red"');
+      expect(code).not.toContain(" css=");
+      expect(code).toContain('className={_cx("base",');
+      expect(code).toContain("className={_cx(styleA)}");
+      expect(code).toContain(
+        'className={_cx(condition ? "active" : "inactive")}'
+      );
+    });
+
+    it("keeps class-value css props on the cx path without double wrapping", async () => {
       const fixturePath = await createBabelFixture(
         `
           import { css } from "@mincho-js/css";
@@ -255,6 +606,262 @@ if (import.meta.vitest) {
             "getClassName()"
           )}\\)\\}`
         )
+      );
+    });
+
+    it("resolves imported named, aliased, default, and nested static css props through a provider", async () => {
+      const fixturePath = await createBabelFixture(
+        `
+          import { button as buttonStyle, aliasStyle, styles } from "./styles";
+          import defaultObject from "./default-object";
+          import defaultConst from "./default-const";
+
+          function App() {
+            return <>
+              <div css={buttonStyle} />
+              <div css={aliasStyle} />
+              <div css={defaultObject} />
+              <div css={defaultConst} />
+              <div css={styles.button.primary} />
+            </>;
+          }
+        `,
+        "css-prop-imported-static-values"
+      );
+      const { result, code } = await babelTransform(fixturePath, {
+        jsxCssProp: true,
+        staticCssEvalProvider: createResolvedStaticCssEvalProvider({
+          buttonStyle: { color: "red" },
+          aliasStyle: { color: "blue" },
+          defaultObject: { color: "green" },
+          defaultConst: { color: "orange" },
+          "styles.button.primary": { color: "purple" }
+        })
+      });
+      const [, sidecarSource] = result;
+      const exportedDeclarations = sidecarSource.match(/export var/g) ?? [];
+
+      expect(exportedDeclarations).toHaveLength(5);
+      expect(sidecarSource).toContain('color: "red"');
+      expect(sidecarSource).toContain('color: "blue"');
+      expect(sidecarSource).toContain('color: "green"');
+      expect(sidecarSource).toContain('color: "orange"');
+      expect(sidecarSource).toContain('color: "purple"');
+      expect(code).not.toContain(" css=");
+      expect(code).not.toContain("_cx(buttonStyle)");
+      expect(code).not.toContain("_cx(aliasStyle)");
+      expect(code).not.toContain("_cx(defaultObject)");
+      expect(code).not.toContain("_cx(defaultConst)");
+      expect(code).not.toContain("_cx(styles.button.primary)");
+    });
+
+    it("runs async prepass only for css-prop-reachable imports", async () => {
+      const path = await import("node:path");
+      const ownerSource = `
+        import { button } from "./styles";
+        import { unused } from "./unused";
+
+        const value = unused;
+
+        function App() {
+          return <>
+            <div css={button} />
+            <span>{value}</span>
+          </>;
+        }
+      `;
+      const fixturePath = await createBabelFixture(
+        ownerSource,
+        "css-prop-async-prepass-reachable-import"
+      );
+      const fixtureRoot = path.dirname(fixturePath);
+      const stylesId = path.join(fixtureRoot, "styles.ts");
+      const unusedId = path.join(fixtureRoot, "unused.ts");
+      const { provider, calls } = createFakeStaticCssEvalSourceProvider({
+        sources: {
+          [fixturePath]: ownerSource,
+          [stylesId]: `export const button = { color: "red" } as const;`,
+          [unusedId]: `export const unused = { color: "blue" } as const;`
+        },
+        resolutions: {
+          [`${fixturePath}\0./styles`]: stylesId,
+          [`${fixturePath}\0./unused`]: unusedId
+        }
+      });
+      const { result, code, staticCssEval } = await babelTransform(
+        fixturePath,
+        {
+          jsxCssProp: true,
+          staticCssEvalSourceProvider: provider
+        }
+      );
+      const [, sidecarSource] = result;
+
+      expect(calls.resolved).toEqual([
+        { importerId: fixturePath, importPath: "./styles" }
+      ]);
+      expect(calls.loaded).toEqual([fixturePath, stylesId]);
+      expect(sidecarSource).toContain('color: "red"');
+      expect(sidecarSource).not.toContain('color: "blue"');
+      expect(code).not.toContain("_cx(button)");
+      expect(staticCssEval?.dependencyFiles).toEqual([stylesId]);
+      expect(staticCssEval?.ownerToDependencies.get(fixturePath)).toEqual([
+        stylesId
+      ]);
+      expect(staticCssEval?.dependencyToOwners.get(stylesId)).toEqual([
+        fixturePath
+      ]);
+      expect(staticCssEval?.resolvedModuleCache.has(fixturePath)).toBe(true);
+      expect(staticCssEval?.resolvedModuleCache.has(stylesId)).toBe(true);
+      expect(staticCssEval?.resolvedModuleCache.has(unusedId)).toBe(false);
+    });
+
+    it("reports dependency maps for unsupported reexport fallback from async prepass", async () => {
+      const path = await import("node:path");
+      const ownerSource = `
+        import { button } from "./barrel";
+
+        function App() {
+          return <div css={button} />;
+        }
+      `;
+      const fixturePath = await createBabelFixture(
+        ownerSource,
+        "css-prop-async-prepass-reexport-fallback"
+      );
+      const fixtureRoot = path.dirname(fixturePath);
+      const barrelId = path.join(fixtureRoot, "barrel.ts");
+      const stylesId = path.join(fixtureRoot, "styles.ts");
+      const { provider, calls } = createFakeStaticCssEvalSourceProvider({
+        sources: {
+          [fixturePath]: ownerSource,
+          [barrelId]: `export { button } from "./styles";`,
+          [stylesId]: `export const button = { color: "red" } as const;`
+        },
+        resolutions: {
+          [`${fixturePath}\0./barrel`]: barrelId,
+          [`${barrelId}\0./styles`]: stylesId
+        }
+      });
+      const { result, code, staticCssEval } = await babelTransform(
+        fixturePath,
+        {
+          jsxCssProp: true,
+          staticCssEvalSourceProvider: provider
+        }
+      );
+
+      expect(result[1]).toBe("");
+      expect(code).toContain("className={_cx(button)}");
+      expect(calls.resolved).toEqual([
+        { importerId: fixturePath, importPath: "./barrel" }
+      ]);
+      expect(calls.loaded).toEqual([fixturePath, barrelId]);
+      expect(staticCssEval?.dependencyFiles).toEqual([barrelId]);
+      expect(staticCssEval?.ownerToDependencies.get(fixturePath)).toEqual([
+        barrelId
+      ]);
+      expect(staticCssEval?.dependencyToOwners.get(barrelId)).toEqual([
+        fixturePath
+      ]);
+      expect(staticCssEval?.resolvedModuleCache.has(fixturePath)).toBe(true);
+      expect(staticCssEval?.resolvedModuleCache.has(barrelId)).toBe(true);
+      expect(staticCssEval?.resolvedModuleCache.has(stylesId)).toBe(false);
+    });
+
+    it("excludes failed dependency parses from async prepass caches", async () => {
+      const path = await import("node:path");
+      const ownerSource = `
+        import { button } from "./styles";
+
+        function App() {
+          return <div css={button} />;
+        }
+      `;
+      const fixturePath = await createBabelFixture(
+        ownerSource,
+        "css-prop-async-prepass-parse-failure"
+      );
+      const fixtureRoot = path.dirname(fixturePath);
+      const stylesId = path.join(fixtureRoot, "styles.ts");
+      const { provider, calls } = createFakeStaticCssEvalSourceProvider({
+        sources: {
+          [fixturePath]: ownerSource,
+          [stylesId]: `export const button = ;`
+        },
+        resolutions: {
+          [`${fixturePath}\0./styles`]: stylesId
+        }
+      });
+      const prepass = await createStaticCssEvalPrepass(fixturePath, provider);
+      const resolution = prepass.provider.getResolvedCssValue({
+        importerId: fixturePath,
+        expressionStart: 0,
+        expressionEnd: "button".length,
+        bindingName: "button"
+      });
+
+      expect(calls.resolved).toEqual([
+        { importerId: fixturePath, importPath: "./styles" }
+      ]);
+      expect(calls.loaded).toEqual([fixturePath, stylesId]);
+      expect(prepass.result.dependencyFiles).toEqual([stylesId]);
+      expect(prepass.result.resolvedModuleCache.has(fixturePath)).toBe(true);
+      expect(prepass.result.resolvedModuleCache.has(stylesId)).toBe(false);
+      expect(resolution.kind).toBe("error");
+
+      if (resolution.kind !== "error") {
+        throw new Error("Expected failed dependency resolution");
+      }
+
+      expect(resolution.dependencies).toEqual([stylesId]);
+      expect(resolution.diagnostic.code).toBe(
+        "failed-project-local-dependency"
+      );
+      expect(resolution.diagnostic.message).toContain(
+        `failed to load project-local dependency ${stylesId}`
+      );
+    });
+
+    it("preserves whole-expression reexport fallback but rejects reexports inside static css rules", async () => {
+      const wholeExpressionPath = await createBabelFixture(
+        `
+          import { button } from "./barrel";
+
+          function App() {
+            return <div css={button} />;
+          }
+        `,
+        "css-prop-reexport-whole-expression"
+      );
+      const provider = createUnsupportedReexportStaticCssEvalProvider();
+      const { result, code } = await babelTransform(wholeExpressionPath, {
+        jsxCssProp: true,
+        staticCssEvalProvider: provider
+      });
+
+      expect(result[1]).toBe("");
+      expect(code).not.toContain(" css=");
+      expect(code).toContain("className={_cx(button)}");
+
+      const staticRulePath = await createBabelFixture(
+        `
+          import { button } from "./barrel";
+
+          function App() {
+            return <div css={{ color: button }} />;
+          }
+        `,
+        "css-prop-reexport-static-rule"
+      );
+
+      await expect(
+        babelTransform(staticRulePath, {
+          jsxCssProp: true,
+          staticCssEvalProvider: provider
+        })
+      ).rejects.toThrow(
+        'Cannot statically evaluate css prop value: export "button" uses unsupported reexport/barrel syntax'
       );
     });
 

--- a/packages/integration/src/index.ts
+++ b/packages/integration/src/index.ts
@@ -11,3 +11,16 @@ export {
   type DefineRulesPresetRegistryFileOptions,
   type DefineRulesPresetRegistryResult
 } from "./defineRulesPreset.js";
+export {
+  createStaticCssEvalSourceHash,
+  createUnsupportedStaticCssEvalResolution,
+  getExistingRealpath,
+  getRealpathOrResolvedPath,
+  hasNodeModulesSegment,
+  isPathInsideRoot,
+  isProjectLocalImportPath,
+  isUnsupportedStaticCssEvalResolutionId,
+  isVirtualStaticCssEvalId,
+  trimTrailingSlash,
+  unsupportedStaticCssEvalResolutionPrefix
+} from "./staticCssEval.js";

--- a/packages/integration/src/staticCssEval.ts
+++ b/packages/integration/src/staticCssEval.ts
@@ -1,0 +1,183 @@
+import * as fs from "node:fs";
+import { join, resolve as resolvePath } from "node:path";
+
+export const unsupportedStaticCssEvalResolutionPrefix =
+  "virtual:mincho-static-css-eval-unsupported:";
+
+export function createUnsupportedStaticCssEvalResolution(importPath: string): {
+  id: string;
+} {
+  return {
+    id: `${unsupportedStaticCssEvalResolutionPrefix}${encodeURIComponent(
+      importPath
+    )}`
+  };
+}
+
+export function isUnsupportedStaticCssEvalResolutionId(id: string): boolean {
+  return id.startsWith(unsupportedStaticCssEvalResolutionPrefix);
+}
+
+export function isProjectLocalImportPath(importPath: string): boolean {
+  return importPath.startsWith(".") || importPath.startsWith("/");
+}
+
+export function isVirtualStaticCssEvalId(id: string): boolean {
+  return (
+    id.startsWith("\0") ||
+    id.includes("\0") ||
+    id.startsWith("virtual:") ||
+    id.includes("__x00__")
+  );
+}
+
+export function hasNodeModulesSegment(
+  filePath: string,
+  normalizeFilePath: (filePath: string) => string
+): boolean {
+  return normalizeFilePath(filePath).split("/").includes("node_modules");
+}
+
+export function isPathInsideRoot(
+  rootPath: string,
+  filePath: string,
+  normalizeFilePath: (filePath: string) => string
+): boolean {
+  const normalizedRoot = trimTrailingSlash(normalizeFilePath(rootPath));
+  const normalizedFilePath = trimTrailingSlash(normalizeFilePath(filePath));
+  const descendantPrefix = normalizedRoot === "/" ? "/" : `${normalizedRoot}/`;
+
+  return (
+    normalizedFilePath === normalizedRoot ||
+    normalizedFilePath.startsWith(descendantPrefix)
+  );
+}
+
+export function trimTrailingSlash(filePath: string): string {
+  if (filePath.length <= 1) {
+    return filePath;
+  }
+
+  let end = filePath.length;
+
+  while (end > 1 && filePath[end - 1] === "/") {
+    end -= 1;
+  }
+
+  return end === filePath.length ? filePath : filePath.slice(0, end);
+}
+
+export async function getRealpathOrResolvedPath(
+  filePath: string,
+  options: {
+    normalizeFilePath: (filePath: string) => string;
+    resolvePath: (filePath: string) => string;
+  }
+): Promise<string> {
+  return (
+    (await getExistingRealpath(filePath, options.normalizeFilePath)) ??
+    options.normalizeFilePath(options.resolvePath(filePath))
+  );
+}
+
+export async function getExistingRealpath(
+  filePath: string,
+  normalizeFilePath: (filePath: string) => string
+): Promise<string | null> {
+  try {
+    return normalizeFilePath(await fs.promises.realpath(filePath));
+  } catch {
+    return null;
+  }
+}
+
+export function createStaticCssEvalSourceHash(stat: {
+  mtimeMs: number;
+  size: number;
+}): string {
+  return `mtime:${stat.mtimeMs}:size:${stat.size}`;
+}
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+  const { describe, expect, it } = import.meta.vitest;
+
+  describe("static css eval shared helpers", () => {
+    it("encodes and matches unsupported virtual resolution ids", () => {
+      const resolution =
+        createUnsupportedStaticCssEvalResolution("./styles?foo=bar");
+
+      expect(resolution.id).toBe(
+        "virtual:mincho-static-css-eval-unsupported:.%2Fstyles%3Ffoo%3Dbar"
+      );
+      expect(isUnsupportedStaticCssEvalResolutionId(resolution.id)).toBe(true);
+      expect(
+        isUnsupportedStaticCssEvalResolutionId("/project/src/styles.ts")
+      ).toBe(false);
+    });
+
+    it("classifies project-local imports and virtual ids", () => {
+      expect(isProjectLocalImportPath("./styles")).toBe(true);
+      expect(isProjectLocalImportPath("/src/styles")).toBe(true);
+      expect(isProjectLocalImportPath("pkg/styles")).toBe(false);
+      expect(isVirtualStaticCssEvalId("virtual:styles")).toBe(true);
+      expect(isVirtualStaticCssEvalId("\0virtual")).toBe(true);
+      expect(isVirtualStaticCssEvalId("/project/src/styles.ts")).toBe(false);
+    });
+
+    it("normalizes node_modules and root boundary checks through callbacks", () => {
+      const normalizeFilePath = (filePath: string) =>
+        filePath.replace(/\\/g, "/");
+
+      expect(
+        hasNodeModulesSegment(
+          "C:\\project\\node_modules\\pkg\\styles.ts",
+          normalizeFilePath
+        )
+      ).toBe(true);
+      expect(
+        isPathInsideRoot("/project", "/project/src/styles.ts", (value) => value)
+      ).toBe(true);
+      expect(
+        isPathInsideRoot("/project/", "/projected/styles.ts", (value) => value)
+      ).toBe(false);
+      expect(
+        isPathInsideRoot("/", "/project/styles.ts", (value) => value)
+      ).toBe(true);
+      expect(trimTrailingSlash("/project/src///")).toBe("/project/src");
+      expect(trimTrailingSlash("/")).toBe("/");
+      expect(trimTrailingSlash("///")).toBe("/");
+    });
+
+    it("falls back to a resolved path when no realpath exists", async () => {
+      const root = await fs.promises.mkdtemp(
+        join(process.cwd(), ".tmp-static-css-eval-")
+      );
+
+      try {
+        const missingPath = join(root, "src", "styles.ts");
+
+        await expect(
+          getExistingRealpath(missingPath, (value) => value)
+        ).resolves.toBeNull();
+        await expect(
+          getRealpathOrResolvedPath(missingPath, {
+            normalizeFilePath: (value) => value,
+            resolvePath: (value) => resolvePath(value)
+          })
+        ).resolves.toBe(resolvePath(missingPath));
+      } finally {
+        await fs.promises.rm(root, { force: true, recursive: true });
+      }
+    });
+
+    it("hashes source metadata deterministically", () => {
+      expect(createStaticCssEvalSourceHash({ mtimeMs: 1.5, size: 42 })).toBe(
+        "mtime:1.5:size:42"
+      );
+    });
+  });
+}

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -62,13 +62,13 @@ export function App() {
 
 With `jsxCssProp: true`, supported values are lowered to either the existing Mincho `css(...)` extraction path or `cx(...)` class-value merging. If `className` is present, merge order is the existing `className` first and the `css` prop class value second, equivalent to `cx(existingClassName, nextCssClassName)`.
 
-### v2 Value Semantics
+### Value Semantics
 
 The scoped React JSX types define the `css` prop value as `ComplexCSSRule | ClassPrimitive`, not the full recursive `ClassValue` type. The primitive side reuses the existing exported `ClassPrimitive` that backs `cx(...)`; React does not duplicate it with a JSX-only union. Object and array syntax belongs to CSS-rule and composition semantics.
 
-- Inline object expressions are CSS-rule mode through `css(...)`, so `<div css={{ color: "red" }} />` extracts a Mincho CSS rule. Transparent direct wrappers keep that mode, including `<div css={{ color: "red" }!} />`, `<div css={{ color: "red" } as const} />`, `<div css={{ color: "red" } satisfies ComplexCSSRule} />`, and `<div css={({ color: "red" })} />`.
+- Inline object and array expressions are CSS-rule mode through `css(...)`, so `<div css={{ color: "red" }} />` extracts a Mincho CSS rule. Transparent direct wrappers keep that mode, including `<div css={{ color: "red" }!} />`, `<div css={{ color: "red" } as const} />`, `<div css={{ color: "red" } satisfies ComplexCSSRule} />`, and `<div css={({ color: "red" })} />`.
 - Strings are class values, not raw CSS declarations. Bare string-literal class values such as `<div css="base" />` and `<div css={"base"} />` lower directly to `className="base"` without `cx(...)` when no explicit `className` or spread-derived `className` must be merged.
-- Dynamic primitive class values lower through `cx(...)`. This includes identifiers, members, calls, conditionals, logicals, non-string literals, and template literals. This is the migration path for existing Mincho class values: `const styleA = css(...); <div css={styleA} />`.
+- Dynamic primitive class values lower through `cx(...)` when they are not proven static CSS rules. This includes identifiers, members, calls, conditionals, logicals, non-string literals, and template literals. This is the migration path for existing Mincho class values: `const styleA = css(...); <div css={styleA} />`.
 - If an explicit `className` or pre-css spread aggregate contributes an existing class, string-literal class values still merge through `cx(existing, cssValue)` with the existing class first.
 - Class dictionaries require explicit `cx(...)`, for example `<div css={cx({ active: condition })} />`. Explicit `css={cx(...)}` remains a class-value escape hatch and is not unwrapped by the JSX transform.
 - Function values are unsupported in compile-away mode.
@@ -82,6 +82,72 @@ Supported expression-valued primitive `css` props lower through `cx(...)`:
 <div css={maybeClass ?? "panel-fallback"} />
 <div css={getClassName()} />
 ```
+
+### Static Evaluation v1
+
+V1 can statically evaluate CSS-rule candidates when the value is a direct object or array, a mutation-free same-file `const`, or a direct project-local ESM named/default import that resolves to a supported object or array. Static member paths over those objects are supported, including `styles.button`, `styles.button.primary`, `styles["button"]`, and `styles["button"].primary`.
+
+The practical literal grammar is intentionally small: string, number, boolean, `null`, unary numeric expressions such as `-1`, no-expression template literals such as `` `grid` ``, and nested object/array literals. Supported values are reconstructed as AST literals and then use the same CSS-rule extraction path as inline `css={{ ... }}`.
+
+Same-file examples:
+
+```tsx
+const button = { color: "red" } as const;
+const stack = [{ display: "flex" }, { gap: 8 }] as const;
+const styles = {
+  button: { color: "blue" },
+  media: { wide: { padding: 24 } }
+} as const;
+
+<div css={button} />
+<div css={stack} />
+<div css={styles.button} />
+<div css={styles["media"].wide} />
+```
+
+Project-local import examples:
+
+```tsx
+// styles.ts
+export const card = { padding: 16 } as const;
+export const layout = { stack: [{ display: "flex" }, { gap: 8 }] } as const;
+
+const panel = { color: "green" } as const;
+export default panel;
+
+// App.tsx
+import panel, { card, layout } from "./styles";
+
+<div css={card} />
+<div css={panel} />
+<div css={layout.stack} />
+```
+
+Bundlers provide source resolution and loading only. Vite and esbuild give Mincho project-local source text plus dependency edges. Mincho parses that source and statically evaluates the supported AST subset. No module execution is used. Mincho never executes user modules to obtain `css` prop values, and it does not use Node, VM, `eval`, `require()`, dynamic import, or bundler runtime execution for static evaluation.
+
+V1 is project-local only. Resolved files must be real files inside the project root, outside `node_modules`, not virtual modules, and not package exports outside the root. V1 does not support namespace imports, reexports or barrels, package exports from `node_modules`, virtual modules, CommonJS, calls/functions/mixins as CSS-rule values, object/array spreads, computed dynamic keys, optional chaining, template expressions, runtime dynamic values, SWC-native integration, or webpack integration.
+
+Failure policy:
+
+- Existing dynamic class-value identifiers and members that cannot be proven static keep class-value behavior, so `css={activeClass}` and `css={styles.activeClass}` still lower through `cx(...)` when accepted as class values.
+- Proven CSS-rule candidates with unsupported internals throw `Cannot statically evaluate css prop value` diagnostics instead of dropping CSS, guessing, or executing code.
+
+Unsupported examples:
+
+```tsx
+const color = "red";
+const badIdentifierValue = { color };
+const badSpread = { ...base, color: "red" };
+const styles = { button: { color: "red" } } as const;
+const variant = "button";
+
+<div css={badIdentifierValue} />
+<div css={badSpread} />
+<div css={styles[variant]} />
+<div css={styles?.button} />
+```
+
+`badIdentifierValue` fails because object values cannot reference identifiers in v1. `badSpread` fails because object and array spreads are not part of the static literal grammar. `styles[variant]` fails because computed dynamic member paths are unsupported. `styles?.button` fails because optional member paths are unsupported.
 
 Static JSX `css` arrays stay on the `css([...])` composition path. They are static `ComplexCSSRule` composition arrays, not recursive `ClassValue` arrays, and they do not lower to `cx(...)` just because they contain string items.
 
@@ -191,9 +257,9 @@ Class-value-only `||` and `??` still lower through `cx(...)` without CSS-rule ex
 <div css={maybeClass ?? "panel-fallback"} />
 ```
 
-The transform only treats syntactic `ObjectExpression` and `ArrayExpression` values, after transparent wrapper normalization, as static CSS rules. It does not evaluate identifiers, member expressions, imports, object variables, constants, or function calls into CSS rules. There is no static evaluation for identifier, member, call, or import-based CSS-rule discovery.
+The transform treats direct object/array syntax plus proven same-file or imported static `const` references as CSS rules. Unresolved identifiers, unsupported imports, calls, and runtime expressions remain class-value expressions when they are not proven CSS-rule candidates.
 
-### v2 Targets and Forwarding
+### Targets and Forwarding
 
 The transform accepts JSX identifiers and member-expression components, including intrinsic elements, custom React components, member-expression components such as `<motion.div />`, and custom elements.
 
@@ -215,7 +281,7 @@ Spread-only css values are not transformed by Babel. If an own `css` prop reache
 
 `@mincho-js/react/jsx-runtime` and `@mincho-js/react/jsx-dev-runtime` are thin wrappers around React's automatic JSX runtimes. They only guard missed transforms for own `css` props.
 
-Supported static rule branches are converted to generated class names before JSX reaches the runtime. Mincho does not provide StyleX `stylex.props` fallback behavior, inject a StyleX helper namespace, evaluate imported files for CSS rules, or fall back to runtime CSS generation.
+Supported static rule branches are converted to generated class names before JSX reaches the runtime. Static imported values are resolved before runtime through the project-local AST evaluator described above. Mincho does not provide StyleX `stylex.props` fallback behavior, inject a StyleX helper namespace, execute imported files, or fall back to runtime CSS generation.
 
 If an own `css` prop reaches either runtime, Mincho throws:
 
@@ -227,7 +293,7 @@ There is no Emotion runtime parity. Mincho does not provide an Emotion runtime s
 
 ### Transform Errors
 
-When `jsxCssProp: true` is enabled, unsupported v2 cases fail during the transform with explicit diagnostics:
+When `jsxCssProp: true` is enabled, unsupported css prop cases fail during the transform with explicit diagnostics:
 
 | Case | Message |
 | --- | --- |
@@ -245,5 +311,7 @@ When `jsxCssProp: true` is enabled, unsupported v2 cases fail during the transfo
 | Duplicate `css` | `Mincho JSX css prop must appear only once` |
 | Duplicate `className` | `Mincho JSX css prop cannot merge duplicate className attributes` |
 | Shorthand or unsupported `className` value | `Mincho JSX css prop requires className to be a string literal or expression` |
+
+Static evaluation failures use diagnostics that start with `Cannot statically evaluate css prop value`, followed by the unsupported reason such as `identifier-object-value`, `object-or-array-spread`, `dynamic-member-path`, `optional-member-path`, `template-expression`, `reexport-or-barrel`, `node-modules-import`, or `virtual-module`.
 
 The same `jsxCssProp: true` transform flag is exposed through `@mincho-js/babel`, `@mincho-js/integration`, `@mincho-js/vite`, and `@mincho-js/esbuild`.

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -2,6 +2,15 @@ import {
   type BabelOptions,
   babelTransform,
   compile,
+  createStaticCssEvalSourceHash as createSharedStaticCssEvalSourceHash,
+  createUnsupportedStaticCssEvalResolution as createSharedUnsupportedStaticCssEvalResolution,
+  getExistingRealpath as getSharedExistingRealpath,
+  getRealpathOrResolvedPath as getSharedRealpathOrResolvedPath,
+  hasNodeModulesSegment as sharedHasNodeModulesSegment,
+  isPathInsideRoot as sharedIsPathInsideRoot,
+  isProjectLocalImportPath as sharedIsProjectLocalImportPath,
+  isUnsupportedStaticCssEvalResolutionId as sharedIsUnsupportedStaticCssEvalResolutionId,
+  isVirtualStaticCssEvalId as sharedIsVirtualStaticCssEvalId,
   processDefineRulesPresetRegistryFile,
   runDefineRulesPresetRegistryStep
 } from "@mincho-js/integration";
@@ -18,7 +27,7 @@ interface Module {
 // Define local interfaces instead of importing directly from Vite
 interface ViteDevServer {
   moduleGraph: {
-    getModuleById: (id: string) => Module;
+    getModuleById: (id: string) => Module | undefined;
     invalidateModule: (module: Module) => void;
   };
 }
@@ -34,6 +43,17 @@ interface ResolvedConfig {
 
 interface PluginContext {
   addWatchFile: (id: string) => void;
+  resolve?: (
+    source: string,
+    importer?: string,
+    options?: { skipSelf?: boolean }
+  ) =>
+    | Promise<{
+        id: string;
+        external?: boolean | "absolute" | "relative";
+      } | null>
+    | { id: string; external?: boolean | "absolute" | "relative" }
+    | null;
 }
 
 // Simplified Plugin interface with only what we need
@@ -77,6 +97,46 @@ function extractedCssFileFilter(filePath: string) {
 
 type MinchoBabelOptions = BabelOptions & { jsxCssProp?: boolean };
 
+interface StaticCssEvalSourceResolution {
+  id: string;
+  realpath?: string;
+  sourceHash?: string;
+  version?: string | number;
+}
+
+interface StaticCssEvalLoadedSource {
+  source: string;
+  realpath?: string;
+  sourceHash?: string;
+  version?: string | number;
+}
+
+interface StaticCssEvalSourceProvider {
+  resolve(
+    importerId: string,
+    importPath: string
+  ):
+    | StaticCssEvalSourceResolution
+    | Promise<StaticCssEvalSourceResolution | null>
+    | null;
+  load(
+    id: string
+  ):
+    | StaticCssEvalLoadedSource
+    | Promise<StaticCssEvalLoadedSource | null>
+    | null;
+}
+
+type MinchoBabelOptionsWithStaticCssEval = MinchoBabelOptions & {
+  staticCssEvalSourceProvider?: StaticCssEvalSourceProvider;
+};
+
+type BabelTransformResult = Awaited<ReturnType<typeof babelTransform>> & {
+  staticCssEval?: {
+    dependencyFiles: string[];
+  };
+};
+
 interface MinchoVitePluginOptions {
   babel?: MinchoBabelOptions;
   jsxCssProp?: boolean;
@@ -91,7 +151,154 @@ export function minchoVitePlugin(
   const resolverCache = new Map<string, string>();
   const resolvers = new Map<string, string>();
   const idToPluginData = new Map<string, Record<string, string>>();
+  const ownerToStaticCssEvalDependencies = new Map<string, Set<string>>();
+  const dependencyToStaticCssEvalOwners = new Map<string, Set<string>>();
+  const ownerToCssPaths = new Map<string, Set<string>>();
+  const cssPathToVirtualCssIds = new Map<string, Set<string>>();
   const virtualExt = ".vanilla.css";
+  let rootRealpath = "";
+
+  function invalidateViteModule(id: string): void {
+    if (!server) {
+      return;
+    }
+
+    const module = server.moduleGraph.getModuleById(id);
+    if (!module) {
+      return;
+    }
+
+    server.moduleGraph.invalidateModule(module);
+    module.lastHMRTimestamp = module.lastInvalidationTimestamp || Date.now();
+  }
+
+  function clearVirtualCssForSidecar(
+    cssPath: string,
+    invalidateModules = true
+  ): void {
+    const virtualCssIds = cssPathToVirtualCssIds.get(cssPath);
+    if (!virtualCssIds) {
+      return;
+    }
+
+    for (const virtualCssId of virtualCssIds) {
+      cssMap.delete(virtualCssId);
+      if (invalidateModules) {
+        invalidateViteModule(virtualCssId);
+      }
+    }
+
+    cssPathToVirtualCssIds.delete(cssPath);
+  }
+
+  function setVirtualCssForSidecar(
+    cssPath: string,
+    virtualCssId: string,
+    source: string
+  ): void {
+    const virtualCssIds =
+      cssPathToVirtualCssIds.get(cssPath) ?? new Set<string>();
+    virtualCssIds.add(virtualCssId);
+    cssPathToVirtualCssIds.set(cssPath, virtualCssIds);
+    cssMap.set(virtualCssId, source);
+  }
+
+  function rememberGeneratedCssForOwner(
+    ownerId: string,
+    cssPath: string
+  ): void {
+    const cssPaths = ownerToCssPaths.get(ownerId) ?? new Set<string>();
+    cssPaths.add(cssPath);
+    ownerToCssPaths.set(ownerId, cssPaths);
+  }
+
+  function clearGeneratedCssForOwner(ownerId: string): void {
+    const cssPaths = ownerToCssPaths.get(ownerId);
+    if (!cssPaths) {
+      return;
+    }
+
+    for (const cssPath of cssPaths) {
+      resolvers.delete(cssPath);
+      resolverCache.delete(cssPath);
+      idToPluginData.delete(cssPath);
+      idToPluginData.delete(customNormalize(cssPath));
+      clearVirtualCssForSidecar(cssPath);
+      invalidateViteModule(cssPath);
+    }
+
+    ownerToCssPaths.delete(ownerId);
+  }
+
+  function removeStaticCssEvalDependenciesForOwner(ownerId: string): void {
+    const dependencies = ownerToStaticCssEvalDependencies.get(ownerId);
+    if (!dependencies) {
+      return;
+    }
+
+    for (const dependency of dependencies) {
+      const owners = dependencyToStaticCssEvalOwners.get(dependency);
+      if (!owners) {
+        continue;
+      }
+
+      owners.delete(ownerId);
+      if (owners.size === 0) {
+        dependencyToStaticCssEvalOwners.delete(dependency);
+      }
+    }
+
+    ownerToStaticCssEvalDependencies.delete(ownerId);
+  }
+
+  function replaceStaticCssEvalDependenciesForOwner(
+    pluginContext: PluginContext,
+    ownerId: string,
+    dependencyFiles: readonly string[]
+  ): void {
+    removeStaticCssEvalDependenciesForOwner(ownerId);
+
+    const dependencies = new Set(
+      dependencyFiles
+        .map(normalizeStaticCssEvalFileId)
+        .filter(isWatchableStaticCssEvalDependency)
+    );
+
+    if (dependencies.size === 0) {
+      return;
+    }
+
+    ownerToStaticCssEvalDependencies.set(ownerId, dependencies);
+
+    for (const dependency of dependencies) {
+      const owners =
+        dependencyToStaticCssEvalOwners.get(dependency) ?? new Set<string>();
+      owners.add(ownerId);
+      dependencyToStaticCssEvalOwners.set(dependency, owners);
+      pluginContext.addWatchFile(dependency);
+    }
+  }
+
+  function invalidateStaticCssEvalDependency(dependencyId: string): void {
+    const owners = dependencyToStaticCssEvalOwners.get(dependencyId);
+    if (!owners) {
+      return;
+    }
+
+    for (const ownerId of owners) {
+      clearGeneratedCssForOwner(ownerId);
+      invalidateViteModule(ownerId);
+    }
+  }
+
+  function isWatchableStaticCssEvalDependency(id: string): boolean {
+    return (
+      rootRealpath !== "" &&
+      !isVirtualStaticCssEvalId(id) &&
+      !hasNodeModulesSegment(id) &&
+      isPathInsideRoot(rootRealpath, id)
+    );
+  }
 
   return {
     name: "mincho-css-vite",
@@ -107,6 +314,7 @@ export function minchoVitePlugin(
     },
     async configResolved(resolvedConfig: ResolvedConfig) {
       config = resolvedConfig;
+      rootRealpath = await getRealpathOrResolvedPath(config.root);
     },
     resolveId(id: string, importer?: string) {
       if (id.startsWith("\0")) return;
@@ -175,6 +383,8 @@ export function minchoVitePlugin(
     },
     async transform(this: PluginContext, code: string, id: string) {
       if (id.startsWith("\0")) return;
+      const fileId = normalizeStaticCssEvalFileId(id);
+      invalidateStaticCssEvalDependency(fileId);
 
       const moduleInfo = idToPluginData.get(id);
 
@@ -187,6 +397,7 @@ export function minchoVitePlugin(
       ) {
         try {
           resolverCache.delete(moduleInfo.originalPath);
+          clearVirtualCssForSidecar(moduleInfo.filePath, false);
           const { source, watchFiles } = await compile({
             filePath: moduleInfo.filePath,
             cwd: config.root,
@@ -228,7 +439,7 @@ export function minchoVitePlugin(
                 }
               }
 
-              cssMap.set(cssFileId, source);
+              setVirtualCssForSidecar(moduleInfo.filePath, cssFileId, source);
 
               return `import "${id}";`;
             }
@@ -250,7 +461,7 @@ export function minchoVitePlugin(
         if (id.endsWith(".css.ts")) return;
 
         try {
-          await fs.promises.access(id, fs.constants.F_OK);
+          await fs.promises.access(fileId, fs.constants.F_OK);
         } catch {
           return;
         }
@@ -259,11 +470,37 @@ export function minchoVitePlugin(
           _options?.jsxCssProp === undefined
             ? _options?.babel
             : { ..._options.babel, jsxCssProp: _options.jsxCssProp };
+        const transformBabelOptions:
+          | MinchoBabelOptionsWithStaticCssEval
+          | undefined =
+          babelOptions?.jsxCssProp === true
+            ? {
+                ...babelOptions,
+                staticCssEvalSourceProvider:
+                  createViteStaticCssEvalSourceProvider(
+                    this,
+                    fileId,
+                    code,
+                    rootRealpath
+                  )
+              }
+            : babelOptions;
+        const transformResult = (await babelTransform(
+          fileId,
+          transformBabelOptions
+        )) as BabelTransformResult;
         const {
           code: transformedCode,
           jsxCssPropTransformed,
-          result: [file, cssExtract]
-        } = await babelTransform(id, babelOptions);
+          result: [file, cssExtract],
+          staticCssEval
+        } = transformResult;
+
+        replaceStaticCssEvalDependenciesForOwner(
+          this,
+          fileId,
+          staticCssEval?.dependencyFiles ?? []
+        );
 
         if (!cssExtract || !file) {
           if (
@@ -283,7 +520,7 @@ export function minchoVitePlugin(
           this.addWatchFile(file);
         }
 
-        const resolvedCssPath = normalizePath(join(id, "..", file));
+        const resolvedCssPath = normalizePath(join(fileId, "..", file));
 
         if (server && resolvers.has(resolvedCssPath)) {
           const { moduleGraph } = server;
@@ -297,17 +534,18 @@ export function minchoVitePlugin(
         const normalizedCssPath = customNormalize(resolvedCssPath);
 
         resolvers.set(resolvedCssPath, cssExtract);
-        resolverCache.delete(id);
-        idToPluginData.delete(id);
+        rememberGeneratedCssForOwner(fileId, resolvedCssPath);
+        resolverCache.delete(fileId);
+        idToPluginData.delete(fileId);
         idToPluginData.delete(normalizedCssPath);
 
-        idToPluginData.set(id, {
-          ...idToPluginData.get(id),
-          mainFilePath: id
+        idToPluginData.set(fileId, {
+          ...idToPluginData.get(fileId),
+          mainFilePath: fileId
         });
         idToPluginData.set(normalizedCssPath, {
           ...idToPluginData.get(normalizedCssPath),
-          mainFilePath: id,
+          mainFilePath: fileId,
           path: resolvedCssPath
         });
 
@@ -338,6 +576,173 @@ async function processDefineRulesPresetViteFile(
 
 function customNormalize(path: string) {
   return path.startsWith("/") ? path.slice(1) : path;
+}
+
+function createViteStaticCssEvalSourceProvider(
+  pluginContext: PluginContext,
+  ownerId: string,
+  ownerSource: string,
+  rootRealpath: string
+): StaticCssEvalSourceProvider {
+  return {
+    async resolve(importerId: string, importPath: string) {
+      if (!isProjectLocalImportPath(importPath)) {
+        return createUnsupportedStaticCssEvalResolution(importPath);
+      }
+
+      const resolved = await pluginContext.resolve?.(importPath, importerId, {
+        skipSelf: true
+      });
+
+      if (!resolved || resolved.external) {
+        return null;
+      }
+
+      if (isVirtualStaticCssEvalId(resolved.id)) {
+        return createUnsupportedStaticCssEvalResolution(importPath);
+      }
+
+      const resolvedId = normalizeStaticCssEvalFileId(resolved.id);
+      const resolvedRealpath = await getExistingRealpath(resolvedId);
+
+      if (!resolvedRealpath) {
+        return null;
+      }
+
+      if (
+        hasNodeModulesSegment(resolvedRealpath) ||
+        !isPathInsideRoot(rootRealpath, resolvedRealpath)
+      ) {
+        return createUnsupportedStaticCssEvalResolution(importPath);
+      }
+
+      let stat: fs.Stats;
+
+      try {
+        stat = await fs.promises.stat(resolvedRealpath);
+      } catch (error) {
+        if (isMissingFileSystemEntryError(error)) {
+          return null;
+        }
+
+        throw error;
+      }
+
+      return {
+        id: resolvedRealpath,
+        realpath: resolvedRealpath,
+        sourceHash: createStaticCssEvalSourceHash(stat),
+        version: stat.mtimeMs
+      };
+    },
+    async load(id: string) {
+      const fileId = normalizeStaticCssEvalFileId(id);
+
+      if (fileId === ownerId) {
+        const ownerRealpath = await getExistingRealpath(fileId);
+        return {
+          source: ownerSource,
+          ...(ownerRealpath ? { realpath: ownerRealpath } : {})
+        };
+      }
+
+      if (isUnsupportedStaticCssEvalResolutionId(id)) {
+        return { source: "export {};" };
+      }
+
+      if (isVirtualStaticCssEvalId(id) || hasNodeModulesSegment(fileId)) {
+        return null;
+      }
+
+      const realpath = await getExistingRealpath(fileId);
+      if (
+        !realpath ||
+        hasNodeModulesSegment(realpath) ||
+        !isPathInsideRoot(rootRealpath, realpath)
+      ) {
+        return null;
+      }
+
+      let source: string;
+      let stat: fs.Stats;
+
+      try {
+        [source, stat] = await Promise.all([
+          fs.promises.readFile(realpath, "utf8"),
+          fs.promises.stat(realpath)
+        ]);
+      } catch (error) {
+        if (isMissingFileSystemEntryError(error)) {
+          return null;
+        }
+
+        throw error;
+      }
+
+      return {
+        source,
+        realpath,
+        sourceHash: createStaticCssEvalSourceHash(stat),
+        version: stat.mtimeMs
+      };
+    }
+  };
+}
+
+function createUnsupportedStaticCssEvalResolution(importPath: string) {
+  return createSharedUnsupportedStaticCssEvalResolution(importPath);
+}
+
+function isUnsupportedStaticCssEvalResolutionId(id: string): boolean {
+  return sharedIsUnsupportedStaticCssEvalResolutionId(id);
+}
+
+function normalizeStaticCssEvalFileId(id: string): string {
+  return normalizePath(stripViteRequestQuery(id));
+}
+
+function stripViteRequestQuery(id: string): string {
+  const queryIndex = id.search(/[?#]/);
+  return queryIndex === -1 ? id : id.slice(0, queryIndex);
+}
+
+function isProjectLocalImportPath(importPath: string): boolean {
+  return sharedIsProjectLocalImportPath(importPath);
+}
+
+function isVirtualStaticCssEvalId(id: string): boolean {
+  return sharedIsVirtualStaticCssEvalId(id);
+}
+
+function hasNodeModulesSegment(filePath: string): boolean {
+  return sharedHasNodeModulesSegment(filePath, normalizePath);
+}
+
+function isPathInsideRoot(rootPath: string, filePath: string): boolean {
+  return sharedIsPathInsideRoot(rootPath, filePath, normalizePath);
+}
+
+async function getRealpathOrResolvedPath(filePath: string): Promise<string> {
+  return getSharedRealpathOrResolvedPath(filePath, {
+    normalizeFilePath: normalizePath,
+    resolvePath: resolve
+  });
+}
+
+async function getExistingRealpath(filePath: string): Promise<string | null> {
+  return getSharedExistingRealpath(filePath, normalizePath);
+}
+
+function createStaticCssEvalSourceHash(stat: fs.Stats): string {
+  return createSharedStaticCssEvalSourceHash(stat);
+}
+
+function isMissingFileSystemEntryError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error.code === "ENOENT" || error.code === "ENOTDIR")
+  );
 }
 
 // == Tests ====================================================================
@@ -892,15 +1297,19 @@ if (import.meta.vitest) {
   async function createViteHarness({
     configOverrides,
     pluginOptions,
+    resolve: resolveImport,
     server
   }: {
     configOverrides?: Partial<ResolvedConfig>;
     pluginOptions?: MinchoVitePluginOptions;
+    resolve?: PluginContext["resolve"];
     server?: ViteDevServer;
   } = {}) {
     const plugin = minchoVitePlugin(pluginOptions);
+    const resolvedConfig = createResolvedConfig(configOverrides);
+    const watchFiles: string[] = [];
 
-    await plugin.configResolved?.(createResolvedConfig(configOverrides));
+    await plugin.configResolved?.(resolvedConfig);
     if (server) {
       plugin.configureServer?.(server);
     }
@@ -915,13 +1324,57 @@ if (import.meta.vitest) {
       async transform(id: string, code: string) {
         return plugin.transform?.call(
           {
-            addWatchFile() {}
+            addWatchFile(file: string) {
+              watchFiles.push(file);
+            },
+            resolve:
+              resolveImport ??
+              ((source, importer) =>
+                resolveViteHarnessImport(source, importer, resolvedConfig.root))
           },
           code,
           id
         );
-      }
+      },
+      watchFiles
     };
+  }
+
+  function resolveViteHarnessImport(
+    source: string,
+    importer: string | undefined,
+    root: string
+  ): { id: string } | null {
+    if (isVirtualStaticCssEvalId(source)) {
+      return { id: source };
+    }
+
+    if (!isProjectLocalImportPath(source)) {
+      return null;
+    }
+
+    const basePath = source.startsWith("/")
+      ? source
+      : resolve(dirname(importer ?? root), source);
+    const candidates = [
+      basePath,
+      `${basePath}.ts`,
+      `${basePath}.tsx`,
+      `${basePath}.js`,
+      `${basePath}.jsx`,
+      join(basePath, "index.ts"),
+      join(basePath, "index.tsx"),
+      join(basePath, "index.js"),
+      join(basePath, "index.jsx")
+    ];
+
+    for (const candidate of candidates) {
+      if (fs.existsSync(candidate)) {
+        return { id: candidate };
+      }
+    }
+
+    return null;
   }
 
   async function createExtractedCssFixture(
@@ -1041,6 +1494,128 @@ if (import.meta.vitest) {
     };
   }
 
+  function createImportedCssPropEntrySource(
+    importPath = "./styles",
+    cssExpression = "button"
+  ): string {
+    return `
+      import { button } from "${importPath}";
+
+      function App() {
+        return <div css={${cssExpression}} />;
+      }
+
+      export { App };
+    `;
+  }
+
+  function createImportedCssPropStaticRuleEntrySource(
+    importPath = "./styles"
+  ): string {
+    return `
+      import { button } from "${importPath}";
+
+      function App() {
+        return <div css={{ color: button }} />;
+      }
+
+      export { App };
+    `;
+  }
+
+  function createImportedStyleSource(color: string): string {
+    return `export const button = { color: "${color}" } as const;`;
+  }
+
+  async function createImportedCssPropViteFixture(
+    prefix: string,
+    options: {
+      entrySource?: string;
+      styleSource?: string;
+    } = {}
+  ) {
+    const cacheRoot = createViteFixtureCacheRoot();
+    await fs.promises.mkdir(cacheRoot, { recursive: true });
+    const root = await fs.promises.mkdtemp(join(cacheRoot, prefix));
+    const srcRoot = join(root, "src");
+    const entryPath = join(srcRoot, "entry.tsx");
+    const stylesPath = join(srcRoot, "styles.ts");
+    const entrySource =
+      options.entrySource ?? createImportedCssPropEntrySource();
+    const styleSource = options.styleSource ?? createImportedStyleSource("red");
+
+    await fs.promises.mkdir(srcRoot, { recursive: true });
+    await fs.promises.writeFile(entryPath, entrySource);
+    await fs.promises.writeFile(stylesPath, styleSource);
+
+    return {
+      entryPath,
+      entrySource,
+      root,
+      srcRoot,
+      stylesPath,
+      styleSource
+    };
+  }
+
+  async function transformImportedCssPropToVirtualCss(
+    harness: Awaited<ReturnType<typeof createViteHarness>>,
+    entryPath: string,
+    entrySource: string
+  ) {
+    const transformedEntry = extractViteTransformCode(
+      await harness.transform(entryPath, entrySource),
+      "Expected imported css-prop entry transform to return code"
+    );
+    const extractedCssImport =
+      extractNamedCssImportFromSource(transformedEntry);
+    const extractedId = harness.resolveId(extractedCssImport.source, entryPath);
+    assertString(
+      extractedId,
+      "Expected imported css-prop sidecar import to resolve"
+    );
+    const extractedSource = await harness.load(extractedId);
+    assertString(
+      extractedSource,
+      "Expected imported css-prop sidecar source to load"
+    );
+    const transformedExtractedCss = await harness.transform(
+      extractedId,
+      extractedSource
+    );
+    assertString(
+      transformedExtractedCss,
+      "Expected imported css-prop sidecar transform to return source text"
+    );
+    const virtualImportMatch = transformedExtractedCss.match(
+      /import\s+"([^"]+\.vanilla\.css)";/
+    );
+
+    if (virtualImportMatch?.[1] == null) {
+      throw new Error(
+        "Expected imported css-prop output to import virtual CSS"
+      );
+    }
+
+    const resolvedVirtualId = harness.resolveId(virtualImportMatch[1]);
+    assertString(
+      resolvedVirtualId,
+      "Expected imported css-prop virtual CSS id to resolve"
+    );
+    const virtualCss = await harness.load(resolvedVirtualId);
+    assertString(virtualCss, "Expected imported css-prop virtual CSS to load");
+
+    return {
+      extractedCssImport,
+      extractedId,
+      extractedSource,
+      resolvedVirtualId,
+      transformedEntry,
+      transformedExtractedCss,
+      virtualCss
+    };
+  }
+
   async function spyOnSourceBabelTransform() {
     const sourceIntegrationUrl = new URL(
       "../../integration/src/babel" + ".ts",
@@ -1146,11 +1721,7 @@ if (import.meta.vitest) {
         `<Button className=\\{${escapeRegExp(cxIdentifier)}\\(styleA\\)\\} />`
       )
     );
-    expect(source).toMatch(
-      new RegExp(
-        `<motion\\.div className=\\{${escapeRegExp(cxIdentifier)}\\(styleB\\)\\} />`
-      )
-    );
+    expect(source).toMatch(/<motion\.div className=\{[A-Za-z_$][\w$]*\} \/>/);
     expect(source).toContain("css: _minchoCssProp");
     expect(source).toContain("..._minchoRest");
     expect(source).toMatch(
@@ -1270,9 +1841,13 @@ if (import.meta.vitest) {
           "Expected enabled css-prop entry transform to return code"
         );
 
-        expect(babelTransformSpy).toHaveBeenCalledWith(fixture.entryPath, {
-          jsxCssProp: true
-        });
+        expect(babelTransformSpy).toHaveBeenCalledWith(
+          fixture.entryPath,
+          expect.objectContaining({
+            jsxCssProp: true,
+            staticCssEvalSourceProvider: expect.any(Object)
+          })
+        );
         const extractedCssImport =
           extractNamedCssImportFromSource(transformedEntry);
         const cxIdentifier = extractCxIdentifierFromSource(transformedEntry);
@@ -1345,6 +1920,303 @@ if (import.meta.vitest) {
       }
     });
 
+    it("refreshes imported static css prop dependencies without stale CSS", async () => {
+      const fixture = await createImportedCssPropViteFixture(
+        "jsx-css-prop-imported-refresh-"
+      );
+      const ownerModule: Module = { lastInvalidationTimestamp: 1001 };
+      const sidecarModule: Module = { lastInvalidationTimestamp: 1002 };
+      const virtualModule: Module = { lastInvalidationTimestamp: 1003 };
+      const modules = new Map<string, Module>([
+        [fixture.entryPath, ownerModule]
+      ]);
+      const getModuleById = vi.fn((moduleId: string) => modules.get(moduleId));
+      const invalidateModule = vi.fn();
+
+      try {
+        await spyOnSourceBabelTransform();
+        const harness = await createViteHarness({
+          configOverrides: {
+            command: "serve",
+            mode: "development",
+            root: fixture.root
+          },
+          pluginOptions: {
+            jsxCssProp: true
+          },
+          server: {
+            moduleGraph: {
+              getModuleById,
+              invalidateModule
+            }
+          }
+        });
+        const redArtifact = await transformImportedCssPropToVirtualCss(
+          harness,
+          fixture.entryPath,
+          fixture.entrySource
+        );
+        modules.set(redArtifact.extractedId, sidecarModule);
+        modules.set(redArtifact.resolvedVirtualId, virtualModule);
+
+        expect(redArtifact.extractedSource).toContain('color: "red"');
+        expect(redArtifact.virtualCss).toContain("color: red;");
+        expect(redArtifact.virtualCss).not.toContain("color: blue;");
+
+        await fs.promises.writeFile(
+          fixture.stylesPath,
+          createImportedStyleSource("blue")
+        );
+        await harness.transform(
+          fixture.stylesPath,
+          await fs.promises.readFile(fixture.stylesPath, "utf8")
+        );
+
+        expect(invalidateModule).toHaveBeenCalledWith(ownerModule);
+        expect(invalidateModule).toHaveBeenCalledWith(sidecarModule);
+        expect(invalidateModule).toHaveBeenCalledWith(virtualModule);
+        expect(ownerModule.lastHMRTimestamp).toBe(1001);
+        expect(await harness.load(redArtifact.extractedId)).toBeNull();
+        expect(await harness.load(redArtifact.resolvedVirtualId)).toBeNull();
+
+        const blueArtifact = await transformImportedCssPropToVirtualCss(
+          harness,
+          fixture.entryPath,
+          fixture.entrySource
+        );
+        expect(blueArtifact.extractedSource).toContain('color: "blue"');
+        expect(blueArtifact.extractedSource).not.toContain('color: "red"');
+        expect(blueArtifact.virtualCss).toContain("color: blue;");
+        expect(blueArtifact.virtualCss).not.toContain("color: red;");
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("registers dependency files for successful and failed imported evaluations", async () => {
+      const supportedFixture = await createImportedCssPropViteFixture(
+        "jsx-css-prop-imported-watch-supported-"
+      );
+      const reexportFixture = await createImportedCssPropViteFixture(
+        "jsx-css-prop-imported-watch-reexport-",
+        {
+          entrySource: createImportedCssPropEntrySource("./barrel")
+        }
+      );
+      const barrelPath = join(reexportFixture.srcRoot, "barrel.ts");
+
+      try {
+        await spyOnSourceBabelTransform();
+        await fs.promises.writeFile(
+          barrelPath,
+          'export { button } from "./styles";'
+        );
+
+        const supportedHarness = await createViteHarness({
+          configOverrides: {
+            root: supportedFixture.root
+          },
+          pluginOptions: {
+            jsxCssProp: true
+          }
+        });
+        await transformImportedCssPropToVirtualCss(
+          supportedHarness,
+          supportedFixture.entryPath,
+          supportedFixture.entrySource
+        );
+        expect(supportedHarness.watchFiles).toContain(
+          normalizePath(await fs.promises.realpath(supportedFixture.stylesPath))
+        );
+
+        const reexportHarness = await createViteHarness({
+          configOverrides: {
+            root: reexportFixture.root
+          },
+          pluginOptions: {
+            jsxCssProp: true
+          }
+        });
+        const reexportCode = extractViteTransformCode(
+          await reexportHarness.transform(
+            reexportFixture.entryPath,
+            reexportFixture.entrySource
+          ),
+          "Expected unsupported reexport fallback transform to return code"
+        );
+
+        expect(reexportCode).toContain("className={_cx(button)}");
+        expect(reexportHarness.watchFiles).toContain(
+          normalizePath(await fs.promises.realpath(barrelPath))
+        );
+      } finally {
+        await Promise.all([
+          fs.promises.rm(supportedFixture.root, {
+            force: true,
+            recursive: true
+          }),
+          fs.promises.rm(reexportFixture.root, {
+            force: true,
+            recursive: true
+          })
+        ]);
+      }
+    });
+
+    it("refuses virtual and third-party static css evaluation at boundaries", async () => {
+      const fallbackFixture = await createJsxCssPropViteFixture(
+        "jsx-css-prop-imported-boundary-fallback-",
+        `
+          import { button } from "virtual:styles";
+          import { packageButton } from "pkg/styles";
+
+          function App() {
+            return <>
+              <div css={button} />
+              <div css={packageButton} />
+            </>;
+          }
+
+          export { App };
+        `
+      );
+      const staticRuleFixture = await createJsxCssPropViteFixture(
+        "jsx-css-prop-imported-boundary-static-rule-",
+        createImportedCssPropStaticRuleEntrySource("pkg/styles")
+      );
+
+      try {
+        await spyOnSourceBabelTransform();
+        const fallbackHarness = await createViteHarness({
+          configOverrides: {
+            root: fallbackFixture.root
+          },
+          pluginOptions: {
+            jsxCssProp: true
+          }
+        });
+        const fallbackCode = extractViteTransformCode(
+          await fallbackHarness.transform(
+            fallbackFixture.entryPath,
+            fallbackFixture.source
+          ),
+          "Expected boundary fallback transform to return code"
+        );
+
+        expect(fallbackCode).toContain("className={_cx(button)}");
+        expect(fallbackCode).toContain("className={_cx(packageButton)}");
+        expect(fallbackCode).not.toContain("extracted_");
+        expect(fallbackHarness.watchFiles).toEqual([]);
+
+        const staticRuleHarness = await createViteHarness({
+          configOverrides: {
+            root: staticRuleFixture.root
+          },
+          pluginOptions: {
+            jsxCssProp: true
+          }
+        });
+        await expect(
+          staticRuleHarness.transform(
+            staticRuleFixture.entryPath,
+            staticRuleFixture.source
+          )
+        ).rejects.toThrow("Cannot statically evaluate css prop value");
+        expect(staticRuleHarness.watchFiles).toEqual([]);
+      } finally {
+        await Promise.all([
+          fs.promises.rm(fallbackFixture.root, {
+            force: true,
+            recursive: true
+          }),
+          fs.promises.rm(staticRuleFixture.root, {
+            force: true,
+            recursive: true
+          })
+        ]);
+      }
+    });
+
+    it("refuses symlinked node_modules sources in static css eval load", async () => {
+      const cacheRoot = createViteFixtureCacheRoot();
+      await fs.promises.mkdir(cacheRoot, { recursive: true });
+      const root = await fs.promises.mkdtemp(
+        join(cacheRoot, "jsx-css-prop-imported-boundary-symlink-")
+      );
+      const srcRoot = join(root, "src");
+      const stylesPath = join(srcRoot, "styles.ts");
+      const nodeModulesStylesPath = join(root, "node_modules/pkg/styles.ts");
+
+      try {
+        await Promise.all([
+          fs.promises.mkdir(srcRoot, { recursive: true }),
+          fs.promises.mkdir(dirname(nodeModulesStylesPath), {
+            recursive: true
+          })
+        ]);
+        await fs.promises.writeFile(
+          nodeModulesStylesPath,
+          createImportedStyleSource("red"),
+          "utf8"
+        );
+        await fs.promises.symlink(nodeModulesStylesPath, stylesPath);
+
+        const sourceProvider = createViteStaticCssEvalSourceProvider(
+          {
+            addWatchFile() {}
+          },
+          join(srcRoot, "entry.tsx"),
+          'export const owner = "ignored";',
+          await getRealpathOrResolvedPath(root)
+        );
+
+        await expect(sourceProvider.load(stylesPath)).resolves.toBeNull();
+      } finally {
+        await fs.promises.rm(root, { force: true, recursive: true });
+      }
+    });
+
+    it("clears stale generated CSS when a project-local dependency disappears", async () => {
+      const fixture = await createImportedCssPropViteFixture(
+        "jsx-css-prop-imported-deleted-dependency-"
+      );
+
+      try {
+        await spyOnSourceBabelTransform();
+        const harness = await createViteHarness({
+          configOverrides: {
+            command: "serve",
+            mode: "development",
+            root: fixture.root
+          },
+          pluginOptions: {
+            jsxCssProp: true
+          }
+        });
+        const redArtifact = await transformImportedCssPropToVirtualCss(
+          harness,
+          fixture.entryPath,
+          fixture.entrySource
+        );
+
+        expect(redArtifact.virtualCss).toContain("color: red;");
+        await fs.promises.rm(fixture.stylesPath, { force: true });
+        await harness.transform(fixture.stylesPath, "");
+
+        expect(await harness.load(redArtifact.extractedId)).toBeNull();
+        expect(await harness.load(redArtifact.resolvedVirtualId)).toBeNull();
+        await expect(
+          harness.transform(fixture.entryPath, fixture.entrySource)
+        ).rejects.toThrow(
+          "Cannot statically evaluate css prop value: failed to resolve project-local dependency ./styles"
+        );
+        expect(await harness.load(redArtifact.extractedId)).toBeNull();
+        expect(await harness.load(redArtifact.resolvedVirtualId)).toBeNull();
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
     it("lowers v2 class-value component and pre-css spread css props before React JSX handling", async () => {
       const fixture = await createJsxCssPropViteFixture(
         "jsx-css-prop-v2-class-value-",
@@ -1367,9 +2239,13 @@ if (import.meta.vitest) {
         );
         const cxIdentifier = extractCxIdentifierFromSource(transformedEntry);
 
-        expect(babelTransformSpy).toHaveBeenCalledWith(fixture.entryPath, {
-          jsxCssProp: true
-        });
+        expect(babelTransformSpy).toHaveBeenCalledWith(
+          fixture.entryPath,
+          expect.objectContaining({
+            jsxCssProp: true,
+            staticCssEvalSourceProvider: expect.any(Object)
+          })
+        );
         expect(transformedEntry).not.toContain(" css=");
         expect(transformedEntry).not.toContain("css={styleA}");
         expect(transformedEntry).not.toContain("css={styleB}");
@@ -1410,9 +2286,14 @@ if (import.meta.vitest) {
         await expect(
           harness.transform(fixture.entryPath, fixture.source)
         ).resolves.toBeNull();
-        expect(babelTransformSpy).toHaveBeenCalledWith(fixture.entryPath, {
-          jsxCssProp: true
-        });
+        expect(babelTransformSpy).toHaveBeenCalledTimes(1);
+        expect(babelTransformSpy).toHaveBeenCalledWith(
+          fixture.entryPath,
+          expect.objectContaining({
+            jsxCssProp: true,
+            staticCssEvalSourceProvider: expect.any(Object)
+          })
+        );
       } finally {
         await fs.promises.rm(fixture.root, { force: true, recursive: true });
       }

--- a/site/src/content/styled.mdx
+++ b/site/src/content/styled.mdx
@@ -390,12 +390,11 @@ const Box = styled('div', {
 
 ---
 
-## CSS Prop (Coming Soon)
+## CSS Prop
 
-The `css` prop for ad-hoc styling is planned but not yet implemented:
+The `css` prop is available when TypeScript uses the scoped JSX runtime and the Mincho transform runs with `jsxCssProp: true`. Supported values compile away before React handles JSX:
 
 ```tsx
-// Future API (not yet available)
 /** @jsxImportSource @mincho-js/react */
 
 function MyComponent() {
@@ -407,7 +406,53 @@ function MyComponent() {
 }
 ```
 
-This feature will enable:
-- Ad-hoc styling directly on JSX elements
-- Zero-runtime CSS extraction (like Emotion but build-time)
-- Array composition for multiple style objects
+V1 static evaluation supports direct object/array values, mutation-free same-file `const` object/array values, direct project-local ESM named imports, aliased named imports, default imports/exports, and static member paths such as `styles.button`:
+
+```tsx
+const button = { color: 'blue' } as const;
+const stack = [{ display: 'flex' }, { gap: 8 }] as const;
+const styles = {
+  button: { color: 'green' },
+} as const;
+
+<div css={button} />
+<div css={stack} />
+<div css={styles.button} />
+```
+
+```tsx
+// styles.ts
+export const card = { padding: 16 } as const;
+
+const panel = { color: 'green' } as const;
+export default panel;
+
+// App.tsx
+import panel, { card } from './styles';
+
+<div css={card} />
+<div css={panel} />
+```
+
+The practical literal grammar is small: string, number, boolean, `null`, unary numeric values, no-expression template literals such as `` `grid` ``, and nested object/array literals.
+
+Bundlers provide source resolution and loading only. Vite and esbuild give Mincho project-local source text and dependency edges, then Mincho parses that source and statically evaluates the supported AST subset. No module execution is used. Mincho never executes user modules to obtain `css` prop values, and it does not use Node, VM, `eval`, `require()`, dynamic import, or bundler runtime execution for static evaluation.
+
+V1 is project-local only. It excludes namespace imports, reexports or barrels, package exports from `node_modules`, virtual modules, CommonJS, calls/functions/mixins as CSS-rule values, object/array spreads, computed dynamic keys, optional chaining, template expressions, runtime dynamic values, SWC-native integration, and webpack integration.
+
+Existing dynamic class-value identifiers keep class-value behavior when they cannot be proven static. Proven CSS-rule candidates with unsupported internals fail with `Cannot statically evaluate css prop value` diagnostics.
+
+```tsx
+const color = 'red';
+const badIdentifierValue = { color };
+const badSpread = { ...base, color: 'red' };
+const styles = { button: { color: 'red' } } as const;
+const variant = 'button';
+
+<div css={badIdentifierValue} />
+<div css={badSpread} />
+<div css={styles[variant]} />
+<div css={styles?.button} />
+```
+
+These examples fail because v1 does not evaluate identifier object values, object spreads, dynamic member paths, or optional member paths inside static CSS-rule candidates.


### PR DESCRIPTION
## Description
- add the static CSS evaluation foundation for the Babel css prop flow, including contracts, same-file analysis, imported module traversal, limits, diagnostics, and cycle handling
- run a static css prepass through the shared integration layer and propagate its dependency tracking through the Vite and esbuild integrations
- document the new behavior and update the React and site examples to cover static evaluation

## Related Issue
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
- #349

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “V1 static evaluation” for the `css` prop, compiling supported same-file constants and project-local ESM imports (including nested member paths) into CSS rules.
  * React `css` prop handling now resolves supported static values more aggressively.
  * Vite and esbuild integrations now pre-resolve and track static CSS dependencies for consistent rebuild/HMR behavior.
* **Bug Fixes**
  * Unsupported/unsafe `css` inputs now fail deterministically with clearer, code-framed diagnostics (while preserving class-value behavior when evaluation can’t be proven).
* **Documentation**
  * Updated React and site docs with the supported value grammar, limits, and failure policy.
* **Tests**
  * Expanded coverage for static evaluation, diagnostics, and dependency invalidation/refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
- base branch: `main`
- this continues the css prop series after the merged branches-and-arrays work

## Checklist
- review the Babel static evaluation pipeline and import traversal boundaries
- review how dependency tracking is threaded through integration, Vite, and esbuild
- review the public-facing docs and examples for the new static css evaluation behavior
