### PR TITLE
Feat: CSS Prop - Resolve static evaluation import graphs

### DIFF
--- a/configs/tsconfig-custom/tsconfig.base.json
+++ b/configs/tsconfig-custom/tsconfig.base.json
@@ -84,7 +84,7 @@
 
     /* Interop Constraints */
     "isolatedModules": true,                             /* Ensure that each file can be safely transpiled without relying on other imports. */
-    "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    "verbatimModuleSyntax": false,                     /* Allow TypeScript to elide type-only imports and transform imports/exports according to the module setting. */
     // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
     // "erasableSyntaxOnly": true,                       /* Do not allow runtime constructs that are not part of ECMAScript. */
     "allowSyntheticDefaultImports": true,                /* Allow 'import x from y' when a module doesn't have a default export. */

--- a/configs/vite-config-custom/src/index.ts
+++ b/configs/vite-config-custom/src/index.ts
@@ -51,7 +51,11 @@ function NodeBuilder(viteConfigEnv: ConfigEnv) {
 
   const runtimeEnv = getRuntimeEnv();
   if (ViteEnv.isProd()) {
-    if (runtimeEnv === "LOCAL" || runtimeEnv === "PUBLISH") {
+    if (
+      runtimeEnv === "LOCAL" ||
+      runtimeEnv === "PUBLISH" ||
+      runtimeEnv === "ACTIONS"
+    ) {
       plugins.add(
         // This is currently a proprietary implementation. You might also like to see
         // https://github.com/qmhc/vite-plugin-dts/issues/267
@@ -61,22 +65,20 @@ function NodeBuilder(viteConfigEnv: ConfigEnv) {
         })
       );
     }
-    if (runtimeEnv === "PUBLISH") {
-      plugins.add(
-        dtsForCjs({
-          include: ["src"],
-          tsconfigPath: resolve(packageRoot, "tsconfig.lib.json"),
-          compilerOptions: {
-            tsBuildInfoFile: resolve(
-              packageRoot,
-              ".cache",
-              "typescript",
-              "tsbuildinfo-cjs"
-            )
-          }
-        })
-      );
-    }
+    plugins.add(
+      dtsForCjs({
+        include: ["src"],
+        tsconfigPath: resolve(packageRoot, "tsconfig.lib.json"),
+        compilerOptions: {
+          tsBuildInfoFile: resolve(
+            packageRoot,
+            ".cache",
+            "typescript",
+            "tsbuildinfo-cjs"
+          )
+        }
+      })
+    );
     plugins.add(externalizeDeps());
   }
 

--- a/packages/babel/src/__snapshots__/index.ts.snap
+++ b/packages/babel/src/__snapshots__/index.ts.snap
@@ -1005,6 +1005,52 @@ const red = _$mincho$$red2;
 console.log(red);"
 `;
 
+exports[`minchoBabelPlugin > non-Mincho styled calls are ignored 1`] = `
+[
+  "extracted_17gu07x.css.ts",
+  "",
+]
+`;
+
+exports[`minchoBabelPlugin > non-Mincho styled calls are ignored 2`] = `
+"import { styled } from '@emotion/styled';
+const Button = styled("button", {
+  color: 'red'
+});
+const Link = styled.a({
+  color: 'blue'
+});
+console.log(Button, Link);"
+`;
+
+exports[`minchoBabelPlugin > react styled components get converted to runtime 1`] = `
+[
+  "extracted_1q59b9y.css.ts",
+  "import { rules as _rules } from "@mincho-js/css";
+export var _$mincho$$Button = _rules({
+  base: {
+    color: 'red'
+  }
+});
+var _$mincho$$Button2 = _$mincho$$Button;
+export var _$mincho$$Link = _rules({
+  base: {
+    color: 'blue'
+  }
+});
+var _$mincho$$Link2 = _$mincho$$Link;",
+]
+`;
+
+exports[`minchoBabelPlugin > react styled components get converted to runtime 2`] = `
+"import { _$mincho$$Button as _$mincho$$Button2, _$mincho$$Link as _$mincho$$Link2 } from "extracted_1q59b9y.css.ts";
+import { rules as _rules } from "@mincho-js/css";
+import { $$styled as _$$styled } from "@mincho-js/react/runtime";
+const Button = /* @__PURE__ */_$$styled("button", _$mincho$$Button2);
+const Link = /* @__PURE__ */_$$styled("a", _$mincho$$Link2);
+console.log(Button, Link);"
+`;
+
 exports[`minchoBabelPlugin > same binding in multiple declarations 1`] = `
 [
   "extracted_141089g.css.ts",

--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -3154,58 +3154,39 @@ if (import.meta.vitest) {
       expect(code).toMatchSnapshot();
     });
 
-    // it("react styled components get converted to recipe", () => {
-    //   const { result, code } = babelTransform(`
-    //   import { styled } from '@macaron-css/react';
+    it("react styled components get converted to runtime", () => {
+      const { result, code } = babelTransform(`
+      import { styled } from '@mincho-js/react';
 
-    //   const Button = styled("button", {
-    //     base: { color: 'red' }
-    //   })
-    //   console.log(Button)
-    // `);
+      const Button = styled("button", {
+        base: { color: 'red' }
+      })
+      const Link = styled.a({
+        base: { color: 'blue' }
+      })
+      console.log(Button, Link)
+    `);
 
-    //   expect(result).toMatchSnapshot();
-    //   expect(code).toMatchSnapshot();
-    // });
+      expect(result).toMatchSnapshot();
+      expect(code).toMatchSnapshot();
+    });
 
-    // it("solid styled components get converted to recipe", () => {
-    //   const { result, code } = babelTransform(`
-    //   import { styled } from '@macaron-css/solid';
+    it("non-Mincho styled calls are ignored", () => {
+      const { result, code } = babelTransform(`
+      import { styled } from '@emotion/styled';
 
-    //   const Button = styled("button", {
-    //     base: { color: 'red' }
-    //   })
-    //   console.log(Button)
-    // `);
+      const Button = styled("button", {
+        color: 'red'
+      })
+      const Link = styled.a({
+        color: 'blue'
+      })
+      console.log(Button, Link)
+    `);
 
-    //   expect(result).toMatchSnapshot();
-    //   expect(code).toMatchSnapshot();
-    // });
-
-    // it("leading comments of `styled` get passed to recipe", () => {
-    //   const { result, code } = babelTransform(`
-    //   import { styled } from '@macaron-css/solid';
-    //   import {macaron$} from '@mincho-js/css';
-
-    //   const fn = () => {
-    //     const arr = [1,2]
-    //     for (const _ of arr) {
-    //       const Button = /* macaron-ignore */ styled("button", {
-    //         base: { color: _ }
-    //       })
-    //     }
-    //     return Button;
-    //   }
-    //   const test = macaron$(() => {
-    //     console.log(fn())
-    //     return "test"
-    //   })
-    //   console.log(test)
-    // `);
-
-    //   expect(result).toMatchSnapshot();
-    //   expect(code).toMatchSnapshot();
-    // });
+      expect(result).toMatchSnapshot();
+      expect(code).toMatchSnapshot();
+    });
 
     it("mincho-ignore on parent node", () => {
       const { result, code } = babelTransform(`

--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -5,9 +5,14 @@ import {
   removeUnusedJsxCssPropCssModuleImports
 } from "./jsxCssProp.js";
 import { supportedJsxCssPropTags } from "./jsxCssPropTags.js";
+import { createImportedStaticCssEvalProvider } from "./staticCssEval/importedModules.js";
 import postprocess from "./transforms/postprocess.js";
 import basePreprocess from "./transforms/preprocess.js";
-import type { PluginOptions, PluginState } from "./types.js";
+import type {
+  MinchoBabelFileMetadata,
+  PluginOptions,
+  PluginState
+} from "./types.js";
 import { styledComponentPlugin } from "./styled.js";
 
 const preprocess = basePreprocess as (
@@ -40,7 +45,11 @@ export {
   createImportedStaticCssEvalModuleRecord as internalCreateImportedStaticCssEvalModuleRecord,
   createImportedStaticCssEvalProvider as internalCreateImportedStaticCssEvalProvider
 } from "./staticCssEval/importedModules.js";
-export type { PluginOptions } from "./types.js";
+export type {
+  MinchoBabelFileMetadata,
+  MinchoStaticCssEvalMetadata,
+  PluginOptions
+} from "./types.js";
 export type {
   ImportedStaticCssEvalImportResolution as InternalImportedStaticCssEvalImportResolution,
   ImportedStaticCssEvalLoadedModule as InternalImportedStaticCssEvalLoadedModule,
@@ -60,20 +69,25 @@ if (import.meta.vitest) {
     code: string,
     pluginOptions: Partial<
       Pick<PluginOptions, "jsxCssProp" | "staticCssEvalProvider">
-    > = {}
+    > = {},
+    transformOptions: { filename?: string } = {}
   ) {
     const options: PluginOptions = { result: ["", ""], ...pluginOptions };
     const result = transformSync(code, {
       plugins: [[minchoBabelPlugin(), options], [styledComponentPlugin()]],
       presets: ["@babel/preset-typescript"],
-      filename: "test.tsx"
+      filename: transformOptions.filename ?? "test.tsx"
     });
 
     if (result === null || result.code == null) {
       throw new Error("Failed to transform code");
     }
 
-    return { result: options.result, code: result.code };
+    return {
+      result: options.result,
+      code: result.code,
+      metadata: (result.metadata ?? {}) as MinchoBabelFileMetadata
+    };
   }
 
   type RuntimeJsx = (
@@ -385,6 +399,56 @@ if (import.meta.vitest) {
     ).toThrow(message);
   }
 
+  function captureJsxCssPropFailure(
+    code: string,
+    pluginOptions: Partial<
+      Pick<PluginOptions, "jsxCssProp" | "staticCssEvalProvider">
+    > = {},
+    transformOptions: { filename?: string } = {}
+  ): {
+    code: string;
+    error: Error;
+    metadata: MinchoBabelFileMetadata;
+  } {
+    const options: PluginOptions = { result: ["", ""], ...pluginOptions };
+    let capturedError: Error | null = null;
+    let capturedMetadata: MinchoBabelFileMetadata = {};
+    const capturePlugin: PluginObj<PluginState> = {
+      visitor: {
+        Program(path, state) {
+          try {
+            preprocess(path, state);
+            preprocessJsxCssProp(path, state);
+          } catch (error) {
+            capturedError =
+              error instanceof Error ? error : new Error(String(error));
+            capturedMetadata = state.file.metadata;
+            path.stop();
+          }
+        }
+      }
+    };
+    const result = transformSync(code, {
+      plugins: [[capturePlugin, options]],
+      presets: ["@babel/preset-typescript"],
+      filename: transformOptions.filename ?? "test.tsx"
+    });
+
+    if (!capturedError) {
+      throw new Error("Expected JSX css prop transform to fail");
+    }
+
+    if (result === null || result.code == null) {
+      throw new Error("Failed to transform failure capture code");
+    }
+
+    return {
+      code: result.code,
+      error: capturedError,
+      metadata: capturedMetadata
+    };
+  }
+
   describe("minchoBabelPlugin", () => {
     it("export default style", () => {
       const { result, code } = babelTransform(`
@@ -550,6 +614,53 @@ if (import.meta.vitest) {
       expect(
         imported.code.match(/className=\{_\$mincho\$\$App\d+\}/g)
       ).toHaveLength(2);
+    });
+
+    it("records imported static css eval metadata during css prop lowering", () => {
+      const ownerFile = "/project/src/App.tsx";
+      const stylesFile = "/project/src/styles.ts";
+      const source = `
+        import { button } from "./styles";
+
+        function App() {
+          return <div css={button} />;
+        }
+      `;
+      const { result, code, metadata } = babelTransform(
+        source,
+        {
+          jsxCssProp: true,
+          staticCssEvalProvider: createImportedStaticCssEvalProvider({
+            modules: [
+              { id: ownerFile, source },
+              {
+                id: stylesFile,
+                source: `export const button = { color: "red" } as const;`
+              }
+            ],
+            importResolutions: [
+              {
+                importerId: ownerFile,
+                importPath: "./styles",
+                resolvedId: stylesFile
+              }
+            ]
+          })
+        },
+        { filename: ownerFile }
+      );
+      const staticCssEvalMetadata = metadata.minchoStaticCssEval;
+
+      expect(staticCssEvalMetadata?.dependencies[0]?.file).toBe(stylesFile);
+      expect(staticCssEvalMetadata?.dependencies[0]?.contributed).toBe(true);
+      expect(staticCssEvalMetadata?.diagnostics).toEqual([]);
+      expect(staticCssEvalMetadata?.cacheKeys[0]?.resolvedId).toBe(stylesFile);
+      expect(staticCssEvalMetadata?.resolvedModuleIds).toContain(stylesFile);
+      expect(code).not.toContain(" css=");
+      expect(code).toMatch(/className=\{_\$mincho\$\$App\d+\}/);
+      expect(code).not.toContain("_cx(button)");
+      expect(result[1]).toContain("_css({");
+      expect(result[1]).toContain('color: "red"');
     });
 
     it("merges expression className before provider-resolved css rule class", () => {
@@ -855,6 +966,34 @@ if (import.meta.vitest) {
           )
         ).toThrow(reason);
       }
+    });
+
+    it("records static css eval metadata before unsupported css prop failures", () => {
+      const source = `
+        const variant = "button";
+        const styles = {
+          button: { color: "red" }
+        };
+
+        function App() {
+          return <div css={styles[variant]} />;
+        }
+      `;
+
+      expect(() => babelTransform(source, { jsxCssProp: true })).toThrow(
+        "dynamic-member-path"
+      );
+
+      const failure = captureJsxCssPropFailure(source, { jsxCssProp: true });
+      const staticCssEvalMetadata = failure.metadata.minchoStaticCssEval;
+
+      expect(failure.error.message).toContain("dynamic-member-path");
+      expect(staticCssEvalMetadata?.diagnostics.map(({ id }) => id)).toContain(
+        "STATIC_CSS_EVAL_COMPUTED_MEMBER_UNSUPPORTED"
+      );
+      expect(failure.code).not.toContain('from "@mincho-js/css"');
+      expect(failure.code).not.toContain("_css(");
+      expect(failure.code).not.toContain("_cx(");
     });
 
     it("preserves class-value fallback when static css rule candidacy is unproven", () => {

--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -670,6 +670,92 @@ if (import.meta.vitest) {
       expect(result[1]).toContain('color: "red"');
     });
 
+    it("lowers whole namespace object imported css prop through static provider", () => {
+      const ownerFile = "/project/src/App.tsx";
+      const stylesFile = "/project/src/styles.ts";
+      const source = `
+        import * as styles from "./styles";
+
+        function App() {
+          return <div css={styles} />;
+        }
+      `;
+      const { result, code } = babelTransform(
+        source,
+        {
+          jsxCssProp: true,
+          staticCssEvalProvider: createImportedStaticCssEvalProvider({
+            modules: [
+              { id: ownerFile, source },
+              {
+                id: stylesFile,
+                source: `export const button = { color: "red" } as const;
+                         export const card = { color: "blue" } as const;`
+              }
+            ],
+            importResolutions: [
+              {
+                importerId: ownerFile,
+                importPath: "./styles",
+                resolvedId: stylesFile
+              }
+            ]
+          })
+        },
+        { filename: ownerFile }
+      );
+
+      expect(code).not.toContain(" css=");
+      expect(code).toMatch(/className=\{_\$mincho\$\$App\d+\}/);
+      expect(code).not.toContain("_cx(styles)");
+      expect(result[1]).toContain("button: {");
+      expect(result[1]).toContain("card: {");
+      expect(result[1]).toContain('color: "red"');
+      expect(result[1]).toContain('color: "blue"');
+    });
+
+    it("keeps local lexical shadowing ahead of whole namespace css prop resolution", () => {
+      const ownerFile = "/project/src/App.tsx";
+      const stylesFile = "/project/src/styles.ts";
+      const source = `
+        import * as styles from "./styles";
+
+        function App() {
+          const styles = { color: "blue" };
+          return <div css={styles} />;
+        }
+      `;
+      const { result, code } = babelTransform(
+        source,
+        {
+          jsxCssProp: true,
+          staticCssEvalProvider: createImportedStaticCssEvalProvider({
+            modules: [
+              { id: ownerFile, source },
+              {
+                id: stylesFile,
+                source: `export const remote = { color: "red" } as const;`
+              }
+            ],
+            importResolutions: [
+              {
+                importerId: ownerFile,
+                importPath: "./styles",
+                resolvedId: stylesFile
+              }
+            ]
+          })
+        },
+        { filename: ownerFile }
+      );
+
+      expect(code).not.toContain(" css=");
+      expect(code).toMatch(/className=\{_\$mincho\$\$App\d+\}/);
+      expect(code).not.toContain("_cx(styles)");
+      expect(result[1]).toContain('color: "blue"');
+      expect(result[1]).not.toContain('color: "red"');
+    });
+
     it("merges expression className before provider-resolved css rule class", () => {
       const { result, code } = babelTransform(
         `

--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -40,6 +40,13 @@ export function minchoBabelPlugin(): PluginObj<PluginState> {
 }
 
 export { styledComponentPlugin as minchoStyledComponentPlugin } from "./styled.js";
+export {
+  appendUniqueMetadataItems as internalAppendUniqueStaticCssEvalMetadataItems,
+  appendUniqueResolvedModuleIds as internalAppendUniqueStaticCssEvalResolvedModuleIds,
+  createResolutionDependencyMetadataKey as internalCreateStaticCssEvalDependencyMetadataKey,
+  createStaticCssEvalCacheKeyMetadataKey as internalCreateStaticCssEvalCacheKeyMetadataKey,
+  createStaticCssEvalDiagnosticMetadataKey as internalCreateStaticCssEvalDiagnosticMetadataKey
+} from "./jsxCssProp.js";
 export { collectJsxCssPropStaticCssEvalCandidates as internalCollectJsxCssPropStaticCssEvalCandidates } from "./staticCssEval/candidates.js";
 export {
   createImportedStaticCssEvalModuleRecord as internalCreateImportedStaticCssEvalModuleRecord,

--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -2826,6 +2826,8 @@ if (import.meta.vitest) {
 
     it("keeps Babel css prop tag literals mirrored from React tags", () => {
       const babelTags = [...supportedJsxCssPropTags];
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
       const reactTagModules = import.meta.glob("../../react/src/tags.ts", {
         query: "?raw",
         import: "default",

--- a/packages/babel/src/jsxCssProp.ts
+++ b/packages/babel/src/jsxCssProp.ts
@@ -1,12 +1,24 @@
 import { types as t } from "@babel/core";
 import type { NodePath } from "@babel/core";
-import { unwrapTransparentCssRuleExpression } from "./staticCssEval/candidates.js";
+import {
+  createStaticCssEvalCandidate,
+  unwrapTransparentCssRuleExpression
+} from "./staticCssEval/candidates.js";
 import {
   findUnsupportedImportedStaticCssEvalReferenceDiagnostic,
   resolveImportedStaticCssEvalExpression
 } from "./staticCssEval/importedModules.js";
+import type {
+  ResolutionDependency,
+  StaticCssEvalCacheKey,
+  StaticCssEvalDiagnostic
+} from "./staticCssEval/types.js";
 import { resolveSameFileStaticCssEvalExpression } from "./staticCssEval/sameFile.js";
-import type { PluginState, ProgramScope } from "./types.js";
+import type {
+  MinchoStaticCssEvalMetadata,
+  PluginState,
+  ProgramScope
+} from "./types.js";
 import { registerImportMethod } from "./utils.js";
 
 const cssAttributeName = "css";
@@ -52,6 +64,13 @@ type CssPropValueClassification =
   | "unsupported-array-spread"
   | "unsupported-first-level-array-branch"
   | "unsupported-function";
+
+type StaticCssEvalMetadataSource = {
+  dependencies?: readonly (ResolutionDependency | string)[];
+  diagnostics?: readonly StaticCssEvalDiagnostic[];
+  diagnostic?: StaticCssEvalDiagnostic;
+  cacheKey?: StaticCssEvalCacheKey;
+};
 
 export function preprocessJsxCssProp(
   path: NodePath<t.Program>,
@@ -276,6 +295,7 @@ function getResolvedCssExpression(
     programPath,
     scope: path.scope
   });
+  registerStaticCssEvalResultMetadata(state, staticCssEvalResult);
 
   if (staticCssEvalResult.kind === "error") {
     throw path.buildCodeFrameError(staticCssEvalResult.diagnostic.message);
@@ -285,6 +305,12 @@ function getResolvedCssExpression(
     return staticCssEvalResult.expression;
   }
 
+  registerImportedStaticCssEvalProviderResultMetadata({
+    expression: cssExpression,
+    ownerFile,
+    state
+  });
+
   const importedStaticCssEvalResult = resolveImportedStaticCssEvalExpression({
     expression: cssExpression,
     ownerFile,
@@ -293,6 +319,10 @@ function getResolvedCssExpression(
   });
 
   if (importedStaticCssEvalResult.kind === "error") {
+    registerStaticCssEvalDiagnosticMetadata(
+      state,
+      importedStaticCssEvalResult.diagnostic
+    );
     throw path.buildCodeFrameError(
       importedStaticCssEvalResult.diagnostic.message
     );
@@ -311,6 +341,10 @@ function getResolvedCssExpression(
     });
 
   if (unsupportedImportedReferenceDiagnostic) {
+    registerStaticCssEvalDiagnosticMetadata(
+      state,
+      unsupportedImportedReferenceDiagnostic
+    );
     throw path.buildCodeFrameError(
       unsupportedImportedReferenceDiagnostic.message
     );
@@ -321,6 +355,200 @@ function getResolvedCssExpression(
 
 function getStaticCssEvalOwnerFile(state: PluginState): string {
   return state.file.opts.filename ?? "<unknown>";
+}
+
+function registerImportedStaticCssEvalProviderResultMetadata(options: {
+  expression: t.Expression;
+  ownerFile: string;
+  state: PluginState;
+}): void {
+  const { staticCssEvalProvider } = options.state.opts;
+
+  if (!staticCssEvalProvider) {
+    return;
+  }
+
+  const candidate = createStaticCssEvalCandidate(
+    options.expression,
+    options.ownerFile
+  );
+
+  if (!candidate) {
+    return;
+  }
+
+  registerStaticCssEvalResultMetadata(
+    options.state,
+    staticCssEvalProvider.getResolvedCssValue(candidate)
+  );
+}
+
+function registerStaticCssEvalResultMetadata(
+  state: PluginState,
+  result: StaticCssEvalMetadataSource
+): void {
+  const dependencies = (result.dependencies ?? []).filter(
+    isResolutionDependency
+  );
+  const diagnostics =
+    result.diagnostics ?? (result.diagnostic ? [result.diagnostic] : []);
+  const cacheKeys = result.cacheKey ? [result.cacheKey] : [];
+
+  if (
+    dependencies.length === 0 &&
+    diagnostics.length === 0 &&
+    cacheKeys.length === 0
+  ) {
+    return;
+  }
+
+  const metadata = getMinchoStaticCssEvalMetadata(state);
+  appendUniqueMetadataItems(
+    metadata.dependencies,
+    dependencies,
+    createResolutionDependencyMetadataKey
+  );
+  appendUniqueMetadataItems(
+    metadata.diagnostics,
+    diagnostics,
+    createStaticCssEvalDiagnosticMetadataKey
+  );
+  appendUniqueMetadataItems(
+    metadata.cacheKeys,
+    cacheKeys,
+    createStaticCssEvalCacheKeyMetadataKey
+  );
+  appendUniqueResolvedModuleIds(metadata, dependencies, cacheKeys);
+}
+
+function registerStaticCssEvalDiagnosticMetadata(
+  state: PluginState,
+  diagnostic: StaticCssEvalDiagnostic
+): void {
+  registerStaticCssEvalResultMetadata(state, { diagnostics: [diagnostic] });
+}
+
+function getMinchoStaticCssEvalMetadata(
+  state: PluginState
+): MinchoStaticCssEvalMetadata {
+  const metadata = state.file.metadata.minchoStaticCssEval;
+
+  if (metadata) {
+    return metadata;
+  }
+
+  const nextMetadata: MinchoStaticCssEvalMetadata = {
+    dependencies: [],
+    diagnostics: [],
+    cacheKeys: [],
+    resolvedModuleIds: []
+  };
+  state.file.metadata.minchoStaticCssEval = nextMetadata;
+  return nextMetadata;
+}
+
+function isResolutionDependency(
+  dependency: ResolutionDependency | string
+): dependency is ResolutionDependency {
+  return typeof dependency === "object" && dependency !== null;
+}
+
+function appendUniqueMetadataItems<T>(
+  target: T[],
+  items: readonly T[],
+  createKey: (item: T) => string
+): void {
+  const existingKeys = new Set(target.map(createKey));
+
+  for (const item of items) {
+    const key = createKey(item);
+
+    if (existingKeys.has(key)) {
+      continue;
+    }
+
+    existingKeys.add(key);
+    target.push(item);
+  }
+}
+
+function appendUniqueResolvedModuleIds(
+  metadata: MinchoStaticCssEvalMetadata,
+  dependencies: readonly ResolutionDependency[],
+  cacheKeys: readonly StaticCssEvalCacheKey[]
+): void {
+  const moduleIds = [
+    ...cacheKeys.flatMap((cacheKey) => cacheKey.resolvedId ?? []),
+    ...dependencies.flatMap((dependency) =>
+      isResolvedModuleDependency(dependency) ? [dependency.file] : []
+    )
+  ];
+
+  appendUniqueMetadataItems(
+    metadata.resolvedModuleIds,
+    moduleIds,
+    (moduleId) => moduleId
+  );
+}
+
+function isResolvedModuleDependency(dependency: ResolutionDependency): boolean {
+  return (
+    dependency.kind !== "local" &&
+    dependency.kind !== "unresolved" &&
+    dependency.inspected &&
+    dependency.file.length > 0
+  );
+}
+
+function createResolutionDependencyMetadataKey(
+  dependency: ResolutionDependency
+): string {
+  return JSON.stringify([
+    dependency.file,
+    dependency.kind,
+    dependency.importer,
+    dependency.specifier,
+    dependency.exportName,
+    dependency.memberPath,
+    dependency.inspected,
+    dependency.contributed
+  ]);
+}
+
+function createStaticCssEvalDiagnosticMetadataKey(
+  diagnostic: StaticCssEvalDiagnostic
+): string {
+  return JSON.stringify([
+    diagnostic.id,
+    diagnostic.code,
+    diagnostic.reason,
+    diagnostic.message,
+    diagnostic.owner.file,
+    diagnostic.owner.start,
+    diagnostic.owner.end,
+    diagnostic.dependency?.file,
+    diagnostic.importPath,
+    diagnostic.exportName,
+    diagnostic.memberPath,
+    diagnostic.importChain
+  ]);
+}
+
+function createStaticCssEvalCacheKeyMetadataKey(
+  cacheKey: StaticCssEvalCacheKey
+): string {
+  return JSON.stringify([
+    cacheKey.importerFile,
+    cacheKey.resolvedFile,
+    cacheKey.exportName,
+    cacheKey.memberPath,
+    cacheKey.sourceHash,
+    cacheKey.sourceVersion,
+    cacheKey.pluginOptionsVersion,
+    cacheKey.resolverOptionsVersion,
+    cacheKey.staticEvalSupportVersion,
+    cacheKey.resolvedId
+  ]);
 }
 
 function assertSupportedCssPropElement(

--- a/packages/babel/src/jsxCssProp.ts
+++ b/packages/babel/src/jsxCssProp.ts
@@ -453,7 +453,7 @@ function isResolutionDependency(
   return typeof dependency === "object" && dependency !== null;
 }
 
-function appendUniqueMetadataItems<T>(
+export function appendUniqueMetadataItems<T>(
   target: T[],
   items: readonly T[],
   createKey: (item: T) => string
@@ -472,7 +472,7 @@ function appendUniqueMetadataItems<T>(
   }
 }
 
-function appendUniqueResolvedModuleIds(
+export function appendUniqueResolvedModuleIds(
   metadata: MinchoStaticCssEvalMetadata,
   dependencies: readonly ResolutionDependency[],
   cacheKeys: readonly StaticCssEvalCacheKey[]
@@ -500,7 +500,7 @@ function isResolvedModuleDependency(dependency: ResolutionDependency): boolean {
   );
 }
 
-function createResolutionDependencyMetadataKey(
+export function createResolutionDependencyMetadataKey(
   dependency: ResolutionDependency
 ): string {
   return JSON.stringify([
@@ -515,7 +515,7 @@ function createResolutionDependencyMetadataKey(
   ]);
 }
 
-function createStaticCssEvalDiagnosticMetadataKey(
+export function createStaticCssEvalDiagnosticMetadataKey(
   diagnostic: StaticCssEvalDiagnostic
 ): string {
   return JSON.stringify([
@@ -534,7 +534,7 @@ function createStaticCssEvalDiagnosticMetadataKey(
   ]);
 }
 
-function createStaticCssEvalCacheKeyMetadataKey(
+export function createStaticCssEvalCacheKeyMetadataKey(
   cacheKey: StaticCssEvalCacheKey
 ): string {
   return JSON.stringify([

--- a/packages/babel/src/jsxCssProp.ts
+++ b/packages/babel/src/jsxCssProp.ts
@@ -511,7 +511,13 @@ export function createResolutionDependencyMetadataKey(
     dependency.exportName,
     dependency.memberPath,
     dependency.inspected,
-    dependency.contributed
+    dependency.contributed,
+    dependency.sourceKind,
+    dependency.sourceOrigin,
+    dependency.canonicalModuleId,
+    dependency.normalizedPathKey,
+    dependency.watchFiles,
+    dependency.unsupportedReason
   ]);
 }
 
@@ -546,8 +552,17 @@ export function createStaticCssEvalCacheKeyMetadataKey(
     cacheKey.sourceVersion,
     cacheKey.pluginOptionsVersion,
     cacheKey.resolverOptionsVersion,
+    cacheKey.parserVersion,
     cacheKey.staticEvalSupportVersion,
-    cacheKey.resolvedId
+    cacheKey.resolvedId,
+    cacheKey.sourceKind,
+    cacheKey.sourceOrigin,
+    cacheKey.canonicalModuleId,
+    cacheKey.normalizedPathKey,
+    cacheKey.watchFiles,
+    cacheKey.unsupportedReason,
+    cacheKey.parserOptions,
+    cacheKey.projectLocalBoundary
   ]);
 }
 

--- a/packages/babel/src/staticCssEval/ast.ts
+++ b/packages/babel/src/staticCssEval/ast.ts
@@ -61,6 +61,13 @@ export function getStaticMemberPropertyName(
 export function getUnsupportedLiteralReason(
   expression: t.Expression
 ): StaticCssEvalUnsupportedReason {
+  if (
+    expression.type === "ImportExpression" ||
+    (t.isCallExpression(expression) && t.isImport(expression.callee))
+  ) {
+    return "dynamic-import";
+  }
+
   if (t.isIdentifier(expression)) {
     return "identifier-object-value";
   }

--- a/packages/babel/src/staticCssEval/boundary.ts
+++ b/packages/babel/src/staticCssEval/boundary.ts
@@ -226,7 +226,13 @@ function trimStaticCssEvalTrailingSlash(filePath: string): string {
   return filePath.length > 1 ? filePath.replace(/\/+$/g, "") : filePath;
 }
 
+// == Tests ====================================================================
+// Ignore errors when compiling to CommonJS.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
 if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
   const { describe, expect, it } = import.meta.vitest;
 
   const owner = { file: "/project/src/App.tsx", start: 11, end: 18 };

--- a/packages/babel/src/staticCssEval/boundary.ts
+++ b/packages/babel/src/staticCssEval/boundary.ts
@@ -1,11 +1,14 @@
 import {
   createStaticCssEvalDiagnostic,
+  createStaticCssEvalProviderSourceUnsupportedDiagnostic,
   type StaticCssEvalDiagnosticContext
 } from "./diagnostics.js";
 import type {
   StaticCssEvalDependencyKind,
   StaticCssEvalDependencyMetadata,
   StaticCssEvalProjectLocalBoundaryState,
+  StaticCssEvalSourceKind,
+  StaticCssEvalSourceOrigin,
   StaticCssEvalUnsupportedReason
 } from "./types.js";
 
@@ -42,6 +45,160 @@ export interface CreateStaticCssEvalDependencyMetadataOptions extends StaticCssE
   importPath?: string;
   sourceHash?: string;
   version?: string | number;
+}
+
+export interface StaticCssEvalProviderSourcePolicyDescriptor {
+  readonly sourceKind?: StaticCssEvalSourceKind;
+  readonly sourceOrigin?: StaticCssEvalSourceOrigin;
+  readonly canonicalModuleId?: string;
+  readonly normalizedPathKey?: string;
+  readonly watchFiles?: readonly string[];
+  readonly unsupportedReason?: StaticCssEvalUnsupportedReason;
+}
+
+export interface StaticCssEvalProviderSourcePolicyCheckOptions
+  extends
+    StaticCssEvalProviderSourcePolicyDescriptor,
+    StaticCssEvalDiagnosticContext {
+  readonly sourceId: string;
+}
+
+export interface StaticCssEvalProviderSourceMetadata {
+  readonly sourceKind: StaticCssEvalSourceKind;
+  readonly sourceOrigin: StaticCssEvalSourceOrigin;
+  readonly canonicalModuleId?: string;
+  readonly normalizedPathKey?: string;
+  readonly watchFiles?: readonly string[];
+  readonly unsupportedReason?: StaticCssEvalUnsupportedReason;
+}
+
+export type StaticCssEvalProviderSourcePolicyResult =
+  | {
+      ok: true;
+      sourceMetadata: StaticCssEvalProviderSourceMetadata;
+    }
+  | {
+      ok: false;
+      sourceMetadata: StaticCssEvalProviderSourceMetadata;
+      diagnostic: ReturnType<typeof createStaticCssEvalDiagnostic>;
+    };
+
+export function createStaticCssEvalProviderSourceMetadata(
+  descriptor: StaticCssEvalProviderSourcePolicyDescriptor
+): StaticCssEvalProviderSourceMetadata {
+  const sourceKind = descriptor.sourceKind ?? "project-source";
+  const sourceOrigin =
+    descriptor.sourceOrigin ?? getStaticCssEvalSourceOrigin(sourceKind);
+
+  return {
+    sourceKind,
+    sourceOrigin,
+    ...(descriptor.canonicalModuleId !== undefined
+      ? { canonicalModuleId: descriptor.canonicalModuleId }
+      : {}),
+    ...(descriptor.normalizedPathKey !== undefined
+      ? { normalizedPathKey: descriptor.normalizedPathKey }
+      : {}),
+    ...(descriptor.watchFiles !== undefined
+      ? { watchFiles: [...descriptor.watchFiles] }
+      : {}),
+    ...(descriptor.unsupportedReason !== undefined
+      ? { unsupportedReason: descriptor.unsupportedReason }
+      : {})
+  };
+}
+
+export function enforceStaticCssEvalProviderSourcePolicy(
+  options: StaticCssEvalProviderSourcePolicyCheckOptions
+): StaticCssEvalProviderSourcePolicyResult {
+  const sourceMetadata = createStaticCssEvalProviderSourceMetadata(options);
+
+  if (
+    sourceMetadata.unsupportedReason === undefined &&
+    isStaticCssEvalProviderSourceKindAllowed(sourceMetadata.sourceKind)
+  ) {
+    return { ok: true, sourceMetadata };
+  }
+
+  return {
+    ok: false,
+    sourceMetadata,
+    diagnostic: createStaticCssEvalProviderSourceUnsupportedDiagnostic({
+      sourceId: options.sourceId,
+      sourceKind: sourceMetadata.sourceKind,
+      sourceOrigin: sourceMetadata.sourceOrigin,
+      reason:
+        sourceMetadata.unsupportedReason ??
+        getStaticCssEvalUnsupportedSourceKindReason(sourceMetadata.sourceKind),
+      owner: options.owner,
+      dependency: options.dependency ?? { file: options.sourceId },
+      importPath: options.importPath,
+      exportName: options.exportName,
+      memberPath: options.memberPath,
+      importChain: options.importChain
+    })
+  };
+}
+
+export function isStaticCssEvalProviderSourceKindAllowed(
+  sourceKind: StaticCssEvalSourceKind
+): boolean {
+  switch (sourceKind) {
+    case "project-source":
+    case "package-source":
+    case "provider-virtual":
+    case "static-data":
+      return true;
+    case "external-no-source":
+    case "unresolved":
+    case "unsupported-source-shape":
+      return false;
+    default:
+      return assertNever(sourceKind);
+  }
+}
+
+export function getStaticCssEvalSourceOrigin(
+  sourceKind: StaticCssEvalSourceKind
+): StaticCssEvalSourceOrigin {
+  switch (sourceKind) {
+    case "project-source":
+      return "project";
+    case "package-source":
+      return "package";
+    case "provider-virtual":
+      return "provider";
+    case "static-data":
+      return "data";
+    case "external-no-source":
+      return "external";
+    case "unresolved":
+      return "unresolved";
+    case "unsupported-source-shape":
+      return "unsupported";
+    default:
+      return assertNever(sourceKind);
+  }
+}
+
+function getStaticCssEvalUnsupportedSourceKindReason(
+  sourceKind: StaticCssEvalSourceKind
+): StaticCssEvalUnsupportedReason {
+  switch (sourceKind) {
+    case "external-no-source":
+      return "external-no-source";
+    case "unresolved":
+      return "unresolved";
+    case "unsupported-source-shape":
+      return "unsupported-source-shape";
+    case "project-source":
+    case "package-source":
+    case "provider-virtual":
+    case "static-data":
+      return "failed-project-local-dependency";
+    default:
+      return assertNever(sourceKind);
+  }
 }
 
 export function createStaticCssEvalProjectLocalBoundaryState(
@@ -226,6 +383,12 @@ function trimStaticCssEvalTrailingSlash(filePath: string): string {
   return filePath.length > 1 ? filePath.replace(/\/+$/g, "") : filePath;
 }
 
+function assertNever(value: never): never {
+  throw new TypeError(
+    `Unexpected static css eval provider source kind: ${value}`
+  );
+}
+
 // == Tests ====================================================================
 // Ignore errors when compiling to CommonJS.
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -236,6 +399,25 @@ if (import.meta.vitest) {
   const { describe, expect, it } = import.meta.vitest;
 
   const owner = { file: "/project/src/App.tsx", start: 11, end: 18 };
+
+  describe("static css eval provider source policy", () => {
+    it("rejects explicit unsupported reasons on otherwise allowed source kinds", () => {
+      expect(
+        enforceStaticCssEvalProviderSourcePolicy({
+          sourceId: "pkg:@scope/styles",
+          sourceKind: "package-source",
+          unsupportedReason: "unsupported-source-shape",
+          owner
+        })
+      ).toMatchObject({
+        ok: false,
+        diagnostic: {
+          reason: "unsupported-source-shape",
+          dependency: { file: "pkg:@scope/styles" }
+        }
+      });
+    });
+  });
 
   describe("static css eval project-local boundary", () => {
     it("accepts real files inside the project root", () => {

--- a/packages/babel/src/staticCssEval/candidates.ts
+++ b/packages/babel/src/staticCssEval/candidates.ts
@@ -271,7 +271,13 @@ function getStaticMemberPropertyName(
   return null;
 }
 
+// == Tests ====================================================================
+// Ignore errors when compiling to CommonJS.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
 if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
   const { describe, expect, it } = import.meta.vitest;
 
   const importerId = "/project/src/App.tsx";

--- a/packages/babel/src/staticCssEval/cycles.ts
+++ b/packages/babel/src/staticCssEval/cycles.ts
@@ -147,7 +147,13 @@ function getStaticCssEvalCycleDependencies(
   return [...dependencies];
 }
 
+// == Tests ====================================================================
+// Ignore errors when compiling to CommonJS.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
 if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
   const { describe, expect, it } = import.meta.vitest;
 
   const owner = { file: "/project/src/App.tsx", start: 10, end: 30 };

--- a/packages/babel/src/staticCssEval/diagnostics.ts
+++ b/packages/babel/src/staticCssEval/diagnostics.ts
@@ -1,6 +1,7 @@
 import type {
   StaticCssEvalDiagnostic,
   StaticCssEvalDiagnosticCode,
+  StaticCssEvalDiagnosticId,
   StaticCssEvalExportName,
   StaticCssEvalSourceLocation,
   StaticCssEvalUnsupportedReason
@@ -8,6 +9,8 @@ import type {
 
 export const STATIC_CSS_EVAL_DIAGNOSTIC_MESSAGE_PREFIX =
   "Cannot statically evaluate css prop value";
+
+export const STATIC_CSS_EVAL_RESOLUTION_DEPTH_LIMIT = 32;
 
 export interface StaticCssEvalDiagnosticContext {
   owner: StaticCssEvalSourceLocation;
@@ -19,9 +22,26 @@ export interface StaticCssEvalDiagnosticContext {
 }
 
 export interface CreateStaticCssEvalDiagnosticOptions extends StaticCssEvalDiagnosticContext {
+  id?: StaticCssEvalDiagnosticId;
   code: StaticCssEvalDiagnosticCode;
   reason: StaticCssEvalUnsupportedReason;
   detail: string;
+}
+
+export interface StaticCssEvalImportCycleKey {
+  file: string;
+  exportName: StaticCssEvalExportName;
+  memberPath?: readonly string[];
+}
+
+export interface StaticCssEvalImportCycleGuardOptions extends StaticCssEvalDiagnosticContext {
+  stack: readonly StaticCssEvalImportCycleKey[];
+  next: StaticCssEvalImportCycleKey;
+}
+
+export interface StaticCssEvalResolutionDepthGuardOptions extends StaticCssEvalDiagnosticContext {
+  resolutionDepth: number;
+  maxResolutionDepth?: number;
 }
 
 export type StaticCssEvalGuardResult =
@@ -36,6 +56,7 @@ export function createStaticCssEvalDiagnostic(
   options: CreateStaticCssEvalDiagnosticOptions
 ): StaticCssEvalDiagnostic {
   const diagnostic: StaticCssEvalDiagnostic = {
+    ...(options.id !== undefined ? { id: options.id } : {}),
     code: options.code,
     message: formatStaticCssEvalDiagnosticMessage(options.detail),
     reason: options.reason,
@@ -65,6 +86,336 @@ export function createStaticCssEvalDiagnostic(
   return diagnostic;
 }
 
+export function createStaticCssEvalDynamicExpressionUnsupportedDiagnostic(
+  context: StaticCssEvalDiagnosticContext,
+  expressionType: string
+): StaticCssEvalDiagnostic {
+  return createStaticCssEvalDiagnostic({
+    id: "STATIC_CSS_EVAL_DYNAMIC_EXPRESSION_UNSUPPORTED",
+    code: "unsupported-source",
+    reason: "runtime-dynamic-value",
+    detail: `dynamic expression is unsupported: ${expressionType}`,
+    owner: context.owner,
+    dependency: context.dependency,
+    importPath: context.importPath,
+    exportName: context.exportName,
+    memberPath: context.memberPath,
+    importChain: context.importChain
+  });
+}
+
+export function createStaticCssEvalMutableBindingDiagnostic(
+  context: StaticCssEvalDiagnosticContext,
+  bindingName: string
+): StaticCssEvalDiagnostic {
+  return createStaticCssEvalDiagnostic({
+    id: "STATIC_CSS_EVAL_MUTABLE_BINDING",
+    code: "unsupported-source",
+    reason: "let-or-var-binding",
+    detail: `binding "${bindingName}" is mutable`,
+    owner: context.owner,
+    dependency: context.dependency,
+    importPath: context.importPath,
+    exportName: context.exportName,
+    memberPath: context.memberPath,
+    importChain: context.importChain
+  });
+}
+
+export function createStaticCssEvalMutatedBindingDiagnostic(
+  context: StaticCssEvalDiagnosticContext,
+  bindingName: string
+): StaticCssEvalDiagnostic {
+  return createStaticCssEvalDiagnostic({
+    id: "STATIC_CSS_EVAL_MUTATED_BINDING",
+    code: "unsupported-source",
+    reason: "mutated-binding",
+    detail: `binding "${bindingName}" is mutated`,
+    owner: context.owner,
+    dependency: context.dependency,
+    importPath: context.importPath,
+    exportName: context.exportName,
+    memberPath: context.memberPath,
+    importChain: context.importChain
+  });
+}
+
+export function createStaticCssEvalObjectSpreadUnsupportedDiagnostic(
+  context: StaticCssEvalDiagnosticContext,
+  bindingName: string,
+  collection: "object" | "array" = "object"
+): StaticCssEvalDiagnostic {
+  return createStaticCssEvalDiagnostic({
+    id: "STATIC_CSS_EVAL_OBJECT_SPREAD_UNSUPPORTED",
+    code: "unsupported-syntax",
+    reason: "object-or-array-spread",
+    detail: `same-file binding "${bindingName}" contains an ${collection} spread`,
+    owner: context.owner,
+    dependency: context.dependency,
+    importPath: context.importPath,
+    exportName: context.exportName,
+    memberPath: context.memberPath,
+    importChain: context.importChain
+  });
+}
+
+export function createStaticCssEvalComputedMemberUnsupportedDiagnostic(
+  context: StaticCssEvalDiagnosticContext
+): StaticCssEvalDiagnostic {
+  return createStaticCssEvalDiagnostic({
+    id: "STATIC_CSS_EVAL_COMPUTED_MEMBER_UNSUPPORTED",
+    code: "unsupported-source",
+    reason: "dynamic-member-path",
+    detail: "computed member access is unsupported",
+    owner: context.owner,
+    dependency: context.dependency,
+    importPath: context.importPath,
+    exportName: context.exportName,
+    memberPath: context.memberPath,
+    importChain: context.importChain
+  });
+}
+
+export function createStaticCssEvalPackageImportUnsupportedDiagnostic(
+  context: StaticCssEvalDiagnosticContext,
+  importPath: string
+): StaticCssEvalDiagnostic {
+  return createStaticCssEvalDiagnostic({
+    id: "STATIC_CSS_EVAL_PACKAGE_IMPORT_UNSUPPORTED",
+    code: "unsupported-source",
+    reason: "node-modules-import",
+    detail: `package import "${importPath}" is unsupported`,
+    owner: context.owner,
+    dependency: context.dependency,
+    importPath,
+    exportName: context.exportName,
+    memberPath: context.memberPath,
+    importChain: context.importChain
+  });
+}
+
+export function createStaticCssEvalCjsUnsupportedDiagnostic(
+  context: StaticCssEvalDiagnosticContext
+): StaticCssEvalDiagnostic {
+  return createStaticCssEvalDiagnostic({
+    id: "STATIC_CSS_EVAL_CJS_UNSUPPORTED",
+    code: "unsupported-source",
+    reason: "commonjs-require",
+    detail: "commonjs require is unsupported",
+    owner: context.owner,
+    dependency: context.dependency,
+    importPath: context.importPath,
+    exportName: context.exportName,
+    memberPath: context.memberPath,
+    importChain: context.importChain
+  });
+}
+
+export function createStaticCssEvalExportStarUnsupportedDiagnostic(
+  context: StaticCssEvalDiagnosticContext,
+  importPath: string
+): StaticCssEvalDiagnostic {
+  return createStaticCssEvalDiagnostic({
+    id: "STATIC_CSS_EVAL_EXPORT_STAR_UNSUPPORTED",
+    code: "unsupported-source",
+    reason: "reexport-or-barrel",
+    detail: `export * from "${importPath}" is unsupported`,
+    owner: context.owner,
+    dependency: context.dependency,
+    importPath,
+    exportName: context.exportName,
+    memberPath: context.memberPath,
+    importChain: context.importChain
+  });
+}
+
+export function createStaticCssEvalNamespaceImportUnsupportedDiagnostic(
+  context: StaticCssEvalDiagnosticContext,
+  importPath: string
+): StaticCssEvalDiagnostic {
+  return createStaticCssEvalDiagnostic({
+    id: "STATIC_CSS_EVAL_NAMESPACE_UNSUPPORTED",
+    code: "unsupported-source",
+    reason: "namespace-import",
+    detail: `namespace import "${importPath}" is unsupported`,
+    owner: context.owner,
+    dependency: context.dependency,
+    importPath,
+    exportName: context.exportName,
+    memberPath: context.memberPath,
+    importChain: context.importChain
+  });
+}
+
+export function createStaticCssEvalNamespaceMemberUnsupportedDiagnostic(
+  context: StaticCssEvalDiagnosticContext,
+  memberPath: readonly string[]
+): StaticCssEvalDiagnostic {
+  return createStaticCssEvalDiagnostic({
+    id: "STATIC_CSS_EVAL_NAMESPACE_UNSUPPORTED",
+    code: "unsupported-source",
+    reason: "dynamic-member-path",
+    detail: `namespace member access ${memberPath.join(".")} is unsupported`,
+    owner: context.owner,
+    dependency: context.dependency,
+    importPath: context.importPath,
+    exportName: context.exportName,
+    memberPath,
+    importChain: context.importChain
+  });
+}
+
+export function createStaticCssEvalUnresolvedImportDiagnostic(
+  context: StaticCssEvalDiagnosticContext,
+  importPath: string,
+  failureDetail?: string
+): StaticCssEvalDiagnostic {
+  return createStaticCssEvalDiagnostic({
+    id: "STATIC_CSS_EVAL_UNRESOLVED_IMPORT",
+    code: "unsupported-source",
+    reason: "failed-project-local-dependency",
+    detail: `import "${importPath}" could not be resolved${
+      failureDetail ? `: ${failureDetail}` : ""
+    }`,
+    owner: context.owner,
+    dependency: context.dependency,
+    importPath,
+    exportName: context.exportName,
+    memberPath: context.memberPath,
+    importChain: context.importChain
+  });
+}
+
+export function createStaticCssEvalUnresolvedExportDiagnostic(
+  context: StaticCssEvalDiagnosticContext,
+  exportName: StaticCssEvalExportName
+): StaticCssEvalDiagnostic {
+  return createStaticCssEvalDiagnostic({
+    id: "STATIC_CSS_EVAL_UNRESOLVED_EXPORT",
+    code: "unsupported-source",
+    reason: "reexport-or-barrel",
+    detail: `export "${exportName ?? "<local>"}" could not be resolved`,
+    owner: context.owner,
+    dependency: context.dependency,
+    importPath: context.importPath,
+    exportName,
+    memberPath: context.memberPath,
+    importChain: context.importChain
+  });
+}
+
+export function createStaticCssEvalImportCycleKey(
+  input: StaticCssEvalImportCycleKey
+): string {
+  return JSON.stringify([
+    input.file,
+    input.exportName,
+    [...(input.memberPath ?? [])]
+  ]);
+}
+
+export function guardStaticCssEvalImportCycle(
+  options: StaticCssEvalImportCycleGuardOptions
+): StaticCssEvalGuardResult {
+  const nextKey = createStaticCssEvalImportCycleKey(options.next);
+  const cycleStartIndex = options.stack.findIndex((entry) => {
+    return createStaticCssEvalImportCycleKey(entry) === nextKey;
+  });
+
+  if (cycleStartIndex === -1) {
+    return { ok: true };
+  }
+
+  const cycle = [...options.stack.slice(cycleStartIndex), options.next];
+  const importChain = cycle.map(formatStaticCssEvalImportCycleFrame);
+  const diagnostic = createStaticCssEvalImportCycleDiagnostic({
+    owner: options.owner,
+    dependency: { file: options.next.file },
+    importPath: options.importPath,
+    exportName: options.next.exportName,
+    memberPath: options.next.memberPath,
+    importChain
+  });
+
+  return {
+    ok: false,
+    diagnostic,
+    dependencies: getStaticCssEvalImportCycleDependencies(
+      cycle,
+      options.owner.file
+    )
+  };
+}
+
+export function createStaticCssEvalImportCycleDiagnostic(
+  context: StaticCssEvalDiagnosticContext & {
+    importChain: readonly string[];
+  }
+): StaticCssEvalDiagnostic {
+  return createStaticCssEvalDiagnostic({
+    id: "STATIC_CSS_EVAL_IMPORT_CYCLE",
+    code: "cycle-detected",
+    reason: "runtime-dynamic-value",
+    detail: `cyclic static css reference detected: ${context.importChain.join(
+      " -> "
+    )}`,
+    owner: context.owner,
+    dependency: context.dependency,
+    importPath: context.importPath,
+    exportName: context.exportName,
+    memberPath: context.memberPath,
+    importChain: context.importChain
+  });
+}
+
+export function guardStaticCssEvalResolutionDepth(
+  options: StaticCssEvalResolutionDepthGuardOptions
+): StaticCssEvalGuardResult {
+  const limit =
+    options.maxResolutionDepth ?? STATIC_CSS_EVAL_RESOLUTION_DEPTH_LIMIT;
+
+  if (options.resolutionDepth <= limit) {
+    return { ok: true };
+  }
+
+  const diagnostic = createStaticCssEvalResolutionDepthExceededDiagnostic({
+    owner: options.owner,
+    dependency: options.dependency,
+    importPath: options.importPath,
+    exportName: options.exportName,
+    memberPath: options.memberPath,
+    resolutionDepth: options.resolutionDepth,
+    maxResolutionDepth: limit
+  });
+
+  return {
+    ok: false,
+    diagnostic,
+    dependencies: getStaticCssEvalDiagnosticDependencies(diagnostic).filter(
+      (file) => file !== options.owner.file
+    )
+  };
+}
+
+export function createStaticCssEvalResolutionDepthExceededDiagnostic(
+  options: StaticCssEvalResolutionDepthGuardOptions
+): StaticCssEvalDiagnostic {
+  const limit =
+    options.maxResolutionDepth ?? STATIC_CSS_EVAL_RESOLUTION_DEPTH_LIMIT;
+
+  return createStaticCssEvalDiagnostic({
+    id: "STATIC_CSS_EVAL_RESOLUTION_DEPTH_EXCEEDED",
+    code: "limit-exceeded",
+    reason: "failed-project-local-dependency",
+    detail: `resolution depth exceeded (${options.resolutionDepth} steps > ${limit} steps)`,
+    owner: options.owner,
+    dependency: options.dependency,
+    importPath: options.importPath,
+    exportName: options.exportName,
+    memberPath: options.memberPath
+  });
+}
+
 export function formatStaticCssEvalDiagnosticMessage(detail: string): string {
   return `${STATIC_CSS_EVAL_DIAGNOSTIC_MESSAGE_PREFIX}: ${detail}`;
 }
@@ -85,6 +436,32 @@ function cloneSourceLocation(
   location: StaticCssEvalSourceLocation
 ): StaticCssEvalSourceLocation {
   return { ...location };
+}
+
+function formatStaticCssEvalImportCycleFrame(
+  frame: StaticCssEvalImportCycleKey
+): string {
+  const exportName = frame.exportName === null ? "<local>" : frame.exportName;
+  const memberPath = frame.memberPath?.length
+    ? `.${frame.memberPath.join(".")}`
+    : "";
+
+  return `${frame.file}#${exportName}${memberPath}`;
+}
+
+function getStaticCssEvalImportCycleDependencies(
+  cycle: readonly StaticCssEvalImportCycleKey[],
+  ownerFile: string
+): string[] {
+  const dependencies = new Set<string>();
+
+  for (const frame of cycle) {
+    if (frame.file !== ownerFile) {
+      dependencies.add(frame.file);
+    }
+  }
+
+  return [...dependencies];
 }
 
 if (import.meta.vitest) {
@@ -122,6 +499,283 @@ if (import.meta.vitest) {
       expect(getStaticCssEvalDiagnosticDependencies(diagnostic)).toEqual([
         "/outside/style.ts"
       ]);
+    });
+
+    it("builds stable diagnostics for unsupported source cases", () => {
+      const owner = { file: "/project/src/App.tsx", start: 1, end: 2 };
+      const dependency = { file: "/project/src/styles.ts" };
+
+      expect(
+        createStaticCssEvalDynamicExpressionUnsupportedDiagnostic(
+          { owner },
+          "CallExpression"
+        )
+      ).toEqual({
+        id: "STATIC_CSS_EVAL_DYNAMIC_EXPRESSION_UNSUPPORTED",
+        code: "unsupported-source",
+        message:
+          "Cannot statically evaluate css prop value: dynamic expression is unsupported: CallExpression",
+        reason: "runtime-dynamic-value",
+        owner
+      });
+
+      expect(
+        createStaticCssEvalMutableBindingDiagnostic({ owner }, "style")
+      ).toEqual({
+        id: "STATIC_CSS_EVAL_MUTABLE_BINDING",
+        code: "unsupported-source",
+        message:
+          'Cannot statically evaluate css prop value: binding "style" is mutable',
+        reason: "let-or-var-binding",
+        owner
+      });
+
+      expect(
+        createStaticCssEvalMutatedBindingDiagnostic({ owner }, "style")
+      ).toEqual({
+        id: "STATIC_CSS_EVAL_MUTATED_BINDING",
+        code: "unsupported-source",
+        message:
+          'Cannot statically evaluate css prop value: binding "style" is mutated',
+        reason: "mutated-binding",
+        owner
+      });
+
+      expect(
+        createStaticCssEvalObjectSpreadUnsupportedDiagnostic({ owner }, "style")
+      ).toEqual({
+        id: "STATIC_CSS_EVAL_OBJECT_SPREAD_UNSUPPORTED",
+        code: "unsupported-syntax",
+        message:
+          'Cannot statically evaluate css prop value: same-file binding "style" contains an object spread',
+        reason: "object-or-array-spread",
+        owner
+      });
+
+      expect(
+        createStaticCssEvalComputedMemberUnsupportedDiagnostic({ owner })
+      ).toEqual({
+        id: "STATIC_CSS_EVAL_COMPUTED_MEMBER_UNSUPPORTED",
+        code: "unsupported-source",
+        message:
+          "Cannot statically evaluate css prop value: computed member access is unsupported",
+        reason: "dynamic-member-path",
+        owner
+      });
+
+      expect(
+        createStaticCssEvalPackageImportUnsupportedDiagnostic(
+          { owner },
+          "pkg/styles"
+        )
+      ).toEqual({
+        id: "STATIC_CSS_EVAL_PACKAGE_IMPORT_UNSUPPORTED",
+        code: "unsupported-source",
+        message:
+          'Cannot statically evaluate css prop value: package import "pkg/styles" is unsupported',
+        reason: "node-modules-import",
+        owner,
+        importPath: "pkg/styles"
+      });
+
+      expect(createStaticCssEvalCjsUnsupportedDiagnostic({ owner })).toEqual({
+        id: "STATIC_CSS_EVAL_CJS_UNSUPPORTED",
+        code: "unsupported-source",
+        message:
+          "Cannot statically evaluate css prop value: commonjs require is unsupported",
+        reason: "commonjs-require",
+        owner
+      });
+
+      expect(
+        createStaticCssEvalExportStarUnsupportedDiagnostic(
+          { owner, dependency },
+          "./barrel"
+        )
+      ).toEqual({
+        id: "STATIC_CSS_EVAL_EXPORT_STAR_UNSUPPORTED",
+        code: "unsupported-source",
+        message:
+          'Cannot statically evaluate css prop value: export * from "./barrel" is unsupported',
+        reason: "reexport-or-barrel",
+        owner,
+        dependency,
+        importPath: "./barrel"
+      });
+
+      expect(
+        createStaticCssEvalNamespaceImportUnsupportedDiagnostic(
+          { owner },
+          "./styles"
+        )
+      ).toEqual({
+        id: "STATIC_CSS_EVAL_NAMESPACE_UNSUPPORTED",
+        code: "unsupported-source",
+        message:
+          'Cannot statically evaluate css prop value: namespace import "./styles" is unsupported',
+        reason: "namespace-import",
+        owner,
+        importPath: "./styles"
+      });
+
+      expect(
+        createStaticCssEvalNamespaceMemberUnsupportedDiagnostic({ owner }, [
+          "styles",
+          "button"
+        ])
+      ).toEqual({
+        id: "STATIC_CSS_EVAL_NAMESPACE_UNSUPPORTED",
+        code: "unsupported-source",
+        message:
+          "Cannot statically evaluate css prop value: namespace member access styles.button is unsupported",
+        reason: "dynamic-member-path",
+        owner,
+        memberPath: ["styles", "button"]
+      });
+
+      expect(
+        createStaticCssEvalUnresolvedImportDiagnostic(
+          { owner, dependency },
+          "./missing"
+        )
+      ).toEqual({
+        id: "STATIC_CSS_EVAL_UNRESOLVED_IMPORT",
+        code: "unsupported-source",
+        message:
+          'Cannot statically evaluate css prop value: import "./missing" could not be resolved',
+        reason: "failed-project-local-dependency",
+        owner,
+        dependency,
+        importPath: "./missing"
+      });
+
+      expect(
+        createStaticCssEvalUnresolvedExportDiagnostic(
+          { owner, dependency },
+          "button"
+        )
+      ).toEqual({
+        id: "STATIC_CSS_EVAL_UNRESOLVED_EXPORT",
+        code: "unsupported-source",
+        message:
+          'Cannot statically evaluate css prop value: export "button" could not be resolved',
+        reason: "reexport-or-barrel",
+        owner,
+        dependency,
+        exportName: "button"
+      });
+    });
+
+    it("guards repeated import chain keys and depth overflow deterministically", () => {
+      const owner = { file: "/project/src/App.tsx", start: 10, end: 20 };
+      const stack = [
+        {
+          file: "/project/src/a.ts",
+          exportName: "styles",
+          memberPath: ["button"]
+        },
+        {
+          file: "/project/src/b.ts",
+          exportName: "styles",
+          memberPath: ["button"]
+        }
+      ] as const;
+
+      expect(
+        createStaticCssEvalImportCycleKey({
+          file: "/project/src/a.ts",
+          exportName: "styles",
+          memberPath: ["button"]
+        })
+      ).toBe(
+        createStaticCssEvalImportCycleKey({
+          file: "/project/src/a.ts",
+          exportName: "styles",
+          memberPath: ["button"]
+        })
+      );
+
+      const cycleResult = guardStaticCssEvalImportCycle({
+        owner,
+        stack,
+        next: {
+          file: "/project/src/a.ts",
+          exportName: "styles",
+          memberPath: ["button"]
+        }
+      });
+
+      expect(cycleResult.ok).toBe(false);
+      if (!cycleResult.ok) {
+        expect(cycleResult.diagnostic).toEqual({
+          id: "STATIC_CSS_EVAL_IMPORT_CYCLE",
+          code: "cycle-detected",
+          message:
+            "Cannot statically evaluate css prop value: cyclic static css reference detected: /project/src/a.ts#styles.button -> /project/src/b.ts#styles.button -> /project/src/a.ts#styles.button",
+          reason: "runtime-dynamic-value",
+          owner,
+          dependency: { file: "/project/src/a.ts" },
+          exportName: "styles",
+          memberPath: ["button"],
+          importChain: [
+            "/project/src/a.ts#styles.button",
+            "/project/src/b.ts#styles.button",
+            "/project/src/a.ts#styles.button"
+          ]
+        });
+        expect(cycleResult.dependencies).toEqual([
+          "/project/src/a.ts",
+          "/project/src/b.ts"
+        ]);
+      }
+
+      expect(
+        guardStaticCssEvalResolutionDepth({
+          owner,
+          dependency: { file: "/project/src/styles.ts" },
+          importPath: "./styles",
+          exportName: "styles",
+          memberPath: ["button"],
+          resolutionDepth: STATIC_CSS_EVAL_RESOLUTION_DEPTH_LIMIT
+        })
+      ).toEqual({ ok: true });
+
+      const depthResult = guardStaticCssEvalResolutionDepth({
+        owner,
+        dependency: { file: "/project/src/styles.ts" },
+        importPath: "./styles",
+        exportName: "styles",
+        memberPath: ["button"],
+        resolutionDepth: STATIC_CSS_EVAL_RESOLUTION_DEPTH_LIMIT + 1
+      });
+
+      expect(depthResult).toEqual({
+        ok: false,
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_RESOLUTION_DEPTH_EXCEEDED",
+          code: "limit-exceeded",
+          message:
+            "Cannot statically evaluate css prop value: resolution depth exceeded (33 steps > 32 steps)",
+          reason: "failed-project-local-dependency",
+          owner,
+          dependency: { file: "/project/src/styles.ts" },
+          importPath: "./styles",
+          exportName: "styles",
+          memberPath: ["button"]
+        },
+        dependencies: ["/project/src/styles.ts"]
+      });
+
+      expect(
+        guardStaticCssEvalResolutionDepth({
+          owner,
+          dependency: { file: owner.file },
+          importPath: "./owner",
+          exportName: "styles",
+          memberPath: ["button"],
+          resolutionDepth: STATIC_CSS_EVAL_RESOLUTION_DEPTH_LIMIT + 1
+        })
+      ).toMatchObject({ ok: false, dependencies: [] });
     });
   });
 }

--- a/packages/babel/src/staticCssEval/diagnostics.ts
+++ b/packages/babel/src/staticCssEval/diagnostics.ts
@@ -464,7 +464,13 @@ function getStaticCssEvalImportCycleDependencies(
   return [...dependencies];
 }
 
+// == Tests ====================================================================
+// Ignore errors when compiling to CommonJS.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
 if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
   const { describe, expect, it } = import.meta.vitest;
 
   describe("static css eval diagnostics", () => {

--- a/packages/babel/src/staticCssEval/diagnostics.ts
+++ b/packages/babel/src/staticCssEval/diagnostics.ts
@@ -3,7 +3,9 @@ import type {
   StaticCssEvalDiagnosticCode,
   StaticCssEvalDiagnosticId,
   StaticCssEvalExportName,
+  StaticCssEvalSourceKind,
   StaticCssEvalSourceLocation,
+  StaticCssEvalSourceOrigin,
   StaticCssEvalUnsupportedReason
 } from "./types.js";
 
@@ -42,6 +44,17 @@ export interface StaticCssEvalImportCycleGuardOptions extends StaticCssEvalDiagn
 export interface StaticCssEvalResolutionDepthGuardOptions extends StaticCssEvalDiagnosticContext {
   resolutionDepth: number;
   maxResolutionDepth?: number;
+}
+
+export interface StaticCssEvalProviderSourceUnsupportedOptions extends StaticCssEvalDiagnosticContext {
+  sourceId: string;
+  sourceKind: StaticCssEvalSourceKind;
+  sourceOrigin: StaticCssEvalSourceOrigin;
+  reason: StaticCssEvalUnsupportedReason;
+}
+
+export interface StaticCssEvalPartialNamespaceFailureOptions extends StaticCssEvalDiagnosticContext {
+  failedReason: StaticCssEvalUnsupportedReason;
 }
 
 export type StaticCssEvalGuardResult =
@@ -176,19 +189,36 @@ export function createStaticCssEvalComputedMemberUnsupportedDiagnostic(
   });
 }
 
-export function createStaticCssEvalPackageImportUnsupportedDiagnostic(
-  context: StaticCssEvalDiagnosticContext,
-  importPath: string
+export function createStaticCssEvalProviderSourceUnsupportedDiagnostic(
+  options: StaticCssEvalProviderSourceUnsupportedOptions
 ): StaticCssEvalDiagnostic {
   return createStaticCssEvalDiagnostic({
-    id: "STATIC_CSS_EVAL_PACKAGE_IMPORT_UNSUPPORTED",
+    id: "STATIC_CSS_EVAL_PROVIDER_SOURCE_UNSUPPORTED",
     code: "unsupported-source",
-    reason: "node-modules-import",
-    detail: `package import "${importPath}" is unsupported`,
+    reason: options.reason,
+    detail: formatStaticCssEvalProviderSourceUnsupportedDetail(options),
+    owner: options.owner,
+    dependency: options.dependency,
+    importPath: options.importPath,
+    exportName: options.exportName,
+    memberPath: options.memberPath,
+    importChain: options.importChain
+  });
+}
+
+export function createStaticCssEvalAmbiguousExportStarDiagnostic(
+  context: StaticCssEvalDiagnosticContext,
+  exportName: StaticCssEvalExportName
+): StaticCssEvalDiagnostic {
+  return createStaticCssEvalDiagnostic({
+    id: "STATIC_CSS_EVAL_EXPORT_STAR_AMBIGUOUS",
+    code: "unsupported-source",
+    reason: "ambiguous-star",
+    detail: `export "${exportName ?? "<local>"}" is ambiguous across export-star sources`,
     owner: context.owner,
     dependency: context.dependency,
-    importPath,
-    exportName: context.exportName,
+    importPath: context.importPath,
+    exportName,
     memberPath: context.memberPath,
     importChain: context.importChain
   });
@@ -229,21 +259,38 @@ export function createStaticCssEvalExportStarUnsupportedDiagnostic(
   });
 }
 
-export function createStaticCssEvalNamespaceImportUnsupportedDiagnostic(
+export function createStaticCssEvalNamespaceReexportUnsupportedDiagnostic(
   context: StaticCssEvalDiagnosticContext,
   importPath: string
 ): StaticCssEvalDiagnostic {
   return createStaticCssEvalDiagnostic({
-    id: "STATIC_CSS_EVAL_NAMESPACE_UNSUPPORTED",
+    id: "STATIC_CSS_EVAL_NAMESPACE_REEXPORT_UNSUPPORTED",
     code: "unsupported-source",
-    reason: "namespace-import",
-    detail: `namespace import "${importPath}" is unsupported`,
+    reason: "unsupported-namespace-reexport",
+    detail: `namespace re-export from "${importPath}" is unsupported`,
     owner: context.owner,
     dependency: context.dependency,
     importPath,
     exportName: context.exportName,
     memberPath: context.memberPath,
     importChain: context.importChain
+  });
+}
+
+export function createStaticCssEvalPartialNamespaceFailureDiagnostic(
+  options: StaticCssEvalPartialNamespaceFailureOptions
+): StaticCssEvalDiagnostic {
+  return createStaticCssEvalDiagnostic({
+    id: "STATIC_CSS_EVAL_NAMESPACE_PARTIAL_UNSUPPORTED",
+    code: "unsupported-source",
+    reason: "partial-namespace-failure",
+    detail: `namespace import cannot be partially evaluated because export "${options.exportName ?? "<local>"}" failed with reason "${options.failedReason}"`,
+    owner: options.owner,
+    dependency: options.dependency,
+    importPath: options.importPath,
+    exportName: options.exportName,
+    memberPath: options.memberPath,
+    importChain: options.importChain
   });
 }
 
@@ -420,6 +467,35 @@ export function formatStaticCssEvalDiagnosticMessage(detail: string): string {
   return `${STATIC_CSS_EVAL_DIAGNOSTIC_MESSAGE_PREFIX}: ${detail}`;
 }
 
+function formatStaticCssEvalProviderSourceUnsupportedDetail(
+  options: StaticCssEvalProviderSourceUnsupportedOptions
+): string {
+  switch (options.reason) {
+    case "external-no-source":
+      return `external module "${options.sourceId}" has no provider source`;
+    case "provider-virtual-no-source":
+      return `provider virtual module "${options.sourceId}" has no source from the bundler provider`;
+    case "dynamic-import":
+      return `dynamic import graph "${options.sourceId}" is unsupported`;
+    case "runtime-wasm-init":
+      return `runtime wasm init output "${options.sourceId}" is unsupported`;
+    case "runtime-wasm-module":
+      return `runtime wasm module output "${options.sourceId}" is unsupported`;
+    case "runtime-wasm-init-or-function":
+      return `runtime wasm init/function output "${options.sourceId}" is unsupported`;
+    case "invalid-json-data":
+      return `JSON data source "${options.sourceId}" is not valid JSON`;
+    case "source-size-limit-exceeded":
+      return `source "${options.sourceId}" exceeds the static css eval source size limit`;
+    case "non-literal-loader-output":
+      return `loader output "${options.sourceId}" is not a static literal`;
+    case "unresolved":
+      return `module "${options.sourceId}" could not be resolved by the provider`;
+    default:
+      return `provider source kind "${options.sourceKind}" from origin "${options.sourceOrigin}" is unsupported`;
+  }
+}
+
 export function getStaticCssEvalDiagnosticDependencies(
   diagnostic: StaticCssEvalDiagnostic
 ): string[] {
@@ -570,18 +646,26 @@ if (import.meta.vitest) {
       });
 
       expect(
-        createStaticCssEvalPackageImportUnsupportedDiagnostic(
-          { owner },
-          "pkg/styles"
-        )
+        createStaticCssEvalProviderSourceUnsupportedDiagnostic({
+          owner,
+          dependency: { file: "external:pkg/styles" },
+          importPath: "pkg/styles",
+          exportName: "button",
+          sourceId: "external:pkg/styles",
+          sourceKind: "external-no-source",
+          sourceOrigin: "external",
+          reason: "external-no-source"
+        })
       ).toEqual({
-        id: "STATIC_CSS_EVAL_PACKAGE_IMPORT_UNSUPPORTED",
+        id: "STATIC_CSS_EVAL_PROVIDER_SOURCE_UNSUPPORTED",
         code: "unsupported-source",
         message:
-          'Cannot statically evaluate css prop value: package import "pkg/styles" is unsupported',
-        reason: "node-modules-import",
+          'Cannot statically evaluate css prop value: external module "external:pkg/styles" has no provider source',
+        reason: "external-no-source",
         owner,
-        importPath: "pkg/styles"
+        dependency: { file: "external:pkg/styles" },
+        importPath: "pkg/styles",
+        exportName: "button"
       });
 
       expect(createStaticCssEvalCjsUnsupportedDiagnostic({ owner })).toEqual({
@@ -610,18 +694,55 @@ if (import.meta.vitest) {
       });
 
       expect(
-        createStaticCssEvalNamespaceImportUnsupportedDiagnostic(
+        createStaticCssEvalNamespaceReexportUnsupportedDiagnostic(
           { owner },
           "./styles"
         )
       ).toEqual({
-        id: "STATIC_CSS_EVAL_NAMESPACE_UNSUPPORTED",
+        id: "STATIC_CSS_EVAL_NAMESPACE_REEXPORT_UNSUPPORTED",
         code: "unsupported-source",
         message:
-          'Cannot statically evaluate css prop value: namespace import "./styles" is unsupported',
-        reason: "namespace-import",
+          'Cannot statically evaluate css prop value: namespace re-export from "./styles" is unsupported',
+        reason: "unsupported-namespace-reexport",
         owner,
         importPath: "./styles"
+      });
+
+      expect(
+        createStaticCssEvalPartialNamespaceFailureDiagnostic({
+          owner,
+          dependency,
+          importPath: "./styles",
+          exportName: "dynamic",
+          failedReason: "function-or-call"
+        })
+      ).toEqual({
+        id: "STATIC_CSS_EVAL_NAMESPACE_PARTIAL_UNSUPPORTED",
+        code: "unsupported-source",
+        message:
+          'Cannot statically evaluate css prop value: namespace import cannot be partially evaluated because export "dynamic" failed with reason "function-or-call"',
+        reason: "partial-namespace-failure",
+        owner,
+        dependency,
+        importPath: "./styles",
+        exportName: "dynamic"
+      });
+
+      expect(
+        createStaticCssEvalAmbiguousExportStarDiagnostic(
+          { owner, dependency, importPath: "./barrel" },
+          "button"
+        )
+      ).toEqual({
+        id: "STATIC_CSS_EVAL_EXPORT_STAR_AMBIGUOUS",
+        code: "unsupported-source",
+        message:
+          'Cannot statically evaluate css prop value: export "button" is ambiguous across export-star sources',
+        reason: "ambiguous-star",
+        owner,
+        dependency,
+        importPath: "./barrel",
+        exportName: "button"
       });
 
       expect(

--- a/packages/babel/src/staticCssEval/importedModules.ts
+++ b/packages/babel/src/staticCssEval/importedModules.ts
@@ -2030,7 +2030,13 @@ function createImportResolutionKey(
   return `${importerId}${importResolutionKeySeparator}${importPath}`;
 }
 
+// == Tests ====================================================================
+// Ignore errors when compiling to CommonJS.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
 if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
   const { describe, expect, it } = import.meta.vitest;
 
   const ownerId = "/project/src/App.tsx";

--- a/packages/babel/src/staticCssEval/importedModules.ts
+++ b/packages/babel/src/staticCssEval/importedModules.ts
@@ -33,15 +33,18 @@ import {
 } from "./limits.js";
 import {
   createExportMapCacheKey,
+  createStaticCssModuleExportNameTable,
   createStaticCssModuleCache,
   formatExportMapCacheKey,
   STATIC_CSS_MODULE_CACHE_SUPPORT_VERSION
 } from "./moduleCache.js";
 import type {
   ExportMapEntry,
+  ExportGraphStarReexportEntry,
   ExportMapLocalEntry,
   ParsedStaticCssModule,
   StaticCssModuleCache,
+  StaticCssModuleExportStarSource,
   StaticCssModuleSource
 } from "./moduleCache.js";
 import {
@@ -100,6 +103,17 @@ type ImportedStaticCssEvalResolutionResult =
       provenance?: BindingProvenance;
       cacheKey?: StaticCssEvalCacheKey;
     };
+
+type ImportedStaticCssEvalExportPresenceResult =
+  | { kind: "found" }
+  | { kind: "missing" }
+  | { kind: "error"; diagnostic: StaticCssEvalDiagnostic };
+
+interface ImportedStaticCssEvalExportStarCandidate {
+  readonly entry: ExportGraphStarReexportEntry;
+  readonly record: ImportedStaticCssEvalModuleRecord;
+  readonly request: ImportedStaticCssEvalResolutionRequest;
+}
 
 interface ImportedStaticCssEvalContext {
   owner: StaticCssEvalSourceLocation;
@@ -579,27 +593,12 @@ class ImportedStaticCssEvalResolver {
     const guardResult = this.#guardResolution(record, request, state);
 
     if (!guardResult.ok) {
-      for (const dependency of guardResult.dependencies) {
-        addResolutionDependency(state, {
-          file: dependency,
-          kind: "reexported",
-          importer: request.importer,
-          specifier: request.specifier,
-          exportName: request.exportName,
-          memberPath: request.memberPath,
-          inspected: true,
-          contributed: false
-        });
-      }
+      addResolutionGuardDependencies(state, guardResult.dependencies, request);
 
       return { kind: "error", diagnostic: guardResult.diagnostic };
     }
 
-    const stackEntry: StaticCssEvalImportCycleKey = {
-      file: record.id,
-      exportName: request.exportName,
-      memberPath: request.memberPath
-    };
+    const stackEntry = createImportCycleStackEntry(record, request);
     state.stack.push(stackEntry);
 
     try {
@@ -617,9 +616,18 @@ class ImportedStaticCssEvalResolver {
     const exportEntry = record.exports.get(request.exportName);
 
     if (!exportEntry) {
-      return this.#createMissingExportResult(record, request, state);
+      return this.#resolveExportStarEntries(record, request, state);
     }
 
+    return this.#resolveExportMapEntry(record, exportEntry, request, state);
+  }
+
+  #resolveExportMapEntry(
+    record: ImportedStaticCssEvalModuleRecord,
+    exportEntry: ExportMapEntry,
+    request: ImportedStaticCssEvalResolutionRequest,
+    state: ImportedStaticCssEvalResolutionState
+  ): ImportedStaticCssEvalResolutionResult {
     const effectiveRequest =
       exportEntry.kind === "reexport"
         ? {
@@ -679,6 +687,271 @@ class ImportedStaticCssEvalResolver {
       state,
       provenance
     );
+  }
+
+  #resolveExportStarEntries(
+    record: ImportedStaticCssEvalModuleRecord,
+    request: ImportedStaticCssEvalResolutionRequest,
+    state: ImportedStaticCssEvalResolutionState
+  ): ImportedStaticCssEvalResolutionResult {
+    if (
+      request.exportName === "default" ||
+      record.parsedModule.exportStarReexports.length === 0
+    ) {
+      return this.#createMissingExportResult(record, request, state);
+    }
+
+    const effectiveRequest = {
+      ...request,
+      dependencyKind: "reexported" as const,
+      provenanceKind: "reexported" as const,
+      reexportName: formatExportName(request.exportName)
+    };
+    const provenance = createBindingProvenance(record.id, effectiveRequest);
+    state.resolutionChain.push({
+      importer: effectiveRequest.importer,
+      source: record.id,
+      exportName: effectiveRequest.exportName,
+      memberPath: [...effectiveRequest.memberPath],
+      provenance
+    });
+    updateResolutionDependencyKind(
+      state,
+      record.id,
+      effectiveRequest.dependencyKind
+    );
+
+    const candidatesResult = this.#collectExportStarCandidates(
+      record,
+      effectiveRequest,
+      state
+    );
+
+    if (candidatesResult.kind === "error") {
+      return {
+        kind: "error",
+        diagnostic: candidatesResult.diagnostic,
+        provenance,
+        cacheKey: createImportedStaticCssEvalCacheKey(
+          state.owner.file,
+          record.parsedModule,
+          effectiveRequest.exportName,
+          effectiveRequest.memberPath
+        )
+      };
+    }
+
+    const exportNameTable = createStaticCssModuleExportNameTable(
+      record.exports,
+      createExportStarSources(effectiveRequest.exportName, candidatesResult.candidates)
+    );
+    const tableEntry = exportNameTable.get(effectiveRequest.exportName);
+
+    if (!tableEntry) {
+      return this.#createMissingExportResult(record, effectiveRequest, state);
+    }
+
+    switch (tableEntry.kind) {
+      case "explicit":
+        return this.#resolveExportMapEntry(
+          record,
+          tableEntry.entry,
+          effectiveRequest,
+          state
+        );
+      case "star": {
+        const candidate = candidatesResult.candidates.find(
+          (exportStarCandidate) => exportStarCandidate.entry === tableEntry.entry
+        );
+
+        return candidate
+          ? this.#resolveModuleExport(candidate.record, candidate.request, state)
+          : this.#createMissingExportResult(record, effectiveRequest, state);
+      }
+      case "ambiguous-star":
+        return {
+          kind: "error",
+          diagnostic: createAmbiguousExportStarDiagnostic(
+            record,
+            effectiveRequest,
+            state,
+            candidatesResult.candidates
+          ),
+          provenance,
+          cacheKey: createImportedStaticCssEvalCacheKey(
+            state.owner.file,
+            record.parsedModule,
+            effectiveRequest.exportName,
+            effectiveRequest.memberPath
+          )
+        };
+      default:
+        return assertNever(tableEntry);
+    }
+  }
+
+  #collectExportStarCandidates(
+    record: ImportedStaticCssEvalModuleRecord,
+    request: ImportedStaticCssEvalResolutionRequest,
+    state: ImportedStaticCssEvalResolutionState
+  ):
+    | {
+        kind: "resolved";
+        candidates: ImportedStaticCssEvalExportStarCandidate[];
+      }
+    | { kind: "error"; diagnostic: StaticCssEvalDiagnostic } {
+    const candidates: ImportedStaticCssEvalExportStarCandidate[] = [];
+
+    for (const starEntry of record.parsedModule.exportStarReexports) {
+      const candidateResult = this.#resolveExportStarCandidate(
+        record,
+        starEntry,
+        request,
+        state
+      );
+
+      if (candidateResult.kind === "error") {
+        return { kind: "error", diagnostic: candidateResult.diagnostic };
+      }
+
+      if (candidateResult.kind === "resolved") {
+        candidates.push(candidateResult.candidate);
+      }
+    }
+
+    return { kind: "resolved", candidates };
+  }
+
+  #resolveExportStarCandidate(
+    record: ImportedStaticCssEvalModuleRecord,
+    starEntry: ExportGraphStarReexportEntry,
+    request: ImportedStaticCssEvalResolutionRequest,
+    state: ImportedStaticCssEvalResolutionState
+  ):
+    | {
+        kind: "resolved";
+        candidate: ImportedStaticCssEvalExportStarCandidate;
+      }
+    | { kind: "missing" }
+    | { kind: "error"; diagnostic: StaticCssEvalDiagnostic } {
+    if (!isProjectLocalStaticCssImportSpecifier(starEntry.source)) {
+      return {
+        kind: "error",
+        diagnostic: createStaticCssEvalPackageImportUnsupportedDiagnostic(
+          {
+            owner: state.owner,
+            dependency: { file: record.id },
+            importPath: starEntry.source,
+            exportName: request.exportName,
+            memberPath: request.memberPath,
+            importChain: createResolutionImportChain(state, record.id)
+          },
+          starEntry.source
+        )
+      };
+    }
+
+    const starRequest = createExportStarRequest(record, starEntry, request);
+    const importResult = this.#resolveProjectLocalImport(
+      starRequest,
+      state.owner,
+      state
+    );
+
+    if (importResult.kind === "error") {
+      return { kind: "error", diagnostic: importResult.diagnostic };
+    }
+
+    const presenceResult = this.#recordExportsName(
+      importResult.record,
+      starRequest,
+      state
+    );
+
+    if (presenceResult.kind === "error") {
+      return { kind: "error", diagnostic: presenceResult.diagnostic };
+    }
+
+    return presenceResult.kind === "found"
+      ? {
+          kind: "resolved",
+          candidate: {
+            entry: starEntry,
+            record: importResult.record,
+            request: starRequest
+          }
+        }
+      : { kind: "missing" };
+  }
+
+  #recordExportsName(
+    record: ImportedStaticCssEvalModuleRecord,
+    request: ImportedStaticCssEvalResolutionRequest,
+    state: ImportedStaticCssEvalResolutionState
+  ): ImportedStaticCssEvalExportPresenceResult {
+    const guardResult = this.#guardResolution(record, request, state);
+
+    if (!guardResult.ok) {
+      addResolutionGuardDependencies(state, guardResult.dependencies, request);
+
+      return { kind: "error", diagnostic: guardResult.diagnostic };
+    }
+
+    const stackEntry = createImportCycleStackEntry(record, request);
+    state.stack.push(stackEntry);
+
+    try {
+      if (record.exports.has(request.exportName)) {
+        return { kind: "found" };
+      }
+
+      if (
+        request.exportName === "default" ||
+        record.parsedModule.exportStarReexports.length === 0
+      ) {
+        return { kind: "missing" };
+      }
+
+      const candidatesResult = this.#collectExportStarCandidates(
+        record,
+        request,
+        state
+      );
+
+      if (candidatesResult.kind === "error") {
+        return { kind: "error", diagnostic: candidatesResult.diagnostic };
+      }
+
+      const exportNameTable = createStaticCssModuleExportNameTable(
+        record.exports,
+        createExportStarSources(request.exportName, candidatesResult.candidates)
+      );
+      const tableEntry = exportNameTable.get(request.exportName);
+
+      if (!tableEntry) {
+        return { kind: "missing" };
+      }
+
+      switch (tableEntry.kind) {
+        case "explicit":
+        case "star":
+          return { kind: "found" };
+        case "ambiguous-star":
+          return {
+            kind: "error",
+            diagnostic: createAmbiguousExportStarDiagnostic(
+              record,
+              request,
+              state,
+              candidatesResult.candidates
+            )
+          };
+        default:
+          return assertNever(tableEntry);
+      }
+    } finally {
+      state.stack.pop();
+    }
   }
 
   #resolveReexportEntry(
@@ -747,31 +1020,6 @@ class ImportedStaticCssEvalResolver {
     request: ImportedStaticCssEvalResolutionRequest,
     state: ImportedStaticCssEvalResolutionState
   ): ImportedStaticCssEvalResolutionResult {
-    const exportStar = record.parsedModule.unsupportedExportStars[0];
-
-    if (exportStar) {
-      return {
-        kind: "error",
-        diagnostic: createStaticCssEvalExportStarUnsupportedDiagnostic(
-          {
-            owner: state.owner,
-            dependency: { file: record.id },
-            importPath: exportStar.source ?? request.specifier,
-            exportName: request.exportName,
-            memberPath: request.memberPath,
-            importChain: createResolutionImportChain(state, record.id)
-          },
-          exportStar.source ?? request.specifier
-        ),
-        cacheKey: createImportedStaticCssEvalCacheKey(
-          state.owner.file,
-          record.parsedModule,
-          request.exportName,
-          request.memberPath
-        )
-      };
-    }
-
     return {
       kind: "error",
       diagnostic: createStaticCssEvalUnresolvedExportDiagnostic(
@@ -2319,6 +2567,235 @@ if (import.meta.vitest) {
       });
     });
 
+    it("resolves named reexport through export star barrel with dependency metadata", () => {
+      const result = resolveFixture(
+        createProvider(
+          `export const button = { color: "red" } as const;`,
+          `import { button } from "./barrel"; <div css={button} />;`,
+          `export * from "./styles";`
+        ),
+        "button"
+      );
+
+      expect(result).toMatchObject({
+        kind: "resolved",
+        value: { color: "red" },
+        provenance: {
+          kind: "reexported",
+          file: stylesId,
+          exportName: "button"
+        },
+        dependencies: [
+          {
+            file: barrelId,
+            kind: "reexported",
+            inspected: true,
+            contributed: true
+          },
+          {
+            file: stylesId,
+            kind: "reexported",
+            inspected: true,
+            contributed: true
+          }
+        ],
+        resolutionChain: [
+          { importer: ownerId, source: barrelId, exportName: "button" },
+          { importer: barrelId, source: stylesId, exportName: "button" }
+        ]
+      });
+    });
+
+    it("resolves namespace members through export star barrels", () => {
+      const result = resolveFixture(
+        createProvider(
+          `export const button = { color: "red" } as const;`,
+          `import * as styles from "./barrel"; <div css={styles.button} />;`,
+          `export * from "./styles";`
+        ),
+        "styles",
+        ["button"]
+      );
+
+      expect(result).toMatchObject({
+        kind: "resolved",
+        value: { color: "red" },
+        dependencies: [
+          {
+            file: barrelId,
+            inspected: true,
+            contributed: true
+          },
+          {
+            file: stylesId,
+            inspected: true,
+            contributed: true
+          }
+        ],
+        resolutionChain: [
+          { importer: ownerId, source: barrelId, exportName: "button" },
+          { importer: barrelId, source: stylesId, exportName: "button" }
+        ]
+      });
+    });
+
+    it("keeps export star default semantics ESM-accurate for namespace members", () => {
+      expect(
+        resolveFixture(
+          createProvider(
+            `export default { color: "red" } as const;`,
+            `import * as styles from "./barrel"; <div css={styles.default} />;`,
+            `export * from "./styles";`
+          ),
+          "styles",
+          ["default"]
+        )
+      ).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_UNRESOLVED_EXPORT",
+          exportName: "default"
+        },
+        dependencies: [{ file: barrelId, inspected: true, contributed: false }]
+      });
+
+      expect(
+        resolveFixture(
+          createProvider(
+            `export const button = { color: "red" } as const;`,
+            `import * as styles from "./barrel"; <div css={styles.default} />;`,
+            `export default { color: "blue" } as const; export * from "./styles";`
+          ),
+          "styles",
+          ["default"]
+        )
+      ).toMatchObject({
+        kind: "resolved",
+        value: { color: "blue" }
+      });
+
+      expect(
+        resolveFixture(
+          createProvider(
+            `export default { color: "green" } as const;`,
+            `import * as styles from "./barrel"; <div css={styles.root} />;`,
+            `export { default as root } from "./styles"; export * from "./styles";`
+          ),
+          "styles",
+          ["root"]
+        )
+      ).toMatchObject({
+        kind: "resolved",
+        value: { color: "green" },
+        provenance: {
+          kind: "reexported",
+          file: stylesId,
+          exportName: "default",
+          reexportName: "root"
+        }
+      });
+    });
+
+    it("lets explicit direct exports override same-named export star candidates", () => {
+      const result = resolveFixture(
+        createProvider(
+          `export const button = { color: "red" } as const;`,
+          `import { button } from "./barrel"; <div css={button} />;`,
+          `export * from "./button"; export { button } from "./styles";`,
+          [{ id: buttonId, source: `export const button = { color: "blue" } as const;` }],
+          [{ importerId: barrelId, importPath: "./button", resolvedId: buttonId }]
+        ),
+        "button"
+      );
+
+      expect(result).toMatchObject({
+        kind: "resolved",
+        value: { color: "red" },
+        dependencies: [
+          { file: barrelId, inspected: true, contributed: true },
+          { file: stylesId, inspected: true, contributed: true }
+        ]
+      });
+      expect(
+        result.kind === "resolved" ? result.dependencies : []
+      ).not.toEqual(expect.arrayContaining([expect.objectContaining({ file: buttonId })]));
+    });
+
+    it("reports ambiguous export star conflict without choosing a candidate", () => {
+      const result = resolveFixture(
+        createProvider(
+          `export const button = { color: "red" } as const;`,
+          `import { button } from "./barrel"; <div css={button} />;`,
+          `export * from "./styles"; export * from "./button";`,
+          [{ id: buttonId, source: `export const button = { color: "blue" } as const;` }],
+          [{ importerId: barrelId, importPath: "./button", resolvedId: buttonId }]
+        ),
+        "button"
+      );
+
+      expect(result).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_UNRESOLVED_EXPORT",
+          exportName: "button",
+          dependency: { file: barrelId },
+          importChain: expect.arrayContaining([
+            expect.stringContaining(`${stylesId}#button`),
+            expect.stringContaining(`${buttonId}#button`)
+          ])
+        },
+        dependencies: [
+          { file: barrelId, inspected: true, contributed: false },
+          { file: stylesId, inspected: true, contributed: false },
+          { file: buttonId, inspected: true, contributed: false }
+        ]
+      });
+      expect(result.kind === "error" ? result.diagnostic.message : "").toContain(
+        "ambiguous"
+      );
+    });
+
+    it("classifies native import expressions as dynamic imports", () => {
+      expect(
+        getUnsupportedLiteralReason(
+          t.importExpression(t.stringLiteral("./styles"))
+        )
+      ).toBe("dynamic-import");
+    });
+
+    it("terminates export star reexport cycles with deterministic diagnostics", () => {
+      const result = resolveFixture(
+        createProviderFromModules({
+          modules: [
+            {
+              id: ownerId,
+              source: `import { button } from "./barrel"; <div css={button} />;`
+            },
+            { id: barrelId, source: `export * from "./button";` },
+            { id: buttonId, source: `export * from "./barrel";` }
+          ],
+          importResolutions: [
+            { importerId: ownerId, importPath: "./barrel", resolvedId: barrelId },
+            { importerId: barrelId, importPath: "./button", resolvedId: buttonId },
+            { importerId: buttonId, importPath: "./barrel", resolvedId: barrelId }
+          ]
+        }),
+        "button"
+      );
+
+      expect(result).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_IMPORT_CYCLE",
+          exportName: "button"
+        },
+        dependencies: expect.arrayContaining([
+          expect.objectContaining({ file: barrelId, inspected: true }),
+          expect.objectContaining({ file: buttonId, inspected: true })
+        ])
+      });
+    });
+
     it("parses one imported source identity once for repeated binding resolutions", () => {
       const { cache, missesByFile } = createCountingStaticCssModuleCache();
       const provider = createProviderFromModules({
@@ -2536,24 +3013,7 @@ if (import.meta.vitest) {
       });
     });
 
-    it("rejects export stars, missing exports, packages, cjs, and cycles with exact diagnostics", () => {
-      expect(
-        resolveFixture(
-          createProvider(
-            `export const button = { color: "red" } as const;`,
-            `import { button } from "./barrel"; <div css={button} />;`,
-            `export * from "./styles";`
-          ),
-          "button"
-        )
-      ).toMatchObject({
-        kind: "error",
-        diagnostic: {
-          id: "STATIC_CSS_EVAL_EXPORT_STAR_UNSUPPORTED"
-        },
-        dependencies: [{ file: barrelId, inspected: true, contributed: false }]
-      });
-
+    it("rejects missing exports, packages, cjs, and cycles with exact diagnostics", () => {
       expect(
         resolveFixture(
           createProvider(

--- a/packages/babel/src/staticCssEval/importedModules.ts
+++ b/packages/babel/src/staticCssEval/importedModules.ts
@@ -1,5 +1,6 @@
 import { types as t } from "@babel/core";
 import type { NodePath } from "@babel/core";
+import hash from "@emotion/hash";
 import {
   getStaticObjectMemberValue,
   getStaticObjectPropertyName,
@@ -11,6 +12,15 @@ import {
   unwrapTransparentCssRuleExpression
 } from "./candidates.js";
 import {
+  createStaticCssEvalProviderSourceMetadata,
+  enforceStaticCssEvalProviderSourcePolicy
+} from "./boundary.js";
+import type {
+  StaticCssEvalProviderSourceMetadata,
+  StaticCssEvalProviderSourcePolicyDescriptor
+} from "./boundary.js";
+import {
+  createStaticCssEvalAmbiguousExportStarDiagnostic,
   createStaticCssEvalCjsUnsupportedDiagnostic,
   createStaticCssEvalComputedMemberUnsupportedDiagnostic,
   createStaticCssEvalDiagnostic,
@@ -18,8 +28,9 @@ import {
   createStaticCssEvalExportStarUnsupportedDiagnostic,
   createStaticCssEvalMutableBindingDiagnostic,
   createStaticCssEvalMutatedBindingDiagnostic,
-  createStaticCssEvalNamespaceImportUnsupportedDiagnostic,
-  createStaticCssEvalPackageImportUnsupportedDiagnostic,
+  createStaticCssEvalNamespaceReexportUnsupportedDiagnostic,
+  createStaticCssEvalPartialNamespaceFailureDiagnostic,
+  createStaticCssEvalProviderSourceUnsupportedDiagnostic,
   createStaticCssEvalUnresolvedExportDiagnostic,
   createStaticCssEvalUnresolvedImportDiagnostic,
   guardStaticCssEvalImportCycle,
@@ -36,6 +47,7 @@ import {
   createStaticCssModuleExportNameTable,
   createStaticCssModuleCache,
   formatExportMapCacheKey,
+  STATIC_CSS_MODULE_CACHE_PARSER_VERSION,
   STATIC_CSS_MODULE_CACHE_SUPPORT_VERSION
 } from "./moduleCache.js";
 import type {
@@ -44,6 +56,7 @@ import type {
   ExportMapLocalEntry,
   ParsedStaticCssModule,
   StaticCssModuleCache,
+  StaticCssModuleExportNameTableEntry,
   StaticCssModuleExportStarSource,
   StaticCssModuleSource
 } from "./moduleCache.js";
@@ -115,6 +128,14 @@ interface ImportedStaticCssEvalExportStarCandidate {
   readonly request: ImportedStaticCssEvalResolutionRequest;
 }
 
+interface ImportedStaticCssEvalNamespaceExportNameTable {
+  readonly table: ReadonlyMap<
+    StaticCssEvalExportName,
+    StaticCssModuleExportNameTableEntry
+  >;
+  readonly candidates: ImportedStaticCssEvalExportStarCandidate[];
+}
+
 interface ImportedStaticCssEvalContext {
   owner: StaticCssEvalSourceLocation;
   dependency: StaticCssEvalSourceLocation;
@@ -137,6 +158,12 @@ interface ImportedStaticCssEvalResolutionRequest {
   provenanceKind: ImportedStaticCssEvalProvenanceKind;
   namespaceBinding?: string;
   reexportName?: string;
+  wholeNamespace?: boolean;
+}
+
+interface ImportedStaticCssEvalResolvedImport {
+  readonly resolvedId: string;
+  readonly sourceMetadata: StaticCssEvalProviderSourceMetadata;
 }
 
 interface ImportedStaticCssEvalResolutionState {
@@ -150,7 +177,7 @@ interface StaticCssLiteralValidationState {
   count: number;
 }
 
-export interface ImportedStaticCssEvalLoadedModule {
+export interface ImportedStaticCssEvalLoadedModule extends StaticCssEvalProviderSourcePolicyDescriptor {
   id: string;
   source: string;
   realpath?: string;
@@ -158,7 +185,7 @@ export interface ImportedStaticCssEvalLoadedModule {
   version?: string | number;
 }
 
-export interface ImportedStaticCssEvalImportResolution {
+export interface ImportedStaticCssEvalImportResolution extends StaticCssEvalProviderSourcePolicyDescriptor {
   importerId: string;
   importPath: string;
   resolvedId: string;
@@ -235,10 +262,12 @@ function createImportedStaticCssEvalModuleRecordWithCache(
     id: loadedModule.id,
     realpath: loadedModule.realpath ?? loadedModule.id,
     sourceHash:
-      loadedModule.sourceHash ?? `inline:${loadedModule.source.length}`,
+      loadedModule.sourceHash ??
+      createInlineStaticCssSourceHash(loadedModule.source),
     ...(loadedModule.version !== undefined
       ? { version: loadedModule.version }
       : {}),
+    ...createStaticCssEvalProviderSourceMetadata(loadedModule),
     dependencies: [],
     source: loadedModule.source,
     imports,
@@ -374,7 +403,11 @@ export function createStaticCssLiteralExpression(
 class ImportedStaticCssEvalResolver {
   readonly #modules = new Map<string, ImportedStaticCssEvalLoadedModule>();
   readonly #records = new Map<string, ImportedStaticCssEvalModuleRecord>();
-  readonly #importResolutions = new Map<string, string>();
+  readonly #parseFailures = new Map<string, string>();
+  readonly #importResolutions = new Map<
+    string,
+    ImportedStaticCssEvalResolvedImport
+  >();
   readonly #moduleCache: StaticCssModuleCache;
 
   constructor(options: ImportedStaticCssEvalResolverOptions) {
@@ -391,7 +424,10 @@ class ImportedStaticCssEvalResolver {
     for (const resolution of options.importResolutions) {
       this.#importResolutions.set(
         createImportResolutionKey(resolution.importerId, resolution.importPath),
-        resolution.resolvedId
+        {
+          resolvedId: resolution.resolvedId,
+          sourceMetadata: createStaticCssEvalProviderSourceMetadata(resolution)
+        }
       );
     }
   }
@@ -426,7 +462,7 @@ class ImportedStaticCssEvalResolver {
 
     const owner = createQueryOwnerLocation(query);
     const state = createResolutionState(owner);
-    const requestResult = createResolutionRequest(query, importBinding, owner);
+    const requestResult = createResolutionRequest(query, importBinding);
 
     if (requestResult.kind === "error") {
       return createImportedStaticCssEvalErrorResult({
@@ -436,7 +472,7 @@ class ImportedStaticCssEvalResolver {
       });
     }
 
-    const importResult = this.#resolveProjectLocalImport(
+    const importResult = this.#resolveProviderImport(
       requestResult.request,
       owner,
       state
@@ -481,16 +517,24 @@ class ImportedStaticCssEvalResolver {
     });
   }
 
-  #resolveProjectLocalImport(
+  #resolveProviderImport(
     request: ImportedStaticCssEvalResolutionRequest,
     owner: StaticCssEvalSourceLocation,
     state: ImportedStaticCssEvalResolutionState
   ):
     | { kind: "resolved"; record: ImportedStaticCssEvalModuleRecord }
     | { kind: "error"; diagnostic: StaticCssEvalDiagnostic } {
-    const resolvedId = this.#resolveImport(request.importer, request.specifier);
+    const resolvedImport = this.#resolveImport(
+      request.importer,
+      request.specifier
+    );
 
-    if (!resolvedId) {
+    if (!resolvedImport) {
+      const sourceMetadata = createStaticCssEvalProviderSourceMetadata({
+        sourceKind: "unresolved",
+        sourceOrigin: "unresolved",
+        unsupportedReason: "unresolved"
+      });
       addResolutionDependency(state, {
         file: request.specifier,
         kind: "unresolved",
@@ -499,7 +543,8 @@ class ImportedStaticCssEvalResolver {
         exportName: request.exportName,
         memberPath: request.memberPath,
         inspected: false,
-        contributed: false
+        contributed: false,
+        ...sourceMetadata
       });
 
       return {
@@ -518,30 +563,83 @@ class ImportedStaticCssEvalResolver {
       };
     }
 
+    const loadedModule = this.#modules.get(resolvedImport.resolvedId);
+    const cachedRecord = this.#records.get(resolvedImport.resolvedId);
+    const resolvedSource = loadedModule ?? cachedRecord;
+    const sourceMetadata = mergeImportedStaticCssEvalSourceMetadata(
+      resolvedImport.sourceMetadata,
+      resolvedSource
+    );
+
     addResolutionDependency(state, {
-      file: resolvedId,
+      file: resolvedImport.resolvedId,
       kind: request.dependencyKind,
       importer: request.importer,
       specifier: request.specifier,
       exportName: request.exportName,
       memberPath: request.memberPath,
       inspected: false,
-      contributed: false
+      contributed: false,
+      ...sourceMetadata
     });
 
-    const loadedModule = this.#modules.get(resolvedId);
+    const sourcePolicyResult = enforceStaticCssEvalProviderSourcePolicy({
+      owner,
+      dependency: { file: resolvedImport.resolvedId },
+      importPath: request.specifier,
+      exportName: request.exportName,
+      memberPath: request.memberPath,
+      importChain: createResolutionImportChain(
+        state,
+        resolvedImport.resolvedId
+      ),
+      sourceId: resolvedImport.resolvedId,
+      ...sourceMetadata
+    });
 
-    if (!loadedModule) {
+    if (!sourcePolicyResult.ok) {
+      markResolutionDependencyInspected(state, resolvedImport.resolvedId);
+      return { kind: "error", diagnostic: sourcePolicyResult.diagnostic };
+    }
+
+    if (!resolvedSource) {
+      markResolutionDependencyInspected(state, resolvedImport.resolvedId);
+
+      if (sourceMetadata.sourceKind === "provider-virtual") {
+        return {
+          kind: "error",
+          diagnostic: createStaticCssEvalProviderSourceUnsupportedDiagnostic({
+            owner,
+            dependency: { file: resolvedImport.resolvedId },
+            importPath: request.specifier,
+            exportName: request.exportName,
+            memberPath: request.memberPath,
+            importChain: createResolutionImportChain(
+              state,
+              resolvedImport.resolvedId
+            ),
+            sourceId: resolvedImport.resolvedId,
+            sourceKind: sourceMetadata.sourceKind,
+            sourceOrigin: sourceMetadata.sourceOrigin,
+            reason:
+              sourceMetadata.unsupportedReason ?? "provider-virtual-no-source"
+          })
+        };
+      }
+
       return {
         kind: "error",
         diagnostic: createStaticCssEvalUnresolvedImportDiagnostic(
           {
             owner,
-            dependency: { file: resolvedId },
+            dependency: { file: resolvedImport.resolvedId },
             importPath: request.specifier,
             exportName: request.exportName,
             memberPath: request.memberPath,
-            importChain: createResolutionImportChain(state, resolvedId)
+            importChain: createResolutionImportChain(
+              state,
+              resolvedImport.resolvedId
+            )
           },
           request.specifier
         )
@@ -550,38 +648,44 @@ class ImportedStaticCssEvalResolver {
 
     const sourceSizeResult = enforceStaticCssEvalSourceSize({
       owner,
-      dependency: { file: resolvedId },
+      dependency: { file: resolvedImport.resolvedId },
       importPath: request.specifier,
       exportName: request.exportName,
       memberPath: request.memberPath,
-      source: loadedModule.source
+      source: resolvedSource.source
     });
 
     if (!sourceSizeResult.ok) {
-      markResolutionDependencyInspected(state, resolvedId);
+      markResolutionDependencyInspected(state, resolvedImport.resolvedId);
       return { kind: "error", diagnostic: sourceSizeResult.diagnostic };
     }
 
-    const record = this.#getModuleRecord(resolvedId);
+    const record =
+      cachedRecord ?? this.#getModuleRecord(resolvedImport.resolvedId);
 
     if (!record) {
+      markResolutionDependencyInspected(state, resolvedImport.resolvedId);
       return {
         kind: "error",
         diagnostic: createStaticCssEvalUnresolvedImportDiagnostic(
           {
             owner,
-            dependency: { file: resolvedId },
+            dependency: { file: resolvedImport.resolvedId },
             importPath: request.specifier,
             exportName: request.exportName,
             memberPath: request.memberPath,
-            importChain: createResolutionImportChain(state, resolvedId)
+            importChain: createResolutionImportChain(
+              state,
+              resolvedImport.resolvedId
+            )
           },
-          request.specifier
+          request.specifier,
+          this.#parseFailures.get(resolvedImport.resolvedId)
         )
       };
     }
 
-    markResolutionDependencyInspected(state, resolvedId);
+    markResolutionDependencyInspected(state, resolvedImport.resolvedId);
     return { kind: "resolved", record };
   }
 
@@ -613,6 +717,10 @@ class ImportedStaticCssEvalResolver {
     request: ImportedStaticCssEvalResolutionRequest,
     state: ImportedStaticCssEvalResolutionState
   ): ImportedStaticCssEvalResolutionResult {
+    if (request.wholeNamespace === true) {
+      return this.#resolveWholeNamespaceExport(record, request, state);
+    }
+
     const exportEntry = record.exports.get(request.exportName);
 
     if (!exportEntry) {
@@ -643,7 +751,8 @@ class ImportedStaticCssEvalResolver {
       source: record.id,
       exportName: effectiveRequest.exportName,
       memberPath: [...effectiveRequest.memberPath],
-      provenance
+      provenance,
+      ...createStaticCssEvalProviderSourceMetadata(record)
     });
     updateResolutionDependencyKind(
       state,
@@ -665,7 +774,8 @@ class ImportedStaticCssEvalResolver {
           state.owner.file,
           record.parsedModule,
           effectiveRequest.exportName,
-          effectiveRequest.memberPath
+          effectiveRequest.memberPath,
+          record
         )
       };
     }
@@ -687,6 +797,296 @@ class ImportedStaticCssEvalResolver {
       state,
       provenance
     );
+  }
+
+  #resolveWholeNamespaceExport(
+    record: ImportedStaticCssEvalModuleRecord,
+    request: ImportedStaticCssEvalResolutionRequest,
+    state: ImportedStaticCssEvalResolutionState
+  ): ImportedStaticCssEvalResolutionResult {
+    const namespaceTableResult = this.#collectNamespaceExportNameTable(
+      record,
+      request,
+      state,
+      true
+    );
+    const provenance = createBindingProvenance(record.id, request);
+    const cacheKey = createImportedStaticCssEvalCacheKey(
+      state.owner.file,
+      record.parsedModule,
+      request.exportName,
+      request.memberPath,
+      record
+    );
+
+    if (namespaceTableResult.kind === "error") {
+      return {
+        kind: "error",
+        diagnostic: namespaceTableResult.diagnostic,
+        provenance,
+        cacheKey
+      };
+    }
+
+    const namespaceValue: Record<string, StaticCssLiteral> =
+      Object.create(null);
+
+    for (const [exportName, tableEntry] of namespaceTableResult.table.table) {
+      if (exportName === null) {
+        continue;
+      }
+
+      const exportRequest: ImportedStaticCssEvalResolutionRequest = {
+        ...request,
+        exportName,
+        memberPath: [],
+        wholeNamespace: false,
+        reexportName: formatExportName(exportName)
+      };
+      const exportResult = this.#resolveNamespaceTableEntry(
+        record,
+        tableEntry,
+        exportRequest,
+        namespaceTableResult.table.candidates,
+        state
+      );
+
+      if (exportResult.kind === "not-candidate") {
+        return this.#createMissingExportResult(record, exportRequest, state);
+      }
+
+      if (exportResult.kind === "error") {
+        return {
+          kind: "error",
+          diagnostic: createStaticCssEvalPartialNamespaceFailureDiagnostic({
+            owner: state.owner,
+            dependency: exportResult.diagnostic.dependency ?? {
+              file: record.id
+            },
+            importPath: request.specifier,
+            exportName: exportRequest.exportName,
+            memberPath: exportRequest.memberPath,
+            importChain: exportResult.diagnostic.importChain,
+            failedReason: exportResult.diagnostic.reason
+          }),
+          provenance,
+          cacheKey
+        };
+      }
+
+      namespaceValue[exportName] = exportResult.value;
+    }
+
+    return {
+      kind: "resolved",
+      value: namespaceValue,
+      provenance,
+      cacheKey
+    };
+  }
+
+  #resolveNamespaceTableEntry(
+    record: ImportedStaticCssEvalModuleRecord,
+    tableEntry: StaticCssModuleExportNameTableEntry,
+    request: ImportedStaticCssEvalResolutionRequest,
+    candidates: readonly ImportedStaticCssEvalExportStarCandidate[],
+    state: ImportedStaticCssEvalResolutionState
+  ): ImportedStaticCssEvalResolutionResult {
+    switch (tableEntry.kind) {
+      case "explicit":
+        return this.#resolveExportMapEntry(
+          record,
+          tableEntry.entry,
+          request,
+          state
+        );
+      case "star": {
+        const candidate = candidates.find(
+          (exportStarCandidate) =>
+            exportStarCandidate.entry === tableEntry.entry
+        );
+
+        return candidate
+          ? this.#resolveModuleExport(
+              candidate.record,
+              {
+                ...candidate.request,
+                exportName: request.exportName,
+                memberPath: [],
+                wholeNamespace: false,
+                reexportName: formatExportName(request.exportName)
+              },
+              state
+            )
+          : this.#createMissingExportResult(record, request, state);
+      }
+      case "ambiguous-star":
+        return {
+          kind: "error",
+          diagnostic: createAmbiguousExportStarDiagnostic(
+            record,
+            request,
+            state,
+            candidates
+          ),
+          cacheKey: createImportedStaticCssEvalCacheKey(
+            state.owner.file,
+            record.parsedModule,
+            request.exportName,
+            request.memberPath,
+            record
+          )
+        };
+      default:
+        return assertNever(tableEntry);
+    }
+  }
+
+  #collectNamespaceExportNames(
+    record: ImportedStaticCssEvalModuleRecord,
+    request: ImportedStaticCssEvalResolutionRequest,
+    state: ImportedStaticCssEvalResolutionState,
+    includeDefaultExport: boolean
+  ):
+    | { kind: "resolved"; exportNames: StaticCssEvalExportName[] }
+    | { kind: "error"; diagnostic: StaticCssEvalDiagnostic } {
+    const guardResult = this.#guardResolution(record, request, state);
+
+    if (!guardResult.ok) {
+      addResolutionGuardDependencies(state, guardResult.dependencies, request);
+
+      return { kind: "error", diagnostic: guardResult.diagnostic };
+    }
+
+    const stackEntry = createImportCycleStackEntry(record, request);
+    state.stack.push(stackEntry);
+
+    try {
+      const namespaceTableResult = this.#collectNamespaceExportNameTable(
+        record,
+        request,
+        state,
+        includeDefaultExport
+      );
+
+      if (namespaceTableResult.kind === "error") {
+        return namespaceTableResult;
+      }
+
+      const exportNames: StaticCssEvalExportName[] = [];
+
+      for (const [exportName, tableEntry] of namespaceTableResult.table.table) {
+        if (exportName === null) {
+          continue;
+        }
+
+        if (tableEntry.kind === "ambiguous-star") {
+          return {
+            kind: "error",
+            diagnostic: createAmbiguousExportStarDiagnostic(
+              record,
+              { ...request, exportName },
+              state,
+              namespaceTableResult.table.candidates
+            )
+          };
+        }
+
+        exportNames.push(exportName);
+      }
+
+      return { kind: "resolved", exportNames };
+    } finally {
+      state.stack.pop();
+    }
+  }
+
+  #collectNamespaceExportNameTable(
+    record: ImportedStaticCssEvalModuleRecord,
+    request: ImportedStaticCssEvalResolutionRequest,
+    state: ImportedStaticCssEvalResolutionState,
+    includeDefaultExport: boolean
+  ):
+    | { kind: "resolved"; table: ImportedStaticCssEvalNamespaceExportNameTable }
+    | { kind: "error"; diagnostic: StaticCssEvalDiagnostic } {
+    const starSourcesResult = this.#collectNamespaceExportStarSources(
+      record,
+      request,
+      state
+    );
+
+    if (starSourcesResult.kind === "error") {
+      return { kind: "error", diagnostic: starSourcesResult.diagnostic };
+    }
+
+    return {
+      kind: "resolved",
+      table: {
+        table: createStaticCssModuleExportNameTable(
+          createNamespaceExplicitExportMap(
+            record.exports,
+            includeDefaultExport
+          ),
+          starSourcesResult.starSources
+        ),
+        candidates: starSourcesResult.candidates
+      }
+    };
+  }
+
+  #collectNamespaceExportStarSources(
+    record: ImportedStaticCssEvalModuleRecord,
+    request: ImportedStaticCssEvalResolutionRequest,
+    state: ImportedStaticCssEvalResolutionState
+  ):
+    | {
+        kind: "resolved";
+        starSources: StaticCssModuleExportStarSource[];
+        candidates: ImportedStaticCssEvalExportStarCandidate[];
+      }
+    | { kind: "error"; diagnostic: StaticCssEvalDiagnostic } {
+    const starSources: StaticCssModuleExportStarSource[] = [];
+    const candidates: ImportedStaticCssEvalExportStarCandidate[] = [];
+
+    for (const starEntry of record.parsedModule.exportStarReexports) {
+      const starRequest = createExportStarRequest(record, starEntry, request);
+      const importResult = this.#resolveProviderImport(
+        starRequest,
+        state.owner,
+        state
+      );
+
+      if (importResult.kind === "error") {
+        return { kind: "error", diagnostic: importResult.diagnostic };
+      }
+
+      const exportNamesResult = this.#collectNamespaceExportNames(
+        importResult.record,
+        { ...starRequest, wholeNamespace: true },
+        state,
+        false
+      );
+
+      if (exportNamesResult.kind === "error") {
+        return { kind: "error", diagnostic: exportNamesResult.diagnostic };
+      }
+
+      if (exportNamesResult.exportNames.length === 0) {
+        continue;
+      }
+
+      candidates.push({
+        entry: starEntry,
+        record: importResult.record,
+        request: starRequest
+      });
+      starSources.push({
+        entry: starEntry,
+        exportNames: exportNamesResult.exportNames
+      });
+    }
+
+    return { kind: "resolved", starSources, candidates };
   }
 
   #resolveExportStarEntries(
@@ -713,7 +1113,8 @@ class ImportedStaticCssEvalResolver {
       source: record.id,
       exportName: effectiveRequest.exportName,
       memberPath: [...effectiveRequest.memberPath],
-      provenance
+      provenance,
+      ...createStaticCssEvalProviderSourceMetadata(record)
     });
     updateResolutionDependencyKind(
       state,
@@ -736,14 +1137,18 @@ class ImportedStaticCssEvalResolver {
           state.owner.file,
           record.parsedModule,
           effectiveRequest.exportName,
-          effectiveRequest.memberPath
+          effectiveRequest.memberPath,
+          record
         )
       };
     }
 
     const exportNameTable = createStaticCssModuleExportNameTable(
       record.exports,
-      createExportStarSources(effectiveRequest.exportName, candidatesResult.candidates)
+      createExportStarSources(
+        effectiveRequest.exportName,
+        candidatesResult.candidates
+      )
     );
     const tableEntry = exportNameTable.get(effectiveRequest.exportName);
 
@@ -761,11 +1166,16 @@ class ImportedStaticCssEvalResolver {
         );
       case "star": {
         const candidate = candidatesResult.candidates.find(
-          (exportStarCandidate) => exportStarCandidate.entry === tableEntry.entry
+          (exportStarCandidate) =>
+            exportStarCandidate.entry === tableEntry.entry
         );
 
         return candidate
-          ? this.#resolveModuleExport(candidate.record, candidate.request, state)
+          ? this.#resolveModuleExport(
+              candidate.record,
+              candidate.request,
+              state
+            )
           : this.#createMissingExportResult(record, effectiveRequest, state);
       }
       case "ambiguous-star":
@@ -782,7 +1192,8 @@ class ImportedStaticCssEvalResolver {
             state.owner.file,
             record.parsedModule,
             effectiveRequest.exportName,
-            effectiveRequest.memberPath
+            effectiveRequest.memberPath,
+            record
           )
         };
       default:
@@ -834,25 +1245,8 @@ class ImportedStaticCssEvalResolver {
       }
     | { kind: "missing" }
     | { kind: "error"; diagnostic: StaticCssEvalDiagnostic } {
-    if (!isProjectLocalStaticCssImportSpecifier(starEntry.source)) {
-      return {
-        kind: "error",
-        diagnostic: createStaticCssEvalPackageImportUnsupportedDiagnostic(
-          {
-            owner: state.owner,
-            dependency: { file: record.id },
-            importPath: starEntry.source,
-            exportName: request.exportName,
-            memberPath: request.memberPath,
-            importChain: createResolutionImportChain(state, record.id)
-          },
-          starEntry.source
-        )
-      };
-    }
-
     const starRequest = createExportStarRequest(record, starEntry, request);
-    const importResult = this.#resolveProjectLocalImport(
+    const importResult = this.#resolveProviderImport(
       starRequest,
       state.owner,
       state
@@ -961,30 +1355,6 @@ class ImportedStaticCssEvalResolver {
     state: ImportedStaticCssEvalResolutionState,
     provenance: BindingProvenance
   ): ImportedStaticCssEvalResolutionResult {
-    if (!isProjectLocalStaticCssImportSpecifier(exportEntry.source)) {
-      return {
-        kind: "error",
-        diagnostic: createStaticCssEvalPackageImportUnsupportedDiagnostic(
-          {
-            owner: state.owner,
-            dependency: { file: record.id },
-            importPath: exportEntry.source,
-            exportName: exportEntry.importedName,
-            memberPath: request.memberPath,
-            importChain: createResolutionImportChain(state, record.id)
-          },
-          exportEntry.source
-        ),
-        provenance,
-        cacheKey: createImportedStaticCssEvalCacheKey(
-          state.owner.file,
-          record.parsedModule,
-          request.exportName,
-          request.memberPath
-        )
-      };
-    }
-
     const reexportRequest: ImportedStaticCssEvalResolutionRequest = {
       importer: record.id,
       specifier: exportEntry.source,
@@ -994,7 +1364,7 @@ class ImportedStaticCssEvalResolver {
       provenanceKind: "reexported",
       reexportName: formatExportName(exportEntry.exportName)
     };
-    const importResult = this.#resolveProjectLocalImport(
+    const importResult = this.#resolveProviderImport(
       reexportRequest,
       state.owner,
       state
@@ -1009,7 +1379,8 @@ class ImportedStaticCssEvalResolver {
             state.owner.file,
             record.parsedModule,
             request.exportName,
-            request.memberPath
+            request.memberPath,
+            record
           )
         }
       : this.#resolveModuleExport(importResult.record, reexportRequest, state);
@@ -1037,7 +1408,8 @@ class ImportedStaticCssEvalResolver {
         state.owner.file,
         record.parsedModule,
         request.exportName,
-        request.memberPath
+        request.memberPath,
+        record
       )
     };
   }
@@ -1104,12 +1476,27 @@ class ImportedStaticCssEvalResolver {
     });
   }
 
-  #resolveImport(importerId: string, importPath: string): string | null {
-    return (
-      this.#importResolutions.get(
-        createImportResolutionKey(importerId, importPath)
-      ) ?? (this.#modules.has(importPath) ? importPath : null)
+  #resolveImport(
+    importerId: string,
+    importPath: string
+  ): ImportedStaticCssEvalResolvedImport | null {
+    const resolvedImport = this.#importResolutions.get(
+      createImportResolutionKey(importerId, importPath)
     );
+
+    if (resolvedImport) {
+      return resolvedImport;
+    }
+
+    const loadedModule = this.#modules.get(importPath);
+
+    return loadedModule
+      ? {
+          resolvedId: importPath,
+          sourceMetadata:
+            createStaticCssEvalProviderSourceMetadata(loadedModule)
+        }
+      : null;
   }
 
   #getModuleRecord(id: string): ImportedStaticCssEvalModuleRecord | null {
@@ -1133,9 +1520,10 @@ class ImportedStaticCssEvalResolver {
       this.#records.set(id, record);
       return record;
     } catch (error) {
-      if (!(error instanceof Error)) {
-        return null;
-      }
+      this.#parseFailures.set(
+        id,
+        error instanceof Error ? error.message : String(error)
+      );
       return null;
     }
   }
@@ -1186,6 +1574,10 @@ function collectModuleImportBindings(
   }
 }
 
+function createInlineStaticCssSourceHash(source: string): string {
+  return `inline:${hash(source)}`;
+}
+
 function createStaticCssModuleSource(
   loadedModule: ImportedStaticCssEvalLoadedModule
 ): StaticCssModuleSource {
@@ -1193,11 +1585,39 @@ function createStaticCssModuleSource(
     resolvedFile: loadedModule.id,
     source: loadedModule.source,
     sourceHash:
-      loadedModule.sourceHash ?? `inline:${loadedModule.source.length}`,
+      loadedModule.sourceHash ??
+      createInlineStaticCssSourceHash(loadedModule.source),
     ...(loadedModule.version !== undefined
       ? { sourceVersion: loadedModule.version }
       : {})
   };
+}
+
+function mergeImportedStaticCssEvalSourceMetadata(
+  resolutionMetadata: StaticCssEvalProviderSourceMetadata,
+  loadedModule: StaticCssEvalProviderSourcePolicyDescriptor | undefined
+): StaticCssEvalProviderSourceMetadata {
+  if (!loadedModule) {
+    return resolutionMetadata;
+  }
+
+  return createStaticCssEvalProviderSourceMetadata({
+    sourceKind: loadedModule.sourceKind ?? resolutionMetadata.sourceKind,
+    sourceOrigin:
+      loadedModule.sourceOrigin ??
+      (loadedModule.sourceKind ? undefined : resolutionMetadata.sourceOrigin),
+    canonicalModuleId:
+      loadedModule.canonicalModuleId ?? resolutionMetadata.canonicalModuleId,
+    normalizedPathKey:
+      loadedModule.normalizedPathKey ?? resolutionMetadata.normalizedPathKey,
+    watchFiles: loadedModule.watchFiles ?? resolutionMetadata.watchFiles,
+    unsupportedReason:
+      loadedModule.unsupportedReason ?? resolutionMetadata.unsupportedReason
+  });
+}
+
+function assertNever(value: never): never {
+  throw new TypeError(`Unexpected imported static css eval value: ${value}`);
 }
 
 function createResolutionState(
@@ -1213,41 +1633,28 @@ function createResolutionState(
 
 function createResolutionRequest(
   query: StaticCssEvalQuery,
-  importBinding: ImportedStaticCssEvalImportBinding,
-  owner: StaticCssEvalSourceLocation
+  importBinding: ImportedStaticCssEvalImportBinding
 ):
   | { kind: "resolved"; request: ImportedStaticCssEvalResolutionRequest }
   | { kind: "error"; diagnostic: StaticCssEvalDiagnostic } {
   const queryMemberPath = [...(query.memberPath ?? [])];
 
   if (importBinding.kind === "namespace") {
-    if (!isProjectLocalStaticCssImportSpecifier(importBinding.importPath)) {
-      return {
-        kind: "error",
-        diagnostic: createStaticCssEvalNamespaceImportUnsupportedDiagnostic(
-          {
-            owner,
-            importPath: importBinding.importPath,
-            memberPath: queryMemberPath
-          },
-          importBinding.importPath
-        )
-      };
-    }
-
     const [exportName, ...memberPath] = queryMemberPath;
 
-    if (!exportName) {
+    if (exportName === undefined) {
       return {
-        kind: "error",
-        diagnostic: createStaticCssEvalNamespaceImportUnsupportedDiagnostic(
-          {
-            owner,
-            importPath: importBinding.importPath,
-            memberPath: queryMemberPath
-          },
-          importBinding.importPath
-        )
+        kind: "resolved",
+        request: {
+          importer: query.importerId,
+          specifier: importBinding.importPath,
+          exportName: null,
+          memberPath: [],
+          dependencyKind: "namespace-member",
+          provenanceKind: "namespace-member",
+          namespaceBinding: importBinding.localName,
+          wholeNamespace: true
+        }
       };
     }
 
@@ -1262,21 +1669,6 @@ function createResolutionRequest(
         provenanceKind: "namespace-member",
         namespaceBinding: importBinding.localName
       }
-    };
-  }
-
-  if (!isProjectLocalStaticCssImportSpecifier(importBinding.importPath)) {
-    return {
-      kind: "error",
-      diagnostic: createStaticCssEvalPackageImportUnsupportedDiagnostic(
-        {
-          owner,
-          importPath: importBinding.importPath,
-          exportName: importBinding.importedName,
-          memberPath: queryMemberPath
-        },
-        importBinding.importPath
-      )
     };
   }
 
@@ -1305,7 +1697,8 @@ function resolveStaticExportMapEntry(
     state.owner.file,
     record.parsedModule,
     request.exportName,
-    request.memberPath
+    request.memberPath,
+    record
   );
 
   if (expressionResult.kind === "error") {
@@ -1474,7 +1867,7 @@ function createUnsupportedExportEntryDiagnostic(
   }
 
   if (exportEntry.unsupportedKind === "export-namespace") {
-    return createStaticCssEvalNamespaceImportUnsupportedDiagnostic(
+    return createStaticCssEvalNamespaceReexportUnsupportedDiagnostic(
       context,
       exportEntry.source ?? request.specifier
     );
@@ -1528,7 +1921,8 @@ function createImportedStaticCssEvalCacheKey(
   importerFile: string,
   parsedModule: ParsedStaticCssModule,
   exportName: StaticCssEvalExportName,
-  memberPath: readonly string[]
+  memberPath: readonly string[],
+  sourceMetadata?: StaticCssEvalProviderSourcePolicyDescriptor
 ): StaticCssEvalCacheKey {
   return {
     importerFile,
@@ -1541,8 +1935,12 @@ function createImportedStaticCssEvalCacheKey(
       : {}),
     pluginOptionsVersion: "static-css-eval-provider:v1",
     resolverOptionsVersion: "static-css-eval-provider:v1",
+    parserVersion: parsedModule.cacheKey.parserVersion,
     staticEvalSupportVersion: STATIC_CSS_MODULE_CACHE_SUPPORT_VERSION,
     resolvedId: parsedModule.resolvedFile,
+    ...(sourceMetadata
+      ? createStaticCssEvalProviderSourceMetadata(sourceMetadata)
+      : {}),
     parserOptions: parsedModule.cacheKey.parserOptions
   };
 }
@@ -1648,7 +2046,8 @@ function getResolutionDependencies(
 ): ResolutionDependency[] {
   return [...state.dependencies.values()].map((dependency) => ({
     ...dependency,
-    memberPath: [...dependency.memberPath]
+    memberPath: [...dependency.memberPath],
+    ...(dependency.watchFiles ? { watchFiles: [...dependency.watchFiles] } : {})
   }));
 }
 
@@ -1683,6 +2082,121 @@ function mergeResolutionDependencyKind(
   return next;
 }
 
+function createImportCycleStackEntry(
+  record: ImportedStaticCssEvalModuleRecord,
+  request: ImportedStaticCssEvalResolutionRequest
+): StaticCssEvalImportCycleKey {
+  return {
+    file: record.id,
+    exportName: request.exportName,
+    memberPath: [...request.memberPath]
+  };
+}
+
+function createExportStarRequest(
+  record: ImportedStaticCssEvalModuleRecord,
+  starEntry: ExportGraphStarReexportEntry,
+  request: ImportedStaticCssEvalResolutionRequest
+): ImportedStaticCssEvalResolutionRequest {
+  return {
+    importer: record.id,
+    specifier: starEntry.source,
+    exportName: request.exportName,
+    memberPath: [...request.memberPath],
+    dependencyKind: "reexported",
+    provenanceKind: "reexported",
+    reexportName: formatExportName(request.exportName)
+  };
+}
+
+function createExportStarSources(
+  exportName: StaticCssEvalExportName,
+  candidates: readonly ImportedStaticCssEvalExportStarCandidate[]
+): StaticCssModuleExportStarSource[] {
+  return candidates.map((candidate) => ({
+    entry: candidate.entry,
+    exportNames: [exportName]
+  }));
+}
+
+function createNamespaceExplicitExportMap(
+  exports: ReadonlyMap<StaticCssEvalExportName, ExportMapEntry>,
+  includeDefaultExport: boolean
+): ReadonlyMap<StaticCssEvalExportName, ExportMapEntry> {
+  const namespaceExports = new Map<StaticCssEvalExportName, ExportMapEntry>();
+
+  for (const [exportName, exportEntry] of exports) {
+    if (exportName === null) {
+      continue;
+    }
+
+    if (!includeDefaultExport && exportName === "default") {
+      continue;
+    }
+
+    namespaceExports.set(exportName, exportEntry);
+  }
+
+  return namespaceExports;
+}
+
+function addResolutionGuardDependencies(
+  state: ImportedStaticCssEvalResolutionState,
+  dependencies: readonly string[],
+  request: ImportedStaticCssEvalResolutionRequest
+): void {
+  for (const file of dependencies) {
+    addResolutionDependency(state, {
+      file,
+      kind: request.dependencyKind,
+      importer: request.importer,
+      specifier: request.specifier,
+      exportName: request.exportName,
+      memberPath: [...request.memberPath],
+      inspected: true,
+      contributed: false
+    });
+  }
+}
+
+function createAmbiguousExportStarDiagnostic(
+  record: ImportedStaticCssEvalModuleRecord,
+  request: ImportedStaticCssEvalResolutionRequest,
+  state: ImportedStaticCssEvalResolutionState,
+  candidates: readonly ImportedStaticCssEvalExportStarCandidate[]
+): StaticCssEvalDiagnostic {
+  return createStaticCssEvalAmbiguousExportStarDiagnostic(
+    {
+      owner: state.owner,
+      dependency: { file: record.id },
+      importPath: request.specifier,
+      exportName: request.exportName,
+      memberPath: request.memberPath,
+      importChain: createAmbiguousExportStarImportChain(
+        state,
+        request,
+        candidates
+      )
+    },
+    request.exportName
+  );
+}
+
+function createAmbiguousExportStarImportChain(
+  state: ImportedStaticCssEvalResolutionState,
+  request: ImportedStaticCssEvalResolutionRequest,
+  candidates: readonly ImportedStaticCssEvalExportStarCandidate[]
+): string[] {
+  return [
+    state.owner.file,
+    ...state.stack.map(formatStaticCssEvalResolutionFrame),
+    ...candidates.map(
+      (candidate) =>
+        `${candidate.record.id}#${formatExportName(request.exportName)}`
+    )
+  ];
+}
+
 function createResolutionImportChain(
   state: ImportedStaticCssEvalResolutionState,
   nextFile: string
@@ -1711,10 +2225,6 @@ function formatStaticCssEvalQueryExpression(query: StaticCssEvalQuery): string {
     : "";
 
   return `${bindingName}${memberPath}`;
-}
-
-function isProjectLocalStaticCssImportSpecifier(importPath: string): boolean {
-  return importPath.startsWith(".") || importPath.startsWith("/");
 }
 
 function isRequireCallExpression(expression: t.Expression): boolean {
@@ -1764,27 +2274,6 @@ function resolveStaticObjectMemberPath(
   return currentExpression
     ? unwrapTransparentCssRuleExpression(currentExpression)
     : null;
-}
-
-function getStaticObjectMemberValue(
-  expression: t.ObjectExpression,
-  memberName: string
-): t.Expression | null {
-  for (let index = expression.properties.length - 1; index >= 0; index -= 1) {
-    const property = expression.properties[index];
-
-    if (!property || !t.isObjectProperty(property) || property.computed) {
-      return null;
-    }
-
-    if (getStaticObjectPropertyName(property.key) !== memberName) {
-      continue;
-    }
-
-    return t.isExpression(property.value) ? property.value : null;
-  }
-
-  return null;
 }
 
 function evaluateStaticCssLiteralExpression(
@@ -1882,9 +2371,10 @@ function evaluateStaticCssLiteralExpression(
       ...context,
       code: "unsupported-syntax",
       reason: getUnsupportedLiteralReason(unwrappedExpression),
-      detail: `imported export "${formatExportName(
-        context.exportName
-      )}" contains unsupported ${unwrappedExpression.type}`
+      detail: createUnsupportedLiteralDetail(
+        context.exportName,
+        unwrappedExpression
+      )
     })
   };
 }
@@ -2261,6 +2751,18 @@ function getModuleStringName(
   return null;
 }
 
+function createUnsupportedLiteralDetail(
+  exportName: StaticCssEvalExportName,
+  expression: t.Expression
+): string {
+  if (getUnsupportedLiteralReason(expression) === "dynamic-import") {
+    return `imported export "${formatExportName(exportName)}" contains a dynamic import`;
+  }
+
+  return `imported export "${formatExportName(
+    exportName
+  )}" contains unsupported ${expression.type}`;
+}
 function isStaticCssRuleLiteralValue(
   value: StaticCssLiteral
 ): value is StaticCssLiteral[] | { [key: string]: StaticCssLiteral } {
@@ -2291,6 +2793,13 @@ if (import.meta.vitest) {
   const stylesId = "/project/src/styles.ts";
   const barrelId = "/project/src/barrel.ts";
   const buttonId = "/project/src/button.ts";
+  const packageBarrelId = "pkg:@scope/styles";
+  const packageLeafId = "pkg:@scope/styles/leaf";
+  const packageDataId = "data:@scope/styles/tokens";
+  const packageJsonId = "data:@scope/styles/theme.json";
+  const packageRawId = "data:@scope/styles/tokens.css?raw";
+  const packageWasmUrlId = "data:@scope/styles/icon.wasm?url";
+  const providerVirtualId = "virtual:mincho-styles";
 
   function createProviderFromModules(options: {
     modules: readonly ImportedStaticCssEvalLoadedModule[];
@@ -2434,6 +2943,21 @@ if (import.meta.vitest) {
           source: `export const value = <div />;`
         })
       ).not.toThrow();
+    });
+
+    it("derives matching module and cache hashes from inline source content", () => {
+      const red = createImportedStaticCssEvalModuleRecord({
+        id: stylesId,
+        source: `export const value = "red";`
+      });
+      const sky = createImportedStaticCssEvalModuleRecord({
+        id: stylesId,
+        source: `export const value = "sky";`
+      });
+
+      expect(red.sourceHash).toMatch(/^inline:[a-z0-9]+$/);
+      expect(red.sourceHash).toBe(red.parsedModule.sourceHash);
+      expect(red.sourceHash).not.toBe(sky.sourceHash);
     });
 
     it("resolves named, aliased, default object, default const, and same-module export aliases", () => {
@@ -2696,14 +3220,551 @@ if (import.meta.vitest) {
       });
     });
 
+    it("resolves package provider named default namespace reexport export-star json raw and wasm imports", () => {
+      const provider = createProviderFromModules({
+        modules: [
+          {
+            id: ownerId,
+            source: `
+              import rootDefault, { button, dataToken } from "@scope/styles";
+              import * as styles from "@scope/styles";
+              import theme, { jsonButton } from "@scope/styles/theme.json";
+              import rawToken from "@scope/styles/tokens.css?raw";
+              import wasmUrl from "@scope/styles/icon.wasm?url";
+              import virtualDefault from "virtual:mincho-styles";
+              <>
+                <div css={button} />
+                <div css={rootDefault} />
+                <div css={dataToken} />
+                <div css={styles.reexported} />
+                <div css={styles.default} />
+                <div css={jsonButton} />
+                <div css={theme.card} />
+                <div css={rawToken} />
+                <div css={wasmUrl} />
+                <div css={virtualDefault} />
+              </>;
+            `
+          },
+          {
+            id: packageBarrelId,
+            source: `
+              export { default, button as reexported } from "@scope/styles/leaf";
+              export * from "@scope/styles/leaf";
+              export * from "@scope/styles/tokens";
+            `,
+            sourceKind: "package-source",
+            sourceOrigin: "package",
+            canonicalModuleId: "npm:@scope/styles",
+            normalizedPathKey: packageBarrelId,
+            watchFiles: ["/project/node_modules/@scope/styles/package.json"]
+          },
+          {
+            id: packageLeafId,
+            source: `
+              export const button = { color: "red" } as const;
+              export default { color: "blue" } as const;
+            `,
+            sourceKind: "package-source",
+            sourceOrigin: "package",
+            canonicalModuleId: "npm:@scope/styles/leaf",
+            normalizedPathKey: packageLeafId
+          },
+          {
+            id: packageDataId,
+            source: `export const dataToken = { color: "green" } as const;`,
+            sourceKind: "static-data",
+            sourceOrigin: "data",
+            canonicalModuleId: "json:@scope/styles/tokens",
+            normalizedPathKey: packageDataId
+          },
+          {
+            id: packageJsonId,
+            source: `
+              export default { card: { color: "orange" } } as const;
+              export const jsonButton = { color: "cyan" } as const;
+            `,
+            sourceKind: "static-data",
+            sourceOrigin: "data",
+            canonicalModuleId: "json:@scope/styles/theme",
+            normalizedPathKey: packageJsonId
+          },
+          {
+            id: packageRawId,
+            source: `export default "tomato";`,
+            sourceKind: "static-data",
+            sourceOrigin: "data",
+            canonicalModuleId: "raw:@scope/styles/tokens",
+            normalizedPathKey: packageRawId
+          },
+          {
+            id: packageWasmUrlId,
+            source: `export default "/assets/icon.wasm";`,
+            sourceKind: "static-data",
+            sourceOrigin: "data",
+            canonicalModuleId: "wasm-url:@scope/styles/icon",
+            normalizedPathKey: packageWasmUrlId
+          },
+          {
+            id: providerVirtualId,
+            source: `export default { color: "purple" } as const;`,
+            sourceKind: "provider-virtual",
+            sourceOrigin: "provider",
+            canonicalModuleId: providerVirtualId,
+            normalizedPathKey: providerVirtualId
+          }
+        ],
+        importResolutions: [
+          {
+            importerId: ownerId,
+            importPath: "@scope/styles",
+            resolvedId: packageBarrelId,
+            sourceKind: "package-source",
+            sourceOrigin: "package",
+            canonicalModuleId: "npm:@scope/styles",
+            normalizedPathKey: packageBarrelId
+          },
+          {
+            importerId: ownerId,
+            importPath: "virtual:mincho-styles",
+            resolvedId: providerVirtualId,
+            sourceKind: "provider-virtual",
+            sourceOrigin: "provider",
+            canonicalModuleId: providerVirtualId,
+            normalizedPathKey: providerVirtualId
+          },
+          {
+            importerId: packageBarrelId,
+            importPath: "@scope/styles/leaf",
+            resolvedId: packageLeafId,
+            sourceKind: "package-source",
+            sourceOrigin: "package",
+            canonicalModuleId: "npm:@scope/styles/leaf",
+            normalizedPathKey: packageLeafId
+          },
+          {
+            importerId: packageBarrelId,
+            importPath: "@scope/styles/tokens",
+            resolvedId: packageDataId,
+            sourceKind: "static-data",
+            sourceOrigin: "data",
+            canonicalModuleId: "json:@scope/styles/tokens",
+            normalizedPathKey: packageDataId
+          },
+          {
+            importerId: ownerId,
+            importPath: "@scope/styles/theme.json",
+            resolvedId: packageJsonId,
+            sourceKind: "static-data",
+            sourceOrigin: "data",
+            canonicalModuleId: "json:@scope/styles/theme",
+            normalizedPathKey: packageJsonId
+          },
+          {
+            importerId: ownerId,
+            importPath: "@scope/styles/tokens.css?raw",
+            resolvedId: packageRawId,
+            sourceKind: "static-data",
+            sourceOrigin: "data",
+            canonicalModuleId: "raw:@scope/styles/tokens",
+            normalizedPathKey: packageRawId
+          },
+          {
+            importerId: ownerId,
+            importPath: "@scope/styles/icon.wasm?url",
+            resolvedId: packageWasmUrlId,
+            sourceKind: "static-data",
+            sourceOrigin: "data",
+            canonicalModuleId: "wasm-url:@scope/styles/icon",
+            normalizedPathKey: packageWasmUrlId
+          }
+        ]
+      });
+      const buttonResult = expectResolvedResult(
+        resolveFixture(provider, "button")
+      );
+
+      expect(buttonResult.value).toEqual({ color: "red" });
+      expect(resolveFixture(provider, "rootDefault")).toMatchObject({
+        kind: "resolved",
+        value: { color: "blue" }
+      });
+      expect(resolveFixture(provider, "dataToken")).toMatchObject({
+        kind: "resolved",
+        value: { color: "green" }
+      });
+      expect(resolveFixture(provider, "styles", ["reexported"])).toMatchObject({
+        kind: "resolved",
+        value: { color: "red" }
+      });
+      expect(resolveFixture(provider, "styles", ["default"])).toMatchObject({
+        kind: "resolved",
+        value: { color: "blue" }
+      });
+      expect(resolveFixture(provider, "jsonButton")).toMatchObject({
+        kind: "resolved",
+        value: { color: "cyan" }
+      });
+      expect(resolveFixture(provider, "theme", ["card"])).toMatchObject({
+        kind: "resolved",
+        value: { color: "orange" }
+      });
+      expect(resolveFixture(provider, "rawToken")).toMatchObject({
+        kind: "resolved",
+        value: "tomato"
+      });
+      expect(resolveFixture(provider, "wasmUrl")).toMatchObject({
+        kind: "resolved",
+        value: "/assets/icon.wasm"
+      });
+      expect(resolveFixture(provider, "virtualDefault")).toMatchObject({
+        kind: "resolved",
+        value: { color: "purple" }
+      });
+      expect(buttonResult.dependencies).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            file: packageBarrelId,
+            sourceKind: "package-source",
+            sourceOrigin: "package",
+            canonicalModuleId: "npm:@scope/styles"
+          }),
+          expect.objectContaining({
+            file: packageLeafId,
+            sourceKind: "package-source",
+            sourceOrigin: "package",
+            canonicalModuleId: "npm:@scope/styles/leaf"
+          })
+        ])
+      );
+      expect(buttonResult.cacheKey).toMatchObject({
+        resolvedFile: packageLeafId,
+        sourceKind: "package-source",
+        sourceOrigin: "package",
+        canonicalModuleId: "npm:@scope/styles/leaf",
+        normalizedPathKey: packageLeafId
+      });
+    });
+
+    it("resolves package whole namespace imports only when every export is static", () => {
+      const staticNamespaceProvider = createProviderFromModules({
+        modules: [
+          {
+            id: ownerId,
+            source: `import * as styles from "@scope/namespace"; <div css={styles} />;`
+          },
+          {
+            id: packageBarrelId,
+            source: `
+              export { default } from "@scope/styles/leaf";
+              export * from "@scope/styles/leaf";
+              export const card = { color: "green" } as const;
+            `,
+            sourceKind: "package-source",
+            sourceOrigin: "package"
+          },
+          {
+            id: packageLeafId,
+            source: `
+              export const button = { color: "red" } as const;
+              export default { color: "blue" } as const;
+            `,
+            sourceKind: "package-source",
+            sourceOrigin: "package"
+          }
+        ],
+        importResolutions: [
+          {
+            importerId: ownerId,
+            importPath: "@scope/namespace",
+            resolvedId: packageBarrelId,
+            sourceKind: "package-source",
+            sourceOrigin: "package"
+          },
+          {
+            importerId: packageBarrelId,
+            importPath: "@scope/styles/leaf",
+            resolvedId: packageLeafId,
+            sourceKind: "package-source",
+            sourceOrigin: "package"
+          }
+        ]
+      });
+      const nonStaticNamespaceProvider = createProviderFromModules({
+        modules: [
+          {
+            id: ownerId,
+            source: `import * as styles from "@scope/namespace"; <div css={styles} />;`
+          },
+          {
+            id: packageBarrelId,
+            source: `
+              export const button = { color: "red" } as const;
+              export const dynamic = createStyle();
+            `,
+            sourceKind: "package-source",
+            sourceOrigin: "package"
+          }
+        ],
+        importResolutions: [
+          {
+            importerId: ownerId,
+            importPath: "@scope/namespace",
+            resolvedId: packageBarrelId,
+            sourceKind: "package-source",
+            sourceOrigin: "package"
+          }
+        ]
+      });
+
+      expect(resolveFixture(staticNamespaceProvider, "styles")).toMatchObject({
+        kind: "resolved",
+        value: {
+          default: { color: "blue" },
+          button: { color: "red" },
+          card: { color: "green" }
+        }
+      });
+      expect(
+        resolveFixture(nonStaticNamespaceProvider, "styles")
+      ).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_NAMESPACE_PARTIAL_UNSUPPORTED",
+          code: "unsupported-source",
+          reason: "partial-namespace-failure",
+          dependency: { file: packageBarrelId },
+          importPath: "@scope/namespace",
+          exportName: "dynamic"
+        }
+      });
+    });
+
+    it("preserves special property names on whole namespace values", () => {
+      const result = expectResolvedResult(
+        resolveFixture(
+          createProvider(
+            `
+              const proto = { color: "red" } as const;
+              const constructorValue = { color: "blue" } as const;
+              export { proto as "__proto__", constructorValue as "constructor" };
+            `,
+            `import * as styles from "./styles"; <div css={styles} />;`
+          ),
+          "styles"
+        )
+      );
+
+      if (
+        result.value === null ||
+        typeof result.value !== "object" ||
+        Array.isArray(result.value)
+      ) {
+        throw new TypeError("expected a static namespace object");
+      }
+
+      expect(Object.hasOwn(result.value, "__proto__")).toBe(true);
+      expect(Object.hasOwn(result.value, "constructor")).toBe(true);
+    });
+
+    it("rejects unsupported provider source kinds with source metadata", () => {
+      const unresolvedId = "unresolved:@scope/missing";
+      const externalId = "external:@scope/external";
+      const virtualNoSourceId = "virtual:missing-styles";
+      const unsupportedShapeId = "unsupported:@scope/runtime";
+      const wasmRuntimeId = "unsupported:@scope/wasm-init";
+      const nonLiteralLoaderId = "unsupported:@scope/nonliteral";
+      const provider = createProviderFromModules({
+        modules: [
+          {
+            id: ownerId,
+            source: `
+              import { button as externalButton } from "@scope/external";
+              import { button as unresolvedButton } from "@scope/missing";
+              import virtualStyles from "virtual:missing-styles";
+              import { button as runtimeButton } from "@scope/runtime";
+              import wasmInit from "@scope/wasm-init";
+              import nonLiteral from "@scope/nonliteral";
+              <>
+                <div css={externalButton} />
+                <div css={unresolvedButton} />
+                <div css={virtualStyles} />
+                <div css={runtimeButton} />
+                <div css={wasmInit} />
+                <div css={nonLiteral} />
+              </>;
+            `
+          }
+        ],
+        importResolutions: [
+          {
+            importerId: ownerId,
+            importPath: "@scope/external",
+            resolvedId: externalId,
+            sourceKind: "external-no-source",
+            sourceOrigin: "external",
+            unsupportedReason: "external-no-source",
+            canonicalModuleId: "npm:@scope/external",
+            normalizedPathKey: externalId,
+            watchFiles: ["/project/package.json"]
+          },
+          {
+            importerId: ownerId,
+            importPath: "@scope/missing",
+            resolvedId: unresolvedId,
+            sourceKind: "unresolved",
+            sourceOrigin: "unresolved",
+            unsupportedReason: "unresolved",
+            canonicalModuleId: "npm:@scope/missing",
+            normalizedPathKey: unresolvedId
+          },
+          {
+            importerId: ownerId,
+            importPath: "virtual:missing-styles",
+            resolvedId: virtualNoSourceId,
+            sourceKind: "provider-virtual",
+            sourceOrigin: "provider",
+            canonicalModuleId: virtualNoSourceId,
+            normalizedPathKey: virtualNoSourceId
+          },
+          {
+            importerId: ownerId,
+            importPath: "@scope/runtime",
+            resolvedId: unsupportedShapeId,
+            sourceKind: "unsupported-source-shape",
+            sourceOrigin: "unsupported",
+            unsupportedReason: "unsupported-source-shape",
+            canonicalModuleId: "npm:@scope/runtime",
+            normalizedPathKey: unsupportedShapeId
+          },
+          {
+            importerId: ownerId,
+            importPath: "@scope/wasm-init",
+            resolvedId: wasmRuntimeId,
+            sourceKind: "unsupported-source-shape",
+            sourceOrigin: "unsupported",
+            unsupportedReason: "runtime-wasm-init-or-function",
+            canonicalModuleId: "npm:@scope/wasm-init",
+            normalizedPathKey: wasmRuntimeId
+          },
+          {
+            importerId: ownerId,
+            importPath: "@scope/nonliteral",
+            resolvedId: nonLiteralLoaderId,
+            sourceKind: "unsupported-source-shape",
+            sourceOrigin: "unsupported",
+            unsupportedReason: "non-literal-loader-output",
+            canonicalModuleId: "npm:@scope/nonliteral",
+            normalizedPathKey: nonLiteralLoaderId
+          }
+        ]
+      });
+
+      const externalResult = resolveFixture(provider, "externalButton");
+
+      expect(externalResult).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_PROVIDER_SOURCE_UNSUPPORTED",
+          code: "unsupported-source",
+          reason: "external-no-source",
+          dependency: { file: externalId },
+          importPath: "@scope/external",
+          exportName: "button"
+        },
+        dependencies: [
+          expect.objectContaining({
+            file: externalId,
+            sourceKind: "external-no-source",
+            sourceOrigin: "external",
+            unsupportedReason: "external-no-source",
+            canonicalModuleId: "npm:@scope/external",
+            normalizedPathKey: externalId,
+            watchFiles: ["/project/package.json"],
+            inspected: true,
+            contributed: false
+          })
+        ]
+      });
+      expect(resolveFixture(provider, "unresolvedButton")).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          code: "unsupported-source",
+          reason: "unresolved",
+          dependency: { file: unresolvedId },
+          importPath: "@scope/missing"
+        }
+      });
+      const virtualResult = resolveFixture(provider, "virtualStyles");
+      expect(virtualResult).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_PROVIDER_SOURCE_UNSUPPORTED",
+          code: "unsupported-source",
+          reason: "provider-virtual-no-source",
+          dependency: { file: virtualNoSourceId },
+          importPath: "virtual:missing-styles"
+        }
+      });
+      expect(resolveFixture(provider, "runtimeButton")).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_PROVIDER_SOURCE_UNSUPPORTED",
+          code: "unsupported-source",
+          reason: "unsupported-source-shape",
+          dependency: { file: unsupportedShapeId },
+          importPath: "@scope/runtime"
+        }
+      });
+      expect(resolveFixture(provider, "wasmInit")).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_PROVIDER_SOURCE_UNSUPPORTED",
+          reason: "runtime-wasm-init-or-function",
+          dependency: { file: wasmRuntimeId },
+          importPath: "@scope/wasm-init"
+        }
+      });
+      expect(resolveFixture(provider, "nonLiteral")).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_PROVIDER_SOURCE_UNSUPPORTED",
+          reason: "non-literal-loader-output",
+          dependency: { file: nonLiteralLoaderId },
+          importPath: "@scope/nonliteral"
+        }
+      });
+      expect(
+        externalResult.kind === "error" ? externalResult.diagnostic.message : ""
+      ).toContain(
+        'Cannot statically evaluate css prop value: external module "external:@scope/external" has no provider source'
+      );
+      expect(
+        virtualResult.kind === "error" ? virtualResult.diagnostic.message : ""
+      ).toContain(
+        'Cannot statically evaluate css prop value: provider virtual module "virtual:missing-styles" has no source from the bundler provider'
+      );
+    });
+
     it("lets explicit direct exports override same-named export star candidates", () => {
       const result = resolveFixture(
         createProvider(
           `export const button = { color: "red" } as const;`,
           `import { button } from "./barrel"; <div css={button} />;`,
           `export * from "./button"; export { button } from "./styles";`,
-          [{ id: buttonId, source: `export const button = { color: "blue" } as const;` }],
-          [{ importerId: barrelId, importPath: "./button", resolvedId: buttonId }]
+          [
+            {
+              id: buttonId,
+              source: `export const button = { color: "blue" } as const;`
+            }
+          ],
+          [
+            {
+              importerId: barrelId,
+              importPath: "./button",
+              resolvedId: buttonId
+            }
+          ]
         ),
         "button"
       );
@@ -2716,9 +3777,9 @@ if (import.meta.vitest) {
           { file: stylesId, inspected: true, contributed: true }
         ]
       });
-      expect(
-        result.kind === "resolved" ? result.dependencies : []
-      ).not.toEqual(expect.arrayContaining([expect.objectContaining({ file: buttonId })]));
+      expect(result.kind === "resolved" ? result.dependencies : []).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ file: buttonId })])
+      );
     });
 
     it("reports ambiguous export star conflict without choosing a candidate", () => {
@@ -2727,8 +3788,19 @@ if (import.meta.vitest) {
           `export const button = { color: "red" } as const;`,
           `import { button } from "./barrel"; <div css={button} />;`,
           `export * from "./styles"; export * from "./button";`,
-          [{ id: buttonId, source: `export const button = { color: "blue" } as const;` }],
-          [{ importerId: barrelId, importPath: "./button", resolvedId: buttonId }]
+          [
+            {
+              id: buttonId,
+              source: `export const button = { color: "blue" } as const;`
+            }
+          ],
+          [
+            {
+              importerId: barrelId,
+              importPath: "./button",
+              resolvedId: buttonId
+            }
+          ]
         ),
         "button"
       );
@@ -2736,7 +3808,8 @@ if (import.meta.vitest) {
       expect(result).toMatchObject({
         kind: "error",
         diagnostic: {
-          id: "STATIC_CSS_EVAL_UNRESOLVED_EXPORT",
+          id: "STATIC_CSS_EVAL_EXPORT_STAR_AMBIGUOUS",
+          reason: "ambiguous-star",
           exportName: "button",
           dependency: { file: barrelId },
           importChain: expect.arrayContaining([
@@ -2750,8 +3823,32 @@ if (import.meta.vitest) {
           { file: buttonId, inspected: true, contributed: false }
         ]
       });
-      expect(result.kind === "error" ? result.diagnostic.message : "").toContain(
-        "ambiguous"
+      expect(
+        result.kind === "error" ? result.diagnostic.message : ""
+      ).toContain("ambiguous");
+    });
+
+    it("rejects dynamic import values with precise diagnostics", () => {
+      const result = resolveFixture(
+        createProvider(
+          `export const button = import("./styles");`,
+          `import { button } from "./styles"; <div css={button} />;`
+        ),
+        "button"
+      );
+
+      expect(result).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          code: "unsupported-syntax",
+          reason: "dynamic-import",
+          dependency: { file: stylesId },
+          importPath: "./styles",
+          exportName: "button"
+        }
+      });
+      expect(result.kind === "error" ? result.diagnostic.message : "").toBe(
+        'Cannot statically evaluate css prop value: imported export "button" contains a dynamic import'
       );
     });
 
@@ -2775,9 +3872,21 @@ if (import.meta.vitest) {
             { id: buttonId, source: `export * from "./barrel";` }
           ],
           importResolutions: [
-            { importerId: ownerId, importPath: "./barrel", resolvedId: barrelId },
-            { importerId: barrelId, importPath: "./button", resolvedId: buttonId },
-            { importerId: buttonId, importPath: "./barrel", resolvedId: barrelId }
+            {
+              importerId: ownerId,
+              importPath: "./barrel",
+              resolvedId: barrelId
+            },
+            {
+              importerId: barrelId,
+              importPath: "./button",
+              resolvedId: buttonId
+            },
+            {
+              importerId: buttonId,
+              importPath: "./barrel",
+              resolvedId: barrelId
+            }
           ]
         }),
         "button"
@@ -2851,6 +3960,7 @@ if (import.meta.vitest) {
           sourceVersion: result.cacheKey.sourceVersion,
           pluginOptionsVersion: result.cacheKey.pluginOptionsVersion,
           resolverOptionsVersion: result.cacheKey.resolverOptionsVersion,
+          parserVersion: result.cacheKey.parserVersion,
           staticEvalSupportVersion: result.cacheKey.staticEvalSupportVersion
         }))
       ).toEqual([
@@ -2860,6 +3970,7 @@ if (import.meta.vitest) {
           sourceVersion: "styles-v1",
           pluginOptionsVersion: "static-css-eval-provider:v1",
           resolverOptionsVersion: "static-css-eval-provider:v1",
+          parserVersion: STATIC_CSS_MODULE_CACHE_PARSER_VERSION,
           staticEvalSupportVersion: STATIC_CSS_MODULE_CACHE_SUPPORT_VERSION
         },
         {
@@ -2868,6 +3979,7 @@ if (import.meta.vitest) {
           sourceVersion: "styles-v1",
           pluginOptionsVersion: "static-css-eval-provider:v1",
           resolverOptionsVersion: "static-css-eval-provider:v1",
+          parserVersion: STATIC_CSS_MODULE_CACHE_PARSER_VERSION,
           staticEvalSupportVersion: STATIC_CSS_MODULE_CACHE_SUPPORT_VERSION
         },
         {
@@ -2876,6 +3988,7 @@ if (import.meta.vitest) {
           sourceVersion: "styles-v1",
           pluginOptionsVersion: "static-css-eval-provider:v1",
           resolverOptionsVersion: "static-css-eval-provider:v1",
+          parserVersion: STATIC_CSS_MODULE_CACHE_PARSER_VERSION,
           staticEvalSupportVersion: STATIC_CSS_MODULE_CACHE_SUPPORT_VERSION
         },
         {
@@ -2884,6 +3997,7 @@ if (import.meta.vitest) {
           sourceVersion: "styles-v1",
           pluginOptionsVersion: "static-css-eval-provider:v1",
           resolverOptionsVersion: "static-css-eval-provider:v1",
+          parserVersion: STATIC_CSS_MODULE_CACHE_PARSER_VERSION,
           staticEvalSupportVersion: STATIC_CSS_MODULE_CACHE_SUPPORT_VERSION
         }
       ]);
@@ -3013,7 +4127,60 @@ if (import.meta.vitest) {
       });
     });
 
-    it("rejects missing exports, packages, cjs, and cycles with exact diagnostics", () => {
+    it("reports imported module parse failures in unresolved diagnostics", () => {
+      expect(
+        resolveFixture(createProvider(`export const button = {`), "button")
+      ).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_UNRESOLVED_IMPORT",
+          message: expect.stringMatching(
+            /Unexpected token|Unexpected end of input/
+          )
+        }
+      });
+    });
+
+    it("preserves non-Error imported module parse failures", () => {
+      const parseFailure = "synthetic parse failure";
+      const delegate = createStaticCssModuleCache();
+      const moduleCache: StaticCssModuleCache = {
+        ...delegate,
+        getParsedModule(source) {
+          if (source.resolvedFile === stylesId) {
+            throw parseFailure;
+          }
+
+          return delegate.getParsedModule(source);
+        }
+      };
+      const provider = createProviderFromModules({
+        modules: [
+          {
+            id: ownerId,
+            source: `import { button } from "./styles"; <div css={button} />;`
+          },
+          {
+            id: stylesId,
+            source: `export const button = { color: "red" } as const;`
+          }
+        ],
+        importResolutions: [
+          { importerId: ownerId, importPath: "./styles", resolvedId: stylesId }
+        ],
+        moduleCache
+      });
+
+      expect(resolveFixture(provider, "button")).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_UNRESOLVED_IMPORT",
+          message: expect.stringContaining(parseFailure)
+        }
+      });
+    });
+
+    it("rejects missing exports, unresolved imports, cjs, and cycles with exact diagnostics", () => {
       expect(
         resolveFixture(
           createProvider(
@@ -3040,7 +4207,8 @@ if (import.meta.vitest) {
       ).toMatchObject({
         kind: "error",
         diagnostic: {
-          id: "STATIC_CSS_EVAL_PACKAGE_IMPORT_UNSUPPORTED"
+          id: "STATIC_CSS_EVAL_UNRESOLVED_IMPORT",
+          importPath: "pkg"
         }
       });
 
@@ -3056,7 +4224,8 @@ if (import.meta.vitest) {
       ).toMatchObject({
         kind: "error",
         diagnostic: {
-          id: "STATIC_CSS_EVAL_NAMESPACE_UNSUPPORTED"
+          id: "STATIC_CSS_EVAL_UNRESOLVED_IMPORT",
+          importPath: "pkg"
         }
       });
 
@@ -3071,7 +4240,10 @@ if (import.meta.vitest) {
       ).toMatchObject({
         kind: "error",
         diagnostic: {
-          id: "STATIC_CSS_EVAL_CJS_UNSUPPORTED"
+          id: "STATIC_CSS_EVAL_CJS_UNSUPPORTED",
+          reason: "commonjs-require",
+          message:
+            "Cannot statically evaluate css prop value: commonjs require is unsupported"
         }
       });
 
@@ -3139,6 +4311,28 @@ if (import.meta.vitest) {
           "button"
         )
       ).toEqual({ kind: "not-candidate" });
+    });
+
+    it("rejects unsupported namespace reexports with exact diagnostics", () => {
+      const result = resolveFixture(
+        createProvider(
+          `export const button = { color: "red" } as const;`,
+          `import { styles } from "./barrel"; <div css={styles} />;`,
+          `export * as styles from "./styles";`
+        ),
+        "styles"
+      );
+
+      expect(result).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_NAMESPACE_REEXPORT_UNSUPPORTED",
+          reason: "unsupported-namespace-reexport",
+          dependency: { file: barrelId },
+          importPath: "./styles",
+          exportName: "styles"
+        }
+      });
     });
 
     it("rejects exported const mutations deterministically", () => {

--- a/packages/babel/src/staticCssEval/importedModules.ts
+++ b/packages/babel/src/staticCssEval/importedModules.ts
@@ -1,5 +1,5 @@
-import { transformSync, types as t } from "@babel/core";
-import type { NodePath, PluginObj } from "@babel/core";
+import { types as t } from "@babel/core";
+import type { NodePath } from "@babel/core";
 import {
   getStaticObjectMemberValue,
   getStaticObjectPropertyName,
@@ -7,19 +7,53 @@ import {
 } from "./ast.js";
 import {
   createStaticCssEvalCandidate,
+  getStaticCssEvalMemberReference,
   unwrapTransparentCssRuleExpression
 } from "./candidates.js";
-import { createStaticCssEvalDiagnostic } from "./diagnostics.js";
+import {
+  createStaticCssEvalCjsUnsupportedDiagnostic,
+  createStaticCssEvalComputedMemberUnsupportedDiagnostic,
+  createStaticCssEvalDiagnostic,
+  createStaticCssEvalDynamicExpressionUnsupportedDiagnostic,
+  createStaticCssEvalExportStarUnsupportedDiagnostic,
+  createStaticCssEvalMutableBindingDiagnostic,
+  createStaticCssEvalMutatedBindingDiagnostic,
+  createStaticCssEvalNamespaceImportUnsupportedDiagnostic,
+  createStaticCssEvalPackageImportUnsupportedDiagnostic,
+  createStaticCssEvalUnresolvedExportDiagnostic,
+  createStaticCssEvalUnresolvedImportDiagnostic,
+  guardStaticCssEvalImportCycle,
+  guardStaticCssEvalResolutionDepth
+} from "./diagnostics.js";
+import type { StaticCssEvalImportCycleKey } from "./diagnostics.js";
 import {
   enforceStaticCssEvalLiteralNodeCount,
   enforceStaticCssEvalObjectArrayRecursionDepth,
   enforceStaticCssEvalSourceSize
 } from "./limits.js";
 import {
+  createExportMapCacheKey,
+  createStaticCssModuleCache,
+  formatExportMapCacheKey,
+  STATIC_CSS_MODULE_CACHE_SUPPORT_VERSION
+} from "./moduleCache.js";
+import type {
+  ExportMapEntry,
+  ExportMapLocalEntry,
+  ParsedStaticCssModule,
+  StaticCssModuleCache,
+  StaticCssModuleSource
+} from "./moduleCache.js";
+import {
   getStaticCssEvalConstBindingInitExpression,
   hasStaticCssEvalBindingMutation
 } from "./sameFile.js";
 import type {
+  BindingProvenance,
+  ResolutionChainEntry,
+  ResolutionDependency,
+  ResolutionDependencyKind,
+  StaticCssEvalCacheKey,
   StaticCssEvalDiagnostic,
   StaticCssEvalExportName,
   StaticCssEvalProvider,
@@ -27,8 +61,8 @@ import type {
   StaticCssEvalResult,
   StaticCssEvalSourceLocation,
   StaticCssEvalUnsupportedReason,
-  StaticCssLiteral,
-  StaticCssEvalModuleRecord
+  StaticCssEvalModuleRecord,
+  StaticCssLiteral
 } from "./types.js";
 
 export type ImportedStaticCssEvalImportBinding =
@@ -50,28 +84,22 @@ export type ImportedStaticCssEvalImportBinding =
       importPath: string;
     };
 
-export type ImportedStaticCssEvalExportBinding =
-  | {
-      kind: "local";
-      exportName: StaticCssEvalExportName;
-      localName: string;
-    }
-  | {
-      kind: "expression";
-      exportName: StaticCssEvalExportName;
-      expression: t.Expression;
-    }
-  | {
-      kind: "unsupported";
-      exportName: StaticCssEvalExportName;
-      reason: StaticCssEvalUnsupportedReason;
-      detail: string;
-    };
+export type ImportedStaticCssEvalExportBinding = ExportMapEntry;
 
 type ImportedStaticCssEvalResolutionResult =
   | { kind: "not-candidate" }
-  | { kind: "resolved"; value: StaticCssLiteral }
-  | { kind: "error"; diagnostic: StaticCssEvalDiagnostic };
+  | {
+      kind: "resolved";
+      value: StaticCssLiteral;
+      provenance: BindingProvenance;
+      cacheKey: StaticCssEvalCacheKey;
+    }
+  | {
+      kind: "error";
+      diagnostic: StaticCssEvalDiagnostic;
+      provenance?: BindingProvenance;
+      cacheKey?: StaticCssEvalCacheKey;
+    };
 
 interface ImportedStaticCssEvalContext {
   owner: StaticCssEvalSourceLocation;
@@ -79,6 +107,29 @@ interface ImportedStaticCssEvalContext {
   importPath: string;
   exportName: StaticCssEvalExportName;
   memberPath: string[];
+}
+
+type ImportedStaticCssEvalProvenanceKind = Exclude<
+  BindingProvenance["kind"],
+  "local"
+>;
+
+interface ImportedStaticCssEvalResolutionRequest {
+  importer: string;
+  specifier: string;
+  exportName: StaticCssEvalExportName;
+  memberPath: string[];
+  dependencyKind: ResolutionDependencyKind;
+  provenanceKind: ImportedStaticCssEvalProvenanceKind;
+  namespaceBinding?: string;
+  reexportName?: string;
+}
+
+interface ImportedStaticCssEvalResolutionState {
+  owner: StaticCssEvalSourceLocation;
+  dependencies: Map<string, ResolutionDependency>;
+  resolutionChain: ResolutionChainEntry[];
+  stack: StaticCssEvalImportCycleKey[];
 }
 
 interface StaticCssLiteralValidationState {
@@ -107,6 +158,7 @@ export interface ImportedStaticCssEvalModuleRecord extends StaticCssEvalModuleRe
     ImportedStaticCssEvalExportBinding
   >;
   exportAllReexportSources: readonly string[];
+  parsedModule: ParsedStaticCssModule;
   programPath: NodePath<t.Program>;
 }
 
@@ -114,6 +166,10 @@ export interface CreateImportedStaticCssEvalProviderOptions {
   modules: readonly ImportedStaticCssEvalLoadedModule[];
   importResolutions: readonly ImportedStaticCssEvalImportResolution[];
   moduleRecords?: readonly ImportedStaticCssEvalModuleRecord[];
+}
+
+interface ImportedStaticCssEvalResolverOptions extends CreateImportedStaticCssEvalProviderOptions {
+  moduleCache?: StaticCssModuleCache;
 }
 
 export type ResolveImportedStaticCssEvalExpressionResult =
@@ -126,6 +182,9 @@ const importResolutionKeySeparator = "\0";
 export function createImportedStaticCssEvalProvider(
   options: CreateImportedStaticCssEvalProviderOptions
 ): StaticCssEvalProvider {
+  // Imported css props are resolved from parsed ESM AST/export maps only.
+  // Keep module execution, `export *`, packages, CJS, spread, computed paths,
+  // and broad namespace handling unsupported instead of adding fallbacks here.
   const resolver = new ImportedStaticCssEvalResolver(options);
 
   return {
@@ -138,52 +197,24 @@ export function createImportedStaticCssEvalProvider(
 export function createImportedStaticCssEvalModuleRecord(
   loadedModule: ImportedStaticCssEvalLoadedModule
 ): ImportedStaticCssEvalModuleRecord {
-  const programPathRef: { current?: NodePath<t.Program> } = {};
-  const isTypeScript = /\.[cm]?tsx?$/.test(loadedModule.id);
-  const isJsx = /\.[jt]sx$/.test(loadedModule.id);
-  const captureProgramPathPlugin: PluginObj = {
-    visitor: {
-      Program(path: NodePath<t.Program>) {
-        programPathRef.current = path;
-        path.stop();
-      }
-    }
-  };
+  return createImportedStaticCssEvalModuleRecordWithCache(
+    loadedModule,
+    createStaticCssModuleCache()
+  );
+}
 
-  transformSync(loadedModule.source, {
-    filename: loadedModule.id,
-    ast: true,
-    code: false,
-    sourceType: "module",
-    configFile: false,
-    babelrc: false,
-    parserOpts: {
-      plugins: [
-        ...(isJsx ? (["jsx"] as const) : []),
-        ...(isTypeScript ? (["typescript"] as const) : [])
-      ]
-    },
-    plugins: [captureProgramPathPlugin]
-  });
-
-  const capturedProgramPath = programPathRef.current;
-
-  if (!capturedProgramPath) {
-    throw new Error(
-      `Failed to create static css module scope ${loadedModule.id}`
-    );
-  }
+function createImportedStaticCssEvalModuleRecordWithCache(
+  loadedModule: ImportedStaticCssEvalLoadedModule,
+  moduleCache: StaticCssModuleCache
+): ImportedStaticCssEvalModuleRecord {
+  const parsedModule = moduleCache.getParsedModule(
+    createStaticCssModuleSource(loadedModule)
+  );
 
   const imports = new Map<string, ImportedStaticCssEvalImportBinding>();
-  const exports = new Map<
-    StaticCssEvalExportName,
-    ImportedStaticCssEvalExportBinding
-  >();
-  const exportAllReexportSources: string[] = [];
 
-  for (const statement of capturedProgramPath.node.body) {
+  for (const statement of parsedModule.program.body) {
     collectModuleImportBindings(statement, imports);
-    collectModuleExportBindings(statement, exports, exportAllReexportSources);
   }
 
   return {
@@ -197,9 +228,12 @@ export function createImportedStaticCssEvalModuleRecord(
     dependencies: [],
     source: loadedModule.source,
     imports,
-    exports,
-    exportAllReexportSources,
-    programPath: capturedProgramPath
+    exports: parsedModule.exportMap,
+    exportAllReexportSources: parsedModule.unsupportedExportStars.flatMap(
+      (entry) => (entry.source ? [entry.source] : [])
+    ),
+    parsedModule,
+    programPath: parsedModule.programPath
   };
 }
 
@@ -231,7 +265,8 @@ export function resolveImportedStaticCssEvalExpression(options: {
   if (result.kind === "error") {
     if (
       options.allowUnsupportedSourceFallback === true &&
-      result.diagnostic.reason === "reexport-or-barrel"
+      result.diagnostic.reason === "reexport-or-barrel" &&
+      result.diagnostic.id === undefined
     ) {
       return { kind: "not-candidate" };
     }
@@ -279,7 +314,14 @@ export function findUnsupportedImportedStaticCssEvalReferenceDiagnostic(options:
     );
   }
 
-  return null;
+  return findUnsupportedImportedExpressionReferenceDiagnostic(
+    unwrappedExpression,
+    {
+      ownerFile: options.ownerFile,
+      provider,
+      includeSupportedReferenceErrors: false
+    }
+  );
 }
 
 export function createStaticCssLiteralExpression(
@@ -319,8 +361,11 @@ class ImportedStaticCssEvalResolver {
   readonly #modules = new Map<string, ImportedStaticCssEvalLoadedModule>();
   readonly #records = new Map<string, ImportedStaticCssEvalModuleRecord>();
   readonly #importResolutions = new Map<string, string>();
+  readonly #moduleCache: StaticCssModuleCache;
 
-  constructor(options: CreateImportedStaticCssEvalProviderOptions) {
+  constructor(options: ImportedStaticCssEvalResolverOptions) {
+    this.#moduleCache = options.moduleCache ?? createStaticCssModuleCache();
+
     for (const loadedModule of options.modules) {
       this.#modules.set(loadedModule.id, loadedModule);
     }
@@ -350,121 +395,465 @@ class ImportedStaticCssEvalResolver {
 
     const importBinding = ownerRecord.imports.get(query.bindingName);
 
-    if (!importBinding || importBinding.kind === "namespace") {
-      return { kind: "not-candidate" };
+    if (!importBinding) {
+      const cjsDiagnostic = this.#createCjsUnsupportedDiagnostic(
+        ownerRecord,
+        query
+      );
+
+      return cjsDiagnostic
+        ? createImportedStaticCssEvalErrorResult({
+            query,
+            diagnostic: cjsDiagnostic,
+            state: createResolutionState(createQueryOwnerLocation(query))
+          })
+        : { kind: "not-candidate" };
     }
 
     const owner = createQueryOwnerLocation(query);
-    const resolvedId = this.#resolveImport(
-      query.importerId,
-      importBinding.importPath
+    const state = createResolutionState(owner);
+    const requestResult = createResolutionRequest(query, importBinding, owner);
+
+    if (requestResult.kind === "error") {
+      return createImportedStaticCssEvalErrorResult({
+        query,
+        diagnostic: requestResult.diagnostic,
+        state
+      });
+    }
+
+    const importResult = this.#resolveProjectLocalImport(
+      requestResult.request,
+      owner,
+      state
     );
 
-    if (!resolvedId) {
-      const diagnostic = createImportedStaticCssEvalDiagnostic({
-        owner,
-        dependency: { file: importBinding.importPath },
-        importPath: importBinding.importPath,
-        exportName: importBinding.importedName,
-        memberPath: query.memberPath ?? [],
-        code: "failed-project-local-dependency",
-        reason: "failed-project-local-dependency",
-        detail: `failed to resolve project-local dependency ${importBinding.importPath}`
+    if (importResult.kind === "error") {
+      return createImportedStaticCssEvalErrorResult({
+        query,
+        diagnostic: importResult.diagnostic,
+        state
       });
-
-      return {
-        kind: "error",
-        diagnostic,
-        dependencies: []
-      };
     }
 
-    const dependency = { file: resolvedId };
-    const loadedModule = this.#modules.get(resolvedId);
-
-    if (!loadedModule) {
-      const diagnostic = createImportedStaticCssEvalDiagnostic({
-        owner,
-        dependency,
-        importPath: importBinding.importPath,
-        exportName: importBinding.importedName,
-        memberPath: query.memberPath ?? [],
-        code: "failed-project-local-dependency",
-        reason: "failed-project-local-dependency",
-        detail: `failed to load project-local dependency ${resolvedId}`
-      });
-
-      return {
-        kind: "error",
-        diagnostic,
-        dependencies: [resolvedId]
-      };
-    }
-
-    const sourceSizeResult = enforceStaticCssEvalSourceSize({
-      owner,
-      dependency,
-      importPath: importBinding.importPath,
-      exportName: importBinding.importedName,
-      memberPath: query.memberPath,
-      source: loadedModule.source
-    });
-
-    if (!sourceSizeResult.ok) {
-      return {
-        kind: "error",
-        diagnostic: sourceSizeResult.diagnostic,
-        dependencies: [resolvedId]
-      };
-    }
-
-    const dependencyRecord = this.#getModuleRecord(resolvedId);
-
-    if (!dependencyRecord) {
-      const diagnostic = createImportedStaticCssEvalDiagnostic({
-        owner,
-        dependency,
-        importPath: importBinding.importPath,
-        exportName: importBinding.importedName,
-        memberPath: query.memberPath ?? [],
-        code: "failed-project-local-dependency",
-        reason: "failed-project-local-dependency",
-        detail: `failed to parse project-local dependency ${resolvedId}`
-      });
-
-      return {
-        kind: "error",
-        diagnostic,
-        dependencies: [resolvedId]
-      };
-    }
-
-    const context: ImportedStaticCssEvalContext = {
-      owner,
-      dependency,
-      importPath: importBinding.importPath,
-      exportName: importBinding.importedName,
-      memberPath: [...(query.memberPath ?? [])]
-    };
-    const result = resolveImportedModuleExport(dependencyRecord, context);
+    const result = this.#resolveModuleExport(
+      importResult.record,
+      requestResult.request,
+      state
+    );
 
     if (result.kind === "not-candidate") {
       return { kind: "not-candidate" };
     }
 
     if (result.kind === "error") {
+      return createImportedStaticCssEvalErrorResult({
+        query,
+        diagnostic: result.diagnostic,
+        state,
+        provenance: result.provenance,
+        cacheKey: result.cacheKey
+      });
+    }
+
+    markResolutionDependenciesContributed(state);
+
+    return createImportedStaticCssEvalResolvedResult({
+      query,
+      value: result.value,
+      provenance: result.provenance,
+      cacheKey: result.cacheKey,
+      state
+    });
+  }
+
+  #resolveProjectLocalImport(
+    request: ImportedStaticCssEvalResolutionRequest,
+    owner: StaticCssEvalSourceLocation,
+    state: ImportedStaticCssEvalResolutionState
+  ):
+    | { kind: "resolved"; record: ImportedStaticCssEvalModuleRecord }
+    | { kind: "error"; diagnostic: StaticCssEvalDiagnostic } {
+    const resolvedId = this.#resolveImport(request.importer, request.specifier);
+
+    if (!resolvedId) {
+      addResolutionDependency(state, {
+        file: request.specifier,
+        kind: "unresolved",
+        importer: request.importer,
+        specifier: request.specifier,
+        exportName: request.exportName,
+        memberPath: request.memberPath,
+        inspected: false,
+        contributed: false
+      });
+
       return {
         kind: "error",
-        diagnostic: result.diagnostic,
-        dependencies: [resolvedId]
+        diagnostic: createStaticCssEvalUnresolvedImportDiagnostic(
+          {
+            owner,
+            dependency: { file: request.specifier },
+            importPath: request.specifier,
+            exportName: request.exportName,
+            memberPath: request.memberPath,
+            importChain: createResolutionImportChain(state, request.specifier)
+          },
+          request.specifier
+        )
+      };
+    }
+
+    addResolutionDependency(state, {
+      file: resolvedId,
+      kind: request.dependencyKind,
+      importer: request.importer,
+      specifier: request.specifier,
+      exportName: request.exportName,
+      memberPath: request.memberPath,
+      inspected: false,
+      contributed: false
+    });
+
+    const loadedModule = this.#modules.get(resolvedId);
+
+    if (!loadedModule) {
+      return {
+        kind: "error",
+        diagnostic: createStaticCssEvalUnresolvedImportDiagnostic(
+          {
+            owner,
+            dependency: { file: resolvedId },
+            importPath: request.specifier,
+            exportName: request.exportName,
+            memberPath: request.memberPath,
+            importChain: createResolutionImportChain(state, resolvedId)
+          },
+          request.specifier
+        )
+      };
+    }
+
+    const sourceSizeResult = enforceStaticCssEvalSourceSize({
+      owner,
+      dependency: { file: resolvedId },
+      importPath: request.specifier,
+      exportName: request.exportName,
+      memberPath: request.memberPath,
+      source: loadedModule.source
+    });
+
+    if (!sourceSizeResult.ok) {
+      markResolutionDependencyInspected(state, resolvedId);
+      return { kind: "error", diagnostic: sourceSizeResult.diagnostic };
+    }
+
+    const record = this.#getModuleRecord(resolvedId);
+
+    if (!record) {
+      return {
+        kind: "error",
+        diagnostic: createStaticCssEvalUnresolvedImportDiagnostic(
+          {
+            owner,
+            dependency: { file: resolvedId },
+            importPath: request.specifier,
+            exportName: request.exportName,
+            memberPath: request.memberPath,
+            importChain: createResolutionImportChain(state, resolvedId)
+          },
+          request.specifier
+        )
+      };
+    }
+
+    markResolutionDependencyInspected(state, resolvedId);
+    return { kind: "resolved", record };
+  }
+
+  #resolveModuleExport(
+    record: ImportedStaticCssEvalModuleRecord,
+    request: ImportedStaticCssEvalResolutionRequest,
+    state: ImportedStaticCssEvalResolutionState
+  ): ImportedStaticCssEvalResolutionResult {
+    const guardResult = this.#guardResolution(record, request, state);
+
+    if (!guardResult.ok) {
+      for (const dependency of guardResult.dependencies) {
+        addResolutionDependency(state, {
+          file: dependency,
+          kind: "reexported",
+          importer: request.importer,
+          specifier: request.specifier,
+          exportName: request.exportName,
+          memberPath: request.memberPath,
+          inspected: true,
+          contributed: false
+        });
+      }
+
+      return { kind: "error", diagnostic: guardResult.diagnostic };
+    }
+
+    const stackEntry: StaticCssEvalImportCycleKey = {
+      file: record.id,
+      exportName: request.exportName,
+      memberPath: request.memberPath
+    };
+    state.stack.push(stackEntry);
+
+    try {
+      return this.#resolveGuardedModuleExport(record, request, state);
+    } finally {
+      state.stack.pop();
+    }
+  }
+
+  #resolveGuardedModuleExport(
+    record: ImportedStaticCssEvalModuleRecord,
+    request: ImportedStaticCssEvalResolutionRequest,
+    state: ImportedStaticCssEvalResolutionState
+  ): ImportedStaticCssEvalResolutionResult {
+    const exportEntry = record.exports.get(request.exportName);
+
+    if (!exportEntry) {
+      return this.#createMissingExportResult(record, request, state);
+    }
+
+    const effectiveRequest =
+      exportEntry.kind === "reexport"
+        ? {
+            ...request,
+            dependencyKind: "reexported" as const,
+            provenanceKind: "reexported" as const,
+            reexportName: formatExportName(exportEntry.exportName)
+          }
+        : request;
+    const provenance = createBindingProvenance(record.id, effectiveRequest);
+    state.resolutionChain.push({
+      importer: effectiveRequest.importer,
+      source: record.id,
+      exportName: effectiveRequest.exportName,
+      memberPath: [...effectiveRequest.memberPath],
+      provenance
+    });
+    updateResolutionDependencyKind(
+      state,
+      record.id,
+      effectiveRequest.dependencyKind
+    );
+
+    if (exportEntry.kind === "unsupported") {
+      return {
+        kind: "error",
+        diagnostic: createUnsupportedExportEntryDiagnostic(
+          exportEntry,
+          record,
+          effectiveRequest,
+          state
+        ),
+        provenance,
+        cacheKey: createImportedStaticCssEvalCacheKey(
+          state.owner.file,
+          record.parsedModule,
+          effectiveRequest.exportName,
+          effectiveRequest.memberPath
+        )
+      };
+    }
+
+    if (exportEntry.kind === "reexport") {
+      return this.#resolveReexportEntry(
+        record,
+        exportEntry,
+        effectiveRequest,
+        state,
+        provenance
+      );
+    }
+
+    return resolveStaticExportMapEntry(
+      record,
+      exportEntry,
+      effectiveRequest,
+      state,
+      provenance
+    );
+  }
+
+  #resolveReexportEntry(
+    record: ImportedStaticCssEvalModuleRecord,
+    exportEntry: Extract<ExportMapEntry, { kind: "reexport" }>,
+    request: ImportedStaticCssEvalResolutionRequest,
+    state: ImportedStaticCssEvalResolutionState,
+    provenance: BindingProvenance
+  ): ImportedStaticCssEvalResolutionResult {
+    if (!isProjectLocalStaticCssImportSpecifier(exportEntry.source)) {
+      return {
+        kind: "error",
+        diagnostic: createStaticCssEvalPackageImportUnsupportedDiagnostic(
+          {
+            owner: state.owner,
+            dependency: { file: record.id },
+            importPath: exportEntry.source,
+            exportName: exportEntry.importedName,
+            memberPath: request.memberPath,
+            importChain: createResolutionImportChain(state, record.id)
+          },
+          exportEntry.source
+        ),
+        provenance,
+        cacheKey: createImportedStaticCssEvalCacheKey(
+          state.owner.file,
+          record.parsedModule,
+          request.exportName,
+          request.memberPath
+        )
+      };
+    }
+
+    const reexportRequest: ImportedStaticCssEvalResolutionRequest = {
+      importer: record.id,
+      specifier: exportEntry.source,
+      exportName: exportEntry.importedName,
+      memberPath: [...request.memberPath],
+      dependencyKind: "reexported",
+      provenanceKind: "reexported",
+      reexportName: formatExportName(exportEntry.exportName)
+    };
+    const importResult = this.#resolveProjectLocalImport(
+      reexportRequest,
+      state.owner,
+      state
+    );
+
+    return importResult.kind === "error"
+      ? {
+          kind: "error",
+          diagnostic: importResult.diagnostic,
+          provenance,
+          cacheKey: createImportedStaticCssEvalCacheKey(
+            state.owner.file,
+            record.parsedModule,
+            request.exportName,
+            request.memberPath
+          )
+        }
+      : this.#resolveModuleExport(importResult.record, reexportRequest, state);
+  }
+
+  #createMissingExportResult(
+    record: ImportedStaticCssEvalModuleRecord,
+    request: ImportedStaticCssEvalResolutionRequest,
+    state: ImportedStaticCssEvalResolutionState
+  ): ImportedStaticCssEvalResolutionResult {
+    const exportStar = record.parsedModule.unsupportedExportStars[0];
+
+    if (exportStar) {
+      return {
+        kind: "error",
+        diagnostic: createStaticCssEvalExportStarUnsupportedDiagnostic(
+          {
+            owner: state.owner,
+            dependency: { file: record.id },
+            importPath: exportStar.source ?? request.specifier,
+            exportName: request.exportName,
+            memberPath: request.memberPath,
+            importChain: createResolutionImportChain(state, record.id)
+          },
+          exportStar.source ?? request.specifier
+        ),
+        cacheKey: createImportedStaticCssEvalCacheKey(
+          state.owner.file,
+          record.parsedModule,
+          request.exportName,
+          request.memberPath
+        )
       };
     }
 
     return {
-      kind: "resolved",
-      value: result.value,
-      dependencies: [resolvedId]
+      kind: "error",
+      diagnostic: createStaticCssEvalUnresolvedExportDiagnostic(
+        {
+          owner: state.owner,
+          dependency: { file: record.id },
+          importPath: request.specifier,
+          exportName: request.exportName,
+          memberPath: request.memberPath,
+          importChain: createResolutionImportChain(state, record.id)
+        },
+        request.exportName
+      ),
+      cacheKey: createImportedStaticCssEvalCacheKey(
+        state.owner.file,
+        record.parsedModule,
+        request.exportName,
+        request.memberPath
+      )
     };
+  }
+
+  #guardResolution(
+    record: ImportedStaticCssEvalModuleRecord,
+    request: ImportedStaticCssEvalResolutionRequest,
+    state: ImportedStaticCssEvalResolutionState
+  ) {
+    const next = {
+      file: record.id,
+      exportName: request.exportName,
+      memberPath: request.memberPath
+    };
+    const cycleResult = guardStaticCssEvalImportCycle({
+      owner: state.owner,
+      dependency: { file: record.id },
+      importPath: request.specifier,
+      exportName: request.exportName,
+      memberPath: request.memberPath,
+      stack: state.stack,
+      next
+    });
+
+    if (!cycleResult.ok) {
+      return cycleResult;
+    }
+
+    return guardStaticCssEvalResolutionDepth({
+      owner: state.owner,
+      dependency: { file: record.id },
+      importPath: request.specifier,
+      exportName: request.exportName,
+      memberPath: request.memberPath,
+      resolutionDepth: state.stack.length + 1
+    });
+  }
+
+  #createCjsUnsupportedDiagnostic(
+    ownerRecord: ImportedStaticCssEvalModuleRecord,
+    query: StaticCssEvalQuery
+  ): StaticCssEvalDiagnostic | null {
+    const bindingName = query.bindingName;
+
+    if (!bindingName) {
+      return null;
+    }
+
+    const binding = ownerRecord.programPath.scope.getBinding(bindingName);
+    const init = binding
+      ? getStaticCssEvalConstBindingInitExpression(binding)
+      : null;
+
+    if (
+      !init ||
+      !isRequireCallExpression(unwrapTransparentCssRuleExpression(init))
+    ) {
+      return null;
+    }
+
+    return createStaticCssEvalCjsUnsupportedDiagnostic({
+      owner: createQueryOwnerLocation(query),
+      memberPath: query.memberPath
+    });
   }
 
   #resolveImport(importerId: string, importPath: string): string | null {
@@ -489,10 +878,16 @@ class ImportedStaticCssEvalResolver {
     }
 
     try {
-      const record = createImportedStaticCssEvalModuleRecord(loadedModule);
+      const record = createImportedStaticCssEvalModuleRecordWithCache(
+        loadedModule,
+        this.#moduleCache
+      );
       this.#records.set(id, record);
       return record;
-    } catch {
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        return null;
+      }
       return null;
     }
   }
@@ -543,239 +938,161 @@ function collectModuleImportBindings(
   }
 }
 
-function collectModuleExportBindings(
-  statement: t.Statement,
-  exports: Map<StaticCssEvalExportName, ImportedStaticCssEvalExportBinding>,
-  exportAllReexportSources: string[]
-): void {
-  if (t.isExportAllDeclaration(statement)) {
-    exportAllReexportSources.push(statement.source.value);
-    return;
-  }
-
-  if (t.isExportDefaultDeclaration(statement)) {
-    collectDefaultExportBinding(statement, exports);
-    return;
-  }
-
-  if (
-    !t.isExportNamedDeclaration(statement) ||
-    statement.exportKind === "type"
-  ) {
-    return;
-  }
-
-  if (statement.source) {
-    collectReexportBindings(statement, exports);
-    return;
-  }
-
-  if (statement.declaration) {
-    collectDeclaredExportBindings(statement.declaration, exports);
-    return;
-  }
-
-  for (const specifier of statement.specifiers) {
-    if (!t.isExportSpecifier(specifier) || specifier.exportKind === "type") {
-      continue;
-    }
-
-    const localName = getModuleStringName(specifier.local);
-    const exportName = getModuleStringName(specifier.exported);
-
-    if (localName && exportName) {
-      exports.set(exportName, {
-        kind: "local",
-        exportName,
-        localName
-      });
-    }
-  }
+function createStaticCssModuleSource(
+  loadedModule: ImportedStaticCssEvalLoadedModule
+): StaticCssModuleSource {
+  return {
+    resolvedFile: loadedModule.id,
+    source: loadedModule.source,
+    sourceHash:
+      loadedModule.sourceHash ?? `inline:${loadedModule.source.length}`,
+    ...(loadedModule.version !== undefined
+      ? { sourceVersion: loadedModule.version }
+      : {})
+  };
 }
 
-function collectDefaultExportBinding(
-  statement: t.ExportDefaultDeclaration,
-  exports: Map<StaticCssEvalExportName, ImportedStaticCssEvalExportBinding>
-): void {
-  const { declaration } = statement;
-
-  if (t.isIdentifier(declaration)) {
-    exports.set("default", {
-      kind: "local",
-      exportName: "default",
-      localName: declaration.name
-    });
-    return;
-  }
-
-  if (t.isExpression(declaration)) {
-    exports.set("default", {
-      kind: "expression",
-      exportName: "default",
-      expression: declaration
-    });
-    return;
-  }
-
-  exports.set("default", {
-    kind: "unsupported",
-    exportName: "default",
-    reason: "function-or-call",
-    detail: "default export declaration is not a static expression"
-  });
+function createResolutionState(
+  owner: StaticCssEvalSourceLocation
+): ImportedStaticCssEvalResolutionState {
+  return {
+    owner,
+    dependencies: new Map<string, ResolutionDependency>(),
+    resolutionChain: [],
+    stack: []
+  };
 }
 
-function collectReexportBindings(
-  statement: t.ExportNamedDeclaration,
-  exports: Map<StaticCssEvalExportName, ImportedStaticCssEvalExportBinding>
-): void {
-  for (const specifier of statement.specifiers) {
-    if (t.isExportSpecifier(specifier)) {
-      const exportName = getModuleStringName(specifier.exported);
+function createResolutionRequest(
+  query: StaticCssEvalQuery,
+  importBinding: ImportedStaticCssEvalImportBinding,
+  owner: StaticCssEvalSourceLocation
+):
+  | { kind: "resolved"; request: ImportedStaticCssEvalResolutionRequest }
+  | { kind: "error"; diagnostic: StaticCssEvalDiagnostic } {
+  const queryMemberPath = [...(query.memberPath ?? [])];
 
-      if (exportName) {
-        exports.set(exportName, {
-          kind: "unsupported",
-          exportName,
-          reason: "reexport-or-barrel",
-          detail: `export "${exportName}" uses unsupported reexport/barrel syntax`
-        });
-      }
-      continue;
-    }
-
-    if (t.isExportNamespaceSpecifier(specifier)) {
-      const exportName = getModuleStringName(specifier.exported);
-
-      if (exportName) {
-        exports.set(exportName, {
-          kind: "unsupported",
-          exportName,
-          reason: "reexport-or-barrel",
-          detail: `export "${exportName}" uses unsupported reexport/barrel syntax`
-        });
-      }
-    }
-  }
-}
-
-function collectDeclaredExportBindings(
-  declaration: t.Declaration,
-  exports: Map<StaticCssEvalExportName, ImportedStaticCssEvalExportBinding>
-): void {
-  if (t.isVariableDeclaration(declaration)) {
-    for (const declarator of declaration.declarations) {
-      if (!t.isIdentifier(declarator.id)) {
-        continue;
-      }
-
-      if (declaration.kind !== "const") {
-        exports.set(declarator.id.name, {
-          kind: "unsupported",
-          exportName: declarator.id.name,
-          reason: "let-or-var-binding",
-          detail: `export "${declarator.id.name}" is not a const binding`
-        });
-        continue;
-      }
-
-      exports.set(declarator.id.name, {
-        kind: "local",
-        exportName: declarator.id.name,
-        localName: declarator.id.name
-      });
-    }
-    return;
-  }
-
-  if (
-    (t.isFunctionDeclaration(declaration) ||
-      t.isClassDeclaration(declaration)) &&
-    declaration.id
-  ) {
-    exports.set(declaration.id.name, {
-      kind: "unsupported",
-      exportName: declaration.id.name,
-      reason: "function-or-call",
-      detail: `export "${declaration.id.name}" is not a static const literal`
-    });
-  }
-}
-
-function resolveImportedModuleExport(
-  record: ImportedStaticCssEvalModuleRecord,
-  context: ImportedStaticCssEvalContext
-): ImportedStaticCssEvalResolutionResult {
-  const exportBinding = record.exports.get(context.exportName);
-
-  if (!exportBinding) {
-    if (record.exportAllReexportSources.length > 0) {
+  if (importBinding.kind === "namespace") {
+    if (!isProjectLocalStaticCssImportSpecifier(importBinding.importPath)) {
       return {
         kind: "error",
-        diagnostic: createImportedStaticCssEvalDiagnostic({
-          ...context,
-          code: "unsupported-source",
-          reason: "reexport-or-barrel",
-          detail: `export "${formatExportName(
-            context.exportName
-          )}" may come from unsupported export * barrel syntax`
-        })
+        diagnostic: createStaticCssEvalNamespaceImportUnsupportedDiagnostic(
+          {
+            owner,
+            importPath: importBinding.importPath,
+            memberPath: queryMemberPath
+          },
+          importBinding.importPath
+        )
       };
     }
 
-    return { kind: "not-candidate" };
-  }
+    const [exportName, ...memberPath] = queryMemberPath;
 
-  if (exportBinding.kind === "unsupported") {
+    if (!exportName) {
+      return {
+        kind: "error",
+        diagnostic: createStaticCssEvalNamespaceImportUnsupportedDiagnostic(
+          {
+            owner,
+            importPath: importBinding.importPath,
+            memberPath: queryMemberPath
+          },
+          importBinding.importPath
+        )
+      };
+    }
+
     return {
-      kind: "error",
-      diagnostic: createImportedStaticCssEvalDiagnostic({
-        ...context,
-        code:
-          exportBinding.reason === "reexport-or-barrel"
-            ? "unsupported-source"
-            : "unsupported-syntax",
-        reason: exportBinding.reason,
-        detail: exportBinding.detail
-      })
+      kind: "resolved",
+      request: {
+        importer: query.importerId,
+        specifier: importBinding.importPath,
+        exportName,
+        memberPath,
+        dependencyKind: "namespace-member",
+        provenanceKind: "namespace-member",
+        namespaceBinding: importBinding.localName
+      }
     };
   }
 
-  const localName =
-    exportBinding.kind === "local" ? exportBinding.localName : null;
-  const expression =
-    exportBinding.kind === "expression"
-      ? exportBinding.expression
-      : getLocalConstBindingExpression(record, exportBinding.localName);
-
-  if (!expression) {
-    return { kind: "not-candidate" };
+  if (!isProjectLocalStaticCssImportSpecifier(importBinding.importPath)) {
+    return {
+      kind: "error",
+      diagnostic: createStaticCssEvalPackageImportUnsupportedDiagnostic(
+        {
+          owner,
+          importPath: importBinding.importPath,
+          exportName: importBinding.importedName,
+          memberPath: queryMemberPath
+        },
+        importBinding.importPath
+      )
+    };
   }
 
-  const memberExpression = resolveStaticObjectMemberPath(
-    expression,
-    context.memberPath
+  return {
+    kind: "resolved",
+    request: {
+      importer: query.importerId,
+      specifier: importBinding.importPath,
+      exportName: importBinding.importedName,
+      memberPath: queryMemberPath,
+      dependencyKind: "imported",
+      provenanceKind: "imported"
+    }
+  };
+}
+
+function resolveStaticExportMapEntry(
+  record: ImportedStaticCssEvalModuleRecord,
+  exportEntry: Exclude<ExportMapEntry, { kind: "reexport" | "unsupported" }>,
+  request: ImportedStaticCssEvalResolutionRequest,
+  state: ImportedStaticCssEvalResolutionState,
+  provenance: BindingProvenance
+): ImportedStaticCssEvalResolutionResult {
+  const expressionResult = getStaticExportEntryExpression(record, exportEntry);
+  const cacheKey = createImportedStaticCssEvalCacheKey(
+    state.owner.file,
+    record.parsedModule,
+    request.exportName,
+    request.memberPath
   );
 
-  if (
-    !memberExpression ||
-    !isStaticCssRuleLiteralExpression(memberExpression)
-  ) {
-    return { kind: "not-candidate" };
+  if (expressionResult.kind === "error") {
+    return {
+      kind: "error",
+      diagnostic: expressionResult.diagnostic,
+      provenance,
+      cacheKey
+    };
   }
+
+  const localName = expressionResult.localName;
 
   if (localName && hasImportedStaticCssBindingMutation(record, localName)) {
     return {
       kind: "error",
-      diagnostic: createImportedStaticCssEvalDiagnostic({
-        ...context,
-        code: "mutation-detected",
-        reason: "mutated-binding",
-        detail: `imported binding "${localName}" from "${context.importPath}" is mutated`
-      })
+      diagnostic: createStaticCssEvalMutatedBindingDiagnostic(
+        createImportedDiagnosticContext(record, request, state),
+        localName
+      ),
+      provenance,
+      cacheKey
     };
   }
 
+  const memberExpression = resolveStaticObjectMemberPath(
+    expressionResult.expression,
+    request.memberPath
+  );
+
+  if (!memberExpression) {
+    return { kind: "not-candidate" };
+  }
+
+  const context = createImportedLiteralContext(record, request, state);
   const literalResult = evaluateStaticCssLiteralExpression(
     memberExpression,
     context,
@@ -784,22 +1101,380 @@ function resolveImportedModuleExport(
   );
 
   if (literalResult.kind === "error") {
-    return literalResult;
+    return {
+      kind: "error",
+      diagnostic: literalResult.diagnostic,
+      provenance,
+      cacheKey
+    };
   }
 
   return {
     kind: "resolved",
-    value: literalResult.value
+    value: literalResult.value,
+    provenance,
+    cacheKey
   };
 }
 
-function getLocalConstBindingExpression(
+function getStaticExportEntryExpression(
   record: ImportedStaticCssEvalModuleRecord,
-  localName: string
-): t.Expression | null {
-  const binding = record.programPath.scope.getBinding(localName);
+  exportEntry:
+    | ExportMapLocalEntry
+    | Extract<ExportMapEntry, { kind: "expression" }>
+):
+  | { kind: "resolved"; expression: t.Expression; localName: string | null }
+  | { kind: "error"; diagnostic: StaticCssEvalDiagnostic } {
+  if (exportEntry.kind === "expression") {
+    const expression = unwrapTransparentCssRuleExpression(
+      exportEntry.expression
+    );
 
-  return binding ? getStaticCssEvalConstBindingInitExpression(binding) : null;
+    if (t.isIdentifier(expression)) {
+      return getLocalBindingExpressionResult(
+        record,
+        expression.name,
+        exportEntry.exportName
+      );
+    }
+
+    return { kind: "resolved", expression, localName: null };
+  }
+
+  return getLocalBindingExpressionResult(
+    record,
+    exportEntry.localName,
+    exportEntry.exportName
+  );
+}
+
+function getLocalBindingExpressionResult(
+  record: ImportedStaticCssEvalModuleRecord,
+  localName: string,
+  exportName: StaticCssEvalExportName
+):
+  | { kind: "resolved"; expression: t.Expression; localName: string }
+  | { kind: "error"; diagnostic: StaticCssEvalDiagnostic } {
+  const binding = record.programPath.scope.getBinding(localName);
+  const expression = binding
+    ? getStaticCssEvalConstBindingInitExpression(binding)
+    : null;
+
+  if (expression) {
+    return {
+      kind: "resolved",
+      expression: unwrapTransparentCssRuleExpression(expression),
+      localName
+    };
+  }
+
+  return {
+    kind: "error",
+    diagnostic: createStaticCssEvalMutableBindingDiagnostic(
+      {
+        owner: { file: record.id },
+        dependency: { file: record.id },
+        exportName
+      },
+      localName
+    )
+  };
+}
+
+function createImportedLiteralContext(
+  record: ImportedStaticCssEvalModuleRecord,
+  request: ImportedStaticCssEvalResolutionRequest,
+  state: ImportedStaticCssEvalResolutionState
+): ImportedStaticCssEvalContext {
+  return {
+    owner: state.owner,
+    dependency: { file: record.id },
+    importPath: request.specifier,
+    exportName: request.exportName,
+    memberPath: [...request.memberPath]
+  };
+}
+
+function createImportedDiagnosticContext(
+  record: ImportedStaticCssEvalModuleRecord,
+  request: ImportedStaticCssEvalResolutionRequest,
+  state: ImportedStaticCssEvalResolutionState
+) {
+  return {
+    owner: state.owner,
+    dependency: { file: record.id },
+    importPath: request.specifier,
+    exportName: request.exportName,
+    memberPath: request.memberPath,
+    importChain: createResolutionImportChain(state, record.id)
+  };
+}
+
+function createUnsupportedExportEntryDiagnostic(
+  exportEntry: Extract<ExportMapEntry, { kind: "unsupported" }>,
+  record: ImportedStaticCssEvalModuleRecord,
+  request: ImportedStaticCssEvalResolutionRequest,
+  state: ImportedStaticCssEvalResolutionState
+): StaticCssEvalDiagnostic {
+  const context = createImportedDiagnosticContext(record, request, state);
+
+  if (exportEntry.unsupportedKind === "export-star") {
+    return createStaticCssEvalExportStarUnsupportedDiagnostic(
+      context,
+      exportEntry.source ?? request.specifier
+    );
+  }
+
+  if (exportEntry.unsupportedKind === "export-namespace") {
+    return createStaticCssEvalNamespaceImportUnsupportedDiagnostic(
+      context,
+      exportEntry.source ?? request.specifier
+    );
+  }
+
+  return createStaticCssEvalDynamicExpressionUnsupportedDiagnostic(
+    context,
+    exportEntry.declaration.type
+  );
+}
+
+function createBindingProvenance(
+  file: string,
+  request: ImportedStaticCssEvalResolutionRequest
+): BindingProvenance {
+  if (request.provenanceKind === "namespace-member") {
+    return {
+      kind: "namespace-member",
+      file,
+      importer: request.importer,
+      specifier: request.specifier,
+      exportName: request.exportName,
+      memberPath: [...request.memberPath],
+      namespaceBinding: request.namespaceBinding ?? "<namespace>"
+    };
+  }
+
+  if (request.provenanceKind === "reexported") {
+    return {
+      kind: "reexported",
+      file,
+      importer: request.importer,
+      specifier: request.specifier,
+      exportName: request.exportName,
+      memberPath: [...request.memberPath],
+      reexportName: request.reexportName ?? formatExportName(request.exportName)
+    };
+  }
+
+  return {
+    kind: "imported",
+    file,
+    importer: request.importer,
+    specifier: request.specifier,
+    exportName: request.exportName,
+    memberPath: [...request.memberPath]
+  };
+}
+
+function createImportedStaticCssEvalCacheKey(
+  importerFile: string,
+  parsedModule: ParsedStaticCssModule,
+  exportName: StaticCssEvalExportName,
+  memberPath: readonly string[]
+): StaticCssEvalCacheKey {
+  return {
+    importerFile,
+    resolvedFile: parsedModule.resolvedFile,
+    exportName,
+    memberPath: [...memberPath],
+    sourceHash: parsedModule.sourceHash,
+    ...(parsedModule.sourceVersion !== undefined
+      ? { sourceVersion: parsedModule.sourceVersion }
+      : {}),
+    pluginOptionsVersion: "static-css-eval-provider:v1",
+    resolverOptionsVersion: "static-css-eval-provider:v1",
+    staticEvalSupportVersion: STATIC_CSS_MODULE_CACHE_SUPPORT_VERSION,
+    resolvedId: parsedModule.resolvedFile,
+    parserOptions: parsedModule.cacheKey.parserOptions
+  };
+}
+
+function createImportedStaticCssEvalResolvedResult(options: {
+  query: StaticCssEvalQuery;
+  value: StaticCssLiteral;
+  provenance: BindingProvenance;
+  cacheKey: StaticCssEvalCacheKey;
+  state: ImportedStaticCssEvalResolutionState;
+}): StaticCssEvalResult {
+  return {
+    kind: "resolved",
+    status: "resolved",
+    expression: formatStaticCssEvalQueryExpression(options.query),
+    value: options.value,
+    provenance: options.provenance,
+    dependencies: getResolutionDependencies(options.state),
+    resolutionChain: [...options.state.resolutionChain],
+    diagnostics: [],
+    cacheKey: options.cacheKey
+  };
+}
+
+function createImportedStaticCssEvalErrorResult(options: {
+  query: StaticCssEvalQuery;
+  diagnostic: StaticCssEvalDiagnostic;
+  state: ImportedStaticCssEvalResolutionState;
+  provenance?: BindingProvenance;
+  cacheKey?: StaticCssEvalCacheKey;
+}): StaticCssEvalResult {
+  return {
+    kind: "error",
+    status: "error",
+    expression: formatStaticCssEvalQueryExpression(options.query),
+    ...(options.provenance ? { provenance: options.provenance } : {}),
+    dependencies: getResolutionDependencies(options.state),
+    resolutionChain: [...options.state.resolutionChain],
+    diagnostic: options.diagnostic,
+    diagnostics: [options.diagnostic],
+    ...(options.cacheKey ? { cacheKey: options.cacheKey } : {})
+  };
+}
+
+function addResolutionDependency(
+  state: ImportedStaticCssEvalResolutionState,
+  dependency: ResolutionDependency
+): void {
+  const key = createResolutionDependencyKey(dependency);
+  const existing = state.dependencies.get(key);
+
+  state.dependencies.set(key, {
+    ...dependency,
+    ...(existing
+      ? {
+          kind: mergeResolutionDependencyKind(existing.kind, dependency.kind),
+          inspected: existing.inspected || dependency.inspected,
+          contributed: existing.contributed || dependency.contributed
+        }
+      : {})
+  });
+}
+
+function updateResolutionDependencyKind(
+  state: ImportedStaticCssEvalResolutionState,
+  file: string,
+  kind: ResolutionDependencyKind
+): void {
+  for (const [key, dependency] of state.dependencies) {
+    if (dependency.file === file) {
+      state.dependencies.set(key, {
+        ...dependency,
+        kind: mergeResolutionDependencyKind(dependency.kind, kind)
+      });
+    }
+  }
+}
+
+function markResolutionDependencyInspected(
+  state: ImportedStaticCssEvalResolutionState,
+  file: string
+): void {
+  for (const [key, dependency] of state.dependencies) {
+    if (dependency.file === file) {
+      state.dependencies.set(key, { ...dependency, inspected: true });
+    }
+  }
+}
+
+function markResolutionDependenciesContributed(
+  state: ImportedStaticCssEvalResolutionState
+): void {
+  for (const [key, dependency] of state.dependencies) {
+    state.dependencies.set(key, {
+      ...dependency,
+      contributed: dependency.inspected && dependency.kind !== "unresolved"
+    });
+  }
+}
+
+function getResolutionDependencies(
+  state: ImportedStaticCssEvalResolutionState
+): ResolutionDependency[] {
+  return [...state.dependencies.values()].map((dependency) => ({
+    ...dependency,
+    memberPath: [...dependency.memberPath]
+  }));
+}
+
+function createResolutionDependencyKey(
+  dependency: ResolutionDependency
+): string {
+  return JSON.stringify([
+    dependency.file,
+    dependency.importer,
+    dependency.specifier,
+    dependency.exportName,
+    dependency.memberPath
+  ]);
+}
+
+function mergeResolutionDependencyKind(
+  previous: ResolutionDependencyKind,
+  next: ResolutionDependencyKind
+): ResolutionDependencyKind {
+  if (previous === "unresolved" || next === "unresolved") {
+    return next === "unresolved" ? previous : next;
+  }
+
+  if (previous === "reexported" || next === "reexported") {
+    return "reexported";
+  }
+
+  if (previous === "namespace-member" || next === "namespace-member") {
+    return "namespace-member";
+  }
+
+  return next;
+}
+
+function createResolutionImportChain(
+  state: ImportedStaticCssEvalResolutionState,
+  nextFile: string
+): string[] {
+  return [
+    state.owner.file,
+    ...state.stack.map(formatStaticCssEvalResolutionFrame),
+    nextFile
+  ];
+}
+
+function formatStaticCssEvalResolutionFrame(
+  frame: StaticCssEvalImportCycleKey
+): string {
+  const memberPath = frame.memberPath?.length
+    ? `.${frame.memberPath.join(".")}`
+    : "";
+
+  return `${frame.file}#${formatExportName(frame.exportName)}${memberPath}`;
+}
+
+function formatStaticCssEvalQueryExpression(query: StaticCssEvalQuery): string {
+  const bindingName = query.bindingName ?? "<unknown>";
+  const memberPath = query.memberPath?.length
+    ? `.${query.memberPath.join(".")}`
+    : "";
+
+  return `${bindingName}${memberPath}`;
+}
+
+function isProjectLocalStaticCssImportSpecifier(importPath: string): boolean {
+  return importPath.startsWith(".") || importPath.startsWith("/");
+}
+
+function isRequireCallExpression(expression: t.Expression): boolean {
+  return (
+    t.isCallExpression(expression) &&
+    t.isIdentifier(expression.callee) &&
+    expression.callee.name === "require"
+  );
 }
 
 function hasImportedStaticCssBindingMutation(
@@ -841,6 +1516,27 @@ function resolveStaticObjectMemberPath(
   return currentExpression
     ? unwrapTransparentCssRuleExpression(currentExpression)
     : null;
+}
+
+function getStaticObjectMemberValue(
+  expression: t.ObjectExpression,
+  memberName: string
+): t.Expression | null {
+  for (let index = expression.properties.length - 1; index >= 0; index -= 1) {
+    const property = expression.properties[index];
+
+    if (!property || !t.isObjectProperty(property) || property.computed) {
+      return null;
+    }
+
+    if (getStaticObjectPropertyName(property.key) !== memberName) {
+      continue;
+    }
+
+    return t.isExpression(property.value) ? property.value : null;
+  }
+
+  return null;
 }
 
 function evaluateStaticCssLiteralExpression(
@@ -1078,6 +1774,7 @@ function findUnsupportedImportedObjectReferenceDiagnostic(
   options: {
     ownerFile: string;
     provider: StaticCssEvalProvider;
+    includeSupportedReferenceErrors?: boolean;
   }
 ): StaticCssEvalDiagnostic | null {
   for (const property of expression.properties) {
@@ -1103,6 +1800,7 @@ function findUnsupportedImportedArrayReferenceDiagnostic(
   options: {
     ownerFile: string;
     provider: StaticCssEvalProvider;
+    includeSupportedReferenceErrors?: boolean;
   }
 ): StaticCssEvalDiagnostic | null {
   for (const element of expression.elements) {
@@ -1128,15 +1826,59 @@ function findUnsupportedImportedExpressionReferenceDiagnostic(
   options: {
     ownerFile: string;
     provider: StaticCssEvalProvider;
+    includeSupportedReferenceErrors?: boolean;
   }
 ): StaticCssEvalDiagnostic | null {
   const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+  const reference = getStaticCssEvalMemberReference(unwrappedExpression);
+
+  if (reference?.kind === "unsupported") {
+    const result = options.provider.getResolvedCssValue({
+      importerId: options.ownerFile,
+      expressionStart: unwrappedExpression.start ?? 0,
+      expressionEnd: unwrappedExpression.end ?? 0,
+      bindingName: reference.bindingName,
+      ...(reference.memberPath.length > 0
+        ? { memberPath: reference.memberPath }
+        : {})
+    });
+
+    if (result.kind === "not-candidate") {
+      return null;
+    }
+
+    if (reference.reason === "dynamic-member-path") {
+      return createStaticCssEvalComputedMemberUnsupportedDiagnostic({
+        owner: createExpressionOwnerLocation(
+          unwrappedExpression,
+          options.ownerFile
+        ),
+        memberPath: reference.memberPath
+      });
+    }
+
+    return result.kind === "error"
+      ? result.diagnostic
+      : createStaticCssEvalDynamicExpressionUnsupportedDiagnostic(
+          {
+            owner: createExpressionOwnerLocation(
+              unwrappedExpression,
+              options.ownerFile
+            )
+          },
+          reference.detail
+        );
+  }
+
   const candidate = createStaticCssEvalCandidate(
     unwrappedExpression,
     options.ownerFile
   );
 
-  if (candidate?.bindingName) {
+  if (
+    options.includeSupportedReferenceErrors !== false &&
+    candidate?.bindingName
+  ) {
     const result = options.provider.getResolvedCssValue(candidate);
 
     if (result.kind === "error") {
@@ -1244,6 +1986,19 @@ function createQueryOwnerLocation(
   };
 }
 
+function createExpressionOwnerLocation(
+  expression: t.Expression,
+  ownerFile: string
+): StaticCssEvalSourceLocation {
+  return {
+    file: ownerFile,
+    ...(typeof expression.start === "number"
+      ? { start: expression.start }
+      : {}),
+    ...(typeof expression.end === "number" ? { end: expression.end } : {})
+  };
+}
+
 function getModuleStringName(
   node: t.Identifier | t.StringLiteral
 ): string | null {
@@ -1256,17 +2011,6 @@ function getModuleStringName(
   }
 
   return null;
-}
-
-function isStaticCssRuleLiteralExpression(
-  expression: t.Expression
-): expression is t.ObjectExpression | t.ArrayExpression {
-  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
-
-  return (
-    t.isObjectExpression(unwrappedExpression) ||
-    t.isArrayExpression(unwrappedExpression)
-  );
 }
 
 function isStaticCssRuleLiteralValue(
@@ -1292,24 +2036,110 @@ if (import.meta.vitest) {
   const ownerId = "/project/src/App.tsx";
   const stylesId = "/project/src/styles.ts";
   const barrelId = "/project/src/barrel.ts";
+  const buttonId = "/project/src/button.ts";
+
+  function createProviderFromModules(options: {
+    modules: readonly ImportedStaticCssEvalLoadedModule[];
+    importResolutions: readonly ImportedStaticCssEvalImportResolution[];
+    moduleCache?: StaticCssModuleCache;
+  }): StaticCssEvalProvider {
+    const resolver = new ImportedStaticCssEvalResolver(options);
+
+    return {
+      getResolvedCssValue(query) {
+        return resolver.resolve(query);
+      }
+    };
+  }
+
+  function createCountingStaticCssModuleCache(): {
+    cache: StaticCssModuleCache;
+    missesByFile: ReadonlyMap<string, number>;
+  } {
+    const delegate = createStaticCssModuleCache();
+    const seenKeys = new Set<string>();
+    const missesByFile = new Map<string, number>();
+    const cache: StaticCssModuleCache = {
+      getParsedModule(source) {
+        const key = formatExportMapCacheKey(createExportMapCacheKey(source));
+
+        if (!seenKeys.has(key)) {
+          seenKeys.add(key);
+          missesByFile.set(
+            source.resolvedFile,
+            (missesByFile.get(source.resolvedFile) ?? 0) + 1
+          );
+        }
+
+        return delegate.getParsedModule(source);
+      },
+      getExportMap(source) {
+        return cache.getParsedModule(source).exportMap;
+      },
+      getExportMapEntry(source, exportName) {
+        return cache.getParsedModule(source).exportMap.get(exportName) ?? null;
+      }
+    };
+
+    return { cache, missesByFile };
+  }
+
+  type ResolvedStaticCssEvalResultWithMetadata = {
+    kind: "resolved";
+    value: StaticCssLiteral;
+    cacheKey: StaticCssEvalCacheKey;
+    dependencies: ResolutionDependency[];
+  };
+
+  function expectResolvedResult(
+    result: StaticCssEvalResult
+  ): ResolvedStaticCssEvalResultWithMetadata {
+    expect(result.kind).toBe("resolved");
+
+    if (result.kind !== "resolved") {
+      throw new Error("Expected static css eval result to resolve");
+    }
+
+    if (!("cacheKey" in result)) {
+      throw new Error(
+        "Expected resolved static css eval result to include cache key"
+      );
+    }
+
+    if (
+      !Array.isArray(result.dependencies) ||
+      result.dependencies.some((dependency) => typeof dependency === "string")
+    ) {
+      throw new Error(
+        "Expected resolved static css eval result dependencies metadata"
+      );
+    }
+
+    return result as ResolvedStaticCssEvalResultWithMetadata;
+  }
 
   function createProvider(
     stylesSource: string,
     ownerSource = `import { button } from "./styles"; <div css={button} />;`,
-    barrelSource = `export { button } from "./styles";`
+    barrelSource = `export { button } from "./styles";`,
+    extraModules: readonly ImportedStaticCssEvalLoadedModule[] = [],
+    extraImportResolutions: readonly ImportedStaticCssEvalImportResolution[] = []
   ): StaticCssEvalProvider {
-    return createImportedStaticCssEvalProvider({
+    return createProviderFromModules({
       modules: [
         { id: ownerId, source: ownerSource },
         { id: stylesId, source: stylesSource },
         {
           id: barrelId,
           source: barrelSource
-        }
+        },
+        ...extraModules
       ],
       importResolutions: [
         { importerId: ownerId, importPath: "./styles", resolvedId: stylesId },
-        { importerId: ownerId, importPath: "./barrel", resolvedId: barrelId }
+        { importerId: ownerId, importPath: "./barrel", resolvedId: barrelId },
+        { importerId: barrelId, importPath: "./styles", resolvedId: stylesId },
+        ...extraImportResolutions
       ]
     });
   }
@@ -1361,7 +2191,19 @@ if (import.meta.vitest) {
       ).toMatchObject({
         kind: "resolved",
         value: { color: "red" },
-        dependencies: [stylesId]
+        provenance: { kind: "imported", file: stylesId, exportName: "button" },
+        dependencies: [
+          {
+            file: stylesId,
+            kind: "imported",
+            importer: ownerId,
+            specifier: "./styles",
+            exportName: "button",
+            memberPath: [],
+            inspected: true,
+            contributed: true
+          }
+        ]
       });
 
       expect(
@@ -1433,8 +2275,148 @@ if (import.meta.vitest) {
       });
     });
 
-    it("rejects reexports and exported const mutations deterministically", () => {
+    it("resolves direct named reexport chains with inspected dependency metadata", () => {
+      const result = resolveFixture(
+        createProvider(
+          `export const button = { color: "red" } as const;`,
+          `import { button } from "./barrel"; <div css={button} />;`
+        ),
+        "button"
+      );
+
+      expect(result).toMatchObject({
+        kind: "resolved",
+        value: { color: "red" },
+        provenance: {
+          kind: "reexported",
+          file: stylesId,
+          exportName: "button"
+        },
+        dependencies: [
+          {
+            file: barrelId,
+            kind: "reexported",
+            inspected: true,
+            contributed: true
+          },
+          {
+            file: stylesId,
+            kind: "reexported",
+            inspected: true,
+            contributed: true
+          }
+        ],
+        resolutionChain: [
+          { importer: ownerId, source: barrelId, exportName: "button" },
+          { importer: barrelId, source: stylesId, exportName: "button" }
+        ]
+      });
+    });
+
+    it("parses one imported source identity once for repeated binding resolutions", () => {
+      const { cache, missesByFile } = createCountingStaticCssModuleCache();
+      const provider = createProviderFromModules({
+        modules: [
+          {
+            id: ownerId,
+            source: `
+              import { button, card, banner } from "./styles";
+              <>
+                <div css={button} />
+                <div css={card} />
+                <div css={banner} />
+                <div css={button} />
+              </>;
+            `,
+            sourceHash: "hash:owner-v1",
+            version: "owner-v1"
+          },
+          {
+            id: stylesId,
+            source: `
+              export const button = { color: "red" } as const;
+              export const card = { color: "blue" } as const;
+              export const banner = { color: "green" } as const;
+            `,
+            sourceHash: "hash:styles-v1",
+            version: "styles-v1"
+          }
+        ],
+        importResolutions: [
+          { importerId: ownerId, importPath: "./styles", resolvedId: stylesId }
+        ],
+        moduleCache: cache
+      });
+
+      const button = expectResolvedResult(resolveFixture(provider, "button"));
+      const card = expectResolvedResult(resolveFixture(provider, "card"));
+      const banner = expectResolvedResult(resolveFixture(provider, "banner"));
+      const repeatedButton = expectResolvedResult(
+        resolveFixture(provider, "button")
+      );
+
+      expect(button.value).toEqual({ color: "red" });
+      expect(card.value).toEqual({ color: "blue" });
+      expect(banner.value).toEqual({ color: "green" });
+      expect(repeatedButton.value).toEqual({ color: "red" });
+      expect(missesByFile.get(stylesId)).toBe(1);
+      expect(missesByFile.get(ownerId)).toBe(1);
       expect(
+        [button, card, banner, repeatedButton].map((result) => ({
+          resolvedFile: result.cacheKey.resolvedFile,
+          sourceHash: result.cacheKey.sourceHash,
+          sourceVersion: result.cacheKey.sourceVersion,
+          pluginOptionsVersion: result.cacheKey.pluginOptionsVersion,
+          resolverOptionsVersion: result.cacheKey.resolverOptionsVersion,
+          staticEvalSupportVersion: result.cacheKey.staticEvalSupportVersion
+        }))
+      ).toEqual([
+        {
+          resolvedFile: stylesId,
+          sourceHash: "hash:styles-v1",
+          sourceVersion: "styles-v1",
+          pluginOptionsVersion: "static-css-eval-provider:v1",
+          resolverOptionsVersion: "static-css-eval-provider:v1",
+          staticEvalSupportVersion: STATIC_CSS_MODULE_CACHE_SUPPORT_VERSION
+        },
+        {
+          resolvedFile: stylesId,
+          sourceHash: "hash:styles-v1",
+          sourceVersion: "styles-v1",
+          pluginOptionsVersion: "static-css-eval-provider:v1",
+          resolverOptionsVersion: "static-css-eval-provider:v1",
+          staticEvalSupportVersion: STATIC_CSS_MODULE_CACHE_SUPPORT_VERSION
+        },
+        {
+          resolvedFile: stylesId,
+          sourceHash: "hash:styles-v1",
+          sourceVersion: "styles-v1",
+          pluginOptionsVersion: "static-css-eval-provider:v1",
+          resolverOptionsVersion: "static-css-eval-provider:v1",
+          staticEvalSupportVersion: STATIC_CSS_MODULE_CACHE_SUPPORT_VERSION
+        },
+        {
+          resolvedFile: stylesId,
+          sourceHash: "hash:styles-v1",
+          sourceVersion: "styles-v1",
+          pluginOptionsVersion: "static-css-eval-provider:v1",
+          resolverOptionsVersion: "static-css-eval-provider:v1",
+          staticEvalSupportVersion: STATIC_CSS_MODULE_CACHE_SUPPORT_VERSION
+        }
+      ]);
+    });
+
+    it("normalizes direct imports and direct reexports to the same terminal dependency file", () => {
+      const directResult = expectResolvedResult(
+        resolveFixture(
+          createProvider(
+            `export const button = { color: "red" } as const;`,
+            `import { button } from "./styles"; <div css={button} />;`
+          ),
+          "button"
+        )
+      );
+      const reexportResult = expectResolvedResult(
         resolveFixture(
           createProvider(
             `export const button = { color: "red" } as const;`,
@@ -1442,15 +2424,113 @@ if (import.meta.vitest) {
           ),
           "button"
         )
-      ).toMatchObject({
-        kind: "error",
-        diagnostic: {
-          code: "unsupported-source",
-          reason: "reexport-or-barrel"
-        },
-        dependencies: [barrelId]
-      });
+      );
+      const directDependency = directResult.dependencies.find(
+        (dependency) => dependency.file === stylesId
+      );
+      const reexportDependency = reexportResult.dependencies.find(
+        (dependency) => dependency.file === stylesId
+      );
 
+      expect(directDependency).toMatchObject({
+        file: stylesId,
+        kind: "imported"
+      });
+      expect(reexportDependency).toMatchObject({
+        file: stylesId,
+        kind: "reexported"
+      });
+      expect(directResult.cacheKey.resolvedFile).toBe(stylesId);
+      expect(reexportResult.cacheKey.resolvedFile).toBe(stylesId);
+      expect(directResult.cacheKey.resolvedId).toBe(
+        reexportResult.cacheKey.resolvedId
+      );
+    });
+
+    it("changes cache identity when imported source content identity changes", () => {
+      const createVersionedProvider = (
+        source: string,
+        sourceHash: string,
+        version: string
+      ) =>
+        createProviderFromModules({
+          modules: [
+            {
+              id: ownerId,
+              source: `import { button } from "./styles"; <div css={button} />;`
+            },
+            { id: stylesId, source, sourceHash, version }
+          ],
+          importResolutions: [
+            {
+              importerId: ownerId,
+              importPath: "./styles",
+              resolvedId: stylesId
+            }
+          ]
+        });
+      const red = expectResolvedResult(
+        resolveFixture(
+          createVersionedProvider(
+            `export const button = { color: "red" } as const;`,
+            "hash:styles-red",
+            "styles-red"
+          ),
+          "button"
+        )
+      );
+      const blue = expectResolvedResult(
+        resolveFixture(
+          createVersionedProvider(
+            `export const button = { color: "blue" } as const;`,
+            "hash:styles-blue",
+            "styles-blue"
+          ),
+          "button"
+        )
+      );
+
+      expect(red.value).toEqual({ color: "red" });
+      expect(blue.value).toEqual({ color: "blue" });
+      expect(red.cacheKey.resolvedFile).toBe(blue.cacheKey.resolvedFile);
+      expect(red.cacheKey.sourceHash).toBe("hash:styles-red");
+      expect(blue.cacheKey.sourceHash).toBe("hash:styles-blue");
+      expect(red.cacheKey.sourceVersion).toBe("styles-red");
+      expect(blue.cacheKey.sourceVersion).toBe("styles-blue");
+      expect(red.cacheKey).not.toEqual(blue.cacheKey);
+    });
+
+    it("resolves limited namespace members from project-local literal chains", () => {
+      expect(
+        resolveFixture(
+          createProvider(
+            `export const button = { color: "red" } as const;`,
+            `import * as styles from "./styles"; <div css={styles.button} />;`
+          ),
+          "styles",
+          ["button"]
+        )
+      ).toMatchObject({
+        kind: "resolved",
+        value: { color: "red" },
+        provenance: {
+          kind: "namespace-member",
+          file: stylesId,
+          exportName: "button",
+          namespaceBinding: "styles"
+        },
+        dependencies: [
+          {
+            file: stylesId,
+            kind: "namespace-member",
+            inspected: true,
+            contributed: true
+          }
+        ]
+      });
+    });
+
+    it("rejects export stars, missing exports, packages, cjs, and cycles with exact diagnostics", () => {
       expect(
         resolveFixture(
           createProvider(
@@ -1463,12 +2543,139 @@ if (import.meta.vitest) {
       ).toMatchObject({
         kind: "error",
         diagnostic: {
-          code: "unsupported-source",
-          reason: "reexport-or-barrel"
+          id: "STATIC_CSS_EVAL_EXPORT_STAR_UNSUPPORTED"
         },
-        dependencies: [barrelId]
+        dependencies: [{ file: barrelId, inspected: true, contributed: false }]
       });
 
+      expect(
+        resolveFixture(
+          createProvider(
+            `export const card = { color: "red" } as const;`,
+            `import { button } from "./styles"; <div css={button} />;`
+          ),
+          "button"
+        )
+      ).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_UNRESOLVED_EXPORT"
+        }
+      });
+
+      expect(
+        resolveFixture(
+          createProvider(
+            `export const button = { color: "red" } as const;`,
+            `import { button } from "pkg"; <div css={button} />;`
+          ),
+          "button"
+        )
+      ).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_PACKAGE_IMPORT_UNSUPPORTED"
+        }
+      });
+
+      expect(
+        resolveFixture(
+          createProvider(
+            `export const button = { color: "red" } as const;`,
+            `import * as styles from "pkg"; <div css={styles.button} />;`
+          ),
+          "styles",
+          ["button"]
+        )
+      ).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_NAMESPACE_UNSUPPORTED"
+        }
+      });
+
+      expect(
+        resolveFixture(
+          createProvider(
+            `export const button = { color: "red" } as const;`,
+            `const button = require("./styles"); <div css={button} />;`
+          ),
+          "button"
+        )
+      ).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_CJS_UNSUPPORTED"
+        }
+      });
+
+      expect(
+        resolveFixture(
+          createProviderFromModules({
+            modules: [
+              {
+                id: ownerId,
+                source: `import { button } from "./a"; <div css={button} />;`
+              },
+              { id: barrelId, source: `export { button } from "./button";` },
+              { id: buttonId, source: `export { button } from "./barrel";` }
+            ],
+            importResolutions: [
+              { importerId: ownerId, importPath: "./a", resolvedId: barrelId },
+              {
+                importerId: barrelId,
+                importPath: "./button",
+                resolvedId: buttonId
+              },
+              {
+                importerId: buttonId,
+                importPath: "./barrel",
+                resolvedId: barrelId
+              }
+            ]
+          }),
+          "button"
+        )
+      ).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_IMPORT_CYCLE"
+        }
+      });
+    });
+
+    it("rejects computed namespace members and ignores type-only imports", () => {
+      const provider = createProvider(
+        `export const button = { color: "red" } as const;`,
+        `import * as styles from "./styles"; <div css={styles[variant]} />;`
+      );
+      const diagnostic =
+        findUnsupportedImportedStaticCssEvalReferenceDiagnostic({
+          expression: t.memberExpression(
+            t.identifier("styles"),
+            t.identifier("variant"),
+            true
+          ),
+          ownerFile: ownerId,
+          provider
+        });
+
+      expect(diagnostic).toMatchObject({
+        id: "STATIC_CSS_EVAL_COMPUTED_MEMBER_UNSUPPORTED"
+      });
+
+      expect(
+        resolveFixture(
+          createProvider(
+            `export const button = { color: "red" } as const;`,
+            `import type { button } from "./styles"; <div css={button} />;`
+          ),
+          "button"
+        )
+      ).toEqual({ kind: "not-candidate" });
+    });
+
+    it("rejects exported const mutations deterministically", () => {
       expect(
         resolveFixture(
           createProvider(
@@ -1479,10 +2686,9 @@ if (import.meta.vitest) {
       ).toMatchObject({
         kind: "error",
         diagnostic: {
-          code: "mutation-detected",
-          reason: "mutated-binding"
+          id: "STATIC_CSS_EVAL_MUTATED_BINDING"
         },
-        dependencies: [stylesId]
+        dependencies: [{ file: stylesId, inspected: true, contributed: false }]
       });
 
       expect(
@@ -1496,10 +2702,9 @@ if (import.meta.vitest) {
       ).toMatchObject({
         kind: "error",
         diagnostic: {
-          code: "mutation-detected",
-          reason: "mutated-binding"
+          id: "STATIC_CSS_EVAL_MUTATED_BINDING"
         },
-        dependencies: [stylesId]
+        dependencies: [{ file: stylesId, inspected: true, contributed: false }]
       });
     });
   });

--- a/packages/babel/src/staticCssEval/limits.ts
+++ b/packages/babel/src/staticCssEval/limits.ts
@@ -159,7 +159,13 @@ export function getStaticCssEvalSourceByteLength(source: string): number {
   return new TextEncoder().encode(source).byteLength;
 }
 
+// == Tests ====================================================================
+// Ignore errors when compiling to CommonJS.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
 if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
   const { describe, expect, it } = import.meta.vitest;
 
   const owner = { file: "/project/src/App.tsx", start: 42, end: 55 };

--- a/packages/babel/src/staticCssEval/moduleCache.ts
+++ b/packages/babel/src/staticCssEval/moduleCache.ts
@@ -9,7 +9,7 @@ import type {
 
 export const STATIC_CSS_MODULE_CACHE_PARSER_VERSION = "babel-core-parser:v2";
 export const STATIC_CSS_MODULE_CACHE_SUPPORT_VERSION =
-  "static-css-module-export-map:v1";
+  "static-css-module-export-graph:v2";
 
 export interface StaticCssModuleSource {
   resolvedFile: string;
@@ -45,7 +45,9 @@ export interface ParsedStaticCssModule {
   importDeclarations: readonly t.ImportDeclaration[];
   exportDeclarations: readonly StaticCssModuleExportDeclaration[];
   exportMap: ReadonlyMap<StaticCssEvalExportName, ExportMapEntry>;
-  unsupportedExportStars: readonly ExportMapUnsupportedEntry[];
+  exportGraph: readonly ExportGraphEntry[];
+  exportStarReexports: readonly ExportGraphStarReexportEntry[];
+  unsupportedExportStars: readonly ExportGraphStarReexportEntry[];
   sourceVersion?: string | number;
 }
 
@@ -88,6 +90,53 @@ export interface ExportMapUnsupportedEntry {
     | t.ExportNamedDeclaration;
   diagnostic: StaticCssEvalDiagnostic;
   source?: string;
+}
+
+export type ExportGraphEntry = ExportMapEntry | ExportGraphStarReexportEntry;
+
+export interface ExportGraphStarReexportEntry {
+  readonly kind: "star-reexport";
+  readonly exportName: "*";
+  readonly source: string;
+  readonly declaration: t.ExportAllDeclaration;
+}
+
+export interface StaticCssModuleExportStarSource {
+  readonly entry: ExportGraphStarReexportEntry;
+  readonly exportNames: readonly StaticCssEvalExportName[];
+}
+
+export type StaticCssModuleExportNameTableEntry =
+  | StaticCssModuleExportNameExplicitEntry
+  | StaticCssModuleExportNameStarEntry
+  | StaticCssModuleExportNameAmbiguousStarEntry;
+
+export interface StaticCssModuleExportNameExplicitEntry {
+  readonly kind: "explicit";
+  readonly exportName: StaticCssEvalExportName;
+  readonly entry: ExportMapEntry;
+}
+
+export interface StaticCssModuleExportNameStarEntry {
+  readonly kind: "star";
+  readonly exportName: StaticCssEvalExportName;
+  readonly source: string;
+  readonly entry: ExportGraphStarReexportEntry;
+}
+
+export interface StaticCssModuleExportNameAmbiguousStarEntry {
+  readonly kind: "ambiguous-star";
+  readonly exportName: StaticCssEvalExportName;
+  readonly sources: readonly string[];
+  readonly starEntries: readonly ExportGraphStarReexportEntry[];
+}
+
+interface StaticCssModuleExportGraphBuildState {
+  file: string;
+  exportMap: Map<StaticCssEvalExportName, ExportMapEntry>;
+  exportGraph: ExportGraphEntry[];
+  exportStarReexports: ExportGraphStarReexportEntry[];
+  unsupportedExportStars: ExportGraphStarReexportEntry[];
 }
 
 export interface StaticCssModuleCache {
@@ -231,10 +280,12 @@ function parseStaticCssModule(
     }
   }
 
-  const { exportMap, unsupportedExportStars } = buildStaticCssModuleExportMap(
-    source.resolvedFile,
-    exportDeclarations
-  );
+  const {
+    exportMap,
+    exportGraph,
+    exportStarReexports,
+    unsupportedExportStars
+  } = buildStaticCssModuleExportMap(source.resolvedFile, exportDeclarations);
 
   return {
     file: source.resolvedFile,
@@ -249,6 +300,8 @@ function parseStaticCssModule(
     importDeclarations,
     exportDeclarations,
     exportMap,
+    exportGraph,
+    exportStarReexports,
     unsupportedExportStars,
     ...(source.sourceVersion !== undefined
       ? { sourceVersion: source.sourceVersion }
@@ -278,35 +331,41 @@ function buildStaticCssModuleExportMap(
   exportDeclarations: readonly StaticCssModuleExportDeclaration[]
 ): {
   exportMap: ReadonlyMap<StaticCssEvalExportName, ExportMapEntry>;
-  unsupportedExportStars: readonly ExportMapUnsupportedEntry[];
+  exportGraph: readonly ExportGraphEntry[];
+  exportStarReexports: readonly ExportGraphStarReexportEntry[];
+  unsupportedExportStars: readonly ExportGraphStarReexportEntry[];
 } {
-  const exportMap = new Map<StaticCssEvalExportName, ExportMapEntry>();
-  const unsupportedExportStars: ExportMapUnsupportedEntry[] = [];
+  const state: StaticCssModuleExportGraphBuildState = {
+    file,
+    exportMap: new Map<StaticCssEvalExportName, ExportMapEntry>(),
+    exportGraph: [],
+    exportStarReexports: [],
+    unsupportedExportStars: []
+  };
 
   for (const declaration of exportDeclarations) {
-    collectStaticCssModuleExportEntries(file, declaration, exportMap);
-
-    if (t.isExportAllDeclaration(declaration)) {
-      const entry = createExportStarUnsupportedEntry(file, declaration);
-      unsupportedExportStars.push(entry);
-      exportMap.set(entry.exportName, entry);
-    }
+    collectStaticCssModuleExportEntries(declaration, state);
   }
 
-  return { exportMap, unsupportedExportStars };
+  return {
+    exportMap: state.exportMap,
+    exportGraph: state.exportGraph,
+    exportStarReexports: state.exportStarReexports,
+    unsupportedExportStars: state.unsupportedExportStars
+  };
 }
 
 function collectStaticCssModuleExportEntries(
-  file: string,
   declaration: StaticCssModuleExportDeclaration,
-  exportMap: Map<StaticCssEvalExportName, ExportMapEntry>
+  state: StaticCssModuleExportGraphBuildState
 ): void {
   if (t.isExportAllDeclaration(declaration)) {
+    collectExportAllDeclaration(declaration, state);
     return;
   }
 
   if (t.isExportDefaultDeclaration(declaration)) {
-    collectDefaultExportEntry(file, declaration, exportMap);
+    collectDefaultExportEntry(declaration, state);
     return;
   }
 
@@ -315,25 +374,40 @@ function collectStaticCssModuleExportEntries(
   }
 
   if (declaration.source) {
-    collectDirectNamedReexportEntries(declaration, exportMap);
+    collectDirectNamedReexportEntries(declaration, state);
     return;
   }
 
   if (declaration.declaration) {
-    collectDeclaredExportEntries(declaration.declaration, exportMap);
+    collectDeclaredExportEntries(declaration.declaration, state);
     return;
   }
 
-  collectLocalSpecifierExportEntries(declaration, exportMap);
+  collectLocalSpecifierExportEntries(declaration, state);
+}
+
+function collectExportAllDeclaration(
+  declaration: t.ExportAllDeclaration,
+  state: StaticCssModuleExportGraphBuildState
+): void {
+  if (declaration.exportKind === "type") {
+    return;
+  }
+
+  addExportStarReexportEntry(state, {
+    kind: "star-reexport",
+    exportName: "*",
+    source: declaration.source.value,
+    declaration
+  });
 }
 
 function collectDefaultExportEntry(
-  file: string,
   declaration: t.ExportDefaultDeclaration,
-  exportMap: Map<StaticCssEvalExportName, ExportMapEntry>
+  state: StaticCssModuleExportGraphBuildState
 ): void {
   if (t.isExpression(declaration.declaration)) {
-    exportMap.set("default", {
+    addExportMapEntry(state, {
       kind: "expression",
       exportName: "default",
       expression: declaration.declaration,
@@ -342,14 +416,14 @@ function collectDefaultExportEntry(
     return;
   }
 
-  exportMap.set("default", {
+  addExportMapEntry(state, {
     kind: "unsupported",
     exportName: "default",
     unsupportedKind: "default-declaration",
     declaration,
     diagnostic: createUnsupportedDiagnostic({
       id: "STATIC_CSS_EVAL_DYNAMIC_EXPRESSION_UNSUPPORTED",
-      owner: { file },
+      owner: { file: state.file },
       detail: "default export declaration is not a static expression",
       exportName: "default"
     })
@@ -358,7 +432,7 @@ function collectDefaultExportEntry(
 
 function collectDeclaredExportEntries(
   declaration: t.Declaration,
-  exportMap: Map<StaticCssEvalExportName, ExportMapEntry>
+  state: StaticCssModuleExportGraphBuildState
 ): void {
   if (t.isVariableDeclaration(declaration)) {
     const declarationKind = declaration.kind;
@@ -372,7 +446,7 @@ function collectDeclaredExportEntries(
         continue;
       }
 
-      exportMap.set(declarator.id.name, {
+      addExportMapEntry(state, {
         kind: "local",
         exportName: declarator.id.name,
         localName: declarator.id.name,
@@ -388,7 +462,7 @@ function collectDeclaredExportEntries(
       t.isClassDeclaration(declaration)) &&
     declaration.id
   ) {
-    exportMap.set(declaration.id.name, {
+    addExportMapEntry(state, {
       kind: "local",
       exportName: declaration.id.name,
       localName: declaration.id.name,
@@ -402,7 +476,7 @@ function collectDeclaredExportEntries(
 
 function collectLocalSpecifierExportEntries(
   declaration: t.ExportNamedDeclaration,
-  exportMap: Map<StaticCssEvalExportName, ExportMapEntry>
+  state: StaticCssModuleExportGraphBuildState
 ): void {
   for (const specifier of declaration.specifiers) {
     if (!t.isExportSpecifier(specifier) || specifier.exportKind === "type") {
@@ -416,7 +490,7 @@ function collectLocalSpecifierExportEntries(
       continue;
     }
 
-    exportMap.set(exportName, {
+    addExportMapEntry(state, {
       kind: "local",
       exportName,
       localName,
@@ -428,7 +502,7 @@ function collectLocalSpecifierExportEntries(
 
 function collectDirectNamedReexportEntries(
   declaration: t.ExportNamedDeclaration,
-  exportMap: Map<StaticCssEvalExportName, ExportMapEntry>
+  state: StaticCssModuleExportGraphBuildState
 ): void {
   for (const specifier of declaration.specifiers) {
     if (t.isExportSpecifier(specifier) && specifier.exportKind !== "type") {
@@ -436,7 +510,7 @@ function collectDirectNamedReexportEntries(
       const exportName = getStaticCssModuleName(specifier.exported);
 
       if (importedName && exportName) {
-        exportMap.set(exportName, {
+        addExportMapEntry(state, {
           kind: "reexport",
           exportName,
           importedName,
@@ -451,7 +525,7 @@ function collectDirectNamedReexportEntries(
       const exportName = getStaticCssModuleName(specifier.exported);
 
       if (exportName) {
-        exportMap.set(exportName, {
+        addExportMapEntry(state, {
           kind: "unsupported",
           exportName,
           unsupportedKind: "export-namespace",
@@ -470,25 +544,111 @@ function collectDirectNamedReexportEntries(
   }
 }
 
-function createExportStarUnsupportedEntry(
-  file: string,
-  declaration: t.ExportAllDeclaration
-): ExportMapUnsupportedEntry {
-  return {
-    kind: "unsupported",
-    exportName: "*",
-    unsupportedKind: "export-star",
-    declaration,
-    source: declaration.source.value,
-    diagnostic: createUnsupportedDiagnostic({
-      id: "STATIC_CSS_EVAL_EXPORT_STAR_UNSUPPORTED",
-      owner: { file },
-      dependency: { file: declaration.source.value },
-      detail: `export * from "${declaration.source.value}" is unsupported`,
-      exportName: "*",
-      importPath: declaration.source.value
-    })
-  };
+function addExportMapEntry(
+  state: StaticCssModuleExportGraphBuildState,
+  entry: ExportMapEntry
+): void {
+  state.exportMap.set(entry.exportName, entry);
+  state.exportGraph.push(entry);
+}
+
+function addExportStarReexportEntry(
+  state: StaticCssModuleExportGraphBuildState,
+  entry: ExportGraphStarReexportEntry
+): void {
+  state.exportStarReexports.push(entry);
+  state.unsupportedExportStars.push(entry);
+  state.exportGraph.push(entry);
+}
+
+export function createStaticCssModuleExportNameTable(
+  explicitExportMap: ReadonlyMap<StaticCssEvalExportName, ExportMapEntry>,
+  starSources: readonly StaticCssModuleExportStarSource[]
+): ReadonlyMap<StaticCssEvalExportName, StaticCssModuleExportNameTableEntry> {
+  const exportNameTable = new Map<
+    StaticCssEvalExportName,
+    StaticCssModuleExportNameTableEntry
+  >();
+
+  for (const [exportName, entry] of explicitExportMap) {
+    exportNameTable.set(exportName, {
+      kind: "explicit",
+      exportName,
+      entry
+    });
+  }
+
+  for (const starSource of starSources) {
+    for (const exportName of starSource.exportNames) {
+      if (exportName === "default" || explicitExportMap.has(exportName)) {
+        continue;
+      }
+
+      addStarExportNameTableEntry(
+        exportNameTable,
+        exportName,
+        starSource.entry
+      );
+    }
+  }
+
+  return exportNameTable;
+}
+
+function addStarExportNameTableEntry(
+  exportNameTable: Map<
+    StaticCssEvalExportName,
+    StaticCssModuleExportNameTableEntry
+  >,
+  exportName: StaticCssEvalExportName,
+  starEntry: ExportGraphStarReexportEntry
+): void {
+  const existing = exportNameTable.get(exportName);
+
+  if (!existing) {
+    exportNameTable.set(exportName, {
+      kind: "star",
+      exportName,
+      source: starEntry.source,
+      entry: starEntry
+    });
+    return;
+  }
+
+  switch (existing.kind) {
+    case "explicit":
+      return;
+    case "star":
+      if (existing.source === starEntry.source) {
+        return;
+      }
+
+      exportNameTable.set(exportName, {
+        kind: "ambiguous-star",
+        exportName,
+        sources: [existing.source, starEntry.source],
+        starEntries: [existing.entry, starEntry]
+      });
+      return;
+    case "ambiguous-star":
+      if (existing.sources.includes(starEntry.source)) {
+        return;
+      }
+
+      exportNameTable.set(exportName, {
+        kind: "ambiguous-star",
+        exportName,
+        sources: [...existing.sources, starEntry.source],
+        starEntries: [...existing.starEntries, starEntry]
+      });
+      return;
+    default:
+      return assertNever(existing);
+  }
+}
+
+function assertNever(value: never): never {
+  throw new TypeError(`Unexpected static css export graph entry: ${value}`);
 }
 
 function createUnsupportedDiagnostic(options: {
@@ -716,31 +876,224 @@ if (import.meta.vitest) {
       );
     });
 
-    it("records export star as deterministic unsupported metadata without recursion", () => {
+    it("records distinct export graph entries for default direct and export star declarations", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(`
+        export const button = { color: "red" };
+        const local = { color: "blue" };
+        export { local as name };
+        export default { color: "green" };
+        export { button as buttonFromLeaf } from "./button";
+        export { default as root } from "./button";
+        export * from "./button";
+      `);
+      const parsedModule = cache.getParsedModule(source);
+
+      expect(parsedModule.exportGraph).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: "local",
+            exportName: "button",
+            localName: "button",
+            declarationKind: "const"
+          }),
+          expect.objectContaining({
+            kind: "local",
+            exportName: "name",
+            localName: "local",
+            declarationKind: "specifier"
+          }),
+          expect.objectContaining({
+            kind: "expression",
+            exportName: "default"
+          }),
+          expect.objectContaining({
+            kind: "reexport",
+            exportName: "buttonFromLeaf",
+            importedName: "button",
+            source: "./button"
+          }),
+          expect.objectContaining({
+            kind: "reexport",
+            exportName: "root",
+            importedName: "default",
+            source: "./button"
+          }),
+          expect.objectContaining({
+            kind: "star-reexport",
+            exportName: "*",
+            source: "./button"
+          })
+        ])
+      );
+      expect(parsedModule.exportStarReexports).toEqual([
+        expect.objectContaining({
+          kind: "star-reexport",
+          exportName: "*",
+          source: "./button"
+        })
+      ]);
+      expect(cache.getExportMapEntry(source, "*")).toBeNull();
+    });
+
+    it("records explicit default reexports as direct graph entries", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(`
+        export { button } from "./button";
+        export { default } from "./button";
+      `);
+      const parsedModule = cache.getParsedModule(source);
+
+      expect(cache.getExportMapEntry(source, "button")).toMatchObject({
+        kind: "reexport",
+        exportName: "button",
+        importedName: "button",
+        source: "./button"
+      });
+      expect(cache.getExportMapEntry(source, "default")).toMatchObject({
+        kind: "reexport",
+        exportName: "default",
+        importedName: "default",
+        source: "./button"
+      });
+      expect(parsedModule.exportGraph).toEqual([
+        expect.objectContaining({
+          kind: "reexport",
+          exportName: "button",
+          importedName: "button",
+          source: "./button"
+        }),
+        expect.objectContaining({
+          kind: "reexport",
+          exportName: "default",
+          importedName: "default",
+          source: "./button"
+        })
+      ]);
+    });
+
+    it("builds export star name tables without default forwarding or ambiguity guesses", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(`
+        export const localButton = { color: "red" };
+        export * from "./button";
+        export * from "./theme";
+      `);
+      const parsedModule = cache.getParsedModule(source);
+      const [buttonStar, themeStar] = parsedModule.exportStarReexports;
+
+      if (!buttonStar || !themeStar) {
+        throw new TypeError("expected two export star graph entries");
+      }
+
+      expect(buttonStar).toMatchObject({ source: "./button" });
+      expect(themeStar).toMatchObject({ source: "./theme" });
+
+      const exportNameTable = createStaticCssModuleExportNameTable(
+        parsedModule.exportMap,
+        [
+          {
+            entry: buttonStar,
+            exportNames: ["localButton", "button", "default", "card"]
+          },
+          { entry: themeStar, exportNames: ["button", "color"] }
+        ]
+      );
+
+      expect(exportNameTable.get("localButton")).toMatchObject({
+        kind: "explicit",
+        exportName: "localButton",
+        entry: expect.objectContaining({ kind: "local" })
+      });
+      expect(exportNameTable.get("default")).toBeUndefined();
+      expect(exportNameTable.get("card")).toMatchObject({
+        kind: "star",
+        exportName: "card",
+        source: "./button"
+      });
+      expect(exportNameTable.get("button")).toMatchObject({
+        kind: "ambiguous-star",
+        exportName: "button",
+        sources: ["./button", "./theme"]
+      });
+    });
+
+    it("keeps namespace re-export unsupported and type-only exports out of value graph", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(`
+        export type { Foo } from "./types";
+        export type * from "./types";
+        export * as ns from "./button";
+      `);
+      const parsedModule = cache.getParsedModule(source);
+
+      expect(cache.getExportMapEntry(source, "Foo")).toBeNull();
+      expect(parsedModule.exportStarReexports).toHaveLength(0);
+      expect(parsedModule.exportGraph).toEqual([
+        expect.objectContaining({
+          kind: "unsupported",
+          exportName: "ns",
+          unsupportedKind: "export-namespace",
+          source: "./button",
+          diagnostic: expect.objectContaining({
+            id: "STATIC_CSS_EVAL_NAMESPACE_UNSUPPORTED",
+            code: "unsupported-source",
+            reason: "reexport-or-barrel",
+            owner: { file: "./button" },
+            importPath: "./button",
+            exportName: "ns"
+          })
+        })
+      ]);
+    });
+
+    it("records export star as deterministic graph metadata without forwarding default", () => {
       const cache = createStaticCssModuleCache();
       const source = createSource(`export * from "./button";`);
       const parsedModule = cache.getParsedModule(source);
-      const exportStarEntry = cache.getExportMapEntry(source, "*");
+      const [buttonStar] = parsedModule.exportStarReexports;
+
+      if (!buttonStar) {
+        throw new TypeError("expected one export star graph entry");
+      }
+
+      const exportNameTable = createStaticCssModuleExportNameTable(
+        parsedModule.exportMap,
+        [
+          {
+            entry: buttonStar,
+            exportNames: ["button", "default"]
+          }
+        ]
+      );
 
       expect(parsedModule.unsupportedExportStars).toHaveLength(1);
-      expect(exportStarEntry).toMatchObject({
-        kind: "unsupported",
-        exportName: "*",
-        unsupportedKind: "export-star",
-        source: "./button",
-        diagnostic: {
-          id: "STATIC_CSS_EVAL_EXPORT_STAR_UNSUPPORTED",
-          code: "unsupported-source",
-          reason: "reexport-or-barrel",
-          owner: { file: stylesId },
-          dependency: { file: "./button" },
-          importPath: "./button",
-          exportName: "*"
-        }
+      expect(parsedModule.exportStarReexports).toEqual([
+        expect.objectContaining({
+          kind: "star-reexport",
+          exportName: "*",
+          source: "./button"
+        })
+      ]);
+      expect(parsedModule.exportGraph).toEqual([
+        expect.objectContaining({
+          kind: "star-reexport",
+          exportName: "*",
+          source: "./button"
+        })
+      ]);
+      expect(cache.getExportMapEntry(source, "*")).toBeNull();
+      expect(exportNameTable.get("button")).toMatchObject({
+        kind: "star",
+        exportName: "button",
+        source: "./button"
       });
-      expect(
-        parsedModule.unsupportedExportStars[0]?.diagnostic.message
-      ).toContain(`export * from "./button" is unsupported`);
+      expect(exportNameTable.get("default")).toBeUndefined();
+      expect(parsedModule.unsupportedExportStars[0]).toMatchObject({
+        kind: "star-reexport",
+        exportName: "*",
+        source: "./button"
+      });
       expect(
         getStaticCssModuleCacheInstrumentation(cache).parseCountByFile
       ).toEqual(new Map([[stylesId, 1]]));

--- a/packages/babel/src/staticCssEval/moduleCache.ts
+++ b/packages/babel/src/staticCssEval/moduleCache.ts
@@ -1,10 +1,12 @@
 import { transformSync, types as t } from "@babel/core";
 import type { NodePath, PluginObj } from "@babel/core";
+import { createStaticCssEvalDiagnostic } from "./diagnostics.js";
 import type {
   StaticCssEvalDiagnostic,
   StaticCssEvalExportName,
   StaticCssEvalParserOptionsKey,
-  StaticCssEvalSourceLocation
+  StaticCssEvalSourceLocation,
+  StaticCssEvalUnsupportedReason
 } from "./types.js";
 
 export const STATIC_CSS_MODULE_CACHE_PARSER_VERSION = "babel-core-parser:v2";
@@ -256,7 +258,10 @@ function parseStaticCssModule(
     configFile: false,
     babelrc: false,
     parserOpts: {
-      plugins: parserOptions.plugins
+      plugins: [
+        ...(parserOptions.jsx ? (["jsx"] as const) : []),
+        ...(parserOptions.typescript ? (["typescript"] as const) : [])
+      ]
     },
     plugins: [captureProgramPathPlugin]
   });
@@ -312,7 +317,9 @@ function parseStaticCssModule(
 function getStaticCssModuleParserOptions(
   filePath: string
 ): StaticCssEvalParserOptionsKey {
-  const typescript = /\.[cm]?tsx?$/.test(filePath);
+  const typescript =
+    /\.[cm]?tsx?$/.test(filePath) ||
+    /^(?:\0?virtual:|pkg:|data:)/.test(filePath);
   const jsx = /\.[jt]sx$/.test(filePath);
 
   return {
@@ -425,6 +432,7 @@ function collectDefaultExportEntry(
       id: "STATIC_CSS_EVAL_DYNAMIC_EXPRESSION_UNSUPPORTED",
       owner: { file: state.file },
       detail: "default export declaration is not a static expression",
+      reason: "runtime-dynamic-value",
       exportName: "default"
     })
   });
@@ -533,8 +541,9 @@ function collectDirectNamedReexportEntries(
           source: declaration.source?.value,
           diagnostic: createUnsupportedDiagnostic({
             id: "STATIC_CSS_EVAL_NAMESPACE_UNSUPPORTED",
-            owner: { file: declaration.source?.value ?? "<unknown>" },
+            owner: { file: state.file },
             detail: `namespace re-export "${exportName}" is unsupported`,
+            reason: "unsupported-namespace-reexport",
             exportName,
             importPath: declaration.source?.value
           })
@@ -655,24 +664,21 @@ function createUnsupportedDiagnostic(options: {
   id: NonNullable<StaticCssEvalDiagnostic["id"]>;
   owner: StaticCssEvalSourceLocation;
   detail: string;
+  reason: StaticCssEvalUnsupportedReason;
   dependency?: StaticCssEvalSourceLocation;
   exportName?: StaticCssEvalExportName;
   importPath?: string;
 }): StaticCssEvalDiagnostic {
-  return {
+  return createStaticCssEvalDiagnostic({
     id: options.id,
     code: "unsupported-source",
-    message: `Cannot statically evaluate css prop value: ${options.detail}`,
-    reason: "reexport-or-barrel",
+    reason: options.reason,
+    detail: options.detail,
     owner: options.owner,
-    ...(options.dependency ? { dependency: options.dependency } : {}),
-    ...(options.exportName !== undefined
-      ? { exportName: options.exportName }
-      : {}),
-    ...(options.importPath !== undefined
-      ? { importPath: options.importPath }
-      : {})
-  };
+    dependency: options.dependency,
+    exportName: options.exportName,
+    importPath: options.importPath
+  });
 }
 
 function isStaticCssModuleExportDeclaration(
@@ -1038,8 +1044,8 @@ if (import.meta.vitest) {
           diagnostic: expect.objectContaining({
             id: "STATIC_CSS_EVAL_NAMESPACE_UNSUPPORTED",
             code: "unsupported-source",
-            reason: "reexport-or-barrel",
-            owner: { file: "./button" },
+            reason: "unsupported-namespace-reexport",
+            owner: { file: stylesId },
             importPath: "./button",
             exportName: "ns"
           })

--- a/packages/babel/src/staticCssEval/moduleCache.ts
+++ b/packages/babel/src/staticCssEval/moduleCache.ts
@@ -1,0 +1,743 @@
+import { transformSync, types as t } from "@babel/core";
+import type { NodePath, PluginObj } from "@babel/core";
+import type {
+  StaticCssEvalDiagnostic,
+  StaticCssEvalExportName,
+  StaticCssEvalParserOptionsKey,
+  StaticCssEvalSourceLocation
+} from "./types.js";
+
+export const STATIC_CSS_MODULE_CACHE_PARSER_VERSION = "babel-core-parser:v2";
+export const STATIC_CSS_MODULE_CACHE_SUPPORT_VERSION =
+  "static-css-module-export-map:v1";
+
+export interface StaticCssModuleSource {
+  resolvedFile: string;
+  source: string;
+  sourceHash: string;
+  sourceVersion?: string | number;
+}
+
+export interface ExportMapCacheKey {
+  resolvedFile: string;
+  sourceHash: string;
+  parserVersion: string;
+  supportVersion: string;
+  parserOptions: StaticCssEvalParserOptionsKey;
+  sourceVersion?: string | number;
+}
+
+export type StaticCssModuleExportDeclaration =
+  | t.ExportAllDeclaration
+  | t.ExportDefaultDeclaration
+  | t.ExportNamedDeclaration;
+
+export interface ParsedStaticCssModule {
+  file: string;
+  resolvedFile: string;
+  source: string;
+  sourceHash: string;
+  sourceVersionHash: string;
+  cacheKey: ExportMapCacheKey;
+  ast: t.File;
+  program: t.Program;
+  programPath: NodePath<t.Program>;
+  importDeclarations: readonly t.ImportDeclaration[];
+  exportDeclarations: readonly StaticCssModuleExportDeclaration[];
+  exportMap: ReadonlyMap<StaticCssEvalExportName, ExportMapEntry>;
+  unsupportedExportStars: readonly ExportMapUnsupportedEntry[];
+  sourceVersion?: string | number;
+}
+
+export type ExportMapEntry =
+  | ExportMapExpressionEntry
+  | ExportMapLocalEntry
+  | ExportMapReexportEntry
+  | ExportMapUnsupportedEntry;
+
+export interface ExportMapExpressionEntry {
+  kind: "expression";
+  exportName: StaticCssEvalExportName;
+  expression: t.Expression;
+  declaration: t.ExportDefaultDeclaration;
+}
+
+export interface ExportMapLocalEntry {
+  kind: "local";
+  exportName: StaticCssEvalExportName;
+  localName: string;
+  declarationKind: "class" | "const" | "function" | "let" | "specifier" | "var";
+  declaration: t.Declaration | t.ExportNamedDeclaration;
+}
+
+export interface ExportMapReexportEntry {
+  kind: "reexport";
+  exportName: StaticCssEvalExportName;
+  importedName: string;
+  source: string;
+  declaration: t.ExportNamedDeclaration;
+}
+
+export interface ExportMapUnsupportedEntry {
+  kind: "unsupported";
+  exportName: StaticCssEvalExportName;
+  unsupportedKind: "default-declaration" | "export-namespace" | "export-star";
+  declaration:
+    | t.ExportAllDeclaration
+    | t.ExportDefaultDeclaration
+    | t.ExportNamedDeclaration;
+  diagnostic: StaticCssEvalDiagnostic;
+  source?: string;
+}
+
+export interface StaticCssModuleCache {
+  getParsedModule(source: StaticCssModuleSource): ParsedStaticCssModule;
+  getExportMap(
+    source: StaticCssModuleSource
+  ): ReadonlyMap<StaticCssEvalExportName, ExportMapEntry>;
+  getExportMapEntry(
+    source: StaticCssModuleSource,
+    exportName: StaticCssEvalExportName
+  ): ExportMapEntry | null;
+}
+
+interface StaticCssModuleCacheInstrumentation {
+  hits: number;
+  misses: number;
+  parseCountByFile: Map<string, number>;
+}
+
+interface StaticCssModuleCacheInstrumentationSnapshot {
+  hits: number;
+  misses: number;
+  parseCountByFile: ReadonlyMap<string, number>;
+}
+
+const cacheInstrumentation = new WeakMap<
+  StaticCssModuleCache,
+  StaticCssModuleCacheInstrumentation
+>();
+
+export function createStaticCssModuleCache(): StaticCssModuleCache {
+  const parsedModules = new Map<string, ParsedStaticCssModule>();
+  const instrumentation: StaticCssModuleCacheInstrumentation = {
+    hits: 0,
+    misses: 0,
+    parseCountByFile: new Map<string, number>()
+  };
+
+  const cache: StaticCssModuleCache = {
+    getParsedModule(source) {
+      const cacheKey = createExportMapCacheKey(source);
+      const formattedCacheKey = formatExportMapCacheKey(cacheKey);
+      const parsedModule = parsedModules.get(formattedCacheKey);
+
+      if (parsedModule) {
+        instrumentation.hits += 1;
+        return parsedModule;
+      }
+
+      instrumentation.misses += 1;
+      instrumentation.parseCountByFile.set(
+        source.resolvedFile,
+        (instrumentation.parseCountByFile.get(source.resolvedFile) ?? 0) + 1
+      );
+
+      const nextParsedModule = parseStaticCssModule(source, cacheKey);
+      parsedModules.set(formattedCacheKey, nextParsedModule);
+      return nextParsedModule;
+    },
+    getExportMap(source) {
+      return this.getParsedModule(source).exportMap;
+    },
+    getExportMapEntry(source, exportName) {
+      return this.getParsedModule(source).exportMap.get(exportName) ?? null;
+    }
+  };
+
+  cacheInstrumentation.set(cache, instrumentation);
+  return cache;
+}
+
+export function createExportMapCacheKey(
+  source: StaticCssModuleSource
+): ExportMapCacheKey {
+  return {
+    resolvedFile: source.resolvedFile,
+    sourceHash: source.sourceHash,
+    parserVersion: STATIC_CSS_MODULE_CACHE_PARSER_VERSION,
+    supportVersion: STATIC_CSS_MODULE_CACHE_SUPPORT_VERSION,
+    parserOptions: getStaticCssModuleParserOptions(source.resolvedFile),
+    ...(source.sourceVersion !== undefined
+      ? { sourceVersion: source.sourceVersion }
+      : {})
+  };
+}
+
+export function formatExportMapCacheKey(cacheKey: ExportMapCacheKey): string {
+  return JSON.stringify({
+    resolvedFile: cacheKey.resolvedFile,
+    sourceHash: cacheKey.sourceHash,
+    sourceVersion: cacheKey.sourceVersion ?? null,
+    parserVersion: cacheKey.parserVersion,
+    supportVersion: cacheKey.supportVersion,
+    parserOptions: cacheKey.parserOptions
+  });
+}
+
+function parseStaticCssModule(
+  source: StaticCssModuleSource,
+  cacheKey: ExportMapCacheKey
+): ParsedStaticCssModule {
+  const parserOptions = cacheKey.parserOptions;
+  const programPathRef: { current?: NodePath<t.Program> } = {};
+  const captureProgramPathPlugin: PluginObj = {
+    visitor: {
+      Program(path: NodePath<t.Program>) {
+        programPathRef.current = path;
+        path.stop();
+      }
+    }
+  };
+  const result = transformSync(source.source, {
+    filename: source.resolvedFile,
+    ast: true,
+    code: false,
+    sourceType: "module",
+    configFile: false,
+    babelrc: false,
+    parserOpts: {
+      plugins: parserOptions.plugins
+    },
+    plugins: [captureProgramPathPlugin]
+  });
+  const programPath = programPathRef.current;
+
+  if (!programPath || !result?.ast) {
+    throw new Error(`Failed to parse static css module ${source.resolvedFile}`);
+  }
+
+  const importDeclarations: t.ImportDeclaration[] = [];
+  const exportDeclarations: StaticCssModuleExportDeclaration[] = [];
+
+  for (const statement of programPath.node.body) {
+    if (t.isImportDeclaration(statement)) {
+      importDeclarations.push(statement);
+      continue;
+    }
+
+    if (isStaticCssModuleExportDeclaration(statement)) {
+      exportDeclarations.push(statement);
+    }
+  }
+
+  const { exportMap, unsupportedExportStars } = buildStaticCssModuleExportMap(
+    source.resolvedFile,
+    exportDeclarations
+  );
+
+  return {
+    file: source.resolvedFile,
+    resolvedFile: source.resolvedFile,
+    source: source.source,
+    sourceHash: source.sourceHash,
+    sourceVersionHash: createSourceVersionHash(source),
+    cacheKey,
+    ast: result.ast,
+    program: programPath.node,
+    programPath,
+    importDeclarations,
+    exportDeclarations,
+    exportMap,
+    unsupportedExportStars,
+    ...(source.sourceVersion !== undefined
+      ? { sourceVersion: source.sourceVersion }
+      : {})
+  };
+}
+
+function getStaticCssModuleParserOptions(
+  filePath: string
+): StaticCssEvalParserOptionsKey {
+  const typescript = /\.[cm]?tsx?$/.test(filePath);
+  const jsx = /\.[jt]sx$/.test(filePath);
+
+  return {
+    plugins: [
+      ...(jsx ? (["jsx"] as const) : []),
+      ...(typescript ? (["typescript"] as const) : [])
+    ],
+    sourceType: "module",
+    jsx,
+    typescript
+  };
+}
+
+function buildStaticCssModuleExportMap(
+  file: string,
+  exportDeclarations: readonly StaticCssModuleExportDeclaration[]
+): {
+  exportMap: ReadonlyMap<StaticCssEvalExportName, ExportMapEntry>;
+  unsupportedExportStars: readonly ExportMapUnsupportedEntry[];
+} {
+  const exportMap = new Map<StaticCssEvalExportName, ExportMapEntry>();
+  const unsupportedExportStars: ExportMapUnsupportedEntry[] = [];
+
+  for (const declaration of exportDeclarations) {
+    collectStaticCssModuleExportEntries(file, declaration, exportMap);
+
+    if (t.isExportAllDeclaration(declaration)) {
+      const entry = createExportStarUnsupportedEntry(file, declaration);
+      unsupportedExportStars.push(entry);
+      exportMap.set(entry.exportName, entry);
+    }
+  }
+
+  return { exportMap, unsupportedExportStars };
+}
+
+function collectStaticCssModuleExportEntries(
+  file: string,
+  declaration: StaticCssModuleExportDeclaration,
+  exportMap: Map<StaticCssEvalExportName, ExportMapEntry>
+): void {
+  if (t.isExportAllDeclaration(declaration)) {
+    return;
+  }
+
+  if (t.isExportDefaultDeclaration(declaration)) {
+    collectDefaultExportEntry(file, declaration, exportMap);
+    return;
+  }
+
+  if (declaration.exportKind === "type") {
+    return;
+  }
+
+  if (declaration.source) {
+    collectDirectNamedReexportEntries(declaration, exportMap);
+    return;
+  }
+
+  if (declaration.declaration) {
+    collectDeclaredExportEntries(declaration.declaration, exportMap);
+    return;
+  }
+
+  collectLocalSpecifierExportEntries(declaration, exportMap);
+}
+
+function collectDefaultExportEntry(
+  file: string,
+  declaration: t.ExportDefaultDeclaration,
+  exportMap: Map<StaticCssEvalExportName, ExportMapEntry>
+): void {
+  if (t.isExpression(declaration.declaration)) {
+    exportMap.set("default", {
+      kind: "expression",
+      exportName: "default",
+      expression: declaration.declaration,
+      declaration
+    });
+    return;
+  }
+
+  exportMap.set("default", {
+    kind: "unsupported",
+    exportName: "default",
+    unsupportedKind: "default-declaration",
+    declaration,
+    diagnostic: createUnsupportedDiagnostic({
+      id: "STATIC_CSS_EVAL_DYNAMIC_EXPRESSION_UNSUPPORTED",
+      owner: { file },
+      detail: "default export declaration is not a static expression",
+      exportName: "default"
+    })
+  });
+}
+
+function collectDeclaredExportEntries(
+  declaration: t.Declaration,
+  exportMap: Map<StaticCssEvalExportName, ExportMapEntry>
+): void {
+  if (t.isVariableDeclaration(declaration)) {
+    const declarationKind = declaration.kind;
+
+    if (!isStaticCssModuleVariableDeclarationKind(declarationKind)) {
+      return;
+    }
+
+    for (const declarator of declaration.declarations) {
+      if (!t.isIdentifier(declarator.id)) {
+        continue;
+      }
+
+      exportMap.set(declarator.id.name, {
+        kind: "local",
+        exportName: declarator.id.name,
+        localName: declarator.id.name,
+        declarationKind,
+        declaration
+      });
+    }
+    return;
+  }
+
+  if (
+    (t.isFunctionDeclaration(declaration) ||
+      t.isClassDeclaration(declaration)) &&
+    declaration.id
+  ) {
+    exportMap.set(declaration.id.name, {
+      kind: "local",
+      exportName: declaration.id.name,
+      localName: declaration.id.name,
+      declarationKind: t.isFunctionDeclaration(declaration)
+        ? "function"
+        : "class",
+      declaration
+    });
+  }
+}
+
+function collectLocalSpecifierExportEntries(
+  declaration: t.ExportNamedDeclaration,
+  exportMap: Map<StaticCssEvalExportName, ExportMapEntry>
+): void {
+  for (const specifier of declaration.specifiers) {
+    if (!t.isExportSpecifier(specifier) || specifier.exportKind === "type") {
+      continue;
+    }
+
+    const localName = getStaticCssModuleName(specifier.local);
+    const exportName = getStaticCssModuleName(specifier.exported);
+
+    if (!localName || !exportName) {
+      continue;
+    }
+
+    exportMap.set(exportName, {
+      kind: "local",
+      exportName,
+      localName,
+      declarationKind: "specifier",
+      declaration
+    });
+  }
+}
+
+function collectDirectNamedReexportEntries(
+  declaration: t.ExportNamedDeclaration,
+  exportMap: Map<StaticCssEvalExportName, ExportMapEntry>
+): void {
+  for (const specifier of declaration.specifiers) {
+    if (t.isExportSpecifier(specifier) && specifier.exportKind !== "type") {
+      const importedName = getStaticCssModuleName(specifier.local);
+      const exportName = getStaticCssModuleName(specifier.exported);
+
+      if (importedName && exportName) {
+        exportMap.set(exportName, {
+          kind: "reexport",
+          exportName,
+          importedName,
+          source: declaration.source?.value ?? "",
+          declaration
+        });
+      }
+      continue;
+    }
+
+    if (t.isExportNamespaceSpecifier(specifier)) {
+      const exportName = getStaticCssModuleName(specifier.exported);
+
+      if (exportName) {
+        exportMap.set(exportName, {
+          kind: "unsupported",
+          exportName,
+          unsupportedKind: "export-namespace",
+          declaration,
+          source: declaration.source?.value,
+          diagnostic: createUnsupportedDiagnostic({
+            id: "STATIC_CSS_EVAL_NAMESPACE_UNSUPPORTED",
+            owner: { file: declaration.source?.value ?? "<unknown>" },
+            detail: `namespace re-export "${exportName}" is unsupported`,
+            exportName,
+            importPath: declaration.source?.value
+          })
+        });
+      }
+    }
+  }
+}
+
+function createExportStarUnsupportedEntry(
+  file: string,
+  declaration: t.ExportAllDeclaration
+): ExportMapUnsupportedEntry {
+  return {
+    kind: "unsupported",
+    exportName: "*",
+    unsupportedKind: "export-star",
+    declaration,
+    source: declaration.source.value,
+    diagnostic: createUnsupportedDiagnostic({
+      id: "STATIC_CSS_EVAL_EXPORT_STAR_UNSUPPORTED",
+      owner: { file },
+      dependency: { file: declaration.source.value },
+      detail: `export * from "${declaration.source.value}" is unsupported`,
+      exportName: "*",
+      importPath: declaration.source.value
+    })
+  };
+}
+
+function createUnsupportedDiagnostic(options: {
+  id: NonNullable<StaticCssEvalDiagnostic["id"]>;
+  owner: StaticCssEvalSourceLocation;
+  detail: string;
+  dependency?: StaticCssEvalSourceLocation;
+  exportName?: StaticCssEvalExportName;
+  importPath?: string;
+}): StaticCssEvalDiagnostic {
+  return {
+    id: options.id,
+    code: "unsupported-source",
+    message: `Cannot statically evaluate css prop value: ${options.detail}`,
+    reason: "reexport-or-barrel",
+    owner: options.owner,
+    ...(options.dependency ? { dependency: options.dependency } : {}),
+    ...(options.exportName !== undefined
+      ? { exportName: options.exportName }
+      : {}),
+    ...(options.importPath !== undefined
+      ? { importPath: options.importPath }
+      : {})
+  };
+}
+
+function isStaticCssModuleExportDeclaration(
+  statement: t.Statement
+): statement is StaticCssModuleExportDeclaration {
+  return (
+    t.isExportAllDeclaration(statement) ||
+    t.isExportDefaultDeclaration(statement) ||
+    t.isExportNamedDeclaration(statement)
+  );
+}
+
+function getStaticCssModuleName(
+  node: t.Identifier | t.StringLiteral
+): string | null {
+  if (t.isIdentifier(node)) {
+    return node.name;
+  }
+
+  if (t.isStringLiteral(node)) {
+    return node.value;
+  }
+
+  return null;
+}
+
+function isStaticCssModuleVariableDeclarationKind(
+  declarationKind: t.VariableDeclaration["kind"]
+): declarationKind is "const" | "let" | "var" {
+  return (
+    declarationKind === "const" ||
+    declarationKind === "let" ||
+    declarationKind === "var"
+  );
+}
+
+function createSourceVersionHash(source: StaticCssModuleSource): string {
+  return source.sourceVersion === undefined
+    ? source.sourceHash
+    : `${source.sourceVersion}:${source.sourceHash}`;
+}
+
+function getStaticCssModuleCacheInstrumentation(
+  cache: StaticCssModuleCache
+): StaticCssModuleCacheInstrumentationSnapshot {
+  const instrumentation = cacheInstrumentation.get(cache);
+
+  if (!instrumentation) {
+    return {
+      hits: 0,
+      misses: 0,
+      parseCountByFile: new Map<string, number>()
+    };
+  }
+
+  return {
+    hits: instrumentation.hits,
+    misses: instrumentation.misses,
+    parseCountByFile: new Map(instrumentation.parseCountByFile)
+  };
+}
+
+if (import.meta.vitest) {
+  const { describe, expect, it } = import.meta.vitest;
+  const stylesId = "/project/src/styles.ts";
+
+  function createSource(
+    source: string,
+    sourceHash = "hash:styles-v1"
+  ): StaticCssModuleSource {
+    return {
+      resolvedFile: stylesId,
+      source,
+      sourceHash,
+      sourceVersion: "1"
+    };
+  }
+
+  describe("static css module parse/export-map cache", () => {
+    it("parses the same resolved file and source identity once per cache instance", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(`
+        export const button = { color: "red" };
+        export const card = { color: "blue" };
+      `);
+
+      expect(cache.getExportMapEntry(source, "button")).toMatchObject({
+        kind: "local",
+        exportName: "button",
+        localName: "button",
+        declarationKind: "const"
+      });
+      expect(cache.getExportMapEntry(source, "card")).toMatchObject({
+        kind: "local",
+        exportName: "card",
+        localName: "card",
+        declarationKind: "const"
+      });
+
+      const instrumentation = getStaticCssModuleCacheInstrumentation(cache);
+      expect(instrumentation.misses).toBe(1);
+      expect(instrumentation.hits).toBe(1);
+      expect(instrumentation.parseCountByFile.get(stylesId)).toBe(1);
+    });
+
+    it("creates a new cache entry when source identity changes", () => {
+      const cache = createStaticCssModuleCache();
+      const firstSource = createSource(
+        `export const button = { color: "red" };`
+      );
+      const secondSource = createSource(
+        `export const button = { color: "blue" };`,
+        "hash:styles-v2"
+      );
+
+      cache.getParsedModule(firstSource);
+      cache.getParsedModule(secondSource);
+
+      const instrumentation = getStaticCssModuleCacheInstrumentation(cache);
+      expect(instrumentation.misses).toBe(2);
+      expect(instrumentation.hits).toBe(0);
+      expect(instrumentation.parseCountByFile.get(stylesId)).toBe(2);
+    });
+
+    it("tracks parsed module identity, program, imports, and exports", () => {
+      const cache = createStaticCssModuleCache();
+      const parsedModule = cache.getParsedModule(
+        createSource(`
+          import { color } from "./tokens";
+          export const button = { color };
+        `)
+      );
+
+      expect(parsedModule).toMatchObject({
+        file: stylesId,
+        resolvedFile: stylesId,
+        sourceHash: "hash:styles-v1",
+        sourceVersion: "1",
+        sourceVersionHash: "1:hash:styles-v1",
+        cacheKey: {
+          resolvedFile: stylesId,
+          sourceHash: "hash:styles-v1",
+          sourceVersion: "1",
+          parserVersion: STATIC_CSS_MODULE_CACHE_PARSER_VERSION,
+          supportVersion: STATIC_CSS_MODULE_CACHE_SUPPORT_VERSION
+        }
+      });
+      expect(parsedModule.ast.type).toBe("File");
+      expect(parsedModule.program.type).toBe("Program");
+      expect(parsedModule.programPath.node).toBe(parsedModule.program);
+      expect(parsedModule.importDeclarations).toHaveLength(1);
+      expect(parsedModule.exportDeclarations).toHaveLength(1);
+    });
+
+    it("recognizes supported export map entry categories", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(`
+        export const button = { color: "red" };
+        const card = { color: "blue" };
+        const buttonAlias = button;
+        export { card, buttonAlias as primaryButton };
+        export default {};
+        export { button as reexportedButton } from "./button";
+      `);
+
+      expect(cache.getExportMapEntry(source, "button")).toMatchObject({
+        kind: "local",
+        exportName: "button",
+        localName: "button",
+        declarationKind: "const"
+      });
+      expect(cache.getExportMapEntry(source, "card")).toMatchObject({
+        kind: "local",
+        exportName: "card",
+        localName: "card",
+        declarationKind: "specifier"
+      });
+      expect(cache.getExportMapEntry(source, "primaryButton")).toMatchObject({
+        kind: "local",
+        exportName: "primaryButton",
+        localName: "buttonAlias",
+        declarationKind: "specifier"
+      });
+      expect(cache.getExportMapEntry(source, "default")).toMatchObject({
+        kind: "expression",
+        exportName: "default"
+      });
+      expect(cache.getExportMapEntry(source, "reexportedButton")).toMatchObject(
+        {
+          kind: "reexport",
+          exportName: "reexportedButton",
+          importedName: "button",
+          source: "./button"
+        }
+      );
+    });
+
+    it("records export star as deterministic unsupported metadata without recursion", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(`export * from "./button";`);
+      const parsedModule = cache.getParsedModule(source);
+      const exportStarEntry = cache.getExportMapEntry(source, "*");
+
+      expect(parsedModule.unsupportedExportStars).toHaveLength(1);
+      expect(exportStarEntry).toMatchObject({
+        kind: "unsupported",
+        exportName: "*",
+        unsupportedKind: "export-star",
+        source: "./button",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_EXPORT_STAR_UNSUPPORTED",
+          code: "unsupported-source",
+          reason: "reexport-or-barrel",
+          owner: { file: stylesId },
+          dependency: { file: "./button" },
+          importPath: "./button",
+          exportName: "*"
+        }
+      });
+      expect(
+        parsedModule.unsupportedExportStars[0]?.diagnostic.message
+      ).toContain(`export * from "./button" is unsupported`);
+      expect(
+        getStaticCssModuleCacheInstrumentation(cache).parseCountByFile
+      ).toEqual(new Map([[stylesId, 1]]));
+    });
+  });
+}

--- a/packages/babel/src/staticCssEval/moduleCache.ts
+++ b/packages/babel/src/staticCssEval/moduleCache.ts
@@ -575,7 +575,13 @@ function getStaticCssModuleCacheInstrumentation(
   };
 }
 
+// == Tests ====================================================================
+// Ignore errors when compiling to CommonJS.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
 if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
   const { describe, expect, it } = import.meta.vitest;
   const stylesId = "/project/src/styles.ts";
 

--- a/packages/babel/src/staticCssEval/sameFile.ts
+++ b/packages/babel/src/staticCssEval/sameFile.ts
@@ -1,9 +1,10 @@
-import { types as t } from "@babel/core";
-import type { NodePath } from "@babel/core";
+import { transformSync, types as t } from "@babel/core";
+import type { NodePath, PluginObj } from "@babel/core";
 import type { Binding, Scope } from "@babel/traverse";
 import {
   getStaticMemberPropertyName,
   getStaticObjectMemberValue,
+  getStaticObjectPropertyName,
   getUnsupportedLiteralReason
 } from "./ast.js";
 import {
@@ -11,26 +12,54 @@ import {
   unwrapTransparentCssRuleExpression
 } from "./candidates.js";
 import type { StaticMemberReference } from "./candidates.js";
-import { createStaticCssEvalDiagnostic } from "./diagnostics.js";
+import {
+  createStaticCssEvalComputedMemberUnsupportedDiagnostic,
+  createStaticCssEvalDiagnostic,
+  createStaticCssEvalDynamicExpressionUnsupportedDiagnostic,
+  createStaticCssEvalMutableBindingDiagnostic,
+  createStaticCssEvalObjectSpreadUnsupportedDiagnostic,
+  guardStaticCssEvalResolutionDepth
+} from "./diagnostics.js";
 import {
   enforceStaticCssEvalLiteralNodeCount,
   enforceStaticCssEvalObjectArrayRecursionDepth
 } from "./limits.js";
 import type {
+  BindingProvenance,
+  ResolutionChainEntry,
+  ResolutionDependency,
   StaticCssEvalDiagnostic,
   StaticCssEvalSourceLocation,
   StaticCssEvalUnsupportedReason
 } from "./types.js";
 
 export type SameFileStaticCssEvalResult =
-  | { kind: "not-candidate" }
+  | {
+      kind: "not-candidate";
+      status?: "unsupported";
+      diagnostic?: StaticCssEvalDiagnostic;
+      diagnostics?: StaticCssEvalDiagnostic[];
+      provenance?: BindingProvenance;
+      dependencies?: ResolutionDependency[];
+      resolutionChain?: ResolutionChainEntry[];
+    }
   | {
       kind: "resolved";
+      status: "resolved";
       expression: t.ObjectExpression | t.ArrayExpression;
+      provenance: BindingProvenance;
+      dependencies: ResolutionDependency[];
+      resolutionChain: ResolutionChainEntry[];
+      diagnostics: [];
     }
   | {
       kind: "error";
+      status: "error";
       diagnostic: StaticCssEvalDiagnostic;
+      diagnostics: StaticCssEvalDiagnostic[];
+      provenance?: BindingProvenance;
+      dependencies: ResolutionDependency[];
+      resolutionChain?: ResolutionChainEntry[];
     };
 
 export interface ResolveSameFileStaticCssEvalOptions {
@@ -41,11 +70,47 @@ export interface ResolveSameFileStaticCssEvalOptions {
 }
 
 interface SameFileStaticCssEvalContext {
-  binding: Binding;
   bindingName: string;
   memberPath: string[];
   owner: StaticCssEvalSourceLocation;
 }
+
+interface SameFileStaticCssEvalMetadata {
+  provenance: BindingProvenance;
+  dependencies: ResolutionDependency[];
+  resolutionChain: ResolutionChainEntry[];
+}
+
+type SameFileBindingResolutionResult =
+  | { kind: "not-candidate" }
+  | {
+      kind: "resolved";
+      expression: t.Expression;
+      metadata: SameFileStaticCssEvalMetadata;
+    }
+  | {
+      kind: "error";
+      diagnostic: StaticCssEvalDiagnostic;
+      metadata?: SameFileStaticCssEvalMetadata;
+    };
+
+interface SameFileBindingResolutionOptions {
+  binding: Binding;
+  bindingName: string;
+  memberPath: string[];
+  ownerFile: string;
+  owner: StaticCssEvalSourceLocation;
+  programPath: NodePath<t.Program>;
+  stack: SameFileBindingStackFrame[];
+}
+
+interface SameFileBindingStackFrame {
+  binding: Binding;
+  bindingName: string;
+  memberPath: string[];
+}
+
+type SameFileDeclarationKind = "const" | "let" | "var" | "function" | "class";
 
 interface LiteralValidationState {
   count: number;
@@ -88,15 +153,8 @@ export function resolveSameFileStaticCssEvalExpression(
     return { kind: "not-candidate" };
   }
 
-  const init = getStaticCssEvalConstBindingInitExpression(binding);
-
-  if (!init) {
-    return { kind: "not-candidate" };
-  }
-
   const memberPath = reference.memberPath;
   const context: SameFileStaticCssEvalContext = {
-    binding,
     bindingName: reference.bindingName,
     memberPath,
     owner: {
@@ -107,47 +165,71 @@ export function resolveSameFileStaticCssEvalExpression(
   };
 
   if (reference.kind === "unsupported") {
-    const unsupportedMemberPathDiagnostic =
-      createUnsupportedMemberPathDiagnostic(init, reference, context);
+    const baseResolution = resolveSameFileBindingExpression({
+      binding,
+      bindingName: reference.bindingName,
+      memberPath,
+      ownerFile: options.ownerFile,
+      owner: context.owner,
+      programPath: options.programPath,
+      stack: []
+    });
 
-    if (!unsupportedMemberPathDiagnostic) {
+    if (baseResolution.kind === "error") {
+      return createSameFileErrorResult(
+        baseResolution.diagnostic,
+        baseResolution.metadata
+      );
+    }
+
+    if (
+      baseResolution.kind !== "resolved" ||
+      !isProvenStaticCssRuleMemberTarget(
+        baseResolution.expression,
+        reference.unsupportedPropertyName
+      )
+    ) {
       return { kind: "not-candidate" };
     }
 
-    if (hasStaticCssEvalBindingMutation(options.programPath, binding)) {
-      return {
-        kind: "error",
-        diagnostic: createSameFileStaticCssEvalDiagnostic(
-          context,
-          "mutation-detected",
-          "mutated-binding",
-          `same-file binding "${reference.bindingName}" is mutated`
-        )
-      };
-    }
-
-    return {
-      kind: "error",
-      diagnostic: unsupportedMemberPathDiagnostic
-    };
+    return createSameFileErrorResult(
+      createUnsupportedMemberReferenceDiagnostic(reference, context),
+      baseResolution.metadata
+    );
   }
 
-  const resolvedExpression = resolveStaticMemberPath(init, memberPath);
+  const bindingResolution = resolveSameFileBindingExpression({
+    binding,
+    bindingName: reference.bindingName,
+    memberPath,
+    ownerFile: options.ownerFile,
+    owner: context.owner,
+    programPath: options.programPath,
+    stack: []
+  });
 
-  if (!resolvedExpression || !isStaticCssRuleLiteral(resolvedExpression)) {
+  if (bindingResolution.kind === "error") {
+    if (bindingResolution.diagnostic.id === "STATIC_CSS_EVAL_MUTABLE_BINDING") {
+      return createSameFileUnsupportedResult(
+        bindingResolution.diagnostic,
+        bindingResolution.metadata
+      );
+    }
+
+    return createSameFileErrorResult(
+      bindingResolution.diagnostic,
+      bindingResolution.metadata
+    );
+  }
+
+  if (bindingResolution.kind === "not-candidate") {
     return { kind: "not-candidate" };
   }
 
-  if (hasStaticCssEvalBindingMutation(options.programPath, binding)) {
-    return {
-      kind: "error",
-      diagnostic: createSameFileStaticCssEvalDiagnostic(
-        context,
-        "mutation-detected",
-        "mutated-binding",
-        `same-file binding "${reference.bindingName}" is mutated`
-      )
-    };
+  const resolvedExpression = bindingResolution.expression;
+
+  if (!isStaticCssRuleLiteral(resolvedExpression)) {
+    return { kind: "not-candidate" };
   }
 
   const validationDiagnostic = validateStaticCssLiteralExpression(
@@ -158,13 +240,464 @@ export function resolveSameFileStaticCssEvalExpression(
   );
 
   if (validationDiagnostic) {
-    return { kind: "error", diagnostic: validationDiagnostic };
+    return createSameFileErrorResult(
+      validationDiagnostic,
+      bindingResolution.metadata
+    );
   }
 
   return {
     kind: "resolved",
-    expression: normalizeStaticCssLiteralExpression(resolvedExpression)
+    status: "resolved",
+    expression: normalizeStaticCssLiteralExpression(resolvedExpression),
+    provenance: bindingResolution.metadata.provenance,
+    dependencies: bindingResolution.metadata.dependencies,
+    resolutionChain: bindingResolution.metadata.resolutionChain,
+    diagnostics: []
   };
+}
+
+function resolveSameFileBindingExpression(
+  options: SameFileBindingResolutionOptions
+): SameFileBindingResolutionResult {
+  const declarationKind = getStaticCssEvalBindingDeclarationKind(
+    options.binding
+  );
+  const init = getStaticCssEvalVariableBindingInitExpression(options.binding);
+
+  if (!declarationKind || !init) {
+    return { kind: "not-candidate" };
+  }
+
+  const context = createSameFileContext(options);
+  const metadata = createSameFileMetadata(
+    options.ownerFile,
+    options.bindingName,
+    options.memberPath,
+    declarationKind
+  );
+
+  if (declarationKind === "let" || declarationKind === "var") {
+    return options.memberPath.length === 0 &&
+      isPotentialStaticCssEvalBindingInit(init, options.memberPath)
+      ? {
+          kind: "error",
+          diagnostic: createStaticCssEvalMutableBindingDiagnostic(
+            createSameFileDiagnosticContext(context),
+            options.bindingName
+          ),
+          metadata
+        }
+      : { kind: "not-candidate" };
+  }
+
+  if (declarationKind !== "const") {
+    return { kind: "not-candidate" };
+  }
+
+  const currentFrame: SameFileBindingStackFrame = {
+    binding: options.binding,
+    bindingName: options.bindingName,
+    memberPath: [...options.memberPath]
+  };
+  const cycleStartIndex = findSameFileAliasCycleStartIndex(
+    options.stack,
+    currentFrame
+  );
+
+  if (cycleStartIndex !== -1) {
+    return {
+      kind: "error",
+      diagnostic: createSameFileLocalAliasCycleDiagnostic(
+        context,
+        options.ownerFile,
+        [...options.stack.slice(cycleStartIndex), currentFrame]
+      ),
+      metadata
+    };
+  }
+
+  const nextStack = [...options.stack, currentFrame];
+  const depthResult = guardStaticCssEvalResolutionDepth({
+    owner: options.owner,
+    dependency: { file: options.ownerFile },
+    exportName: options.bindingName,
+    memberPath: options.memberPath,
+    resolutionDepth: nextStack.length
+  });
+
+  if (!depthResult.ok) {
+    return {
+      kind: "error",
+      diagnostic: depthResult.diagnostic,
+      metadata
+    };
+  }
+
+  if (hasStaticCssEvalBindingMutation(options.programPath, options.binding)) {
+    return {
+      kind: "error",
+      diagnostic: createSameFileStaticCssEvalDiagnostic(
+        context,
+        "mutation-detected",
+        "mutated-binding",
+        `same-file binding "${options.bindingName}" is mutated`,
+        "STATIC_CSS_EVAL_MUTATED_BINDING"
+      ),
+      metadata
+    };
+  }
+
+  const unwrappedInit = unwrapTransparentCssRuleExpression(init);
+  const initReference = getStaticCssEvalMemberReference(unwrappedInit);
+
+  if (initReference?.kind === "supported") {
+    const referencedBinding = options.binding.scope.getBinding(
+      initReference.bindingName
+    );
+
+    if (!referencedBinding) {
+      return { kind: "not-candidate" };
+    }
+
+    const referencedResolution = resolveSameFileBindingExpression({
+      binding: referencedBinding,
+      bindingName: initReference.bindingName,
+      memberPath: [...initReference.memberPath, ...options.memberPath],
+      ownerFile: options.ownerFile,
+      owner: options.owner,
+      programPath: options.programPath,
+      stack: nextStack
+    });
+
+    return prependSameFileMetadata(metadata, referencedResolution);
+  }
+
+  if (initReference?.kind === "unsupported") {
+    const referencedBinding = options.binding.scope.getBinding(
+      initReference.bindingName
+    );
+
+    if (!referencedBinding) {
+      return { kind: "not-candidate" };
+    }
+
+    const baseResolution = resolveSameFileBindingExpression({
+      binding: referencedBinding,
+      bindingName: initReference.bindingName,
+      memberPath: initReference.memberPath,
+      ownerFile: options.ownerFile,
+      owner: options.owner,
+      programPath: options.programPath,
+      stack: nextStack
+    });
+
+    if (baseResolution.kind !== "resolved") {
+      return prependSameFileMetadata(metadata, baseResolution);
+    }
+
+    if (
+      !isProvenStaticCssRuleMemberTarget(
+        baseResolution.expression,
+        initReference.unsupportedPropertyName
+      )
+    ) {
+      return { kind: "not-candidate" };
+    }
+
+    return {
+      kind: "error",
+      diagnostic: createUnsupportedMemberReferenceDiagnostic(
+        initReference,
+        createSameFileContext({
+          ...options,
+          memberPath: initReference.memberPath
+        })
+      ),
+      metadata: mergeSameFileMetadata(metadata, baseResolution.metadata)
+    };
+  }
+
+  const resolvedExpression = resolveStaticMemberPath(
+    unwrappedInit,
+    options.memberPath
+  );
+
+  if (resolvedExpression) {
+    return {
+      kind: "resolved",
+      expression: resolvedExpression,
+      metadata
+    };
+  }
+
+  return { kind: "not-candidate" };
+}
+
+function createSameFileContext(
+  options: Pick<
+    SameFileBindingResolutionOptions,
+    "bindingName" | "memberPath" | "owner"
+  >
+): SameFileStaticCssEvalContext {
+  return {
+    bindingName: options.bindingName,
+    memberPath: [...options.memberPath],
+    owner: options.owner
+  };
+}
+
+function createSameFileDiagnosticContext(
+  context: SameFileStaticCssEvalContext
+): {
+  owner: StaticCssEvalSourceLocation;
+  memberPath?: readonly string[];
+} {
+  return {
+    owner: context.owner,
+    ...(context.memberPath.length > 0 ? { memberPath: context.memberPath } : {})
+  };
+}
+
+function prependSameFileMetadata(
+  metadata: SameFileStaticCssEvalMetadata,
+  result: SameFileBindingResolutionResult
+): SameFileBindingResolutionResult {
+  if (result.kind === "not-candidate") {
+    return result;
+  }
+
+  if (result.kind === "error") {
+    return {
+      kind: "error",
+      diagnostic: result.diagnostic,
+      metadata: result.metadata
+        ? mergeSameFileMetadata(metadata, result.metadata)
+        : metadata
+    };
+  }
+
+  return {
+    kind: "resolved",
+    expression: result.expression,
+    metadata: mergeSameFileMetadata(metadata, result.metadata)
+  };
+}
+
+function mergeSameFileMetadata(
+  parent: SameFileStaticCssEvalMetadata,
+  child: SameFileStaticCssEvalMetadata
+): SameFileStaticCssEvalMetadata {
+  return {
+    provenance: parent.provenance,
+    dependencies: [...parent.dependencies, ...child.dependencies],
+    resolutionChain: [...parent.resolutionChain, ...child.resolutionChain]
+  };
+}
+
+function createSameFileMetadata(
+  ownerFile: string,
+  bindingName: string,
+  memberPath: readonly string[],
+  declarationKind: SameFileDeclarationKind
+): SameFileStaticCssEvalMetadata {
+  const provenance: BindingProvenance = {
+    kind: "local",
+    file: ownerFile,
+    bindingName,
+    declarationKind
+  };
+
+  return {
+    provenance,
+    dependencies: [
+      {
+        file: ownerFile,
+        kind: "local",
+        importer: ownerFile,
+        specifier: "<local>",
+        exportName: bindingName,
+        memberPath: [...memberPath],
+        inspected: true,
+        contributed: true
+      }
+    ],
+    resolutionChain: [
+      {
+        importer: ownerFile,
+        source: ownerFile,
+        exportName: bindingName,
+        memberPath: [...memberPath],
+        provenance
+      }
+    ]
+  };
+}
+
+function createSameFileErrorResult(
+  diagnostic: StaticCssEvalDiagnostic,
+  metadata?: SameFileStaticCssEvalMetadata
+): SameFileStaticCssEvalResult {
+  return {
+    kind: "error",
+    status: "error",
+    diagnostic,
+    diagnostics: [diagnostic],
+    ...(metadata
+      ? {
+          provenance: metadata.provenance,
+          dependencies: metadata.dependencies,
+          resolutionChain: metadata.resolutionChain
+        }
+      : { dependencies: [] })
+  };
+}
+
+function createSameFileUnsupportedResult(
+  diagnostic: StaticCssEvalDiagnostic,
+  metadata?: SameFileStaticCssEvalMetadata
+): SameFileStaticCssEvalResult {
+  return {
+    kind: "not-candidate",
+    status: "unsupported",
+    diagnostic,
+    diagnostics: [diagnostic],
+    ...(metadata
+      ? {
+          provenance: metadata.provenance,
+          dependencies: metadata.dependencies,
+          resolutionChain: metadata.resolutionChain
+        }
+      : { dependencies: [] })
+  };
+}
+
+function findSameFileAliasCycleStartIndex(
+  stack: readonly SameFileBindingStackFrame[],
+  currentFrame: SameFileBindingStackFrame
+): number {
+  const currentKey = createSameFileAliasCycleKey(currentFrame);
+
+  return stack.findIndex(
+    (frame) =>
+      frame.binding === currentFrame.binding &&
+      createSameFileAliasCycleKey(frame) === currentKey
+  );
+}
+
+function createSameFileAliasCycleKey(frame: SameFileBindingStackFrame): string {
+  return JSON.stringify(frame.memberPath);
+}
+
+function createSameFileLocalAliasCycleDiagnostic(
+  context: SameFileStaticCssEvalContext,
+  ownerFile: string,
+  cycle: readonly SameFileBindingStackFrame[]
+): StaticCssEvalDiagnostic {
+  const importChain = cycle.map((frame) =>
+    formatSameFileAliasCycleFrame(ownerFile, frame)
+  );
+
+  return createStaticCssEvalDiagnostic({
+    id: "STATIC_CSS_EVAL_LOCAL_ALIAS_CYCLE",
+    code: "cycle-detected",
+    reason: "runtime-dynamic-value",
+    detail: `cyclic same-file static css alias detected: ${importChain.join(
+      " -> "
+    )}`,
+    owner: context.owner,
+    dependency: { file: ownerFile },
+    exportName: context.bindingName,
+    memberPath: context.memberPath,
+    importChain
+  });
+}
+
+function formatSameFileAliasCycleFrame(
+  ownerFile: string,
+  frame: SameFileBindingStackFrame
+): string {
+  const memberPath = frame.memberPath.length
+    ? `.${frame.memberPath.join(".")}`
+    : "";
+
+  return `${ownerFile}#${frame.bindingName}${memberPath}`;
+}
+
+function createUnsupportedMemberReferenceDiagnostic(
+  reference: Extract<StaticMemberReference, { kind: "unsupported" }>,
+  context: SameFileStaticCssEvalContext
+): StaticCssEvalDiagnostic {
+  if (reference.reason === "optional-member-path") {
+    return createSameFileStaticCssEvalDiagnostic(
+      context,
+      "unsupported-syntax",
+      reference.reason,
+      `same-file binding "${context.bindingName}" contains unsupported ${reference.reason}: ${reference.detail}`,
+      "STATIC_CSS_EVAL_DYNAMIC_EXPRESSION_UNSUPPORTED"
+    );
+  }
+
+  return createSameFileStaticCssEvalDiagnostic(
+    context,
+    "unsupported-syntax",
+    reference.reason,
+    `same-file binding "${context.bindingName}" contains unsupported ${reference.reason}: ${reference.detail}`,
+    "STATIC_CSS_EVAL_COMPUTED_MEMBER_UNSUPPORTED"
+  );
+}
+
+function createUnsupportedDynamicExpressionDiagnostic(
+  context: SameFileStaticCssEvalContext,
+  expression: t.Expression
+): StaticCssEvalDiagnostic | null {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+
+  const memberReference = getStaticCssEvalMemberReference(unwrappedExpression);
+
+  if (memberReference?.kind === "unsupported") {
+    return createUnsupportedMemberReferenceDiagnostic(memberReference, context);
+  }
+
+  if (isSupportedStaticCssPrimitiveLiteral(unwrappedExpression)) {
+    return null;
+  }
+
+  if (
+    t.isCallExpression(unwrappedExpression) ||
+    t.isOptionalCallExpression(unwrappedExpression) ||
+    t.isNewExpression(unwrappedExpression) ||
+    t.isFunctionExpression(unwrappedExpression) ||
+    t.isArrowFunctionExpression(unwrappedExpression) ||
+    t.isConditionalExpression(unwrappedExpression) ||
+    t.isLogicalExpression(unwrappedExpression) ||
+    t.isBinaryExpression(unwrappedExpression) ||
+    t.isTaggedTemplateExpression(unwrappedExpression) ||
+    t.isOptionalMemberExpression(unwrappedExpression)
+  ) {
+    return createStaticCssEvalDynamicExpressionUnsupportedDiagnostic(
+      createSameFileDiagnosticContext(context),
+      unwrappedExpression.type
+    );
+  }
+
+  return null;
+}
+
+function isPotentialStaticCssEvalBindingInit(
+  expression: t.Expression,
+  memberPath: readonly string[]
+): boolean {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+  const resolvedExpression = resolveStaticMemberPath(
+    unwrappedExpression,
+    memberPath
+  );
+
+  return (
+    Boolean(resolvedExpression && isStaticCssRuleLiteral(resolvedExpression)) ||
+    Boolean(getStaticCssEvalMemberReference(unwrappedExpression))
+  );
 }
 
 function getExpressionRange(
@@ -182,17 +715,51 @@ function getExpressionRange(
 export function getStaticCssEvalConstBindingInitExpression(
   binding: Binding
 ): t.Expression | null {
+  if (getStaticCssEvalBindingDeclarationKind(binding) !== "const") {
+    return null;
+  }
+
+  return getStaticCssEvalVariableBindingInitExpression(binding);
+}
+
+function getStaticCssEvalBindingDeclarationKind(
+  binding: Binding
+): SameFileDeclarationKind | null {
   const bindingPath = binding.path;
 
-  if (!bindingPath.isVariableDeclarator()) {
-    return null;
+  if (bindingPath.isVariableDeclarator()) {
+    if (!t.isIdentifier(bindingPath.node.id)) {
+      return null;
+    }
+
+    if (!bindingPath.parentPath.isVariableDeclaration()) {
+      return null;
+    }
+
+    const { kind } = bindingPath.parentPath.node;
+    return kind === "const" || kind === "let" || kind === "var" ? kind : null;
   }
 
-  if (!t.isIdentifier(bindingPath.node.id)) {
-    return null;
+  if (bindingPath.isFunctionDeclaration()) {
+    return "function";
   }
 
-  if (!bindingPath.parentPath.isVariableDeclaration({ kind: "const" })) {
+  if (bindingPath.isClassDeclaration()) {
+    return "class";
+  }
+
+  return null;
+}
+
+function getStaticCssEvalVariableBindingInitExpression(
+  binding: Binding
+): t.Expression | null {
+  const bindingPath = binding.path;
+
+  if (
+    !bindingPath.isVariableDeclarator() ||
+    !t.isIdentifier(bindingPath.node.id)
+  ) {
     return null;
   }
 
@@ -256,34 +823,6 @@ function isStaticCssRuleLiteral(
   return (
     t.isObjectExpression(unwrappedExpression) ||
     t.isArrayExpression(unwrappedExpression)
-  );
-}
-
-function createUnsupportedMemberPathDiagnostic(
-  expression: t.Expression,
-  reference: Extract<StaticMemberReference, { kind: "unsupported" }>,
-  context: SameFileStaticCssEvalContext
-): StaticCssEvalDiagnostic | null {
-  const baseExpression = resolveStaticMemberPath(
-    expression,
-    reference.memberPath
-  );
-
-  if (
-    !baseExpression ||
-    !isProvenStaticCssRuleMemberTarget(
-      baseExpression,
-      reference.unsupportedPropertyName
-    )
-  ) {
-    return null;
-  }
-
-  return createSameFileStaticCssEvalDiagnostic(
-    context,
-    "unsupported-syntax",
-    reference.reason,
-    `same-file binding "${context.bindingName}" contains unsupported ${reference.reason}: ${reference.detail}`
   );
 }
 
@@ -594,29 +1133,23 @@ function validateStaticCssObjectExpression(
 ): StaticCssEvalDiagnostic | null {
   for (const property of expression.properties) {
     if (t.isSpreadElement(property)) {
-      return createSameFileStaticCssEvalDiagnostic(
-        context,
-        "unsupported-syntax",
-        "object-or-array-spread",
-        `same-file binding "${context.bindingName}" contains an object spread`
+      return createStaticCssEvalObjectSpreadUnsupportedDiagnostic(
+        createSameFileDiagnosticContext(context),
+        context.bindingName,
+        "object"
       );
     }
 
     if (!t.isObjectProperty(property)) {
-      return createSameFileStaticCssEvalDiagnostic(
-        context,
-        "unsupported-syntax",
-        "function-or-call",
-        `same-file binding "${context.bindingName}" contains an object method`
+      return createStaticCssEvalDynamicExpressionUnsupportedDiagnostic(
+        createSameFileDiagnosticContext(context),
+        property.type
       );
     }
 
     if (property.computed) {
-      return createSameFileStaticCssEvalDiagnostic(
-        context,
-        "unsupported-syntax",
-        "computed-object-key",
-        `same-file binding "${context.bindingName}" contains a computed object key`
+      return createStaticCssEvalComputedMemberUnsupportedDiagnostic(
+        createSameFileDiagnosticContext(context)
       );
     }
 
@@ -661,11 +1194,10 @@ function validateStaticCssArrayExpression(
     }
 
     if (t.isSpreadElement(element)) {
-      return createSameFileStaticCssEvalDiagnostic(
-        context,
-        "unsupported-syntax",
-        "object-or-array-spread",
-        `same-file binding "${context.bindingName}" contains an array spread`
+      return createStaticCssEvalObjectSpreadUnsupportedDiagnostic(
+        createSameFileDiagnosticContext(context),
+        context.bindingName,
+        "array"
       );
     }
 
@@ -778,6 +1310,15 @@ function createUnsupportedLiteralDiagnostic(
   context: SameFileStaticCssEvalContext,
   expression: t.Expression
 ): StaticCssEvalDiagnostic {
+  const dynamicDiagnostic = createUnsupportedDynamicExpressionDiagnostic(
+    context,
+    expression
+  );
+
+  if (dynamicDiagnostic) {
+    return dynamicDiagnostic;
+  }
+
   const reason = getUnsupportedLiteralReason(expression);
 
   return createSameFileStaticCssEvalDiagnostic(
@@ -787,18 +1328,345 @@ function createUnsupportedLiteralDiagnostic(
     `same-file binding "${context.bindingName}" contains unsupported ${reason}: ${expression.type}`
   );
 }
-
 function createSameFileStaticCssEvalDiagnostic(
   context: SameFileStaticCssEvalContext,
   code: StaticCssEvalDiagnostic["code"],
   reason: StaticCssEvalUnsupportedReason,
-  detail: string
+  detail: string,
+  id?: StaticCssEvalDiagnostic["id"]
 ): StaticCssEvalDiagnostic {
   return createStaticCssEvalDiagnostic({
+    ...(id !== undefined ? { id } : {}),
     code,
     reason,
     detail,
     owner: context.owner,
     ...(context.memberPath.length > 0 ? { memberPath: context.memberPath } : {})
+  });
+}
+
+if (import.meta.vitest) {
+  const { describe, expect, it } = import.meta.vitest;
+
+  const ownerFile = "/project/src/App.tsx";
+
+  function resolveSameFileFixture(
+    source: string
+  ): SameFileStaticCssEvalResult[] {
+    const results: SameFileStaticCssEvalResult[] = [];
+    const result = transformSync(source, {
+      filename: ownerFile,
+      ast: true,
+      code: false,
+      sourceType: "module",
+      configFile: false,
+      babelrc: false,
+      parserOpts: {
+        plugins: ["jsx", "typescript"]
+      },
+      plugins: [
+        function sameFileStaticCssEvalFixturePlugin(): PluginObj {
+          return {
+            visitor: {
+              Program(programPath) {
+                programPath.traverse({
+                  JSXAttribute(attributePath) {
+                    const expression = getCssFixtureExpression(
+                      attributePath.node
+                    );
+
+                    if (!expression) {
+                      return;
+                    }
+
+                    results.push(
+                      resolveSameFileStaticCssEvalExpression({
+                        expression,
+                        ownerFile,
+                        programPath,
+                        scope: attributePath.scope
+                      })
+                    );
+                  }
+                });
+              }
+            }
+          };
+        }
+      ]
+    });
+
+    if (result === null) {
+      throw new Error("Failed to parse same-file static css eval fixture");
+    }
+
+    return results;
+  }
+
+  function getCssFixtureExpression(
+    attribute: t.JSXAttribute
+  ): t.Expression | null {
+    if (!t.isJSXIdentifier(attribute.name) || attribute.name.name !== "css") {
+      return null;
+    }
+
+    if (!t.isJSXExpressionContainer(attribute.value)) {
+      return null;
+    }
+
+    const { expression } = attribute.value;
+
+    return t.isJSXEmptyExpression(expression) ? null : expression;
+  }
+
+  function expectSingleResolved(
+    source: string
+  ): Extract<SameFileStaticCssEvalResult, { kind: "resolved" }> {
+    const [result] = resolveSameFileFixture(source);
+    expect(result?.kind).toBe("resolved");
+
+    if (!result || result.kind !== "resolved") {
+      throw new Error("Expected same-file fixture to resolve");
+    }
+
+    return result;
+  }
+
+  function expectSingleDiagnosticId(
+    source: string,
+    diagnosticId: NonNullable<StaticCssEvalDiagnostic["id"]>
+  ): void {
+    const [result] = resolveSameFileFixture(source);
+    const diagnostic =
+      result?.kind === "error" ||
+      (result?.kind === "not-candidate" && result.status === "unsupported")
+        ? result.diagnostic
+        : undefined;
+    const diagnostics =
+      result?.kind === "error" ||
+      (result?.kind === "not-candidate" && result.status === "unsupported")
+        ? result.diagnostics
+        : undefined;
+
+    if (!diagnostic || !diagnostics) {
+      throw new Error("Expected same-file fixture to return a diagnostic");
+    }
+
+    expect(diagnostic.id).toBe(diagnosticId);
+    expect(diagnostics.map((item) => item.id)).toEqual([diagnosticId]);
+  }
+
+  function getStringObjectProperty(
+    expression: t.ObjectExpression | t.ArrayExpression,
+    propertyName: string
+  ): string | null {
+    if (!t.isObjectExpression(expression)) {
+      return null;
+    }
+
+    for (const property of expression.properties) {
+      if (!t.isObjectProperty(property) || property.computed) {
+        continue;
+      }
+
+      if (getStaticObjectPropertyName(property.key) !== propertyName) {
+        continue;
+      }
+
+      return t.isStringLiteral(property.value) ? property.value.value : null;
+    }
+
+    return null;
+  }
+
+  describe("same-file static css eval resolver", () => {
+    it("resolves local const objects with local provenance and dependencies", () => {
+      const resolved = expectSingleResolved(`
+        const button = { color: "red" };
+        function App() {
+          return <button css={button} />;
+        }
+      `);
+
+      expect(getStringObjectProperty(resolved.expression, "color")).toBe("red");
+      expect(resolved).toMatchObject({
+        status: "resolved",
+        provenance: {
+          kind: "local",
+          file: ownerFile,
+          bindingName: "button",
+          declarationKind: "const"
+        },
+        dependencies: [
+          {
+            file: ownerFile,
+            kind: "local",
+            importer: ownerFile,
+            specifier: "<local>",
+            exportName: "button",
+            memberPath: [],
+            inspected: true,
+            contributed: true
+          }
+        ],
+        resolutionChain: [
+          {
+            importer: ownerFile,
+            source: ownerFile,
+            exportName: "button",
+            memberPath: []
+          }
+        ],
+        diagnostics: []
+      });
+    });
+
+    it("resolves safe local aliases through transparent TypeScript wrappers", () => {
+      const resolved = expectSingleResolved(`
+        const base = ({ color: "red" } as const)!;
+        const button = (base satisfies unknown)!;
+        function App() {
+          return <button css={button} />;
+        }
+      `);
+
+      expect(getStringObjectProperty(resolved.expression, "color")).toBe("red");
+      expect(resolved.resolutionChain.map((entry) => entry.exportName)).toEqual(
+        ["button", "base"]
+      );
+      expect(
+        resolved.dependencies.map((dependency) => dependency.exportName)
+      ).toEqual(["button", "base"]);
+    });
+
+    it("resolves local shadowing before imported bindings with the same name", () => {
+      const resolved = expectSingleResolved(`
+        import { button } from "./styles";
+        function App() {
+          const button = { color: "local" } as const;
+          return <button css={button} />;
+        }
+      `);
+
+      expect(getStringObjectProperty(resolved.expression, "color")).toBe(
+        "local"
+      );
+      expect(resolved.provenance).toMatchObject({
+        kind: "local",
+        file: ownerFile,
+        bindingName: "button"
+      });
+    });
+
+    it("records literal member paths in local resolution metadata", () => {
+      const resolved = expectSingleResolved(`
+        const styles = {
+          buttons: {
+            primary: { color: "red" }
+          }
+        } as const;
+        function App() {
+          return <button css={styles.buttons.primary} />;
+        }
+      `);
+
+      expect(getStringObjectProperty(resolved.expression, "color")).toBe("red");
+      expect(resolved.dependencies[0]?.memberPath).toEqual([
+        "buttons",
+        "primary"
+      ]);
+      expect(resolved.resolutionChain[0]?.memberPath).toEqual([
+        "buttons",
+        "primary"
+      ]);
+    });
+
+    it("returns exact diagnostics for unsafe same-file bindings", () => {
+      expectSingleDiagnosticId(
+        `
+          let button = { color: "red" };
+          function App() {
+            return <button css={button} />;
+          }
+        `,
+        "STATIC_CSS_EVAL_MUTABLE_BINDING"
+      );
+      expectSingleDiagnosticId(
+        `
+          const button = { color: "red" };
+          button.color = "blue";
+          function App() {
+            return <button css={button} />;
+          }
+        `,
+        "STATIC_CSS_EVAL_MUTATED_BINDING"
+      );
+      expectSingleDiagnosticId(
+        `
+          const base = { color: "red" };
+          const button = { ...base };
+          function App() {
+            return <button css={button} />;
+          }
+        `,
+        "STATIC_CSS_EVAL_OBJECT_SPREAD_UNSUPPORTED"
+      );
+      expectSingleDiagnosticId(
+        `
+          const styles = { button: { color: "red" } };
+          const variant = "button";
+          function App() {
+            return <button css={styles[variant]} />;
+          }
+        `,
+        "STATIC_CSS_EVAL_COMPUTED_MEMBER_UNSUPPORTED"
+      );
+      expectSingleDiagnosticId(
+        `
+          const styles = { button: { color: "red" } };
+          function App() {
+            return <button css={styles?.button} />;
+          }
+        `,
+        "STATIC_CSS_EVAL_DYNAMIC_EXPRESSION_UNSUPPORTED"
+      );
+      expectSingleDiagnosticId(
+        `
+          const button = { color: getColor() };
+          function App() {
+            return <button css={button} />;
+          }
+        `,
+        "STATIC_CSS_EVAL_DYNAMIC_EXPRESSION_UNSUPPORTED"
+      );
+    });
+
+    it("guards local alias cycles deterministically", () => {
+      expectSingleDiagnosticId(
+        `
+          const button = base;
+          const base = button;
+          function App() {
+            return <button css={button} />;
+          }
+        `,
+        "STATIC_CSS_EVAL_LOCAL_ALIAS_CYCLE"
+      );
+    });
+
+    it("distinguishes shadowed aliases with the same name", () => {
+      const resolved = expectSingleResolved(`
+        const leaf = { color: "red" };
+        const value = leaf;
+        function App() {
+          {
+            const leaf = value;
+            return <button css={leaf} />;
+          }
+        }
+      `);
+
+      expect(getStringObjectProperty(resolved.expression, "color")).toBe("red");
+    });
   });
 }

--- a/packages/babel/src/staticCssEval/sameFile.ts
+++ b/packages/babel/src/staticCssEval/sameFile.ts
@@ -1345,7 +1345,13 @@ function createSameFileStaticCssEvalDiagnostic(
   });
 }
 
+// == Tests ====================================================================
+// Ignore errors when compiling to CommonJS.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
 if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
   const { describe, expect, it } = import.meta.vitest;
 
   const ownerFile = "/project/src/App.tsx";

--- a/packages/babel/src/staticCssEval/types.ts
+++ b/packages/babel/src/staticCssEval/types.ts
@@ -10,6 +10,32 @@ export interface StaticCssEvalQuery {
   memberPath?: string[];
 }
 
+export const STATIC_CSS_EVAL_SOURCE_KINDS = [
+  "project-source",
+  "package-source",
+  "provider-virtual",
+  "static-data",
+  "external-no-source",
+  "unresolved",
+  "unsupported-source-shape"
+] as const;
+
+export type StaticCssEvalSourceKind =
+  (typeof STATIC_CSS_EVAL_SOURCE_KINDS)[number];
+
+export const STATIC_CSS_EVAL_SOURCE_ORIGINS = [
+  "project",
+  "package",
+  "provider",
+  "data",
+  "external",
+  "unresolved",
+  "unsupported"
+] as const;
+
+export type StaticCssEvalSourceOrigin =
+  (typeof STATIC_CSS_EVAL_SOURCE_ORIGINS)[number];
+
 // Maintainer boundary: these contracts model AST-derived css values only.
 // Token/theme semantics are not interpreted unless they arrive as JS bindings.
 export type StaticCssEvalResult =
@@ -131,6 +157,12 @@ export interface ResolutionDependency {
   memberPath: string[];
   inspected: boolean;
   contributed: boolean;
+  readonly sourceKind?: StaticCssEvalSourceKind;
+  readonly sourceOrigin?: StaticCssEvalSourceOrigin;
+  readonly canonicalModuleId?: string;
+  readonly normalizedPathKey?: string;
+  readonly watchFiles?: readonly string[];
+  readonly unsupportedReason?: StaticCssEvalUnsupportedReason;
 }
 
 export interface ResolutionChainEntry {
@@ -139,6 +171,12 @@ export interface ResolutionChainEntry {
   exportName: StaticCssEvalExportName;
   memberPath: string[];
   provenance?: BindingProvenance;
+  readonly sourceKind?: StaticCssEvalSourceKind;
+  readonly sourceOrigin?: StaticCssEvalSourceOrigin;
+  readonly canonicalModuleId?: string;
+  readonly normalizedPathKey?: string;
+  readonly watchFiles?: readonly string[];
+  readonly unsupportedReason?: StaticCssEvalUnsupportedReason;
 }
 
 export interface StaticCssEvalCacheKey {
@@ -150,8 +188,15 @@ export interface StaticCssEvalCacheKey {
   sourceVersion?: string | number;
   pluginOptionsVersion: string | number;
   resolverOptionsVersion: string | number;
+  parserVersion?: string | number;
   staticEvalSupportVersion: string | number;
   resolvedId?: string;
+  readonly sourceKind?: StaticCssEvalSourceKind;
+  readonly sourceOrigin?: StaticCssEvalSourceOrigin;
+  readonly canonicalModuleId?: string;
+  readonly normalizedPathKey?: string;
+  readonly watchFiles?: readonly string[];
+  readonly unsupportedReason?: StaticCssEvalUnsupportedReason;
   parserOptions?: StaticCssEvalParserOptionsKey;
   projectLocalBoundary?: StaticCssEvalProjectLocalBoundaryState;
 }
@@ -164,9 +209,12 @@ export type StaticCssEvalDiagnosticId =
   | "STATIC_CSS_EVAL_OBJECT_SPREAD_UNSUPPORTED"
   | "STATIC_CSS_EVAL_COMPUTED_MEMBER_UNSUPPORTED"
   | "STATIC_CSS_EVAL_DYNAMIC_EXPRESSION_UNSUPPORTED"
+  | "STATIC_CSS_EVAL_PROVIDER_SOURCE_UNSUPPORTED"
   | "STATIC_CSS_EVAL_EXPORT_STAR_UNSUPPORTED"
+  | "STATIC_CSS_EVAL_EXPORT_STAR_AMBIGUOUS"
   | "STATIC_CSS_EVAL_NAMESPACE_UNSUPPORTED"
-  | "STATIC_CSS_EVAL_PACKAGE_IMPORT_UNSUPPORTED"
+  | "STATIC_CSS_EVAL_NAMESPACE_REEXPORT_UNSUPPORTED"
+  | "STATIC_CSS_EVAL_NAMESPACE_PARTIAL_UNSUPPORTED"
   | "STATIC_CSS_EVAL_CJS_UNSUPPORTED"
   | "STATIC_CSS_EVAL_IMPORT_CYCLE"
   | "STATIC_CSS_EVAL_UNRESOLVED_IMPORT"
@@ -181,9 +229,12 @@ export const STATIC_CSS_EVAL_DIAGNOSTIC_IDS = [
   "STATIC_CSS_EVAL_OBJECT_SPREAD_UNSUPPORTED",
   "STATIC_CSS_EVAL_COMPUTED_MEMBER_UNSUPPORTED",
   "STATIC_CSS_EVAL_DYNAMIC_EXPRESSION_UNSUPPORTED",
+  "STATIC_CSS_EVAL_PROVIDER_SOURCE_UNSUPPORTED",
   "STATIC_CSS_EVAL_EXPORT_STAR_UNSUPPORTED",
+  "STATIC_CSS_EVAL_EXPORT_STAR_AMBIGUOUS",
   "STATIC_CSS_EVAL_NAMESPACE_UNSUPPORTED",
-  "STATIC_CSS_EVAL_PACKAGE_IMPORT_UNSUPPORTED",
+  "STATIC_CSS_EVAL_NAMESPACE_REEXPORT_UNSUPPORTED",
+  "STATIC_CSS_EVAL_NAMESPACE_PARTIAL_UNSUPPORTED",
   "STATIC_CSS_EVAL_CJS_UNSUPPORTED",
   "STATIC_CSS_EVAL_IMPORT_CYCLE",
   "STATIC_CSS_EVAL_UNRESOLVED_IMPORT",
@@ -229,8 +280,12 @@ export const STATIC_CSS_EVAL_UNSUPPORTED_REASONS = [
   "commonjs-require",
   "node-modules-import",
   "virtual-module",
+  "provider-virtual-no-source",
   "function-or-call",
   "runtime-dynamic-value",
+  "dynamic-import",
+  "runtime-wasm-init-or-function",
+  "non-literal-loader-output",
   "computed-object-key",
   "object-or-array-spread",
   "conditional-or-logical-expression",
@@ -242,8 +297,18 @@ export const STATIC_CSS_EVAL_UNSUPPORTED_REASONS = [
   "numeric-member-path",
   "optional-member-path",
   "unsupported-literal",
+  "runtime-wasm-init",
+  "runtime-wasm-module",
+  "invalid-json-data",
+  "source-size-limit-exceeded",
   "not-project-local",
-  "failed-project-local-dependency"
+  "failed-project-local-dependency",
+  "external-no-source",
+  "unresolved",
+  "unsupported-source-shape",
+  "ambiguous-star",
+  "partial-namespace-failure",
+  "unsupported-namespace-reexport"
 ] as const;
 
 export type StaticCssEvalUnsupportedReason =
@@ -275,6 +340,12 @@ export interface StaticCssEvalDependencyMetadata {
   projectLocal: boolean;
   insideNodeModules: boolean;
   virtual: boolean;
+  readonly sourceKind?: StaticCssEvalSourceKind;
+  readonly sourceOrigin?: StaticCssEvalSourceOrigin;
+  readonly canonicalModuleId?: string;
+  readonly normalizedPathKey?: string;
+  readonly watchFiles?: readonly string[];
+  readonly unsupportedReason?: StaticCssEvalUnsupportedReason;
 }
 
 export interface StaticCssEvalModuleRecord {
@@ -283,6 +354,12 @@ export interface StaticCssEvalModuleRecord {
   sourceHash: string;
   version?: string | number;
   dependencies: StaticCssEvalDependencyMetadata[];
+  readonly sourceKind?: StaticCssEvalSourceKind;
+  readonly sourceOrigin?: StaticCssEvalSourceOrigin;
+  readonly canonicalModuleId?: string;
+  readonly normalizedPathKey?: string;
+  readonly watchFiles?: readonly string[];
+  readonly unsupportedReason?: StaticCssEvalUnsupportedReason;
 }
 
 export interface StaticCssEvalDependencyMaps {
@@ -322,13 +399,14 @@ export const STATIC_CSS_EVAL_CYCLE_KEY_FIELDS = [
 ] as const satisfies readonly (keyof StaticCssEvalCacheKey)[];
 
 export const STATIC_CSS_EVAL_GUARDRAILS = [
-  "project-local-files-only",
   "no-module-execution",
   "no-node-vm-eval-dynamic-import",
   "no-bundler-runtime-evaluation",
-  "project-local-esm-source-provider-export-graph-v2",
-  "limited-project-local-namespace-values-v2",
-  "no-node-modules-virtual-cjs-or-outside-root-v1",
+  "esm-source-provider-export-graph-v3",
+  "all-esm-package-source-provider-policy-v1",
+  "provider-backed-static-data-json-raw-url-wasm-string-v1",
+  "provider-backed-virtual-source-v1",
+  "fail-closed-namespace-star-and-source-shape-v1",
   "async-prepass-sync-babel-boundary"
 ] as const;
 
@@ -423,15 +501,16 @@ export const STATIC_CSS_EVAL_SUPPORT_MATRIX = [
   },
   {
     construct:
-      'Project-local ESM re-export graph (`export { x } from "./x"`, barrels, and transitive aliases)',
+      'Provider-backed ESM re-export graph (`export { x } from "./x"`, barrels, package barrels, and transitive aliases)',
     behavior:
-      "Supported under source-provider constraints with dependency chain metadata",
+      "Supported for project, package, data, and provider-backed virtual ESM source with dependency chain metadata",
     status: "supported"
   },
   {
-    construct: 'Project-local export-star barrel graph (`export * from "./x"`)',
+    construct:
+      'Provider-backed export-star barrel graph (`export * from "./x"`)',
     behavior:
-      "Supported under source-provider constraints; explicit exports win, `default` is not forwarded, and ambiguity fails closed",
+      "Supported for project and package barrels; explicit exports win, `default` is not forwarded, and ambiguity fails closed",
     status: "supported"
   },
   {
@@ -465,14 +544,48 @@ export const STATIC_CSS_EVAL_SUPPORT_MATRIX = [
     status: "unsupported"
   },
   {
-    construct: "Package, `node_modules`, or outside-root imports",
+    construct:
+      "Provider-backed package, `node_modules`, and outside-root ESM source",
     behavior:
-      "Unsupported; preserve class-value or error per candidate policy without filesystem fallback",
+      "Supported when the bundler/provider supplies parseable ESM source and identity metadata; no Babel filesystem package resolver is used",
+    status: "supported"
+  },
+  {
+    construct: "Package barrel reexports",
+    behavior:
+      "Supported with the same direct reexport, `export *`, namespace, and default semantics as project source",
+    status: "supported"
+  },
+  {
+    construct:
+      "Static data imports (JSON, `?raw`, `?url`, and safe wasm string forms)",
+    behavior:
+      "Supported when the provider synthesizes literal ESM source for JSON default/named exports or string payloads",
+    status: "supported"
+  },
+  {
+    construct: "Provider-backed virtual modules with supplied source",
+    behavior:
+      "Supported when the bundler/provider returns deterministic source or literal ESM payload plus source identity",
+    status: "supported"
+  },
+  {
+    construct: "Provider/external modules without loadable source",
+    behavior:
+      "Unsupported with source-kind diagnostics such as `external-no-source` or `provider-virtual-no-source`",
     status: "unsupported"
   },
   {
-    construct: "Virtual modules",
-    behavior: "Unsupported",
+    construct:
+      "Runtime wasm init/functions, non-literal loader output, and dynamic import graphs",
+    behavior:
+      "Unsupported; static evaluation never runs loader/runtime functions or dynamic import graphs",
+    status: "unsupported"
+  },
+  {
+    construct: "Remote/http modules",
+    behavior:
+      "Unsupported in the first iteration; providers must supply deterministic local/package/data/virtual source or literal payloads",
     status: "unsupported"
   },
   {
@@ -546,9 +659,12 @@ if (import.meta.vitest) {
     STATIC_CSS_EVAL_OBJECT_SPREAD_UNSUPPORTED: true,
     STATIC_CSS_EVAL_COMPUTED_MEMBER_UNSUPPORTED: true,
     STATIC_CSS_EVAL_DYNAMIC_EXPRESSION_UNSUPPORTED: true,
+    STATIC_CSS_EVAL_PROVIDER_SOURCE_UNSUPPORTED: true,
     STATIC_CSS_EVAL_EXPORT_STAR_UNSUPPORTED: true,
+    STATIC_CSS_EVAL_EXPORT_STAR_AMBIGUOUS: true,
     STATIC_CSS_EVAL_NAMESPACE_UNSUPPORTED: true,
-    STATIC_CSS_EVAL_PACKAGE_IMPORT_UNSUPPORTED: true,
+    STATIC_CSS_EVAL_NAMESPACE_REEXPORT_UNSUPPORTED: true,
+    STATIC_CSS_EVAL_NAMESPACE_PARTIAL_UNSUPPORTED: true,
     STATIC_CSS_EVAL_CJS_UNSUPPORTED: true,
     STATIC_CSS_EVAL_IMPORT_CYCLE: true,
     STATIC_CSS_EVAL_UNRESOLVED_IMPORT: true,
@@ -704,12 +820,24 @@ if (import.meta.vitest) {
         "async-prepass-sync-babel-boundary"
       );
       expect(STATIC_CSS_EVAL_GUARDRAILS).toContain(
-        "project-local-esm-source-provider-export-graph-v2"
+        "esm-source-provider-export-graph-v3"
       );
       expect(STATIC_CSS_EVAL_GUARDRAILS).toContain(
-        "limited-project-local-namespace-values-v2"
+        "all-esm-package-source-provider-policy-v1"
       );
       expect(STATIC_CSS_EVAL_GUARDRAILS).toContain(
+        "provider-backed-static-data-json-raw-url-wasm-string-v1"
+      );
+      expect(STATIC_CSS_EVAL_GUARDRAILS).toContain(
+        "provider-backed-virtual-source-v1"
+      );
+      expect(STATIC_CSS_EVAL_GUARDRAILS).toContain(
+        "fail-closed-namespace-star-and-source-shape-v1"
+      );
+      expect(STATIC_CSS_EVAL_GUARDRAILS).not.toContain(
+        "project-local-files-only"
+      );
+      expect(STATIC_CSS_EVAL_GUARDRAILS).not.toContain(
         "no-node-modules-virtual-cjs-or-outside-root-v1"
       );
       expect(STATIC_CSS_EVAL_GUARDRAILS).not.toContain(
@@ -726,12 +854,12 @@ if (import.meta.vitest) {
 
       expect(
         supportMatrixByConstruct.get(
-          'Project-local ESM re-export graph (`export { x } from "./x"`, barrels, and transitive aliases)'
+          'Provider-backed ESM re-export graph (`export { x } from "./x"`, barrels, package barrels, and transitive aliases)'
         )
       ).toMatchObject({ status: "supported" });
       expect(
         supportMatrixByConstruct.get(
-          'Project-local export-star barrel graph (`export * from "./x"`)'
+          'Provider-backed export-star barrel graph (`export * from "./x"`)'
         )
       ).toMatchObject({ status: "supported" });
       expect(
@@ -756,9 +884,35 @@ if (import.meta.vitest) {
       ).toMatchObject({ status: "unsupported" });
       expect(
         supportMatrixByConstruct.get(
-          "Package, `node_modules`, or outside-root imports"
+          "Provider-backed package, `node_modules`, and outside-root ESM source"
+        )
+      ).toMatchObject({ status: "supported" });
+      expect(
+        supportMatrixByConstruct.get("Package barrel reexports")
+      ).toMatchObject({ status: "supported" });
+      expect(
+        supportMatrixByConstruct.get(
+          "Static data imports (JSON, `?raw`, `?url`, and safe wasm string forms)"
+        )
+      ).toMatchObject({ status: "supported" });
+      expect(
+        supportMatrixByConstruct.get(
+          "Provider-backed virtual modules with supplied source"
+        )
+      ).toMatchObject({ status: "supported" });
+      expect(
+        supportMatrixByConstruct.get(
+          "Provider/external modules without loadable source"
         )
       ).toMatchObject({ status: "unsupported" });
+      expect(
+        supportMatrixByConstruct.get(
+          "Runtime wasm init/functions, non-literal loader output, and dynamic import graphs"
+        )
+      ).toMatchObject({ status: "unsupported" });
+      expect(supportMatrixByConstruct.get("Remote/http modules")).toMatchObject(
+        { status: "unsupported" }
+      );
       expect(
         supportMatrixByConstruct.get("CommonJS / `require()`")
       ).toMatchObject({ status: "unsupported" });
@@ -767,7 +921,7 @@ if (import.meta.vitest) {
           (construct) => construct === "Export star (`export *`)"
         )
       ).toBe(false);
-      expect(STATIC_CSS_EVAL_SUPPORT_MATRIX).toHaveLength(34);
+      expect(STATIC_CSS_EVAL_SUPPORT_MATRIX).toHaveLength(39);
     });
 
     it("accepts synchronous provider and cache key contracts", () => {
@@ -869,7 +1023,7 @@ if (import.meta.vitest) {
       expect(staticCssEvalDiagnosticIds).toEqual(
         STATIC_CSS_EVAL_DIAGNOSTIC_IDS
       );
-      expect(staticCssEvalDiagnosticIds).toHaveLength(15);
+      expect(staticCssEvalDiagnosticIds).toHaveLength(18);
     });
   });
 }

--- a/packages/babel/src/staticCssEval/types.ts
+++ b/packages/babel/src/staticCssEval/types.ts
@@ -425,7 +425,8 @@ export const STATIC_CSS_EVAL_SUPPORT_MATRIX = [
   },
   {
     construct: 'Direct named re-export (`export { x } from "./x"`)',
-    behavior: "Supported for project-local ESM source with dependency chain metadata",
+    behavior:
+      "Supported for project-local ESM source with dependency chain metadata",
     status: "supported"
   },
   {

--- a/packages/babel/src/staticCssEval/types.ts
+++ b/packages/babel/src/staticCssEval/types.ts
@@ -10,18 +10,186 @@ export interface StaticCssEvalQuery {
   memberPath?: string[];
 }
 
+// Maintainer boundary: these contracts model AST-derived css values only.
+// Token/theme semantics are not interpreted unless they arrive as JS bindings.
 export type StaticCssEvalResult =
-  | { kind: "not-candidate" }
+  | StaticCssEvalLegacyNotCandidateResult
+  | StaticCssEvalLegacyResolvedResult
+  | StaticCssEvalLegacyErrorResult
+  | StaticCssEvalResolvedResult
+  | StaticCssEvalUnsupportedResult
+  | StaticCssEvalErrorResult;
+
+type StaticCssEvalLegacyNotCandidateResult = {
+  kind: "not-candidate";
+  value?: never;
+  diagnostic?: never;
+};
+
+type StaticCssEvalLegacyResolvedResult = {
+  kind: "resolved";
+  value: StaticCssLiteral;
+  dependencies: string[];
+  diagnostic?: never;
+};
+
+type StaticCssEvalLegacyErrorResult = {
+  kind: "error";
+  diagnostic: StaticCssEvalDiagnostic;
+  dependencies: string[];
+  value?: never;
+};
+
+export interface StaticCssEvalResolvedResult {
+  kind: "resolved";
+  status: "resolved";
+  expression: string;
+  value: StaticCssLiteral;
+  provenance?: BindingProvenance;
+  dependencies: ResolutionDependency[];
+  resolutionChain?: ResolutionChainEntry[];
+  diagnostics?: [];
+  cacheKey?: StaticCssEvalCacheKey;
+  diagnostic?: never;
+}
+
+export interface StaticCssEvalUnsupportedResult {
+  kind: "not-candidate";
+  status: "unsupported";
+  expression: string;
+  provenance?: BindingProvenance;
+  dependencies: ResolutionDependency[];
+  resolutionChain?: ResolutionChainEntry[];
+  diagnostics: StaticCssEvalDiagnostic[];
+  cacheKey?: StaticCssEvalCacheKey;
+  value?: never;
+  diagnostic?: never;
+}
+
+export interface StaticCssEvalErrorResult {
+  kind: "error";
+  status: "error";
+  expression: string;
+  provenance?: BindingProvenance;
+  dependencies: ResolutionDependency[];
+  resolutionChain?: ResolutionChainEntry[];
+  diagnostic: StaticCssEvalDiagnostic;
+  diagnostics: StaticCssEvalDiagnostic[];
+  cacheKey?: StaticCssEvalCacheKey;
+  value?: never;
+}
+
+export type StaticCssEvalResultStatus = "resolved" | "unsupported" | "error";
+
+export type BindingProvenance =
   | {
-      kind: "resolved";
-      value: StaticCssLiteral;
-      dependencies: string[];
+      kind: "local";
+      file: string;
+      bindingName: string;
+      declarationKind?: "const" | "let" | "var" | "function" | "class";
     }
   | {
-      kind: "error";
-      diagnostic: StaticCssEvalDiagnostic;
-      dependencies: string[];
+      kind: "imported";
+      file: string;
+      importer: string;
+      specifier: string;
+      exportName: StaticCssEvalExportName;
+      memberPath: string[];
+    }
+  | {
+      kind: "reexported";
+      file: string;
+      importer: string;
+      specifier: string;
+      exportName: StaticCssEvalExportName;
+      memberPath: string[];
+      reexportName: string;
+    }
+  | {
+      kind: "namespace-member";
+      file: string;
+      importer: string;
+      specifier: string;
+      exportName: StaticCssEvalExportName;
+      memberPath: string[];
+      namespaceBinding: string;
     };
+
+export type ResolutionDependencyKind =
+  | "local"
+  | "imported"
+  | "reexported"
+  | "namespace-member"
+  | "unresolved";
+
+export interface ResolutionDependency {
+  file: string;
+  kind: ResolutionDependencyKind;
+  importer: string;
+  specifier: string;
+  exportName: StaticCssEvalExportName;
+  memberPath: string[];
+  inspected: boolean;
+  contributed: boolean;
+}
+
+export interface ResolutionChainEntry {
+  importer: string;
+  source: string;
+  exportName: StaticCssEvalExportName;
+  memberPath: string[];
+  provenance?: BindingProvenance;
+}
+
+export interface StaticCssEvalCacheKey {
+  importerFile: string;
+  resolvedFile: string;
+  exportName: StaticCssEvalExportName;
+  memberPath: string[];
+  sourceHash: string;
+  sourceVersion?: string | number;
+  pluginOptionsVersion: string | number;
+  resolverOptionsVersion: string | number;
+  staticEvalSupportVersion: string | number;
+  resolvedId?: string;
+  parserOptions?: StaticCssEvalParserOptionsKey;
+  projectLocalBoundary?: StaticCssEvalProjectLocalBoundaryState;
+}
+
+export type StaticCssEvalDiagnosticId =
+  | "STATIC_CSS_EVAL_LOCAL_ALIAS_CYCLE"
+  | "STATIC_CSS_EVAL_MUTABLE_BINDING"
+  | "STATIC_CSS_EVAL_MUTATED_BINDING"
+  | "STATIC_CSS_EVAL_UNSUPPORTED_ARRAY_ELEMENT"
+  | "STATIC_CSS_EVAL_OBJECT_SPREAD_UNSUPPORTED"
+  | "STATIC_CSS_EVAL_COMPUTED_MEMBER_UNSUPPORTED"
+  | "STATIC_CSS_EVAL_DYNAMIC_EXPRESSION_UNSUPPORTED"
+  | "STATIC_CSS_EVAL_EXPORT_STAR_UNSUPPORTED"
+  | "STATIC_CSS_EVAL_NAMESPACE_UNSUPPORTED"
+  | "STATIC_CSS_EVAL_PACKAGE_IMPORT_UNSUPPORTED"
+  | "STATIC_CSS_EVAL_CJS_UNSUPPORTED"
+  | "STATIC_CSS_EVAL_IMPORT_CYCLE"
+  | "STATIC_CSS_EVAL_UNRESOLVED_IMPORT"
+  | "STATIC_CSS_EVAL_UNRESOLVED_EXPORT"
+  | "STATIC_CSS_EVAL_RESOLUTION_DEPTH_EXCEEDED";
+
+export const STATIC_CSS_EVAL_DIAGNOSTIC_IDS = [
+  "STATIC_CSS_EVAL_LOCAL_ALIAS_CYCLE",
+  "STATIC_CSS_EVAL_MUTABLE_BINDING",
+  "STATIC_CSS_EVAL_MUTATED_BINDING",
+  "STATIC_CSS_EVAL_UNSUPPORTED_ARRAY_ELEMENT",
+  "STATIC_CSS_EVAL_OBJECT_SPREAD_UNSUPPORTED",
+  "STATIC_CSS_EVAL_COMPUTED_MEMBER_UNSUPPORTED",
+  "STATIC_CSS_EVAL_DYNAMIC_EXPRESSION_UNSUPPORTED",
+  "STATIC_CSS_EVAL_EXPORT_STAR_UNSUPPORTED",
+  "STATIC_CSS_EVAL_NAMESPACE_UNSUPPORTED",
+  "STATIC_CSS_EVAL_PACKAGE_IMPORT_UNSUPPORTED",
+  "STATIC_CSS_EVAL_CJS_UNSUPPORTED",
+  "STATIC_CSS_EVAL_IMPORT_CYCLE",
+  "STATIC_CSS_EVAL_UNRESOLVED_IMPORT",
+  "STATIC_CSS_EVAL_UNRESOLVED_EXPORT",
+  "STATIC_CSS_EVAL_RESOLUTION_DEPTH_EXCEEDED"
+] as const satisfies readonly StaticCssEvalDiagnosticId[];
 
 export type StaticCssLiteral =
   | string
@@ -82,6 +250,7 @@ export type StaticCssEvalUnsupportedReason =
   (typeof STATIC_CSS_EVAL_UNSUPPORTED_REASONS)[number];
 
 export interface StaticCssEvalDiagnostic {
+  id?: StaticCssEvalDiagnosticId;
   code: StaticCssEvalDiagnosticCode;
   message: string;
   reason: StaticCssEvalUnsupportedReason;
@@ -138,16 +307,6 @@ export interface StaticCssEvalParserOptionsKey {
   typescript: boolean;
 }
 
-export interface StaticCssEvalCacheKey {
-  resolvedId: string;
-  sourceHash: string;
-  sourceVersion?: string | number;
-  parserOptions: StaticCssEvalParserOptionsKey;
-  exportName: StaticCssEvalExportName;
-  memberPath: string[];
-  projectLocalBoundary: StaticCssEvalProjectLocalBoundaryState;
-}
-
 export const STATIC_CSS_EVAL_LIMITS = {
   maxImportDepth: 10,
   maxEvaluatedModulesPerOwner: 100,
@@ -167,12 +326,14 @@ export const STATIC_CSS_EVAL_GUARDRAILS = [
   "no-module-execution",
   "no-node-vm-eval-dynamic-import",
   "no-bundler-runtime-evaluation",
-  "no-reexports-or-barrels-v1",
-  "no-namespace-imports-v1",
+  "direct-named-reexports-only-v1",
+  "limited-project-local-namespace-members-v1",
   "no-node-modules-or-virtual-modules-v1",
   "async-prepass-sync-babel-boundary"
 ] as const;
 
+// Keep unsupported boundaries fail-closed: dynamic/export-star/package/CJS,
+// object spread, computed paths, and runtime fallback are outside this model.
 export type StaticCssEvalSupportStatus =
   | "preserved"
   | "supported"
@@ -263,12 +424,24 @@ export const STATIC_CSS_EVAL_SUPPORT_MATRIX = [
     status: "supported"
   },
   {
-    construct: 'Reexports / barrels (`export { x } from "./x"`, `export *`)',
+    construct: 'Direct named re-export (`export { x } from "./x"`)',
+    behavior: "Supported for project-local ESM source with dependency chain metadata",
+    status: "supported"
+  },
+  {
+    construct: "Export star (`export *`)",
     behavior: "Unsupported",
     status: "unsupported"
   },
   {
-    construct: "Namespace imports (`import * as styles`)",
+    construct:
+      'Limited namespace member import (`import * as styles from "./style"; styles.x.y`)',
+    behavior:
+      "Supported for project-local ESM source and literal member chains only",
+    status: "supported"
+  },
+  {
+    construct: "Broad/package/computed namespace usage",
     behavior: "Unsupported",
     status: "unsupported"
   },
@@ -344,6 +517,158 @@ export const STATIC_CSS_EVAL_SUPPORT_MATRIX = [
 if (import.meta.vitest) {
   const { describe, expect, it } = import.meta.vitest;
 
+  const staticCssEvalDiagnosticExhaustiveMap = {
+    STATIC_CSS_EVAL_LOCAL_ALIAS_CYCLE: true,
+    STATIC_CSS_EVAL_MUTABLE_BINDING: true,
+    STATIC_CSS_EVAL_MUTATED_BINDING: true,
+    STATIC_CSS_EVAL_UNSUPPORTED_ARRAY_ELEMENT: true,
+    STATIC_CSS_EVAL_OBJECT_SPREAD_UNSUPPORTED: true,
+    STATIC_CSS_EVAL_COMPUTED_MEMBER_UNSUPPORTED: true,
+    STATIC_CSS_EVAL_DYNAMIC_EXPRESSION_UNSUPPORTED: true,
+    STATIC_CSS_EVAL_EXPORT_STAR_UNSUPPORTED: true,
+    STATIC_CSS_EVAL_NAMESPACE_UNSUPPORTED: true,
+    STATIC_CSS_EVAL_PACKAGE_IMPORT_UNSUPPORTED: true,
+    STATIC_CSS_EVAL_CJS_UNSUPPORTED: true,
+    STATIC_CSS_EVAL_IMPORT_CYCLE: true,
+    STATIC_CSS_EVAL_UNRESOLVED_IMPORT: true,
+    STATIC_CSS_EVAL_UNRESOLVED_EXPORT: true,
+    STATIC_CSS_EVAL_RESOLUTION_DEPTH_EXCEEDED: true
+  } satisfies Record<StaticCssEvalDiagnosticId, true>;
+
+  const staticCssEvalDiagnosticIds = Object.keys(
+    staticCssEvalDiagnosticExhaustiveMap
+  ) as StaticCssEvalDiagnosticId[];
+
+  const staticCssEvalResolvedResult = {
+    kind: "resolved",
+    status: "resolved",
+    expression: "styles.button",
+    value: { color: "red" },
+    provenance: {
+      kind: "imported",
+      file: "/project/src/styles.ts",
+      importer: "/project/src/App.tsx",
+      specifier: "./styles",
+      exportName: "default",
+      memberPath: ["button"]
+    },
+    dependencies: [
+      {
+        file: "/project/src/styles.ts",
+        kind: "imported",
+        importer: "/project/src/App.tsx",
+        specifier: "./styles",
+        exportName: "default",
+        memberPath: ["button"],
+        inspected: true,
+        contributed: true
+      }
+    ],
+    resolutionChain: [
+      {
+        importer: "/project/src/App.tsx",
+        source: "/project/src/styles.ts",
+        exportName: "default",
+        memberPath: ["button"],
+        provenance: {
+          kind: "imported",
+          file: "/project/src/styles.ts",
+          importer: "/project/src/App.tsx",
+          specifier: "./styles",
+          exportName: "default",
+          memberPath: ["button"]
+        }
+      }
+    ],
+    cacheKey: {
+      importerFile: "/project/src/App.tsx",
+      resolvedFile: "/project/src/styles.ts",
+      exportName: "default",
+      memberPath: ["button"],
+      sourceHash: "sha256:source",
+      sourceVersion: 1,
+      pluginOptionsVersion: 1,
+      resolverOptionsVersion: 1,
+      staticEvalSupportVersion: 1,
+      resolvedId: "/project/src/styles.ts",
+      parserOptions: {
+        plugins: ["jsx", "typescript"],
+        sourceType: "module",
+        jsx: true,
+        typescript: true
+      },
+      projectLocalBoundary: {
+        rootRealpath: "/project",
+        resolvedRealpath: "/project/src/styles.ts",
+        insideRoot: true,
+        insideNodeModules: false,
+        virtual: false,
+        packageExportOutsideRoot: false
+      }
+    }
+  } satisfies StaticCssEvalResult;
+
+  const staticCssEvalUnsupportedResult = {
+    kind: "not-candidate",
+    status: "unsupported",
+    expression: "styles[key]",
+    dependencies: [],
+    diagnostics: [
+      {
+        id: "STATIC_CSS_EVAL_COMPUTED_MEMBER_UNSUPPORTED",
+        code: "unsupported-source",
+        message: "computed member access is unsupported",
+        reason: "dynamic-member-path",
+        owner: {
+          file: "/project/src/App.tsx",
+          start: 42,
+          end: 55
+        }
+      }
+    ],
+    cacheKey: {
+      importerFile: "/project/src/App.tsx",
+      resolvedFile: "/project/src/styles.ts",
+      exportName: "default",
+      memberPath: ["button"],
+      sourceHash: "sha256:source",
+      pluginOptionsVersion: 1,
+      resolverOptionsVersion: 1,
+      staticEvalSupportVersion: 1
+    }
+  } satisfies StaticCssEvalResult;
+
+  const staticCssEvalErrorResult = {
+    kind: "error",
+    status: "error",
+    expression: "missing.button",
+    dependencies: [],
+    diagnostic: {
+      id: "STATIC_CSS_EVAL_UNRESOLVED_EXPORT",
+      code: "unsupported-source",
+      message: "export could not be resolved",
+      reason: "reexport-or-barrel",
+      owner: {
+        file: "/project/src/App.tsx",
+        start: 42,
+        end: 55
+      }
+    },
+    diagnostics: [
+      {
+        id: "STATIC_CSS_EVAL_UNRESOLVED_EXPORT",
+        code: "unsupported-source",
+        message: "export could not be resolved",
+        reason: "reexport-or-barrel",
+        owner: {
+          file: "/project/src/App.tsx",
+          start: 42,
+          end: 55
+        }
+      }
+    ]
+  } satisfies StaticCssEvalResult;
+
   describe("static css evaluator contracts", () => {
     it("encodes v1 static evaluator limits and guardrails", () => {
       expect(STATIC_CSS_EVAL_LIMITS).toEqual({
@@ -363,7 +688,19 @@ if (import.meta.vitest) {
       expect(
         STATIC_CSS_EVAL_SUPPORT_MATRIX.find(
           ({ construct }) =>
-            construct === "Namespace imports (`import * as styles`)"
+            construct ===
+            'Limited namespace member import (`import * as styles from "./style"; styles.x.y`)'
+        )?.status
+      ).toBe("supported");
+      expect(
+        STATIC_CSS_EVAL_SUPPORT_MATRIX.find(
+          ({ construct }) =>
+            construct === 'Direct named re-export (`export { x } from "./x"`)'
+        )?.status
+      ).toBe("supported");
+      expect(
+        STATIC_CSS_EVAL_SUPPORT_MATRIX.find(
+          ({ construct }) => construct === "Export star (`export *`)"
         )?.status
       ).toBe("unsupported");
       expect(
@@ -371,7 +708,7 @@ if (import.meta.vitest) {
           ({ construct }) => construct === '`import x from "./style"`'
         )?.status
       ).toBe("supported");
-      expect(STATIC_CSS_EVAL_SUPPORT_MATRIX).toHaveLength(30);
+      expect(STATIC_CSS_EVAL_SUPPORT_MATRIX).toHaveLength(32);
     });
 
     it("accepts synchronous provider and cache key contracts", () => {
@@ -391,16 +728,22 @@ if (import.meta.vitest) {
         }
       };
       const cacheKey: StaticCssEvalCacheKey = {
-        resolvedId: "/project/src/styles.ts",
+        importerFile: "/project/src/App.tsx",
+        resolvedFile: "/project/src/styles.ts",
+        exportName: "default",
+        memberPath: ["button"],
         sourceHash: "sha256:source",
+        sourceVersion: 1,
+        pluginOptionsVersion: 1,
+        resolverOptionsVersion: 1,
+        staticEvalSupportVersion: 1,
+        resolvedId: "/project/src/styles.ts",
         parserOptions: {
           plugins: ["jsx", "typescript"],
           sourceType: "module",
           jsx: true,
           typescript: true
         },
-        exportName: "default",
-        memberPath: ["button"],
         projectLocalBoundary: {
           rootRealpath: "/project",
           resolvedRealpath: "/project/src/styles.ts",
@@ -411,7 +754,8 @@ if (import.meta.vitest) {
         }
       };
 
-      expect(cacheKey.projectLocalBoundary.insideRoot).toBe(true);
+      expect(cacheKey.importerFile).toBe("/project/src/App.tsx");
+      expect(cacheKey.projectLocalBoundary?.insideRoot).toBe(true);
       expect(
         provider.getResolvedCssValue({
           importerId: "/project/src/App.tsx",
@@ -425,6 +769,48 @@ if (import.meta.vitest) {
         value: { color: "red" },
         dependencies: ["/project/src/styles.ts"]
       });
+    });
+
+    it("models resolved, unsupported, and error result shapes", () => {
+      expect(staticCssEvalResolvedResult.status).toBe("resolved");
+      expect(staticCssEvalResolvedResult.kind).toBe("resolved");
+      expect(staticCssEvalResolvedResult.dependencies[0]?.file).toBe(
+        "/project/src/styles.ts"
+      );
+      expect(staticCssEvalUnsupportedResult.status).toBe("unsupported");
+      expect(staticCssEvalUnsupportedResult.kind).toBe("not-candidate");
+      expect(staticCssEvalUnsupportedResult.diagnostics[0]?.id).toBe(
+        "STATIC_CSS_EVAL_COMPUTED_MEMBER_UNSUPPORTED"
+      );
+      expect(staticCssEvalErrorResult.status).toBe("error");
+      expect(staticCssEvalErrorResult.kind).toBe("error");
+      expect(staticCssEvalErrorResult.diagnostics[0]?.id).toBe(
+        "STATIC_CSS_EVAL_UNRESOLVED_EXPORT"
+      );
+    });
+
+    it("keeps legacy kind narrowing ergonomic", () => {
+      const legacyResult: StaticCssEvalResult = {
+        kind: "error",
+        diagnostic: {
+          code: "unsupported-source",
+          message: "legacy error",
+          reason: "reexport-or-barrel",
+          owner: { file: "/project/src/App.tsx" }
+        },
+        dependencies: []
+      };
+
+      if (legacyResult.kind === "error") {
+        expect(legacyResult.diagnostic.message).toBe("legacy error");
+      }
+    });
+
+    it("keeps diagnostic ids exhaustive", () => {
+      expect(staticCssEvalDiagnosticIds).toEqual(
+        STATIC_CSS_EVAL_DIAGNOSTIC_IDS
+      );
+      expect(staticCssEvalDiagnosticIds).toHaveLength(15);
     });
   });
 }

--- a/packages/babel/src/staticCssEval/types.ts
+++ b/packages/babel/src/staticCssEval/types.ts
@@ -326,14 +326,12 @@ export const STATIC_CSS_EVAL_GUARDRAILS = [
   "no-module-execution",
   "no-node-vm-eval-dynamic-import",
   "no-bundler-runtime-evaluation",
-  "direct-named-reexports-only-v1",
-  "limited-project-local-namespace-members-v1",
-  "no-node-modules-or-virtual-modules-v1",
+  "project-local-esm-source-provider-export-graph-v2",
+  "limited-project-local-namespace-values-v2",
+  "no-node-modules-virtual-cjs-or-outside-root-v1",
   "async-prepass-sync-babel-boundary"
 ] as const;
 
-// Keep unsupported boundaries fail-closed: dynamic/export-star/package/CJS,
-// object spread, computed paths, and runtime fallback are outside this model.
 export type StaticCssEvalSupportStatus =
   | "preserved"
   | "supported"
@@ -424,26 +422,41 @@ export const STATIC_CSS_EVAL_SUPPORT_MATRIX = [
     status: "supported"
   },
   {
-    construct: 'Direct named re-export (`export { x } from "./x"`)',
+    construct:
+      'Project-local ESM re-export graph (`export { x } from "./x"`, barrels, and transitive aliases)',
     behavior:
-      "Supported for project-local ESM source with dependency chain metadata",
+      "Supported under source-provider constraints with dependency chain metadata",
     status: "supported"
   },
   {
-    construct: "Export star (`export *`)",
-    behavior: "Unsupported",
+    construct: 'Project-local export-star barrel graph (`export * from "./x"`)',
+    behavior:
+      "Supported under source-provider constraints; explicit exports win, `default` is not forwarded, and ambiguity fails closed",
+    status: "supported"
+  },
+  {
+    construct: 'Namespace re-export (`export * as ns from "./x"`)',
+    behavior: "Unsupported; namespace re-export entries fail closed",
     status: "unsupported"
   },
   {
     construct:
       'Limited namespace member import (`import * as styles from "./style"; styles.x.y`)',
     behavior:
-      "Supported for project-local ESM source and literal member chains only",
+      "Supported for project-local ESM source-provider literal member chains, including export-star barrels",
     status: "supported"
   },
   {
-    construct: "Broad/package/computed namespace usage",
-    behavior: "Unsupported",
+    construct:
+      'Whole namespace import object (`import * as styles from "./style"; css={styles}`)',
+    behavior:
+      "Supported under source-provider constraints when every exported namespace value is statically evaluable",
+    status: "supported"
+  },
+  {
+    construct: "Computed, optional, destructured, or broad namespace access",
+    behavior:
+      "Unsupported; namespace access must resolve to literal member chains or a whole namespace object",
     status: "unsupported"
   },
   {
@@ -452,8 +465,9 @@ export const STATIC_CSS_EVAL_SUPPORT_MATRIX = [
     status: "unsupported"
   },
   {
-    construct: "`node_modules` imports",
-    behavior: "Unsupported; preserve class-value or error per candidate policy",
+    construct: "Package, `node_modules`, or outside-root imports",
+    behavior:
+      "Unsupported; preserve class-value or error per candidate policy without filesystem fallback",
     status: "unsupported"
   },
   {
@@ -677,7 +691,7 @@ if (import.meta.vitest) {
   } satisfies StaticCssEvalResult;
 
   describe("static css evaluator contracts", () => {
-    it("encodes v1 static evaluator limits and guardrails", () => {
+    it("encodes static evaluator limits and source-provider guardrails", () => {
       expect(STATIC_CSS_EVAL_LIMITS).toEqual({
         maxImportDepth: 10,
         maxEvaluatedModulesPerOwner: 100,
@@ -689,33 +703,71 @@ if (import.meta.vitest) {
       expect(STATIC_CSS_EVAL_GUARDRAILS).toContain(
         "async-prepass-sync-babel-boundary"
       );
+      expect(STATIC_CSS_EVAL_GUARDRAILS).toContain(
+        "project-local-esm-source-provider-export-graph-v2"
+      );
+      expect(STATIC_CSS_EVAL_GUARDRAILS).toContain(
+        "limited-project-local-namespace-values-v2"
+      );
+      expect(STATIC_CSS_EVAL_GUARDRAILS).toContain(
+        "no-node-modules-virtual-cjs-or-outside-root-v1"
+      );
+      expect(STATIC_CSS_EVAL_GUARDRAILS).not.toContain(
+        "direct-named-reexports-only-v1"
+      );
     });
 
-    it("keeps the v1 support matrix testable", () => {
+    it("keeps the source-provider export graph support matrix testable", () => {
+      const supportMatrixByConstruct = new Map(
+        STATIC_CSS_EVAL_SUPPORT_MATRIX.map((entry) => [entry.construct, entry])
+      );
+      const supportMatrixConstructs: readonly string[] =
+        STATIC_CSS_EVAL_SUPPORT_MATRIX.map((entry) => entry.construct);
+
       expect(
-        STATIC_CSS_EVAL_SUPPORT_MATRIX.find(
-          ({ construct }) =>
-            construct ===
-            'Limited namespace member import (`import * as styles from "./style"; styles.x.y`)'
-        )?.status
-      ).toBe("supported");
+        supportMatrixByConstruct.get(
+          'Project-local ESM re-export graph (`export { x } from "./x"`, barrels, and transitive aliases)'
+        )
+      ).toMatchObject({ status: "supported" });
       expect(
-        STATIC_CSS_EVAL_SUPPORT_MATRIX.find(
-          ({ construct }) =>
-            construct === 'Direct named re-export (`export { x } from "./x"`)'
-        )?.status
-      ).toBe("supported");
+        supportMatrixByConstruct.get(
+          'Project-local export-star barrel graph (`export * from "./x"`)'
+        )
+      ).toMatchObject({ status: "supported" });
       expect(
-        STATIC_CSS_EVAL_SUPPORT_MATRIX.find(
-          ({ construct }) => construct === "Export star (`export *`)"
-        )?.status
-      ).toBe("unsupported");
+        supportMatrixByConstruct.get(
+          'Limited namespace member import (`import * as styles from "./style"; styles.x.y`)'
+        )
+      ).toMatchObject({ status: "supported" });
       expect(
-        STATIC_CSS_EVAL_SUPPORT_MATRIX.find(
-          ({ construct }) => construct === '`import x from "./style"`'
-        )?.status
-      ).toBe("supported");
-      expect(STATIC_CSS_EVAL_SUPPORT_MATRIX).toHaveLength(32);
+        supportMatrixByConstruct.get(
+          'Whole namespace import object (`import * as styles from "./style"; css={styles}`)'
+        )
+      ).toMatchObject({ status: "supported" });
+      expect(
+        supportMatrixByConstruct.get(
+          'Namespace re-export (`export * as ns from "./x"`)'
+        )
+      ).toMatchObject({ status: "unsupported" });
+      expect(
+        supportMatrixByConstruct.get(
+          "Computed, optional, destructured, or broad namespace access"
+        )
+      ).toMatchObject({ status: "unsupported" });
+      expect(
+        supportMatrixByConstruct.get(
+          "Package, `node_modules`, or outside-root imports"
+        )
+      ).toMatchObject({ status: "unsupported" });
+      expect(
+        supportMatrixByConstruct.get("CommonJS / `require()`")
+      ).toMatchObject({ status: "unsupported" });
+      expect(
+        supportMatrixConstructs.some(
+          (construct) => construct === "Export star (`export *`)"
+        )
+      ).toBe(false);
+      expect(STATIC_CSS_EVAL_SUPPORT_MATRIX).toHaveLength(34);
     });
 
     it("accepts synchronous provider and cache key contracts", () => {

--- a/packages/babel/src/staticCssEval/types.ts
+++ b/packages/babel/src/staticCssEval/types.ts
@@ -515,7 +515,13 @@ export const STATIC_CSS_EVAL_SUPPORT_MATRIX = [
   }
 ] as const satisfies readonly StaticCssEvalSupportMatrixEntry[];
 
+// == Tests ====================================================================
+// Ignore errors when compiling to CommonJS.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
 if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
   const { describe, expect, it } = import.meta.vitest;
 
   const staticCssEvalDiagnosticExhaustiveMap = {

--- a/packages/babel/src/styled.ts
+++ b/packages/babel/src/styled.ts
@@ -3,6 +3,14 @@ import type { NodePath, PluginObj } from "@babel/core";
 import type { PluginState, ProgramScope } from "./types.js";
 import { registerImportMethod } from "./utils.js";
 
+const runtimeImport = "@mincho-js/react/runtime";
+
+type NormalizedStyledCall = {
+  tag: t.Expression;
+  styles: t.Expression;
+  rest: Array<t.Expression | t.SpreadElement>;
+};
+
 /**
  * The plugin for transforming styled components
  *
@@ -32,10 +40,6 @@ export function styledComponentPlugin(): PluginObj<PluginState> {
                 return;
               }
 
-              const { tag, styles, rest } = normalizedArguments;
-
-              const runtimeImport = "@mincho-js/react/runtime";
-
               const styledIdentifier = registerImportMethod(
                 callPath,
                 "$$styled",
@@ -48,36 +52,12 @@ export function styledComponentPlugin(): PluginObj<PluginState> {
                 "@mincho-js/css"
               );
 
-              // Create the recipe call expression
-              const recipeCallExpression = t.callExpression(recipeIdentifier, [
-                t.cloneNode(styles)
-              ]);
-
-              // Preserve existing comments if any
-              if (callPath.node.leadingComments?.length) {
-                t.addComments(
-                  recipeCallExpression,
-                  "leading",
-                  callPath.node.leadingComments
-                );
-              }
-
-              // Preserve source locations for better source maps
-              recipeCallExpression.loc = styles.loc;
-
-              const callExpression = t.callExpression(styledIdentifier, [
-                t.cloneNode(tag),
-                recipeCallExpression,
-                ...rest.map((argument) => t.cloneNode(argument))
-              ]);
-
-              // Add @__PURE__ annotation for tree-shaking
-              t.addComments(callExpression, "leading", [
-                { type: "CommentBlock", value: " @__PURE__ " }
-              ]);
-
-              // Preserve source locations
-              callExpression.loc = callPath.node.loc;
+              const callExpression = createStyledRuntimeCall(
+                normalizedArguments,
+                styledIdentifier,
+                recipeIdentifier,
+                callPath.node
+              );
 
               callPath.replaceWith(callExpression);
 
@@ -91,21 +71,66 @@ export function styledComponentPlugin(): PluginObj<PluginState> {
   };
 }
 
-function normalizeStyledCall(callPath: NodePath<t.CallExpression>): {
-  tag: t.Expression;
-  styles: t.Expression;
-  rest: Array<t.Expression | t.SpreadElement>;
-} | null {
+function createStyledRuntimeCall(
+  normalizedCall: NormalizedStyledCall,
+  styledIdentifier: t.Expression,
+  recipeIdentifier: t.Expression,
+  originalCall: t.CallExpression
+): t.CallExpression {
+  const { tag, styles, rest } = normalizedCall;
+  const recipeCallExpression = createRecipeCallExpression(
+    styles,
+    recipeIdentifier,
+    originalCall
+  );
+  const callExpression = t.callExpression(styledIdentifier, [
+    t.cloneNode(tag),
+    recipeCallExpression,
+    ...cloneStyledRestArguments(rest)
+  ]);
+
+  t.addComments(callExpression, "leading", [
+    { type: "CommentBlock", value: " @__PURE__ " }
+  ]);
+
+  callExpression.loc = originalCall.loc;
+
+  return callExpression;
+}
+
+function createRecipeCallExpression(
+  styles: t.Expression,
+  recipeIdentifier: t.Expression,
+  originalCall: t.CallExpression
+): t.CallExpression {
+  const recipeCallExpression = t.callExpression(recipeIdentifier, [
+    t.cloneNode(styles)
+  ]);
+
+  if (originalCall.leadingComments?.length) {
+    t.addComments(
+      recipeCallExpression,
+      "leading",
+      originalCall.leadingComments
+    );
+  }
+
+  recipeCallExpression.loc = styles.loc;
+
+  return recipeCallExpression;
+}
+
+function cloneStyledRestArguments(
+  rest: NormalizedStyledCall["rest"]
+): NormalizedStyledCall["rest"] {
+  return rest.map((argument) => t.cloneNode(argument));
+}
+
+function normalizeStyledCall(
+  callPath: NodePath<t.CallExpression>
+): NormalizedStyledCall | null {
   const callee = callPath.get("callee");
   const args = callPath.node.arguments;
-
-  const toValidRestArguments = (
-    input: typeof args
-  ): Array<t.Expression | t.SpreadElement> =>
-    input.filter(
-      (arg): arg is t.Expression | t.SpreadElement =>
-        t.isExpression(arg) || t.isSpreadElement(arg)
-    );
 
   if (callee.isIdentifier()) {
     if (!callee.referencesImport("@mincho-js/react", "styled")) {
@@ -167,4 +192,13 @@ function normalizeStyledCall(callPath: NodePath<t.CallExpression>): {
     styles,
     rest: toValidRestArguments(restArgs)
   };
+}
+
+function toValidRestArguments(
+  input: t.CallExpression["arguments"]
+): Array<t.Expression | t.SpreadElement> {
+  return input.filter(
+    (arg): arg is t.Expression | t.SpreadElement =>
+      t.isExpression(arg) || t.isSpreadElement(arg)
+  );
 }

--- a/packages/babel/src/types.ts
+++ b/packages/babel/src/types.ts
@@ -1,6 +1,11 @@
 import type { NodePath, PluginPass, types as t } from "@babel/core";
 import type { Scope } from "@babel/traverse";
-import type { StaticCssEvalProvider } from "./staticCssEval/types.js";
+import type {
+  ResolutionDependency,
+  StaticCssEvalCacheKey,
+  StaticCssEvalDiagnostic,
+  StaticCssEvalProvider
+} from "./staticCssEval/types.js";
 
 export interface PluginOptions {
   result: [string, string];
@@ -10,8 +15,23 @@ export interface PluginOptions {
   staticCssEvalProvider?: StaticCssEvalProvider;
 }
 
+export interface MinchoStaticCssEvalMetadata {
+  dependencies: ResolutionDependency[];
+  diagnostics: StaticCssEvalDiagnostic[];
+  cacheKeys: StaticCssEvalCacheKey[];
+  resolvedModuleIds: string[];
+}
+
+export interface MinchoBabelFileMetadata {
+  minchoStaticCssEval?: MinchoStaticCssEvalMetadata;
+  [key: string]: unknown;
+}
+
 export interface PluginState extends PluginPass {
   opts: PluginOptions;
+  file: Omit<PluginPass["file"], "metadata"> & {
+    metadata: MinchoBabelFileMetadata;
+  };
 }
 
 export interface ProgramScope extends Scope {

--- a/packages/css/src/defineRules/index.ts
+++ b/packages/css/src/defineRules/index.ts
@@ -363,8 +363,9 @@ function formatConfigPathSegment(key: string): string {
 if (import.meta.vitest) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+  const vitest = import.meta.vitest;
   const { describe, it, expect, afterEach, assertType, expectTypeOf, vi } =
-    import.meta.vitest;
+    vitest;
 
   const debugId = "myCSS";
   setFileScope("test");

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -10,18 +10,20 @@ import {
   type BabelOptions,
   babelTransform,
   compile,
-  createUnsupportedStaticCssEvalResolution as createSharedUnsupportedStaticCssEvalResolution,
-  isUnsupportedStaticCssEvalResolutionId as sharedIsUnsupportedStaticCssEvalResolutionId,
   internalCollectStaticCssEvalDependencyIds as collectStaticCssEvalDependencyIds,
   internalCreateStaticCssEvalSourceIdentity as createStaticCssEvalSourceIdentity,
   internalGetExistingStaticCssEvalRealpath as getExistingRealpath,
   internalGetExistingStaticCssEvalStat as getExistingStat,
   internalGetStaticCssEvalRealpathOrResolvedPath as getRealpathOrResolvedPath,
   internalHasStaticCssEvalNodeModulesSegment as hasNodeModulesSegment,
+  internalIsMissingStaticCssEvalFileSystemEntryError as isMissingFileSystemEntryError,
   internalIsProjectLocalStaticCssEvalImportPath as isProjectLocalImportPath,
+  internalIsStaticCssEvalStaticDataFile as isStaticCssEvalStaticDataFile,
   internalIsStaticCssEvalPathInsideRoot as isPathInsideRoot,
   internalIsVirtualStaticCssEvalId as isVirtualStaticCssEvalId,
   internalNormalizeStaticCssEvalFileId as normalizeStaticCssEvalFileId,
+  internalPrepareStaticCssEvalStaticDataSource as prepareStaticCssEvalStaticDataSource,
+  internalStaticCssEvalExternalResolutionPrefix as externalStaticCssEvalResolutionPrefix,
   processDefineRulesPresetRegistryFile,
   runDefineRulesPresetRegistryStep
 } from "@mincho-js/integration";
@@ -39,6 +41,10 @@ interface StaticCssEvalSourceResolution {
   sourceHash?: string;
   version?: string | number;
   sourceIdentity?: StaticCssEvalSourceIdentity;
+  sourceKind?: StaticCssEvalSourceKind;
+  sourceOrigin?: StaticCssEvalSourceOrigin;
+  unsupportedReason?: StaticCssEvalSourceUnsupportedReason;
+  watchFiles?: readonly string[];
   resolverKind?: StaticCssEvalResolverKind;
 }
 
@@ -52,6 +58,10 @@ interface StaticCssEvalLoadedSource {
   sourceHash?: string;
   version?: string | number;
   sourceIdentity?: StaticCssEvalSourceIdentity;
+  sourceKind?: StaticCssEvalSourceKind;
+  sourceOrigin?: StaticCssEvalSourceOrigin;
+  unsupportedReason?: StaticCssEvalSourceUnsupportedReason;
+  watchFiles?: readonly string[];
   resolverKind?: StaticCssEvalResolverKind;
 }
 
@@ -67,6 +77,29 @@ type StaticCssEvalResolverKind =
   | "esbuild"
   | "test"
   | (string & {});
+
+type StaticCssEvalSourceKind =
+  | "project-source"
+  | "package-source"
+  | "provider-virtual"
+  | "static-data"
+  | "external-no-source"
+  | "unresolved"
+  | "unsupported-source-shape";
+
+type StaticCssEvalSourceOrigin =
+  | "project"
+  | "package"
+  | "provider"
+  | "data"
+  | "external"
+  | "unresolved"
+  | "unsupported";
+
+type StaticCssEvalSourceUnsupportedReason =
+  | "external-no-source"
+  | "unresolved"
+  | "unsupported-source-shape";
 
 interface StaticCssEvalSourceProvider {
   resolve(
@@ -111,12 +144,20 @@ interface StaticCssEvalMetadata {
 interface StaticCssEvalResolutionDependency {
   file: string;
   kind?: string;
+  sourceKind?: StaticCssEvalSourceKind;
+  sourceOrigin?: StaticCssEvalSourceOrigin;
+  unsupportedReason?: StaticCssEvalSourceUnsupportedReason;
+  watchFiles?: readonly string[];
 }
 
 interface StaticCssEvalResolvedDependency {
   resolvedFile: string;
   canonicalModuleId?: string;
   normalizedPathKey?: string;
+  sourceKind?: StaticCssEvalSourceKind;
+  sourceOrigin?: StaticCssEvalSourceOrigin;
+  unsupportedReason?: StaticCssEvalSourceUnsupportedReason;
+  watchFiles?: readonly string[];
 }
 
 interface StaticCssEvalDiagnostic {
@@ -130,6 +171,13 @@ interface StaticCssEvalCacheKey {
   importerFile?: string;
   resolvedFile?: string;
   resolvedId?: string;
+  canonicalModuleId?: string;
+  normalizedPathKey?: string;
+  sourceKind?: StaticCssEvalSourceKind;
+  sourceOrigin?: StaticCssEvalSourceOrigin;
+  unsupportedReason?: StaticCssEvalSourceUnsupportedReason;
+  watchFiles?: readonly string[];
+  parserVersion?: string | number;
 }
 
 type StaticCssEvalResolutionCache = Map<
@@ -141,6 +189,10 @@ type StaticCssEvalLoadedSourceCache = Map<
   string,
   StaticCssEvalLoadedSource | null
 >;
+
+const unsupportedStaticCssEvalResolutionPrefix =
+  "virtual:mincho-static-css-eval-unsupported:";
+const esbuildStaticCssEvalModuleIdPrefix = "esbuild:";
 
 function getScriptLoader(path: string): ScriptLoader {
   if (/\.tsx$/i.test(path)) return "tsx";
@@ -203,10 +255,6 @@ async function resolveEsbuildStaticCssEvalImport(options: {
   importPath: string;
   rootRealpath: Promise<string>;
 }): Promise<StaticCssEvalSourceResolution | null> {
-  if (!isProjectLocalImportPath(options.importPath)) {
-    return createUnsupportedStaticCssEvalResolution(options.importPath);
-  }
-
   const resolved = await resolveEsbuildImport(
     options.build,
     options.importerId,
@@ -217,55 +265,24 @@ async function resolveEsbuildStaticCssEvalImport(options: {
     return null;
   }
 
+  if (resolved.external) {
+    return createExternalStaticCssEvalResolution(resolved, options.importPath);
+  }
+
   if (
-    resolved.external ||
-    (resolved.namespace !== "" && resolved.namespace !== "file") ||
+    !isEsbuildStaticCssEvalFileNamespace(resolved.namespace) ||
     isVirtualStaticCssEvalId(resolved.path)
   ) {
-    return createUnsupportedStaticCssEvalResolution(options.importPath);
+    return createUnsupportedStaticCssEvalResolution(
+      options.importPath,
+      createEsbuildStaticCssEvalCanonicalModuleId(resolved)
+    );
   }
 
-  const canonicalModuleId = normalizeStaticCssEvalFileId(resolved.path);
-  const resolvedId = canonicalModuleId;
-  const resolvedRealpath = await getExistingRealpath(resolvedId);
-
-  if (!resolvedRealpath) {
-    return null;
-  }
-
-  const rootRealpath = await options.rootRealpath;
-
-  if (
-    hasNodeModulesSegment(resolvedRealpath) ||
-    !isPathInsideRoot(rootRealpath, resolvedRealpath)
-  ) {
-    return createUnsupportedStaticCssEvalResolution(options.importPath);
-  }
-
-  let stat: fs.Stats;
-
-  try {
-    stat = await fs.promises.stat(resolvedRealpath);
-  } catch (error) {
-    if (isMissingFileSystemEntryError(error)) {
-      return null;
-    }
-
-    throw error;
-  }
-  const sourceIdentity = createStaticCssEvalSourceIdentity(stat);
-
-  return {
-    id: resolvedRealpath,
-    resolvedFile: resolvedRealpath,
-    canonicalModuleId,
-    normalizedPathKey: resolvedRealpath,
-    realpath: resolvedRealpath,
-    sourceHash: sourceIdentity.sourceHash,
-    version: sourceIdentity.version,
-    sourceIdentity,
-    resolverKind: "esbuild"
-  };
+  return createEsbuildStaticCssEvalFileResolution(
+    resolved,
+    await options.rootRealpath
+  );
 }
 
 async function resolveEsbuildImport(
@@ -318,28 +335,42 @@ async function loadEsbuildStaticCssEvalSource(options: {
       normalizedPathKey: options.ownerId,
       ...(ownerRealpath ? { realpath: ownerRealpath } : {}),
       ...(sourceIdentity ? { sourceIdentity } : {}),
+      sourceKind: "project-source",
+      sourceOrigin: "project",
+      ...(ownerRealpath ? { watchFiles: [ownerRealpath] } : {}),
       resolverKind: "esbuild"
     };
   }
 
   if (isUnsupportedStaticCssEvalResolutionId(options.id)) {
-    return { sourceText: "export {};", source: "export {};" };
+    return {
+      sourceText: "export {};",
+      source: "export {};",
+      sourceKind: "unsupported-source-shape",
+      sourceOrigin: "unsupported",
+      unsupportedReason: "unsupported-source-shape",
+      resolverKind: "esbuild"
+    };
   }
 
-  if (isVirtualStaticCssEvalId(options.id) || hasNodeModulesSegment(fileId)) {
+  if (isExternalStaticCssEvalResolutionId(options.id)) {
     return null;
   }
 
-  const realpath = await getExistingRealpath(fileId);
+  const loadId = parseEsbuildStaticCssEvalLoadId(options.id);
+
+  if (!isEsbuildStaticCssEvalFileNamespace(loadId.namespace)) {
+    return null;
+  }
+
+  const loadFileId = normalizeStaticCssEvalFileId(loadId.path);
+  const realpath = await getExistingRealpath(loadFileId);
+
+  if (!realpath) {
+    return null;
+  }
+
   const rootRealpath = await options.rootRealpath;
-
-  if (
-    !realpath ||
-    hasNodeModulesSegment(realpath) ||
-    !isPathInsideRoot(rootRealpath, realpath)
-  ) {
-    return null;
-  }
 
   let source: string;
   let stat: fs.Stats;
@@ -356,39 +387,305 @@ async function loadEsbuildStaticCssEvalSource(options: {
 
     throw error;
   }
-  const sourceIdentity = createStaticCssEvalSourceIdentity(stat);
+  const metadata = createEsbuildStaticCssEvalFileMetadata({
+    realpath,
+    rootRealpath,
+    stat,
+    suffix: loadId.suffix
+  });
+  const staticDataSource = new URLSearchParams(loadId.suffix.slice(1)).has(
+    "url"
+  )
+    ? getEsbuildStaticCssEvalUrlSource(realpath, rootRealpath)
+    : source;
+  const sourceText = prepareStaticCssEvalStaticDataSource(
+    metadata.normalizedPathKey,
+    staticDataSource
+  );
 
   return {
-    sourceText: source,
-    source,
-    resolvedFile: realpath,
-    canonicalModuleId: fileId,
-    normalizedPathKey: realpath,
+    sourceText,
+    source: sourceText,
+    ...metadata
+  };
+}
+
+function getEsbuildStaticCssEvalUrlSource(
+  realpath: string,
+  rootRealpath: string
+): string {
+  const normalizedRealpath = normalizeStaticCssEvalFileId(realpath);
+  const normalizedRootRealpath = normalizeStaticCssEvalFileId(rootRealpath);
+
+  if (isPathInsideRoot(normalizedRootRealpath, normalizedRealpath)) {
+    return `/${normalizedRealpath
+      .slice(normalizedRootRealpath.length)
+      .replace(/^\/+/, "")}`;
+  }
+
+  return `/@fs/${normalizedRealpath.replace(/^\/+/, "")}`;
+}
+
+interface EsbuildStaticCssEvalFileMetadataOptions {
+  realpath: string;
+  rootRealpath: string;
+  stat: fs.Stats;
+  suffix: string;
+}
+
+interface EsbuildStaticCssEvalLoadId {
+  namespace: string;
+  path: string;
+  suffix: string;
+}
+
+async function createEsbuildStaticCssEvalFileResolution(
+  resolved: ResolveResult,
+  rootRealpath: string
+): Promise<StaticCssEvalSourceResolution | null> {
+  const fileId = normalizeStaticCssEvalFileId(resolved.path);
+  const realpath = await getExistingRealpath(fileId);
+
+  if (!realpath) {
+    return null;
+  }
+
+  const stat = await getExistingStat(realpath);
+
+  if (!stat) {
+    return null;
+  }
+
+  const metadata = createEsbuildStaticCssEvalFileMetadata({
+    realpath,
+    rootRealpath,
+    stat,
+    suffix: getEsbuildStaticCssEvalResolveSuffix(resolved)
+  });
+
+  return {
+    id: metadata.resolvedFile,
+    ...metadata
+  };
+}
+
+function createEsbuildStaticCssEvalFileMetadata({
+  realpath,
+  rootRealpath,
+  stat,
+  suffix
+}: EsbuildStaticCssEvalFileMetadataOptions): Required<
+  Pick<
+    StaticCssEvalSourceResolution,
+    | "canonicalModuleId"
+    | "normalizedPathKey"
+    | "realpath"
+    | "resolvedFile"
+    | "resolverKind"
+    | "sourceHash"
+    | "sourceIdentity"
+    | "sourceKind"
+    | "sourceOrigin"
+    | "version"
+    | "watchFiles"
+  >
+> {
+  const sourceIdentity = createStaticCssEvalSourceIdentity(stat);
+  const sourceKind = getEsbuildStaticCssEvalFileSourceKind({
+    moduleId: `${realpath}${suffix}`,
+    realpath,
+    rootRealpath
+  });
+  const querySuffix = sourceKind === "static-data" ? suffix : "";
+  const resolvedFile = `${realpath}${querySuffix}`;
+
+  return {
+    resolvedFile,
+    canonicalModuleId: resolvedFile,
+    normalizedPathKey: resolvedFile,
     realpath,
     sourceHash: sourceIdentity.sourceHash,
     version: sourceIdentity.version,
     sourceIdentity,
+    sourceKind,
+    sourceOrigin: getStaticCssEvalSourceOrigin(sourceKind),
+    watchFiles: [realpath],
     resolverKind: "esbuild"
   };
 }
 
+function getEsbuildStaticCssEvalFileSourceKind({
+  moduleId,
+  realpath,
+  rootRealpath
+}: {
+  moduleId: string;
+  realpath: string;
+  rootRealpath: string;
+}): StaticCssEvalSourceKind {
+  if (isStaticCssEvalStaticDataFile(moduleId, realpath)) {
+    return "static-data";
+  }
+
+  return hasNodeModulesSegment(realpath) ||
+    !isPathInsideRoot(rootRealpath, realpath)
+    ? "package-source"
+    : "project-source";
+}
+
+function getStaticCssEvalSourceOrigin(
+  sourceKind: StaticCssEvalSourceKind
+): StaticCssEvalSourceOrigin {
+  switch (sourceKind) {
+    case "project-source":
+      return "project";
+    case "package-source":
+      return "package";
+    case "provider-virtual":
+      return "provider";
+    case "static-data":
+      return "data";
+    case "external-no-source":
+      return "external";
+    case "unresolved":
+      return "unresolved";
+    case "unsupported-source-shape":
+      return "unsupported";
+    default:
+      return assertNeverStaticCssEvalSourceKind(sourceKind);
+  }
+}
+
+function assertNeverStaticCssEvalSourceKind(value: never): never {
+  throw new TypeError(`Unexpected static css eval source kind: ${value}`);
+}
+
+function createEsbuildStaticCssEvalCanonicalModuleId(
+  resolved: ResolveResult
+): string {
+  return createEsbuildStaticCssEvalModuleId({
+    namespace: normalizeEsbuildStaticCssEvalNamespace(resolved.namespace),
+    path: resolved.path,
+    suffix: getEsbuildStaticCssEvalResolveSuffix(resolved)
+  });
+}
+
+function createEsbuildStaticCssEvalModuleId({
+  namespace,
+  path,
+  suffix
+}: EsbuildStaticCssEvalLoadId): string {
+  return `${esbuildStaticCssEvalModuleIdPrefix}${namespace}:${path}${suffix}`;
+}
+
+function parseEsbuildStaticCssEvalLoadId(
+  id: string
+): EsbuildStaticCssEvalLoadId {
+  if (!id.startsWith(esbuildStaticCssEvalModuleIdPrefix)) {
+    return createEsbuildStaticCssEvalLoadId("file", id);
+  }
+
+  const payload = id.slice(esbuildStaticCssEvalModuleIdPrefix.length);
+  const namespaceEnd = payload.indexOf(":");
+
+  if (namespaceEnd === -1) {
+    return createEsbuildStaticCssEvalLoadId("file", payload);
+  }
+
+  return createEsbuildStaticCssEvalLoadId(
+    payload.slice(0, namespaceEnd),
+    payload.slice(namespaceEnd + 1)
+  );
+}
+
+function createEsbuildStaticCssEvalLoadId(
+  namespace: string,
+  pathWithSuffix: string
+): EsbuildStaticCssEvalLoadId {
+  return {
+    namespace,
+    path: stripStaticCssEvalQuery(pathWithSuffix),
+    suffix: getStaticCssEvalQuerySuffix(pathWithSuffix)
+  };
+}
+
+function getEsbuildStaticCssEvalResolveSuffix(resolved: ResolveResult): string {
+  return resolved.suffix || getStaticCssEvalQuerySuffix(resolved.path);
+}
+
+function normalizeEsbuildStaticCssEvalNamespace(namespace: string): string {
+  return namespace === "" ? "file" : namespace;
+}
+
+function isEsbuildStaticCssEvalFileNamespace(namespace: string): boolean {
+  return namespace === "" || namespace === "file";
+}
+
+function getStaticCssEvalQuerySuffix(sourceId: string): string {
+  const queryIndex = sourceId.indexOf("?");
+
+  if (queryIndex === -1) {
+    return "";
+  }
+
+  const hashIndex = sourceId.indexOf("#", queryIndex);
+
+  return sourceId.slice(queryIndex, hashIndex === -1 ? undefined : hashIndex);
+}
+
+function stripStaticCssEvalQuery(sourceId: string): string {
+  const queryIndex = sourceId.search(/[?#]/);
+  return queryIndex === -1 ? sourceId : sourceId.slice(0, queryIndex);
+}
+
 function createUnsupportedStaticCssEvalResolution(
+  importPath: string,
+  canonicalModuleId?: string
+): StaticCssEvalSourceResolution {
+  const id = `${unsupportedStaticCssEvalResolutionPrefix}${encodeURIComponent(
+    importPath
+  )}`;
+
+  return {
+    id,
+    resolvedFile: id,
+    canonicalModuleId: canonicalModuleId ?? id,
+    normalizedPathKey: id,
+    sourceKind: "unsupported-source-shape",
+    sourceOrigin: "unsupported",
+    unsupportedReason: "unsupported-source-shape",
+    resolverKind: "esbuild"
+  };
+}
+
+function createExternalStaticCssEvalResolution(
+  resolved: ResolveResult,
   importPath: string
 ): StaticCssEvalSourceResolution {
-  return createSharedUnsupportedStaticCssEvalResolution(importPath);
+  const externalId = `${externalStaticCssEvalResolutionPrefix}${encodeURIComponent(
+    resolved.path || importPath
+  )}`;
+
+  return {
+    id: externalId,
+    resolvedFile: externalId,
+    canonicalModuleId: createEsbuildStaticCssEvalCanonicalModuleId(resolved),
+    normalizedPathKey: externalId,
+    sourceKind: "external-no-source",
+    sourceOrigin: "external",
+    unsupportedReason: "external-no-source",
+    resolverKind: "esbuild"
+  };
 }
 
 function isUnsupportedStaticCssEvalResolutionId(id: string): boolean {
-  return sharedIsUnsupportedStaticCssEvalResolutionId(id);
+  return id.startsWith(unsupportedStaticCssEvalResolutionPrefix);
 }
 
-function isMissingFileSystemEntryError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    "code" in error &&
-    (error.code === "ENOENT" || error.code === "ENOTDIR")
-  );
+function isExternalStaticCssEvalResolutionId(id: string): boolean {
+  return id.startsWith(externalStaticCssEvalResolutionPrefix);
 }
+
 function getWatchableStaticCssEvalDependencyFiles(
   rootRealpath: string,
   staticCssEval: StaticCssEvalMetadata | undefined,
@@ -406,12 +703,7 @@ function getWatchableStaticCssEvalDependencyFiles(
   )) {
     const fileId = normalizeStaticCssEvalFileId(dependencyFile, rootRealpath);
 
-    if (
-      fileId === ownerFileId ||
-      isVirtualStaticCssEvalId(fileId) ||
-      hasNodeModulesSegment(fileId) ||
-      !isPathInsideRoot(rootRealpath, fileId)
-    ) {
+    if (fileId === ownerFileId || !fs.existsSync(fileId)) {
       continue;
     }
 
@@ -1163,21 +1455,6 @@ if (import.meta.vitest) {
     `;
   }
 
-  function createImportedCssPropStaticRuleEntrySource(
-    importPath = "./styles",
-    importedName = "button"
-  ): string {
-    return `
-      import { ${importedName} } from "${importPath}";
-
-      function App() {
-        return <div css={{ color: ${importedName} }} />;
-      }
-
-      export { App };
-    `;
-  }
-
   function createImportedStyleSource(color: string): string {
     return `export const button = { color: "${color}" } as const;`;
   }
@@ -1272,6 +1549,83 @@ if (import.meta.vitest) {
       srcRoot,
       stylesPath,
       styleSource
+    };
+  }
+
+  function createMappedEsbuildResolve(
+    resolutions: Record<string, ResolveResult>
+  ): PluginBuild["resolve"] {
+    return async (source, options) => {
+      const importer = options?.importer ?? "";
+      const mappedResolution =
+        resolutions[`${importer}\0${source}`] ??
+        resolutions[source] ??
+        resolutions[stripStaticCssEvalQuery(source)];
+
+      if (mappedResolution) {
+        return mappedResolution;
+      }
+
+      const resolvedPath = resolveStaticCssEvalImportFromFileSystem(
+        importer,
+        source
+      );
+
+      return resolvedPath
+        ? createStaticCssEvalResolveResult(resolvedPath)
+        : createStaticCssEvalResolveResult("");
+    };
+  }
+
+  function createSuffixedEsbuildResolveResult(
+    path: string,
+    suffix: string
+  ): ResolveResult {
+    return {
+      ...createStaticCssEvalResolveResult(path),
+      suffix
+    };
+  }
+
+  async function loadCssPropSidecarSourceFromHarness(
+    harness: ReturnType<typeof createBuildHarness>,
+    entryPath: string
+  ): Promise<{ scriptSource: string; sidecarSource: string }> {
+    const compileSpy = vi
+      .spyOn(integrationHelpers, "compile")
+      .mockResolvedValue({ source: "compiled static css" } as Awaited<
+        ReturnType<typeof compile>
+      >);
+    vi.spyOn(
+      integrationHelpers,
+      "processDefineRulesPresetRegistryFile"
+    ).mockResolvedValue(createRegistryResult("registered static css"));
+
+    const scriptLoadResult = (await harness.loadScript({
+      path: entryPath
+    })) as ScriptLoadResult;
+    const { file: sidecarFile } = extractCssPropSidecarImport(
+      scriptLoadResult.contents
+    );
+    const resolveResult = (await harness.resolveExtractedCss({
+      path: sidecarFile,
+      importer: entryPath,
+      pluginData: scriptLoadResult.pluginData
+    })) as ResolvedExtractedCssResult;
+    await harness.loadExtractedCss({
+      path: resolveResult.path,
+      pluginData: resolveResult.pluginData
+    });
+
+    const compileOptions = compileSpy.mock.calls[0]?.[0];
+
+    if (compileOptions == null) {
+      throw new Error("Expected extracted css sidecar to be compiled");
+    }
+
+    return {
+      scriptSource: scriptLoadResult.contents,
+      sidecarSource: compileOptions.contents
     };
   }
 
@@ -1739,20 +2093,27 @@ if (import.meta.vitest) {
       }
     });
 
-    it("static css eval shared helpers ignore virtual node_modules and outside-root dependencies for esbuild", async () => {
+    it("static css eval shared helpers watch real package and outside-root dependencies for esbuild", async () => {
       const fixture = await createImportedCssPropEsbuildFixture(
         "static-css-eval-shared-helper-boundary-"
       );
 
       try {
-        const rootRealpath = normalizeStaticCssEvalFileId(
-          await fs.promises.realpath(fixture.root)
-        );
         const stylesRealpath = normalizeStaticCssEvalFileId(
           await fs.promises.realpath(fixture.stylesPath)
         );
         const outsideRootFile = normalizeStaticCssEvalFileId(
           join(process.cwd(), "package.json")
+        );
+        const packagePath = join(fixture.root, "node_modules/pkg/styles.ts");
+        await fs.promises.mkdir(dirname(packagePath), { recursive: true });
+        await fs.promises.writeFile(
+          packagePath,
+          createImportedStyleSource("blue"),
+          "utf8"
+        );
+        const packageRealpath = normalizeStaticCssEvalFileId(
+          await fs.promises.realpath(packagePath)
         );
 
         vi.spyOn(integrationHelpers, "babelTransform").mockResolvedValue({
@@ -1762,7 +2123,7 @@ if (import.meta.vitest) {
             dependencyFiles: [
               stylesRealpath,
               "virtual:mincho-static-css-eval-test",
-              `${rootRealpath}/node_modules/pkg/styles.ts`,
+              packageRealpath,
               outsideRootFile
             ]
           }
@@ -1776,7 +2137,9 @@ if (import.meta.vitest) {
           path: fixture.entryPath
         })) as ScriptLoadResult;
 
-        expect(scriptLoadResult.watchFiles).toEqual([stylesRealpath]);
+        expect(new Set(scriptLoadResult.watchFiles)).toEqual(
+          new Set([stylesRealpath, packageRealpath, outsideRootFile])
+        );
       } finally {
         await fs.promises.rm(fixture.root, { force: true, recursive: true });
       }
@@ -2076,6 +2439,7 @@ if (import.meta.vitest) {
         const stylesRealpath = normalizeStaticCssEvalFileId(
           await fs.promises.realpath(fixture.stylesPath)
         );
+        const canonicalModuleId = stylesRealpath;
         const resolution = captured.resolution;
         const loadedSource = captured.loadedSource;
 
@@ -2086,10 +2450,10 @@ if (import.meta.vitest) {
         }
 
         expect(resolution).toMatchObject({
-          id: stylesRealpath,
-          resolvedFile: stylesRealpath,
-          canonicalModuleId: stylesRealpath,
-          normalizedPathKey: stylesRealpath,
+          id: canonicalModuleId,
+          resolvedFile: canonicalModuleId,
+          canonicalModuleId,
+          normalizedPathKey: canonicalModuleId,
           realpath: stylesRealpath,
           sourceIdentity: {
             sourceHash: expect.stringMatching(/^mtime:/)
@@ -2098,9 +2462,9 @@ if (import.meta.vitest) {
         });
         expect(loadedSource).toMatchObject({
           sourceText: fixture.styleSource,
-          resolvedFile: stylesRealpath,
-          canonicalModuleId: stylesRealpath,
-          normalizedPathKey: stylesRealpath,
+          resolvedFile: canonicalModuleId,
+          canonicalModuleId,
+          normalizedPathKey: canonicalModuleId,
           realpath: stylesRealpath,
           sourceIdentity: {
             sourceHash: expect.stringMatching(/^mtime:/)
@@ -2148,14 +2512,21 @@ if (import.meta.vitest) {
       const fixture = await createImportedCssPropEsbuildFixture(
         "static-css-eval-watch-files-"
       );
-      const rootRealpath = normalizeStaticCssEvalFileId(
-        await fs.promises.realpath(fixture.root)
-      );
       const stylesRealpath = normalizeStaticCssEvalFileId(
         await fs.promises.realpath(fixture.stylesPath)
       );
       const outsideRootFile = normalizeStaticCssEvalFileId(
         join(process.cwd(), "package.json")
+      );
+      const packagePath = join(fixture.root, "node_modules/pkg/styles.ts");
+      await fs.promises.mkdir(dirname(packagePath), { recursive: true });
+      await fs.promises.writeFile(
+        packagePath,
+        createImportedStyleSource("blue"),
+        "utf8"
+      );
+      const packageRealpath = normalizeStaticCssEvalFileId(
+        await fs.promises.realpath(packagePath)
       );
       let resolveCalls = 0;
       const loadedStyleSources: string[] = [];
@@ -2203,8 +2574,15 @@ if (import.meta.vitest) {
               dependencyFiles: [
                 stylesRealpath,
                 "virtual:mincho-static-css-eval-test",
-                `${rootRealpath}/node_modules/pkg/styles.ts`,
                 outsideRootFile
+              ],
+              resolvedDependencies: [
+                {
+                  resolvedFile: "virtual:mincho-static-css-eval-provider",
+                  canonicalModuleId: "virtual:mincho-static-css-eval-provider",
+                  normalizedPathKey: "virtual:mincho-static-css-eval-provider",
+                  watchFiles: [packageRealpath]
+                }
               ]
             }
           } as BabelTransformResult;
@@ -2236,7 +2614,9 @@ if (import.meta.vitest) {
           path: fixture.entryPath
         })) as ScriptLoadResult;
 
-        expect(firstLoadResult.watchFiles).toEqual([stylesRealpath]);
+        expect(new Set(firstLoadResult.watchFiles)).toEqual(
+          new Set([stylesRealpath, packageRealpath, outsideRootFile])
+        );
         expect(resolveCalls).toBe(1);
         expect(loadedStyleSources).toEqual([fixture.styleSource]);
 
@@ -2252,7 +2632,9 @@ if (import.meta.vitest) {
           path: fixture.entryPath
         })) as ScriptLoadResult;
 
-        expect(secondLoadResult.watchFiles).toEqual([stylesRealpath]);
+        expect(new Set(secondLoadResult.watchFiles)).toEqual(
+          new Set([stylesRealpath, packageRealpath, outsideRootFile])
+        );
         expect(resolveCalls).toBe(2);
         expect(loadedStyleSources).toEqual([
           fixture.styleSource,
@@ -2647,132 +3029,493 @@ if (import.meta.vitest) {
       }
     }, 20000);
 
-    it("refuses virtual, package, and node_modules static css evaluation at esbuild boundaries", async () => {
-      const fallbackFixture = await createJsxCssPropFixture(
-        "jsx-css-prop-esbuild-boundary-fallback-",
-        `
-          import { button as virtualButton } from "virtual:styles";
-          import { button as packageButton } from "pkg/styles";
-          import { button as nodeModuleButton } from "./node_modules/pkg/styles";
+    it("supports static css eval package named default and namespace imports from esbuild file namespace packages", async () => {
+      const fixture = await createImportedCssPropEsbuildFixture(
+        "static-css-eval-package-file-namespace-",
+        {
+          entrySource: `
+            import defaultButton, { button } from "@pkg/styles";
+            import * as styles from "@pkg/styles";
 
-          function App() {
-            return <>
-              <div css={virtualButton} />
-              <div css={packageButton} />
-              <div css={nodeModuleButton} />
-            </>;
-          }
-        `
+            function App() {
+              return <>
+                <div css={button} />
+                <div css={defaultButton} />
+                <div css={styles.card} />
+              </>;
+            }
+
+            export { App };
+          `
+        }
       );
-      const staticRuleFixture = await createJsxCssPropFixture(
-        "jsx-css-prop-esbuild-boundary-static-rule-",
-        createImportedCssPropStaticRuleEntrySource(
-          "./node_modules/pkg/styles",
-          "button"
+      const packageRoot = join(fixture.root, "node_modules/@pkg/styles");
+      const packageIndexPath = join(packageRoot, "index.ts");
+      await spyOnSourceBabelTransform();
+
+      try {
+        await fs.promises.mkdir(packageRoot, { recursive: true });
+        await fs.promises.writeFile(
+          packageIndexPath,
+          `
+            export const button = { color: "red" } as const;
+            export const card = { color: "green" } as const;
+            export default { color: "orange" } as const;
+          `,
+          "utf8"
+        );
+
+        const harness = createBuildHarness({
+          absWorkingDir: fixture.root,
+          plugin: minchoEsbuildPlugin({ jsxCssProp: true }),
+          resolve: createMappedEsbuildResolve({
+            "@pkg/styles": createStaticCssEvalResolveResult(packageIndexPath)
+          })
+        });
+        const { scriptSource, sidecarSource } =
+          await loadCssPropSidecarSourceFromHarness(harness, fixture.entryPath);
+
+        expect(scriptSource).not.toContain("css={button}");
+        expect(sidecarSource).toContain('color: "red"');
+        expect(sidecarSource).toContain('color: "orange"');
+        expect(sidecarSource).toContain('color: "green"');
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("supports static css eval package export-star barrels resolved by esbuild", async () => {
+      const fixture = await createImportedCssPropEsbuildFixture(
+        "static-css-eval-package-export-star-",
+        {
+          entrySource: createImportedCssPropEntrySource("@pkg/styles")
+        }
+      );
+      const packageRoot = join(fixture.root, "node_modules/@pkg/styles");
+      const packageIndexPath = join(packageRoot, "index.ts");
+      const packageButtonPath = join(packageRoot, "button.ts");
+      await spyOnSourceBabelTransform();
+
+      try {
+        await fs.promises.mkdir(packageRoot, { recursive: true });
+        await fs.promises.writeFile(
+          packageIndexPath,
+          'export * from "./button";',
+          "utf8"
+        );
+        await fs.promises.writeFile(
+          packageButtonPath,
+          createImportedStyleSource("blue"),
+          "utf8"
+        );
+
+        const harness = createBuildHarness({
+          absWorkingDir: fixture.root,
+          plugin: minchoEsbuildPlugin({ jsxCssProp: true }),
+          resolve: createMappedEsbuildResolve({
+            "@pkg/styles": createStaticCssEvalResolveResult(packageIndexPath)
+          })
+        });
+        const { sidecarSource } = await loadCssPropSidecarSourceFromHarness(
+          harness,
+          fixture.entryPath
+        );
+
+        expect(sidecarSource).toContain('color: "blue"');
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("supports static css eval json default and named imports from esbuild packages", async () => {
+      const fixture = await createImportedCssPropEsbuildFixture(
+        "static-css-eval-json-package-",
+        {
+          entrySource: `
+            import jsonStyles, { button } from "@pkg/styles/styles.json";
+
+            function App() {
+              return <>
+                <div css={button} />
+                <div css={jsonStyles.card} />
+              </>;
+            }
+          `
+        }
+      );
+      const packageRoot = join(fixture.root, "node_modules/@pkg/styles");
+      const packageJsonPath = join(packageRoot, "styles.json");
+      await spyOnSourceBabelTransform();
+
+      try {
+        await fs.promises.mkdir(packageRoot, { recursive: true });
+        await fs.promises.writeFile(
+          packageJsonPath,
+          JSON.stringify({
+            button: { color: "red" },
+            card: { color: "green" }
+          }),
+          "utf8"
+        );
+
+        const harness = createBuildHarness({
+          absWorkingDir: fixture.root,
+          plugin: minchoEsbuildPlugin({ jsxCssProp: true }),
+          resolve: createMappedEsbuildResolve({
+            "@pkg/styles/styles.json":
+              createStaticCssEvalResolveResult(packageJsonPath)
+          })
+        });
+        const { sidecarSource } = await loadCssPropSidecarSourceFromHarness(
+          harness,
+          fixture.entryPath
+        );
+
+        expect(sidecarSource).toContain('color: "red"');
+        expect(sidecarSource).toContain('color: "green"');
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("supports static css eval raw string imports from esbuild package suffixes", async () => {
+      const fixture = await createImportedCssPropEsbuildFixture(
+        "static-css-eval-raw-package-",
+        {
+          entrySource: `
+            import rawColor from "@pkg/styles/color.txt?raw";
+
+            function App() {
+              return <div css={{ color: rawColor }} />;
+            }
+          `
+        }
+      );
+      const packageRoot = join(fixture.root, "node_modules/@pkg/styles");
+      const rawColorPath = join(packageRoot, "color.txt");
+      const captured: {
+        loadedSource?: StaticCssEvalLoadedSource | null;
+        resolution?: StaticCssEvalSourceResolution | null;
+      } = {};
+
+      try {
+        await fs.promises.mkdir(packageRoot, { recursive: true });
+        await fs.promises.writeFile(rawColorPath, "red", "utf8");
+        vi.spyOn(integrationHelpers, "babelTransform").mockImplementation(
+          async (
+            _path: string,
+            options: MinchoBabelOptionsWithStaticCssEval = {}
+          ) => {
+            const sourceProvider = options.staticCssEvalSourceProvider;
+
+            if (!sourceProvider) {
+              throw new Error(
+                "Expected esbuild static css eval source provider"
+              );
+            }
+
+            captured.resolution = await sourceProvider.resolve(
+              fixture.entryPath,
+              "@pkg/styles/color.txt?raw"
+            );
+
+            if (!captured.resolution?.normalizedPathKey) {
+              throw new Error("Expected raw data source resolution");
+            }
+
+            captured.loadedSource = await sourceProvider.load(
+              captured.resolution.normalizedPathKey
+            );
+
+            return {
+              code: fixture.entrySource,
+              result: ["", ""]
+            } as BabelTransformResult;
+          }
+        );
+
+        const harness = createBuildHarness({
+          absWorkingDir: fixture.root,
+          plugin: minchoEsbuildPlugin({ jsxCssProp: true }),
+          resolve: createMappedEsbuildResolve({
+            "@pkg/styles/color.txt?raw": createSuffixedEsbuildResolveResult(
+              rawColorPath,
+              "?raw"
+            )
+          })
+        });
+        await harness.loadScript({ path: fixture.entryPath });
+        const rawRealpath = normalizeStaticCssEvalFileId(
+          await fs.promises.realpath(rawColorPath)
+        );
+
+        expect(captured.resolution).toMatchObject({
+          resolvedFile: `${rawRealpath}?raw`,
+          canonicalModuleId: `${rawRealpath}?raw`,
+          normalizedPathKey: `${rawRealpath}?raw`,
+          realpath: rawRealpath,
+          sourceKind: "static-data",
+          sourceOrigin: "data",
+          watchFiles: [rawRealpath],
+          resolverKind: "esbuild"
+        });
+        expect(captured.loadedSource).toMatchObject({
+          sourceText: "red",
+          resolvedFile: `${rawRealpath}?raw`,
+          sourceKind: "static-data",
+          sourceOrigin: "data",
+          watchFiles: [rawRealpath],
+          resolverKind: "esbuild"
+        });
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("supports static css eval wasm url string imports from esbuild package suffixes", async () => {
+      const fixture = await createImportedCssPropEsbuildFixture(
+        "static-css-eval-wasm-url-package-",
+        {
+          entrySource: `
+            import wasmUrl from "@pkg/styles/icon.wasm?url";
+
+            function App() {
+              return <div css={{ backgroundImage: wasmUrl }} />;
+            }
+          `
+        }
+      );
+      const packageRoot = join(fixture.root, "node_modules/@pkg/styles");
+      const wasmPath = join(packageRoot, "icon.wasm");
+      const captured: {
+        loadedSource?: StaticCssEvalLoadedSource | null;
+        resolution?: StaticCssEvalSourceResolution | null;
+      } = {};
+
+      try {
+        await fs.promises.mkdir(packageRoot, { recursive: true });
+        await fs.promises.writeFile(wasmPath, "wasm-init", "utf8");
+        vi.spyOn(integrationHelpers, "babelTransform").mockImplementation(
+          async (
+            _path: string,
+            options: MinchoBabelOptionsWithStaticCssEval = {}
+          ) => {
+            const sourceProvider = options.staticCssEvalSourceProvider;
+
+            if (!sourceProvider) {
+              throw new Error(
+                "Expected esbuild static css eval source provider"
+              );
+            }
+
+            captured.resolution = await sourceProvider.resolve(
+              fixture.entryPath,
+              "@pkg/styles/icon.wasm?url"
+            );
+
+            if (!captured.resolution?.normalizedPathKey) {
+              throw new Error("Expected wasm url data source resolution");
+            }
+
+            captured.loadedSource = await sourceProvider.load(
+              captured.resolution.normalizedPathKey
+            );
+
+            return {
+              code: fixture.entrySource,
+              result: ["", ""]
+            } as BabelTransformResult;
+          }
+        );
+
+        const harness = createBuildHarness({
+          absWorkingDir: fixture.root,
+          plugin: minchoEsbuildPlugin({ jsxCssProp: true }),
+          resolve: createMappedEsbuildResolve({
+            "@pkg/styles/icon.wasm?url": createSuffixedEsbuildResolveResult(
+              wasmPath,
+              "?url"
+            )
+          })
+        });
+        await harness.loadScript({ path: fixture.entryPath });
+        const wasmRealpath = normalizeStaticCssEvalFileId(
+          await fs.promises.realpath(wasmPath)
+        );
+
+        expect(captured.resolution).toMatchObject({
+          resolvedFile: `${wasmRealpath}?url`,
+          canonicalModuleId: `${wasmRealpath}?url`,
+          normalizedPathKey: `${wasmRealpath}?url`,
+          realpath: wasmRealpath,
+          sourceKind: "static-data",
+          sourceOrigin: "data",
+          watchFiles: [wasmRealpath],
+          resolverKind: "esbuild"
+        });
+        expect(captured.loadedSource).toMatchObject({
+          sourceText: "/node_modules/@pkg/styles/icon.wasm",
+          resolvedFile: `${wasmRealpath}?url`,
+          sourceKind: "static-data",
+          sourceOrigin: "data",
+          watchFiles: [wasmRealpath],
+          resolverKind: "esbuild"
+        });
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("uses Vite-compatible /@fs URLs for static data outside root", () => {
+      expect(
+        getEsbuildStaticCssEvalUrlSource(
+          "/workspace/shared/icon.wasm",
+          "/workspace/app"
         )
+      ).toBe("/@fs/workspace/shared/icon.wasm");
+    });
+
+    it("rejects static css eval external no-source imports without filesystem fallback", async () => {
+      const fixture = await createImportedCssPropEsbuildFixture(
+        "static-css-eval-external-no-source-",
+        {
+          entrySource: createImportedCssPropEntrySource("@pkg/external")
+        }
       );
       await spyOnSourceBabelTransform();
 
       try {
-        await Promise.all([
-          fs.promises.mkdir(
-            join(fallbackFixture.root, "src/node_modules/pkg"),
-            { recursive: true }
-          ),
-          fs.promises.mkdir(
-            join(staticRuleFixture.root, "src/node_modules/pkg"),
-            { recursive: true }
-          )
-        ]);
-        await Promise.all([
-          fs.promises.writeFile(
-            join(fallbackFixture.root, "src/node_modules/pkg/styles.ts"),
-            createImportedStyleSource("red"),
-            "utf8"
-          ),
-          fs.promises.writeFile(
-            join(staticRuleFixture.root, "src/node_modules/pkg/styles.ts"),
-            createImportedStyleSource("red"),
-            "utf8"
-          )
-        ]);
+        const harness = createBuildHarness({
+          absWorkingDir: fixture.root,
+          plugin: minchoEsbuildPlugin({ jsxCssProp: true }),
+          resolve: createMappedEsbuildResolve({
+            "@pkg/external": {
+              ...createStaticCssEvalResolveResult("@pkg/external"),
+              external: true
+            }
+          })
+        });
 
+        await expect(
+          harness.loadScript({ path: fixture.entryPath })
+        ).rejects.toThrow("Cannot statically evaluate css prop value");
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("rejects static css eval unsupported non-file namespace virtual imports", async () => {
+      const fixture = await createImportedCssPropEsbuildFixture(
+        "static-css-eval-unsupported-non-file-namespace-",
+        {
+          entrySource: createImportedCssPropEntrySource("virtual:styles")
+        }
+      );
+      await spyOnSourceBabelTransform();
+
+      try {
+        const harness = createBuildHarness({
+          absWorkingDir: fixture.root,
+          plugin: minchoEsbuildPlugin({ jsxCssProp: true }),
+          resolve: createMappedEsbuildResolve({
+            "virtual:styles": {
+              ...createStaticCssEvalResolveResult("virtual:styles"),
+              namespace: "virtual"
+            }
+          })
+        });
+
+        await expect(
+          harness.loadScript({ path: fixture.entryPath })
+        ).rejects.toThrow("Cannot statically evaluate css prop value");
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("rejects static css eval wasm runtime and direct imports from esbuild packages", async () => {
+      const wasmCases = [
+        {
+          importPath: "@pkg/styles/icon.wasm?init",
+          localName: "initWasm",
+          prefix: "static-css-eval-wasm-runtime-package-",
+          suffix: "?init"
+        },
+        {
+          importPath: "@pkg/styles/icon.wasm",
+          localName: "directWasm",
+          prefix: "static-css-eval-wasm-direct-package-",
+          suffix: ""
+        }
+      ] as const;
+
+      for (const wasmCase of wasmCases) {
+        const fixture = await createImportedCssPropEsbuildFixture(
+          wasmCase.prefix,
+          {
+            entrySource: `
+              import ${wasmCase.localName} from "${wasmCase.importPath}";
+
+              function App() {
+                return <div css={{ color: ${wasmCase.localName} }} />;
+              }
+            `
+          }
+        );
+        const packageRoot = join(fixture.root, "node_modules/@pkg/styles");
+        const wasmPath = join(packageRoot, "icon.wasm");
+        await spyOnSourceBabelTransform();
+
+        try {
+          await fs.promises.mkdir(packageRoot, { recursive: true });
+          await fs.promises.writeFile(wasmPath, "wasm-runtime", "utf8");
+
+          const harness = createBuildHarness({
+            absWorkingDir: fixture.root,
+            plugin: minchoEsbuildPlugin({ jsxCssProp: true }),
+            resolve: createMappedEsbuildResolve({
+              [wasmCase.importPath]: createSuffixedEsbuildResolveResult(
+                wasmPath,
+                wasmCase.suffix
+              )
+            })
+          });
+
+          await expect(
+            harness.loadScript({ path: fixture.entryPath })
+          ).rejects.toThrow("Cannot statically evaluate css prop value");
+        } finally {
+          await fs.promises.rm(fixture.root, { force: true, recursive: true });
+        }
+      }
+    });
+
+    it("rejects virtual static css evaluation at esbuild boundaries", async () => {
+      const fallbackFixture = await createJsxCssPropFixture(
+        "jsx-css-prop-esbuild-boundary-fallback-",
+        `
+          import { button as virtualButton } from "virtual:styles";
+
+          function App() {
+            return <div css={virtualButton} />;
+          }
+        `
+      );
+      await spyOnSourceBabelTransform();
+
+      try {
         const fallbackHarness = createBuildHarness({
           absWorkingDir: fallbackFixture.root,
           plugin: minchoEsbuildPlugin({ jsxCssProp: true })
         });
         await expect(
           fallbackHarness.loadScript({ path: fallbackFixture.entryPath })
-        ).rejects.toThrow('package import "virtual:styles" is unsupported');
-
-        const staticRuleHarness = createBuildHarness({
-          absWorkingDir: staticRuleFixture.root,
-          plugin: minchoEsbuildPlugin({ jsxCssProp: true })
-        });
-
-        await expect(
-          staticRuleHarness.loadScript({ path: staticRuleFixture.entryPath })
-        ).rejects.toThrow("Cannot statically evaluate css prop value");
+        ).rejects.toThrow('import "virtual:styles" could not be resolved');
       } finally {
-        await Promise.all([
-          fs.promises.rm(fallbackFixture.root, {
-            force: true,
-            recursive: true
-          }),
-          fs.promises.rm(staticRuleFixture.root, {
-            force: true,
-            recursive: true
-          })
-        ]);
-      }
-    });
-
-    it("returns null when a resolved static css dependency disappears before stat", async () => {
-      const fixture = await createImportedCssPropEsbuildFixture(
-        "jsx-css-prop-esbuild-disappeared-before-stat-"
-      );
-      const originalStat = fs.promises.stat.bind(fs.promises);
-      const targetRealpath = normalizeStaticCssEvalFileId(
-        await fs.promises.realpath(fixture.stylesPath)
-      );
-      const statSpy = vi
-        .spyOn(fs.promises, "stat")
-        .mockImplementation(
-          async (...args: Parameters<typeof fs.promises.stat>) => {
-            const [path] = args;
-
-            if (String(path).replace(/\\/g, "/") === targetRealpath) {
-              const missingError = new Error(
-                `ENOENT: ${targetRealpath}`
-              ) as Error & {
-                code?: string;
-              };
-              missingError.code = "ENOENT";
-              throw missingError;
-            }
-
-            return originalStat(...args);
-          }
-        );
-
-      try {
-        const resolution = await resolveEsbuildStaticCssEvalImport({
-          build: {
-            resolve: vi
-              .fn()
-              .mockResolvedValue(
-                createStaticCssEvalResolveResult(fixture.stylesPath)
-              )
-          } as PluginBuild,
-          importerId: fixture.entryPath,
-          importPath: "./styles",
-          rootRealpath: getRealpathOrResolvedPath(fixture.root)
+        await fs.promises.rm(fallbackFixture.root, {
+          force: true,
+          recursive: true
         });
-
-        expect(resolution).toBeNull();
-      } finally {
-        statSpy.mockRestore();
-        await fs.promises.rm(fixture.root, { force: true, recursive: true });
       }
     });
 

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -10,15 +10,18 @@ import {
   type BabelOptions,
   babelTransform,
   compile,
-  createStaticCssEvalSourceHash as createSharedStaticCssEvalSourceHash,
   createUnsupportedStaticCssEvalResolution as createSharedUnsupportedStaticCssEvalResolution,
-  getExistingRealpath as getSharedExistingRealpath,
-  getRealpathOrResolvedPath as getSharedRealpathOrResolvedPath,
-  hasNodeModulesSegment as sharedHasNodeModulesSegment,
-  isPathInsideRoot as sharedIsPathInsideRoot,
-  isProjectLocalImportPath as sharedIsProjectLocalImportPath,
   isUnsupportedStaticCssEvalResolutionId as sharedIsUnsupportedStaticCssEvalResolutionId,
-  isVirtualStaticCssEvalId as sharedIsVirtualStaticCssEvalId,
+  internalCollectStaticCssEvalDependencyIds as collectStaticCssEvalDependencyIds,
+  internalCreateStaticCssEvalSourceIdentity as createStaticCssEvalSourceIdentity,
+  internalGetExistingStaticCssEvalRealpath as getExistingRealpath,
+  internalGetExistingStaticCssEvalStat as getExistingStat,
+  internalGetStaticCssEvalRealpathOrResolvedPath as getRealpathOrResolvedPath,
+  internalHasStaticCssEvalNodeModulesSegment as hasNodeModulesSegment,
+  internalIsProjectLocalStaticCssEvalImportPath as isProjectLocalImportPath,
+  internalIsStaticCssEvalPathInsideRoot as isPathInsideRoot,
+  internalIsVirtualStaticCssEvalId as isVirtualStaticCssEvalId,
+  internalNormalizeStaticCssEvalFileId as normalizeStaticCssEvalFileId,
   processDefineRulesPresetRegistryFile,
   runDefineRulesPresetRegistryStep
 } from "@mincho-js/integration";
@@ -379,98 +382,6 @@ function isUnsupportedStaticCssEvalResolutionId(id: string): boolean {
   return sharedIsUnsupportedStaticCssEvalResolutionId(id);
 }
 
-function normalizeStaticCssEvalFileId(id: string, rootPath = ""): string {
-  const filePath = normalizeStaticCssEvalPathSyntax(id);
-  const normalizedRoot = rootPath
-    ? normalizeStaticCssEvalPathSyntax(rootPath)
-    : "";
-
-  if (
-    normalizedRoot &&
-    filePath.startsWith("/") &&
-    !isPathInsideRoot(normalizedRoot, filePath) &&
-    !fs.existsSync(filePath)
-  ) {
-    return `${trimTrailingSlash(normalizedRoot)}/${filePath.replace(/^\/+/, "")}`;
-  }
-
-  return filePath;
-}
-
-function normalizeStaticCssEvalPathSyntax(id: string): string {
-  const normalizedId = stripStaticCssEvalRequestQuery(
-    stripStaticCssEvalSsrPrefix(id)
-  ).replace(/\\/g, "/");
-
-  if (normalizedId.startsWith("/@fs/")) {
-    return normalizedId.slice("/@fs".length);
-  }
-
-  return normalizedId;
-}
-
-function stripStaticCssEvalSsrPrefix(id: string): string {
-  let normalizedId = id;
-
-  while (normalizedId.startsWith("ssr:")) {
-    normalizedId = normalizedId.slice("ssr:".length);
-  }
-
-  return normalizedId;
-}
-
-function stripStaticCssEvalRequestQuery(id: string): string {
-  const queryIndex = id.search(/[?#]/);
-  return queryIndex === -1 ? id : id.slice(0, queryIndex);
-}
-
-function isProjectLocalImportPath(importPath: string): boolean {
-  return sharedIsProjectLocalImportPath(importPath);
-}
-
-function isVirtualStaticCssEvalId(id: string): boolean {
-  return sharedIsVirtualStaticCssEvalId(id);
-}
-
-function hasNodeModulesSegment(filePath: string): boolean {
-  return sharedHasNodeModulesSegment(filePath, normalizeStaticCssEvalFileId);
-}
-
-function isPathInsideRoot(rootPath: string, filePath: string): boolean {
-  return sharedIsPathInsideRoot(
-    rootPath,
-    filePath,
-    normalizeStaticCssEvalFileId
-  );
-}
-
-function trimTrailingSlash(filePath: string): string {
-  return filePath.length > 1 ? filePath.replace(/\/+$/g, "") : filePath;
-}
-
-async function getRealpathOrResolvedPath(filePath: string): Promise<string> {
-  return getSharedRealpathOrResolvedPath(filePath, {
-    normalizeFilePath: normalizeStaticCssEvalFileId,
-    resolvePath
-  });
-}
-
-async function getExistingRealpath(filePath: string): Promise<string | null> {
-  return getSharedExistingRealpath(filePath, normalizeStaticCssEvalFileId);
-}
-
-async function getExistingStat(filePath: string): Promise<fs.Stats | null> {
-  try {
-    return await fs.promises.stat(filePath);
-  } catch {
-    return null;
-  }
-}
-
-function createStaticCssEvalSourceHash(stat: fs.Stats): string {
-  return createSharedStaticCssEvalSourceHash(stat);
-}
-
 function isMissingFileSystemEntryError(error: unknown): boolean {
   return (
     error instanceof Error &&
@@ -478,16 +389,6 @@ function isMissingFileSystemEntryError(error: unknown): boolean {
     (error.code === "ENOENT" || error.code === "ENOTDIR")
   );
 }
-
-function createStaticCssEvalSourceIdentity(
-  stat: fs.Stats
-): StaticCssEvalSourceIdentity {
-  return {
-    sourceHash: createStaticCssEvalSourceHash(stat),
-    version: stat.mtimeMs
-  };
-}
-
 function getWatchableStaticCssEvalDependencyFiles(
   rootRealpath: string,
   staticCssEval: StaticCssEvalMetadata | undefined,
@@ -518,39 +419,6 @@ function getWatchableStaticCssEvalDependencyFiles(
   }
 
   return [...watchFiles];
-}
-
-function collectStaticCssEvalDependencyIds(
-  staticCssEval: StaticCssEvalMetadata | undefined
-): string[] {
-  if (!staticCssEval) {
-    return [];
-  }
-
-  return dedupeStrings([
-    ...(staticCssEval.dependencyFiles ?? []),
-    ...(staticCssEval.dependencies ?? [])
-      .filter((dependency) => dependency.kind !== "local")
-      .map((dependency) => dependency.file),
-    ...(staticCssEval.resolvedDependencies ?? []).flatMap((dependency) => [
-      dependency.resolvedFile,
-      dependency.canonicalModuleId,
-      dependency.normalizedPathKey
-    ]),
-    ...(staticCssEval.cacheKeys ?? []).flatMap((cacheKey) => [
-      cacheKey.resolvedFile,
-      cacheKey.resolvedId
-    ]),
-    ...(staticCssEval.resolvedModuleIds ?? [])
-  ]);
-}
-
-function dedupeStrings(values: readonly (string | undefined)[]): string[] {
-  return [...new Set(values.filter(isStringValue))];
-}
-
-function isStringValue(value: string | undefined): value is string {
-  return typeof value === "string" && value !== "";
 }
 
 function resolveStaticCssEvalImportFromFileSystem(
@@ -1766,6 +1634,85 @@ if (import.meta.vitest) {
   });
 
   describe("minchoEsbuildPlugin", () => {
+    it("static css eval shared helpers normalize file ids and preserve source identity for esbuild", async () => {
+      const fixture = await createImportedCssPropEsbuildFixture(
+        "static-css-eval-shared-helper-identity-"
+      );
+
+      try {
+        const rootRealpath = normalizeStaticCssEvalFileId(
+          await fs.promises.realpath(fixture.root)
+        );
+        const stylesRealpath = normalizeStaticCssEvalFileId(
+          await fs.promises.realpath(fixture.stylesPath)
+        );
+        const stat = await fs.promises.stat(stylesRealpath);
+        const sourceIdentity = createStaticCssEvalSourceIdentity(stat);
+
+        expect(
+          normalizeStaticCssEvalFileId(
+            `/@fs${stylesRealpath}?import#hash`,
+            rootRealpath
+          )
+        ).toBe(stylesRealpath);
+        expect(
+          normalizeStaticCssEvalFileId(
+            `ssr:/@fs${stylesRealpath}?used#hash`,
+            rootRealpath
+          )
+        ).toBe(stylesRealpath);
+        expect(sourceIdentity).toEqual({
+          sourceHash: `mtime:${stat.mtimeMs}:size:${stat.size}`,
+          version: stat.mtimeMs
+        });
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("static css eval shared helpers ignore virtual node_modules and outside-root dependencies for esbuild", async () => {
+      const fixture = await createImportedCssPropEsbuildFixture(
+        "static-css-eval-shared-helper-boundary-"
+      );
+
+      try {
+        const rootRealpath = normalizeStaticCssEvalFileId(
+          await fs.promises.realpath(fixture.root)
+        );
+        const stylesRealpath = normalizeStaticCssEvalFileId(
+          await fs.promises.realpath(fixture.stylesPath)
+        );
+        const outsideRootFile = normalizeStaticCssEvalFileId(
+          join(process.cwd(), "package.json")
+        );
+
+        vi.spyOn(integrationHelpers, "babelTransform").mockResolvedValue({
+          code: fixture.entrySource,
+          result: ["", ""],
+          staticCssEval: {
+            dependencyFiles: [
+              stylesRealpath,
+              "virtual:mincho-static-css-eval-test",
+              `${rootRealpath}/node_modules/pkg/styles.ts`,
+              outsideRootFile
+            ]
+          }
+        } as BabelTransformResult);
+
+        const harness = createBuildHarness({
+          absWorkingDir: fixture.root,
+          plugin: minchoEsbuildPlugin({ jsxCssProp: true })
+        });
+        const scriptLoadResult = (await harness.loadScript({
+          path: fixture.entryPath
+        })) as ScriptLoadResult;
+
+        expect(scriptLoadResult.watchFiles).toEqual([stylesRealpath]);
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
     it("loads a TSX fixture with jsxCssProp enabled and registers extracted css sidecar content", async () => {
       const { entryPath, root } = await createJsxCssPropFixture(
         "jsx-css-prop-enabled-"
@@ -2123,6 +2070,125 @@ if (import.meta.vitest) {
         })) as ScriptLoadResult;
 
         expect(scriptLoadResult.watchFiles).toEqual([stylesRealpath]);
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("static css eval watch files include dependencies and caches clear on end", async () => {
+      const fixture = await createImportedCssPropEsbuildFixture(
+        "static-css-eval-watch-files-"
+      );
+      const rootRealpath = normalizeStaticCssEvalFileId(
+        await fs.promises.realpath(fixture.root)
+      );
+      const stylesRealpath = normalizeStaticCssEvalFileId(
+        await fs.promises.realpath(fixture.stylesPath)
+      );
+      const outsideRootFile = normalizeStaticCssEvalFileId(
+        join(process.cwd(), "package.json")
+      );
+      let resolveCalls = 0;
+      const loadedStyleSources: string[] = [];
+
+      vi.spyOn(integrationHelpers, "babelTransform").mockImplementation(
+        async (
+          _path: Parameters<typeof babelTransform>[0],
+          options: MinchoBabelOptionsWithStaticCssEval = {}
+        ) => {
+          const sourceProvider = options.staticCssEvalSourceProvider;
+
+          if (!sourceProvider) {
+            throw new Error("Expected esbuild static css eval source provider");
+          }
+
+          const firstResolution = await sourceProvider.resolve(
+            fixture.entryPath,
+            "./styles"
+          );
+          const secondResolution = await sourceProvider.resolve(
+            fixture.entryPath,
+            "./styles"
+          );
+
+          expect(secondResolution).toBe(firstResolution);
+
+          if (!firstResolution?.normalizedPathKey) {
+            throw new Error("Expected esbuild static css eval resolution");
+          }
+
+          const firstLoadedSource = await sourceProvider.load(
+            firstResolution.normalizedPathKey
+          );
+          const secondLoadedSource = await sourceProvider.load(
+            firstResolution.normalizedPathKey
+          );
+
+          expect(secondLoadedSource).toBe(firstLoadedSource);
+          loadedStyleSources.push(firstLoadedSource?.sourceText ?? "");
+
+          return {
+            code: fixture.entrySource,
+            result: ["", ""],
+            staticCssEval: {
+              dependencyFiles: [
+                stylesRealpath,
+                "virtual:mincho-static-css-eval-test",
+                `${rootRealpath}/node_modules/pkg/styles.ts`,
+                outsideRootFile
+              ]
+            }
+          } as BabelTransformResult;
+        }
+      );
+
+      try {
+        const harness = createBuildHarness({
+          absWorkingDir: fixture.root,
+          plugin: minchoEsbuildPlugin({ jsxCssProp: true }),
+          async resolve(
+            source: string,
+            options?: Parameters<PluginBuild["resolve"]>[1]
+          ) {
+            if (source !== "./styles") {
+              return createStaticCssEvalResolveResult("");
+            }
+
+            resolveCalls += 1;
+            return createStaticCssEvalResolveResult(
+              resolveStaticCssEvalImportFromFileSystem(
+                options?.importer ?? fixture.entryPath,
+                source
+              ) ?? ""
+            );
+          }
+        });
+        const firstLoadResult = (await harness.loadScript({
+          path: fixture.entryPath
+        })) as ScriptLoadResult;
+
+        expect(firstLoadResult.watchFiles).toEqual([stylesRealpath]);
+        expect(resolveCalls).toBe(1);
+        expect(loadedStyleSources).toEqual([fixture.styleSource]);
+
+        await fs.promises.writeFile(
+          fixture.stylesPath,
+          createImportedStyleSource("blue"),
+          "utf8"
+        );
+
+        harness.endBuild();
+
+        const secondLoadResult = (await harness.loadScript({
+          path: fixture.entryPath
+        })) as ScriptLoadResult;
+
+        expect(secondLoadResult.watchFiles).toEqual([stylesRealpath]);
+        expect(resolveCalls).toBe(2);
+        expect(loadedStyleSources).toEqual([
+          fixture.styleSource,
+          createImportedStyleSource("blue")
+        ]);
       } finally {
         await fs.promises.rm(fixture.root, { force: true, recursive: true });
       }

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -28,18 +28,42 @@ type ScriptLoader = "js" | "jsx" | "ts" | "tsx";
 type MaybePromise<T> = T | Promise<T>;
 
 interface StaticCssEvalSourceResolution {
-  id: string;
+  id?: string;
+  resolvedFile?: string;
+  canonicalModuleId?: string;
+  normalizedPathKey?: string;
   realpath?: string;
+  sourceHash?: string;
+  version?: string | number;
+  sourceIdentity?: StaticCssEvalSourceIdentity;
+  resolverKind?: StaticCssEvalResolverKind;
+}
+
+interface StaticCssEvalLoadedSource {
+  source?: string;
+  sourceText?: string;
+  resolvedFile?: string;
+  canonicalModuleId?: string;
+  normalizedPathKey?: string;
+  realpath?: string;
+  sourceHash?: string;
+  version?: string | number;
+  sourceIdentity?: StaticCssEvalSourceIdentity;
+  resolverKind?: StaticCssEvalResolverKind;
+}
+
+interface StaticCssEvalSourceIdentity {
   sourceHash?: string;
   version?: string | number;
 }
 
-interface StaticCssEvalLoadedSource {
-  source: string;
-  realpath?: string;
-  sourceHash?: string;
-  version?: string | number;
-}
+type StaticCssEvalResolverKind =
+  | "source-provider"
+  | "filesystem"
+  | "vite"
+  | "esbuild"
+  | "test"
+  | (string & {});
 
 interface StaticCssEvalSourceProvider {
   resolve(
@@ -58,15 +82,52 @@ const integrationHelpers = {
 
 type MinchoBabelOptions = BabelOptions & { jsxCssProp?: boolean };
 
-type MinchoBabelOptionsWithStaticCssEval = MinchoBabelOptions & {
+type MinchoBabelOptionsWithStaticCssEval = Omit<
+  MinchoBabelOptions,
+  "staticCssEvalSourceProvider"
+> & {
   staticCssEvalSourceProvider?: StaticCssEvalSourceProvider;
 };
 
-type BabelTransformResult = Awaited<ReturnType<typeof babelTransform>> & {
-  staticCssEval?: {
-    dependencyFiles: string[];
-  };
+type BabelTransformResult = Omit<
+  Awaited<ReturnType<typeof babelTransform>>,
+  "staticCssEval"
+> & {
+  staticCssEval?: StaticCssEvalMetadata;
 };
+
+interface StaticCssEvalMetadata {
+  dependencyFiles?: readonly string[];
+  dependencies?: readonly StaticCssEvalResolutionDependency[];
+  resolvedDependencies?: readonly StaticCssEvalResolvedDependency[];
+  diagnostics?: readonly StaticCssEvalDiagnostic[];
+  cacheKeys?: readonly StaticCssEvalCacheKey[];
+  resolvedModuleIds?: readonly string[];
+}
+
+interface StaticCssEvalResolutionDependency {
+  file: string;
+  kind?: string;
+}
+
+interface StaticCssEvalResolvedDependency {
+  resolvedFile: string;
+  canonicalModuleId?: string;
+  normalizedPathKey?: string;
+}
+
+interface StaticCssEvalDiagnostic {
+  id?: string;
+  dependency?: {
+    file: string;
+  };
+}
+
+interface StaticCssEvalCacheKey {
+  importerFile?: string;
+  resolvedFile?: string;
+  resolvedId?: string;
+}
 
 type StaticCssEvalResolutionCache = Map<
   string,
@@ -161,7 +222,8 @@ async function resolveEsbuildStaticCssEvalImport(options: {
     return createUnsupportedStaticCssEvalResolution(options.importPath);
   }
 
-  const resolvedId = normalizeStaticCssEvalFileId(resolved.path);
+  const canonicalModuleId = normalizeStaticCssEvalFileId(resolved.path);
+  const resolvedId = canonicalModuleId;
   const resolvedRealpath = await getExistingRealpath(resolvedId);
 
   if (!resolvedRealpath) {
@@ -188,12 +250,18 @@ async function resolveEsbuildStaticCssEvalImport(options: {
 
     throw error;
   }
+  const sourceIdentity = createStaticCssEvalSourceIdentity(stat);
 
   return {
     id: resolvedRealpath,
+    resolvedFile: resolvedRealpath,
+    canonicalModuleId,
+    normalizedPathKey: resolvedRealpath,
     realpath: resolvedRealpath,
-    sourceHash: createStaticCssEvalSourceHash(stat),
-    version: stat.mtimeMs
+    sourceHash: sourceIdentity.sourceHash,
+    version: sourceIdentity.version,
+    sourceIdentity,
+    resolverKind: "esbuild"
   };
 }
 
@@ -234,15 +302,25 @@ async function loadEsbuildStaticCssEvalSource(options: {
 
   if (fileId === options.ownerId) {
     const ownerRealpath = await getExistingRealpath(fileId);
+    const stat = ownerRealpath ? await getExistingStat(ownerRealpath) : null;
+    const sourceIdentity = stat
+      ? createStaticCssEvalSourceIdentity(stat)
+      : undefined;
 
     return {
+      sourceText: options.ownerSource,
       source: options.ownerSource,
-      ...(ownerRealpath ? { realpath: ownerRealpath } : {})
+      resolvedFile: ownerRealpath ?? options.ownerId,
+      canonicalModuleId: options.ownerId,
+      normalizedPathKey: options.ownerId,
+      ...(ownerRealpath ? { realpath: ownerRealpath } : {}),
+      ...(sourceIdentity ? { sourceIdentity } : {}),
+      resolverKind: "esbuild"
     };
   }
 
   if (isUnsupportedStaticCssEvalResolutionId(options.id)) {
-    return { source: "export {};" };
+    return { sourceText: "export {};", source: "export {};" };
   }
 
   if (isVirtualStaticCssEvalId(options.id) || hasNodeModulesSegment(fileId)) {
@@ -275,12 +353,19 @@ async function loadEsbuildStaticCssEvalSource(options: {
 
     throw error;
   }
+  const sourceIdentity = createStaticCssEvalSourceIdentity(stat);
 
   return {
+    sourceText: source,
     source,
+    resolvedFile: realpath,
+    canonicalModuleId: fileId,
+    normalizedPathKey: realpath,
     realpath,
-    sourceHash: createStaticCssEvalSourceHash(stat),
-    version: stat.mtimeMs
+    sourceHash: sourceIdentity.sourceHash,
+    version: sourceIdentity.version,
+    sourceIdentity,
+    resolverKind: "esbuild"
   };
 }
 
@@ -294,8 +379,44 @@ function isUnsupportedStaticCssEvalResolutionId(id: string): boolean {
   return sharedIsUnsupportedStaticCssEvalResolutionId(id);
 }
 
-function normalizeStaticCssEvalFileId(id: string): string {
-  return stripStaticCssEvalRequestQuery(id).replace(/\\/g, "/");
+function normalizeStaticCssEvalFileId(id: string, rootPath = ""): string {
+  const filePath = normalizeStaticCssEvalPathSyntax(id);
+  const normalizedRoot = rootPath
+    ? normalizeStaticCssEvalPathSyntax(rootPath)
+    : "";
+
+  if (
+    normalizedRoot &&
+    filePath.startsWith("/") &&
+    !isPathInsideRoot(normalizedRoot, filePath) &&
+    !fs.existsSync(filePath)
+  ) {
+    return `${trimTrailingSlash(normalizedRoot)}/${filePath.replace(/^\/+/, "")}`;
+  }
+
+  return filePath;
+}
+
+function normalizeStaticCssEvalPathSyntax(id: string): string {
+  const normalizedId = stripStaticCssEvalRequestQuery(
+    stripStaticCssEvalSsrPrefix(id)
+  ).replace(/\\/g, "/");
+
+  if (normalizedId.startsWith("/@fs/")) {
+    return normalizedId.slice("/@fs".length);
+  }
+
+  return normalizedId;
+}
+
+function stripStaticCssEvalSsrPrefix(id: string): string {
+  let normalizedId = id;
+
+  while (normalizedId.startsWith("ssr:")) {
+    normalizedId = normalizedId.slice("ssr:".length);
+  }
+
+  return normalizedId;
 }
 
 function stripStaticCssEvalRequestQuery(id: string): string {
@@ -323,6 +444,10 @@ function isPathInsideRoot(rootPath: string, filePath: string): boolean {
   );
 }
 
+function trimTrailingSlash(filePath: string): string {
+  return filePath.length > 1 ? filePath.replace(/\/+$/g, "") : filePath;
+}
+
 async function getRealpathOrResolvedPath(filePath: string): Promise<string> {
   return getSharedRealpathOrResolvedPath(filePath, {
     normalizeFilePath: normalizeStaticCssEvalFileId,
@@ -332,6 +457,14 @@ async function getRealpathOrResolvedPath(filePath: string): Promise<string> {
 
 async function getExistingRealpath(filePath: string): Promise<string | null> {
   return getSharedExistingRealpath(filePath, normalizeStaticCssEvalFileId);
+}
+
+async function getExistingStat(filePath: string): Promise<fs.Stats | null> {
+  try {
+    return await fs.promises.stat(filePath);
+  } catch {
+    return null;
+  }
 }
 
 function createStaticCssEvalSourceHash(stat: fs.Stats): string {
@@ -346,16 +479,34 @@ function isMissingFileSystemEntryError(error: unknown): boolean {
   );
 }
 
+function createStaticCssEvalSourceIdentity(
+  stat: fs.Stats
+): StaticCssEvalSourceIdentity {
+  return {
+    sourceHash: createStaticCssEvalSourceHash(stat),
+    version: stat.mtimeMs
+  };
+}
+
 function getWatchableStaticCssEvalDependencyFiles(
   rootRealpath: string,
-  dependencyFiles: readonly string[] | undefined
+  staticCssEval: StaticCssEvalMetadata | undefined,
+  ownerId?: string
 ): string[] {
+  // esbuild watch files come from shared static css eval metadata.
+  // Normalize ids for watchFiles, but do not re-derive symbol provenance here.
   const watchFiles = new Set<string>();
+  const ownerFileId = ownerId
+    ? normalizeStaticCssEvalFileId(ownerId, rootRealpath)
+    : "";
 
-  for (const dependencyFile of dependencyFiles ?? []) {
-    const fileId = normalizeStaticCssEvalFileId(dependencyFile);
+  for (const dependencyFile of collectStaticCssEvalDependencyIds(
+    staticCssEval
+  )) {
+    const fileId = normalizeStaticCssEvalFileId(dependencyFile, rootRealpath);
 
     if (
+      fileId === ownerFileId ||
       isVirtualStaticCssEvalId(fileId) ||
       hasNodeModulesSegment(fileId) ||
       !isPathInsideRoot(rootRealpath, fileId)
@@ -367,6 +518,39 @@ function getWatchableStaticCssEvalDependencyFiles(
   }
 
   return [...watchFiles];
+}
+
+function collectStaticCssEvalDependencyIds(
+  staticCssEval: StaticCssEvalMetadata | undefined
+): string[] {
+  if (!staticCssEval) {
+    return [];
+  }
+
+  return dedupeStrings([
+    ...(staticCssEval.dependencyFiles ?? []),
+    ...(staticCssEval.dependencies ?? [])
+      .filter((dependency) => dependency.kind !== "local")
+      .map((dependency) => dependency.file),
+    ...(staticCssEval.resolvedDependencies ?? []).flatMap((dependency) => [
+      dependency.resolvedFile,
+      dependency.canonicalModuleId,
+      dependency.normalizedPathKey
+    ]),
+    ...(staticCssEval.cacheKeys ?? []).flatMap((cacheKey) => [
+      cacheKey.resolvedFile,
+      cacheKey.resolvedId
+    ]),
+    ...(staticCssEval.resolvedModuleIds ?? [])
+  ]);
+}
+
+function dedupeStrings(values: readonly (string | undefined)[]): string[] {
+  return [...new Set(values.filter(isStringValue))];
+}
+
+function isStringValue(value: string | undefined): value is string {
+  return typeof value === "string" && value !== "";
 }
 
 function resolveStaticCssEvalImportFromFileSystem(
@@ -534,7 +718,7 @@ export function minchoEsbuildPlugin({
         // gets handled by vanilla-extract/esbuild-plugin
         if (args.path.endsWith(".css.ts")) return;
 
-        const babelOptions: MinchoBabelOptions | undefined =
+        const babelOptions: MinchoBabelOptionsWithStaticCssEval | undefined =
           jsxCssProp === undefined ? undefined : { jsxCssProp };
         const transformBabelOptions:
           | MinchoBabelOptionsWithStaticCssEval
@@ -576,7 +760,8 @@ export function minchoEsbuildPlugin({
           },
           watchFiles: getWatchableStaticCssEvalDependencyFiles(
             await rootRealpath,
-            staticCssEval?.dependencyFiles
+            staticCssEval,
+            args.path
           )
         };
       });
@@ -705,6 +890,7 @@ if (import.meta.vitest) {
     pluginData: {
       mainFilePath: string;
     };
+    watchFiles: string[];
   };
 
   type ResolvedExtractedCssResult = {
@@ -1097,6 +1283,30 @@ if (import.meta.vitest) {
 
   function createImportedStyleSource(color: string): string {
     return `export const button = { color: "${color}" } as const;`;
+  }
+
+  function createDuplicatedStaticCssEvalMetadataVariants(
+    filePath: string,
+    kind = "imported"
+  ): StaticCssEvalMetadata {
+    return {
+      dependencyFiles: [`/@fs${filePath}?import#dep`],
+      dependencies: [{ file: `ssr:/@fs${filePath}?dep#hash`, kind }],
+      resolvedDependencies: [
+        {
+          resolvedFile: `/@fs${filePath}?resolved#hash`,
+          canonicalModuleId: `ssr:/@fs${filePath}?canonical#hash`,
+          normalizedPathKey: `/@fs${filePath}?normalized#hash`
+        }
+      ],
+      cacheKeys: [
+        {
+          resolvedFile: `/@fs${filePath}?cache#hash`,
+          resolvedId: `ssr:/@fs${filePath}?cache-id#hash`
+        }
+      ],
+      resolvedModuleIds: [`ssr:/@fs${filePath}?module#hash`]
+    };
   }
 
   async function createImportedCssPropEsbuildFixture(
@@ -1738,6 +1948,16 @@ if (import.meta.vitest) {
         "jsx-css-prop-imported-rebuild-"
       );
       await spyOnSourceBabelTransform();
+      const harness = createBuildHarness({
+        absWorkingDir: fixture.root,
+        plugin: minchoEsbuildPlugin({ jsxCssProp: true })
+      });
+      const scriptLoadResult = (await harness.loadScript({
+        path: fixture.entryPath
+      })) as ScriptLoadResult;
+      const stylesRealpath = normalizeStaticCssEvalFileId(
+        await fs.promises.realpath(fixture.stylesPath)
+      );
       const context = await realEsbuild.context({
         absWorkingDir: fixture.root,
         bundle: true,
@@ -1751,6 +1971,8 @@ if (import.meta.vitest) {
       });
 
       try {
+        expect(scriptLoadResult.watchFiles).toContain(stylesRealpath);
+
         const redOutput = collectEsbuildOutputTexts(await context.rebuild());
 
         expectCssPropBuildOutputToContainColor(redOutput, "red");
@@ -1771,6 +1993,297 @@ if (import.meta.vitest) {
         await fs.promises.rm(fixture.root, { force: true, recursive: true });
       }
     }, 20000);
+
+    it("supplies esbuild canonical resolver fields to the static css eval source provider", async () => {
+      const fixture = await createImportedCssPropEsbuildFixture(
+        "jsx-css-prop-provider-canonical-"
+      );
+      const captured: {
+        loadedSource?: StaticCssEvalLoadedSource | null;
+        resolution?: StaticCssEvalSourceResolution | null;
+      } = {};
+
+      try {
+        vi.spyOn(integrationHelpers, "babelTransform").mockImplementation(
+          async (
+            _path: string,
+            options: MinchoBabelOptionsWithStaticCssEval = {}
+          ) => {
+            const sourceProvider = options.staticCssEvalSourceProvider;
+
+            if (!sourceProvider) {
+              throw new Error(
+                "Expected esbuild static css eval source provider"
+              );
+            }
+
+            captured.resolution = await sourceProvider.resolve(
+              fixture.entryPath,
+              "./styles"
+            );
+
+            if (!captured.resolution?.normalizedPathKey) {
+              throw new Error("Expected canonical esbuild source resolution");
+            }
+
+            captured.loadedSource = await sourceProvider.load(
+              captured.resolution.normalizedPathKey
+            );
+
+            return {
+              code: fixture.entrySource,
+              result: ["", ""],
+              staticCssEval: {
+                dependencyFiles: [
+                  captured.resolution.resolvedFile ?? captured.resolution.id
+                ]
+              }
+            } as BabelTransformResult;
+          }
+        );
+
+        const emptyResolveResult = createStaticCssEvalResolveResult("");
+        const harness = createBuildHarness({
+          absWorkingDir: fixture.root,
+          plugin: minchoEsbuildPlugin({ jsxCssProp: true }),
+          async resolve(source) {
+            return source === "./styles"
+              ? createStaticCssEvalResolveResult(
+                  `/@fs${fixture.stylesPath}?import#hmr`
+                )
+              : emptyResolveResult;
+          }
+        });
+        const scriptLoadResult = (await harness.loadScript({
+          path: fixture.entryPath
+        })) as ScriptLoadResult;
+        const stylesRealpath = normalizeStaticCssEvalFileId(
+          await fs.promises.realpath(fixture.stylesPath)
+        );
+        const resolution = captured.resolution;
+        const loadedSource = captured.loadedSource;
+
+        if (!resolution || !loadedSource) {
+          throw new Error(
+            "Expected captured esbuild static css provider metadata"
+          );
+        }
+
+        expect(resolution).toMatchObject({
+          id: stylesRealpath,
+          resolvedFile: stylesRealpath,
+          canonicalModuleId: stylesRealpath,
+          normalizedPathKey: stylesRealpath,
+          realpath: stylesRealpath,
+          sourceIdentity: {
+            sourceHash: expect.stringMatching(/^mtime:/)
+          },
+          resolverKind: "esbuild"
+        });
+        expect(loadedSource).toMatchObject({
+          sourceText: fixture.styleSource,
+          resolvedFile: stylesRealpath,
+          canonicalModuleId: stylesRealpath,
+          normalizedPathKey: stylesRealpath,
+          realpath: stylesRealpath,
+          sourceIdentity: {
+            sourceHash: expect.stringMatching(/^mtime:/)
+          },
+          resolverKind: "esbuild"
+        });
+        expect(scriptLoadResult.watchFiles).toContain(stylesRealpath);
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("dedupes query, hash, /@fs, and SSR metadata variants to one watch key", async () => {
+      const fixture = await createImportedCssPropEsbuildFixture(
+        "jsx-css-prop-normalized-metadata-"
+      );
+
+      try {
+        const stylesRealpath = normalizeStaticCssEvalFileId(
+          await fs.promises.realpath(fixture.stylesPath)
+        );
+
+        vi.spyOn(integrationHelpers, "babelTransform").mockResolvedValue({
+          code: fixture.entrySource,
+          result: ["", ""],
+          staticCssEval:
+            createDuplicatedStaticCssEvalMetadataVariants(stylesRealpath)
+        } as BabelTransformResult);
+
+        const harness = createBuildHarness({
+          absWorkingDir: fixture.root,
+          plugin: minchoEsbuildPlugin({ jsxCssProp: true })
+        });
+        const scriptLoadResult = (await harness.loadScript({
+          path: fixture.entryPath
+        })) as ScriptLoadResult;
+
+        expect(scriptLoadResult.watchFiles).toEqual([stylesRealpath]);
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("registers direct re-export dependency metadata without re-deriving provenance", async () => {
+      const fixture = await createImportedCssPropEsbuildFixture(
+        "jsx-css-prop-imported-watch-reexport-",
+        {
+          entrySource: createImportedCssPropEntrySource("./barrel")
+        }
+      );
+      const barrelPath = join(fixture.srcRoot, "barrel.ts");
+      const buttonPath = join(fixture.srcRoot, "button.ts");
+
+      try {
+        await fs.promises.writeFile(
+          barrelPath,
+          'export { button } from "./button";',
+          "utf8"
+        );
+        await fs.promises.writeFile(
+          buttonPath,
+          'export const button = { color: "red" } as const;',
+          "utf8"
+        );
+
+        const barrelRealpath = normalizeStaticCssEvalFileId(
+          await fs.promises.realpath(barrelPath)
+        );
+        const buttonRealpath = normalizeStaticCssEvalFileId(
+          await fs.promises.realpath(buttonPath)
+        );
+
+        vi.spyOn(integrationHelpers, "babelTransform").mockResolvedValue({
+          code: fixture.entrySource,
+          result: ["", ""],
+          staticCssEval: {
+            dependencyFiles: [barrelRealpath],
+            dependencies: [
+              { file: barrelRealpath, kind: "reexported" },
+              { file: buttonRealpath, kind: "reexported" }
+            ],
+            resolvedDependencies: [
+              {
+                resolvedFile: barrelRealpath,
+                canonicalModuleId: `/@fs${barrelRealpath}?import`,
+                normalizedPathKey: barrelRealpath
+              },
+              {
+                resolvedFile: buttonRealpath,
+                canonicalModuleId: `ssr:/@fs${buttonRealpath}?import`,
+                normalizedPathKey: buttonRealpath
+              }
+            ],
+            cacheKeys: [
+              {
+                resolvedFile: buttonRealpath,
+                resolvedId: `/@fs${buttonRealpath}?import`
+              }
+            ],
+            resolvedModuleIds: [
+              `/@fs${barrelRealpath}?import`,
+              `ssr:/@fs${buttonRealpath}?import`
+            ]
+          }
+        } as BabelTransformResult);
+
+        const harness = createBuildHarness({
+          absWorkingDir: fixture.root,
+          plugin: minchoEsbuildPlugin({ jsxCssProp: true })
+        });
+        const scriptLoadResult = (await harness.loadScript({
+          path: fixture.entryPath
+        })) as ScriptLoadResult;
+
+        expect(new Set(scriptLoadResult.watchFiles)).toEqual(
+          new Set([barrelRealpath, buttonRealpath])
+        );
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("surfaces import-cycle static css eval diagnostics without hanging", async () => {
+      const fixture = await createImportedCssPropEsbuildFixture(
+        "jsx-css-prop-imported-cycle-",
+        {
+          entrySource: createImportedCssPropEntrySource("./barrel")
+        }
+      );
+      const barrelPath = join(fixture.srcRoot, "barrel.ts");
+      const buttonPath = join(fixture.srcRoot, "button.ts");
+
+      try {
+        await fs.promises.writeFile(
+          barrelPath,
+          'export { button } from "./button";',
+          "utf8"
+        );
+        await fs.promises.writeFile(
+          buttonPath,
+          'export { button } from "./barrel";',
+          "utf8"
+        );
+
+        const barrelRealpath = normalizeStaticCssEvalFileId(
+          await fs.promises.realpath(barrelPath)
+        );
+        const buttonRealpath = normalizeStaticCssEvalFileId(
+          await fs.promises.realpath(buttonPath)
+        );
+        const cycleStaticCssEval: StaticCssEvalMetadata = {
+          dependencyFiles: [barrelRealpath, buttonRealpath],
+          dependencies: [
+            { file: barrelRealpath, kind: "reexported" },
+            { file: buttonRealpath, kind: "reexported" }
+          ],
+          resolvedDependencies: [
+            { resolvedFile: barrelRealpath },
+            { resolvedFile: buttonRealpath }
+          ],
+          diagnostics: [
+            {
+              id: "STATIC_CSS_EVAL_IMPORT_CYCLE",
+              dependency: { file: buttonRealpath }
+            }
+          ],
+          resolvedModuleIds: [barrelRealpath, buttonRealpath]
+        };
+        const cycleError = new Error(
+          "STATIC_CSS_EVAL_IMPORT_CYCLE: cyclic static css reference detected"
+        ) as Error & { staticCssEval: StaticCssEvalMetadata };
+        cycleError.staticCssEval = cycleStaticCssEval;
+
+        vi.spyOn(integrationHelpers, "babelTransform").mockRejectedValue(
+          cycleError
+        );
+
+        const harness = createBuildHarness({
+          absWorkingDir: fixture.root,
+          plugin: minchoEsbuildPlugin({ jsxCssProp: true })
+        });
+        let thrownError: unknown;
+
+        try {
+          await harness.loadScript({ path: fixture.entryPath });
+        } catch (error) {
+          thrownError = error;
+        }
+
+        expect(thrownError).toBe(cycleError);
+        expect(
+          (
+            thrownError as { staticCssEval?: StaticCssEvalMetadata }
+          ).staticCssEval?.diagnostics?.map((diagnostic) => diagnostic.id)
+        ).toContain("STATIC_CSS_EVAL_IMPORT_CYCLE");
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
 
     it("scopes imported static css eval source caches to independent esbuild build contexts", async () => {
       const realEsbuild = await import("esbuild");
@@ -1880,25 +2393,9 @@ if (import.meta.vitest) {
           absWorkingDir: fallbackFixture.root,
           plugin: minchoEsbuildPlugin({ jsxCssProp: true })
         });
-        const fallbackResult = (await fallbackHarness.loadScript({
-          path: fallbackFixture.entryPath
-        })) as ScriptLoadResult;
-        const cxIdentifier = extractCxIdentifierFromSource(
-          fallbackResult.contents
-        );
-
-        expect(fallbackResult.contents).not.toContain("extracted_");
-        for (const localName of [
-          "virtualButton",
-          "packageButton",
-          "nodeModuleButton"
-        ]) {
-          expect(fallbackResult.contents).toMatch(
-            new RegExp(
-              `className=\\{${escapeRegExp(cxIdentifier)}\\(${localName}\\)\\}`
-            )
-          );
-        }
+        await expect(
+          fallbackHarness.loadScript({ path: fallbackFixture.entryPath })
+        ).rejects.toThrow('package import "virtual:styles" is unsupported');
 
         const staticRuleHarness = createBuildHarness({
           absWorkingDir: staticRuleFixture.root,
@@ -1996,7 +2493,7 @@ if (import.meta.vitest) {
 
         await fs.promises.rm(fixture.stylesPath, { force: true });
         await expect(context.rebuild()).rejects.toThrow(
-          "Cannot statically evaluate css prop value: failed to resolve project-local dependency ./styles"
+          'import "./styles" could not be resolved'
         );
       } finally {
         await context.dispose();

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -689,6 +689,8 @@ if (import.meta.vitest) {
   function getDefineRulesPresetSerializationManifestUrl(): string {
     return new URL(
       "../../integration/src/__fixtures__/defineRules-preset-serialization/manifest.ts",
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
       import.meta.url
     ).href;
   }
@@ -1573,6 +1575,8 @@ if (import.meta.vitest) {
   async function spyOnSourceBabelTransform() {
     const sourceIntegrationUrl = new URL(
       "../../integration/src/babel" + ".ts",
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
       import.meta.url
     ).href;
     const sourceIntegrationModule = (await import(

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -763,6 +763,20 @@ if (import.meta.vitest) {
     watchFiles: string[];
   };
 
+  function getScriptLoadWatchFiles(value: unknown): string[] {
+    if (
+      typeof value !== "object" ||
+      value === null ||
+      !("watchFiles" in value) ||
+      !Array.isArray(value.watchFiles) ||
+      !value.watchFiles.every((file) => typeof file === "string")
+    ) {
+      throw new Error("Expected script load result to include watch files");
+    }
+
+    return value.watchFiles;
+  }
+
   type ResolvedExtractedCssResult = {
     namespace: string;
     path: string;
@@ -1136,6 +1150,19 @@ if (import.meta.vitest) {
     `;
   }
 
+  function createNamespaceCssPropEntrySource(
+    importPath = "./barrel",
+    cssExpression = "styles.button.primary"
+  ): string {
+    return `
+      import * as styles from "${importPath}";
+
+      function App() {
+        return <div css={${cssExpression}} />;
+      }
+    `;
+  }
+
   function createImportedCssPropStaticRuleEntrySource(
     importPath = "./styles",
     importedName = "button"
@@ -1176,6 +1203,44 @@ if (import.meta.vitest) {
         }
       ],
       resolvedModuleIds: [`ssr:/@fs${filePath}?module#hash`]
+    };
+  }
+
+  function createExportStarStaticCssEvalMetadata({
+    barrelPath,
+    explicitDefaultPath,
+    terminalLeafPath
+  }: {
+    readonly barrelPath: string;
+    readonly explicitDefaultPath?: string;
+    readonly terminalLeafPath: string;
+  }): StaticCssEvalMetadata {
+    const dependencyPaths = [
+      barrelPath,
+      ...(explicitDefaultPath ? [explicitDefaultPath] : []),
+      terminalLeafPath
+    ];
+
+    return {
+      dependencyFiles: dependencyPaths.map(
+        (filePath) => `/@fs${filePath}?import#dep`
+      ),
+      dependencies: dependencyPaths.map((filePath) => ({
+        file: `ssr:/@fs${filePath}?dep#hash`,
+        kind: "reexported"
+      })),
+      resolvedDependencies: dependencyPaths.map((filePath) => ({
+        resolvedFile: `/@fs${filePath}?resolved#hash`,
+        canonicalModuleId: `ssr:/@fs${filePath}?canonical#hash`,
+        normalizedPathKey: `/@fs${filePath}?normalized#hash`
+      })),
+      cacheKeys: dependencyPaths.map((filePath) => ({
+        resolvedFile: `/@fs${filePath}?cache#hash`,
+        resolvedId: `ssr:/@fs${filePath}?cache-id#hash`
+      })),
+      resolvedModuleIds: dependencyPaths.map(
+        (filePath) => `ssr:/@fs${filePath}?module#hash`
+      )
     };
   }
 
@@ -2271,6 +2336,179 @@ if (import.meta.vitest) {
 
         expect(new Set(scriptLoadResult.watchFiles)).toEqual(
           new Set([barrelRealpath, buttonRealpath])
+        );
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("refreshes export-star namespace member watch files when leaf and barrel targets change", async () => {
+      const realEsbuild = await import("esbuild");
+      const fixture = await createImportedCssPropEsbuildFixture(
+        "jsx-css-prop-export-star-namespace-watch-",
+        {
+          entrySource: createNamespaceCssPropEntrySource()
+        }
+      );
+      const barrelPath = join(fixture.srcRoot, "barrel.ts");
+      const buttonPath = join(fixture.srcRoot, "button.ts");
+      const primaryButtonPath = join(fixture.srcRoot, "primaryButton.ts");
+
+      await spyOnSourceBabelTransform();
+      await fs.promises.writeFile(
+        barrelPath,
+        'export * from "./button";',
+        "utf8"
+      );
+      await fs.promises.writeFile(
+        buttonPath,
+        'export const button = { primary: { color: "red" } } as const;',
+        "utf8"
+      );
+      await fs.promises.writeFile(
+        primaryButtonPath,
+        'export const button = { primary: { color: "green" } } as const;',
+        "utf8"
+      );
+
+      const harness = createBuildHarness({
+        absWorkingDir: fixture.root,
+        plugin: minchoEsbuildPlugin({ jsxCssProp: true })
+      });
+      const context = await realEsbuild.context({
+        absWorkingDir: fixture.root,
+        bundle: true,
+        entryPoints: [fixture.entryPath],
+        external: ["@mincho-js/css"],
+        format: "esm",
+        minify: false,
+        outdir: join(fixture.root, "dist"),
+        plugins: minchoEsbuildPlugins({ jsxCssProp: true }),
+        write: false
+      });
+
+      try {
+        const barrelRealpath = normalizeStaticCssEvalFileId(
+          await fs.promises.realpath(barrelPath)
+        );
+        const buttonRealpath = normalizeStaticCssEvalFileId(
+          await fs.promises.realpath(buttonPath)
+        );
+        const primaryButtonRealpath = normalizeStaticCssEvalFileId(
+          await fs.promises.realpath(primaryButtonPath)
+        );
+        const firstWatchFiles = getScriptLoadWatchFiles(
+          await harness.loadScript({
+            path: fixture.entryPath
+          })
+        );
+
+        expect(new Set(firstWatchFiles)).toEqual(
+          new Set([barrelRealpath, buttonRealpath])
+        );
+
+        const redOutput = collectEsbuildOutputTexts(await context.rebuild());
+        expectCssPropBuildOutputToContainColor(redOutput, "red");
+
+        await fs.promises.writeFile(
+          buttonPath,
+          'export const button = { primary: { color: "blue" } } as const;',
+          "utf8"
+        );
+
+        const blueOutput = collectEsbuildOutputTexts(await context.rebuild());
+        expectCssPropBuildOutputToContainColor(blueOutput, "blue");
+        expect(blueOutput.all).not.toContain("color: red");
+
+        await fs.promises.writeFile(
+          barrelPath,
+          'export * from "./primaryButton";',
+          "utf8"
+        );
+
+        const greenOutput = collectEsbuildOutputTexts(await context.rebuild());
+        expectCssPropBuildOutputToContainColor(greenOutput, "green");
+        expect(greenOutput.all).not.toContain("color: blue");
+
+        harness.endBuild();
+        const secondWatchFiles = getScriptLoadWatchFiles(
+          await harness.loadScript({
+            path: fixture.entryPath
+          })
+        );
+
+        expect(new Set(secondWatchFiles)).toEqual(
+          new Set([barrelRealpath, primaryButtonRealpath])
+        );
+        expect(secondWatchFiles).not.toContain(buttonRealpath);
+      } finally {
+        await context.dispose();
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    }, 20000);
+
+    it("registers whole namespace export-star watch metadata from Babel integration", async () => {
+      const fixture = await createImportedCssPropEsbuildFixture(
+        "jsx-css-prop-whole-namespace-export-star-watch-",
+        {
+          entrySource: createNamespaceCssPropEntrySource("./barrel", "styles")
+        }
+      );
+      const barrelPath = join(fixture.srcRoot, "barrel.ts");
+      const resetPath = join(fixture.srcRoot, "reset.ts");
+      const buttonPath = join(fixture.srcRoot, "button.ts");
+
+      try {
+        await fs.promises.writeFile(
+          barrelPath,
+          'export { default } from "./reset"; export * from "./button";',
+          "utf8"
+        );
+        await fs.promises.writeFile(
+          resetPath,
+          "export default { margin: 0 } as const;",
+          "utf8"
+        );
+        await fs.promises.writeFile(
+          buttonPath,
+          'export const button = { color: "red" } as const;',
+          "utf8"
+        );
+
+        const barrelRealpath = normalizeStaticCssEvalFileId(
+          await fs.promises.realpath(barrelPath)
+        );
+        const resetRealpath = normalizeStaticCssEvalFileId(
+          await fs.promises.realpath(resetPath)
+        );
+        const buttonRealpath = normalizeStaticCssEvalFileId(
+          await fs.promises.realpath(buttonPath)
+        );
+        const transformResult: BabelTransformResult = {
+          code: fixture.entrySource,
+          result: ["", ""],
+          staticCssEval: createExportStarStaticCssEvalMetadata({
+            barrelPath: barrelRealpath,
+            explicitDefaultPath: resetRealpath,
+            terminalLeafPath: buttonRealpath
+          })
+        };
+        vi.spyOn(integrationHelpers, "babelTransform").mockResolvedValue(
+          transformResult
+        );
+
+        const harness = createBuildHarness({
+          absWorkingDir: fixture.root,
+          plugin: minchoEsbuildPlugin({ jsxCssProp: true })
+        });
+        const watchFiles = getScriptLoadWatchFiles(
+          await harness.loadScript({
+            path: fixture.entryPath
+          })
+        );
+
+        expect(new Set(watchFiles)).toEqual(
+          new Set([barrelRealpath, resetRealpath, buttonRealpath])
         );
       } finally {
         await fs.promises.rm(fixture.root, { force: true, recursive: true });

--- a/packages/integration/src/babel.ts
+++ b/packages/integration/src/babel.ts
@@ -1297,6 +1297,405 @@ if (import.meta.vitest) {
       expect(staticCssEval?.resolvedModuleIds).toContain(stylesId);
     });
 
+    it("loads export-star namespace members from the async source-provider prepass", async () => {
+      const path = await import("node:path");
+      const ownerSource = `
+        import * as styles from "./barrel";
+
+        function App() {
+          return <div css={styles.button.primary} />;
+        }
+      `;
+      const fixturePath = await createBabelFixture(
+        ownerSource,
+        "css-prop-async-prepass-export-star-namespace-member"
+      );
+      const fixtureRoot = path.dirname(fixturePath);
+      const barrelId = path.join(fixtureRoot, "barrel.ts");
+      const stylesId = path.join(fixtureRoot, "styles.ts");
+      const { provider, calls } = createFakeStaticCssEvalSourceProvider({
+        sources: {
+          [fixturePath]: ownerSource,
+          [barrelId]: `export * from "./styles";`,
+          [stylesId]: `export const button = { primary: { color: "red" } } as const;`
+        },
+        resolutions: {
+          [`${fixturePath}\0./barrel`]: barrelId,
+          [`${barrelId}\0./styles`]: stylesId
+        }
+      });
+      const { result, code, staticCssEval } = await babelTransform(
+        fixturePath,
+        {
+          jsxCssProp: true,
+          staticCssEvalSourceProvider: provider
+        }
+      );
+      const [, sidecarSource] = result;
+
+      expect(calls.resolved).toEqual([
+        { importerId: fixturePath, importPath: "./barrel" },
+        { importerId: barrelId, importPath: "./styles" }
+      ]);
+      expect(calls.loaded).toEqual([fixturePath, barrelId, stylesId]);
+      expect(sidecarSource).toContain('color: "red"');
+      expect(code).not.toContain("_cx(styles.button.primary)");
+      expect(staticCssEval?.dependencyFiles).toEqual([barrelId, stylesId]);
+      expect(staticCssEval?.ownerToDependencies.get(fixturePath)).toEqual([
+        barrelId,
+        stylesId
+      ]);
+      expect(staticCssEval?.dependencyToOwners.get(barrelId)).toEqual([
+        fixturePath
+      ]);
+      expect(staticCssEval?.dependencyToOwners.get(stylesId)).toEqual([
+        fixturePath
+      ]);
+      expect(staticCssEval?.resolvedModuleCache.has(fixturePath)).toBe(true);
+      expect(staticCssEval?.resolvedModuleCache.has(barrelId)).toBe(true);
+      expect(staticCssEval?.resolvedModuleCache.has(stylesId)).toBe(true);
+      expect(staticCssEval?.resolvedDependencies).toEqual([
+        expect.objectContaining({
+          importerId: fixturePath,
+          specifier: "./barrel",
+          resolvedFile: barrelId,
+          loaded: true
+        }),
+        expect.objectContaining({
+          importerId: barrelId,
+          specifier: "./styles",
+          resolvedFile: stylesId,
+          loaded: true
+        })
+      ]);
+      expect(staticCssEval?.resolvedModuleIds).toEqual(
+        expect.arrayContaining([barrelId, stylesId])
+      );
+    });
+
+    it("loads whole namespace export-star graphs with explicit default reexports from the async source-provider prepass", async () => {
+      const path = await import("node:path");
+      const ownerSource = `
+        import * as styles from "./barrel";
+
+        function App() {
+          return <div css={styles} />;
+        }
+      `;
+      const fixturePath = await createBabelFixture(
+        ownerSource,
+        "css-prop-async-prepass-whole-namespace-export-star-default"
+      );
+      const fixtureRoot = path.dirname(fixturePath);
+      const barrelId = path.join(fixtureRoot, "barrel.ts");
+      const resetId = path.join(fixtureRoot, "reset.ts");
+      const stylesId = path.join(fixtureRoot, "styles.ts");
+      const { provider, calls } = createFakeStaticCssEvalSourceProvider({
+        sources: {
+          [fixturePath]: ownerSource,
+          [barrelId]: `
+            export { default } from "./reset";
+            export * from "./styles";
+          `,
+          [resetId]: `export default { margin: 0 } as const;`,
+          [stylesId]: `export const button = { color: "red" } as const;`
+        },
+        resolutions: {
+          [`${fixturePath}\0./barrel`]: barrelId,
+          [`${barrelId}\0./reset`]: resetId,
+          [`${barrelId}\0./styles`]: stylesId
+        }
+      });
+      const { result: staticCssEval } = await createStaticCssEvalPrepass(
+        fixturePath,
+        provider
+      );
+
+      expect(calls.resolved).toEqual([
+        { importerId: fixturePath, importPath: "./barrel" },
+        { importerId: barrelId, importPath: "./reset" },
+        { importerId: barrelId, importPath: "./styles" }
+      ]);
+      expect(calls.loaded).toEqual([fixturePath, barrelId, resetId, stylesId]);
+      expect(staticCssEval.dependencyFiles).toEqual([
+        barrelId,
+        resetId,
+        stylesId
+      ]);
+      expect(staticCssEval.ownerToDependencies.get(fixturePath)).toEqual([
+        barrelId,
+        resetId,
+        stylesId
+      ]);
+      expect(staticCssEval.dependencyToOwners.get(resetId)).toEqual([
+        fixturePath
+      ]);
+      expect(staticCssEval.dependencyToOwners.get(stylesId)).toEqual([
+        fixturePath
+      ]);
+      expect(staticCssEval.resolvedModuleCache.has(resetId)).toBe(true);
+      expect(staticCssEval.resolvedModuleCache.has(stylesId)).toBe(true);
+      expect(staticCssEval.resolvedDependencies).toEqual([
+        expect.objectContaining({
+          importerId: fixturePath,
+          specifier: "./barrel",
+          resolvedFile: barrelId,
+          loaded: true
+        }),
+        expect.objectContaining({
+          importerId: barrelId,
+          specifier: "./reset",
+          resolvedFile: resetId,
+          loaded: true
+        }),
+        expect.objectContaining({
+          importerId: barrelId,
+          specifier: "./styles",
+          resolvedFile: stylesId,
+          loaded: true
+        })
+      ]);
+    });
+
+    it("excludes star-only default reexports from whole namespace export-star async source-provider prepass", async () => {
+      const path = await import("node:path");
+      const ownerSource = `
+        import * as styles from "./barrel";
+
+        function App() {
+          return <div css={styles} />;
+        }
+      `;
+      const fixturePath = await createBabelFixture(
+        ownerSource,
+        "css-prop-async-prepass-star-only-default-exclusion"
+      );
+      const fixtureRoot = path.dirname(fixturePath);
+      const barrelId = path.join(fixtureRoot, "barrel.ts");
+      const defaultBarrelId = path.join(fixtureRoot, "defaultBarrel.ts");
+      const defaultLeafId = path.join(fixtureRoot, "defaultLeaf.ts");
+      const { provider, calls } = createFakeStaticCssEvalSourceProvider({
+        sources: {
+          [fixturePath]: ownerSource,
+          [barrelId]: `export * from "./defaultBarrel";`,
+          [defaultBarrelId]: `
+            export { default } from "./defaultLeaf";
+            export const button = { color: "red" } as const;
+          `,
+          [defaultLeafId]: `export default { color: "blue" } as const;`
+        },
+        resolutions: {
+          [`${fixturePath}\0./barrel`]: barrelId,
+          [`${barrelId}\0./defaultBarrel`]: defaultBarrelId,
+          [`${defaultBarrelId}\0./defaultLeaf`]: defaultLeafId
+        }
+      });
+      const { result: staticCssEval } = await createStaticCssEvalPrepass(
+        fixturePath,
+        provider
+      );
+
+      expect(calls.resolved).toEqual([
+        { importerId: fixturePath, importPath: "./barrel" },
+        { importerId: barrelId, importPath: "./defaultBarrel" }
+      ]);
+      expect(calls.loaded).toEqual([fixturePath, barrelId, defaultBarrelId]);
+      expect(staticCssEval.dependencyFiles).toEqual([
+        barrelId,
+        defaultBarrelId
+      ]);
+      expect(staticCssEval.ownerToDependencies.get(fixturePath)).toEqual([
+        barrelId,
+        defaultBarrelId
+      ]);
+      expect(staticCssEval.resolvedModuleCache.has(defaultBarrelId)).toBe(true);
+      expect(staticCssEval.resolvedModuleCache.has(defaultLeafId)).toBe(false);
+    });
+
+    it("bounds export-star cycles in namespace async source-provider prepass", async () => {
+      const path = await import("node:path");
+      const ownerSource = `
+        import * as styles from "./barrel";
+
+        function App() {
+          return <div css={styles.button} />;
+        }
+      `;
+      const fixturePath = await createBabelFixture(
+        ownerSource,
+        "css-prop-async-prepass-export-star-cycle"
+      );
+      const fixtureRoot = path.dirname(fixturePath);
+      const barrelId = path.join(fixtureRoot, "barrel.ts");
+      const loopId = path.join(fixtureRoot, "loop.ts");
+      const { provider, calls } = createFakeStaticCssEvalSourceProvider({
+        sources: {
+          [fixturePath]: ownerSource,
+          [barrelId]: `export * from "./loop";`,
+          [loopId]: `export * from "./barrel";`
+        },
+        resolutions: {
+          [`${fixturePath}\0./barrel`]: barrelId,
+          [`${barrelId}\0./loop`]: loopId,
+          [`${loopId}\0./barrel`]: barrelId
+        }
+      });
+      let thrownError: unknown;
+
+      try {
+        await babelTransform(fixturePath, {
+          jsxCssProp: true,
+          staticCssEvalSourceProvider: provider
+        });
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBeInstanceOf(BabelTransformError);
+
+      if (!(thrownError instanceof BabelTransformError)) {
+        throw new Error("Expected BabelTransformError for export-star cycle");
+      }
+
+      expect(calls.resolved).toEqual([
+        { importerId: fixturePath, importPath: "./barrel" },
+        { importerId: barrelId, importPath: "./loop" },
+        { importerId: loopId, importPath: "./barrel" }
+      ]);
+      expect(calls.loaded).toEqual([fixturePath, barrelId, loopId]);
+      expect(thrownError.staticCssEval?.dependencyFiles).toEqual([
+        barrelId,
+        loopId
+      ]);
+      expect(thrownError.staticCssEval?.diagnostics[0]).toMatchObject({
+        id: "STATIC_CSS_EVAL_IMPORT_CYCLE",
+        owner: { file: fixturePath }
+      });
+    });
+
+    it("keeps unresolved export-star namespace prepass failures bounded", async () => {
+      const path = await import("node:path");
+      const ownerSource = `
+        import * as styles from "./barrel";
+
+        function App() {
+          return <div css={styles.button} />;
+        }
+      `;
+      const fixturePath = await createBabelFixture(
+        ownerSource,
+        "css-prop-async-prepass-unresolved-export-star"
+      );
+      const fixtureRoot = path.dirname(fixturePath);
+      const barrelId = path.join(fixtureRoot, "barrel.ts");
+      const { provider, calls } = createFakeStaticCssEvalSourceProvider({
+        sources: {
+          [fixturePath]: ownerSource,
+          [barrelId]: `export * from "./missing";`
+        },
+        resolutions: {
+          [`${fixturePath}\0./barrel`]: barrelId
+        }
+      });
+      let thrownError: unknown;
+
+      try {
+        await babelTransform(fixturePath, {
+          jsxCssProp: true,
+          staticCssEvalSourceProvider: provider
+        });
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBeInstanceOf(BabelTransformError);
+
+      if (!(thrownError instanceof BabelTransformError)) {
+        throw new Error(
+          "Expected BabelTransformError for unresolved export-star"
+        );
+      }
+
+      expect(calls.resolved).toEqual([
+        { importerId: fixturePath, importPath: "./barrel" },
+        { importerId: barrelId, importPath: "./missing" }
+      ]);
+      expect(calls.loaded).toEqual([fixturePath, barrelId]);
+      expect(thrownError.staticCssEval?.dependencyFiles).toEqual([barrelId]);
+      expect(thrownError.staticCssEval?.diagnostics[0]).toMatchObject({
+        id: "STATIC_CSS_EVAL_UNRESOLVED_IMPORT",
+        owner: { file: fixturePath },
+        dependency: { file: "./missing" },
+        importPath: "./missing",
+        exportName: "button"
+      });
+      expect(thrownError.staticCssEval?.resolvedDependencies).toEqual([
+        expect.objectContaining({
+          importerId: fixturePath,
+          specifier: "./barrel",
+          resolvedFile: barrelId,
+          loaded: true
+        })
+      ]);
+    });
+
+    it("keeps package boundary export-star namespace prepass failures bounded", async () => {
+      const path = await import("node:path");
+      const ownerSource = `
+        import * as styles from "./barrel";
+
+        function App() {
+          return <div css={styles.button} />;
+        }
+      `;
+      const fixturePath = await createBabelFixture(
+        ownerSource,
+        "css-prop-async-prepass-package-boundary-export-star"
+      );
+      const fixtureRoot = path.dirname(fixturePath);
+      const barrelId = path.join(fixtureRoot, "barrel.ts");
+      const { provider, calls } = createFakeStaticCssEvalSourceProvider({
+        sources: {
+          [fixturePath]: ownerSource,
+          [barrelId]: `export * from "@scope/styles";`
+        },
+        resolutions: {
+          [`${fixturePath}\0./barrel`]: barrelId
+        }
+      });
+      let thrownError: unknown;
+
+      try {
+        await babelTransform(fixturePath, {
+          jsxCssProp: true,
+          staticCssEvalSourceProvider: provider
+        });
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBeInstanceOf(BabelTransformError);
+
+      if (!(thrownError instanceof BabelTransformError)) {
+        throw new Error(
+          "Expected BabelTransformError for package boundary export-star"
+        );
+      }
+
+      expect(calls.resolved).toEqual([
+        { importerId: fixturePath, importPath: "./barrel" }
+      ]);
+      expect(calls.loaded).toEqual([fixturePath, barrelId]);
+      expect(thrownError.staticCssEval?.dependencyFiles).toEqual([barrelId]);
+      expect(thrownError.staticCssEval?.diagnostics[0]).toMatchObject({
+        id: "STATIC_CSS_EVAL_PACKAGE_IMPORT_UNSUPPORTED",
+        owner: { file: fixturePath },
+        dependency: { file: barrelId },
+        importPath: "@scope/styles",
+        exportName: "button"
+      });
+    });
+
     it("preserves whole-expression reexport fallback but rejects reexports inside static css rules", async () => {
       const wholeExpressionPath = await createBabelFixture(
         `

--- a/packages/integration/src/babel.ts
+++ b/packages/integration/src/babel.ts
@@ -1,38 +1,28 @@
 import { type TransformOptions, transformFileAsync } from "@babel/core";
 import {
-  internalCollectJsxCssPropStaticCssEvalCandidates as collectJsxCssPropStaticCssEvalCandidates,
-  internalCreateImportedStaticCssEvalModuleRecord as createImportedStaticCssEvalModuleRecord,
-  internalCreateImportedStaticCssEvalProvider as createImportedStaticCssEvalProvider,
-  type InternalImportedStaticCssEvalImportResolution as ImportedStaticCssEvalImportResolution,
-  type InternalImportedStaticCssEvalLoadedModule as ImportedStaticCssEvalLoadedModule,
   type InternalImportedStaticCssEvalModuleRecord as ImportedStaticCssEvalModuleRecord,
   type MinchoStaticCssEvalMetadata,
   type PluginOptions,
   minchoBabelPlugin,
   minchoStyledComponentPlugin
 } from "@mincho-js/babel";
+import {
+  createEmptyStaticCssEvalMetadata,
+  createObservingStaticCssEvalProvider,
+  createStaticCssEvalTransformResult,
+  getStaticCssEvalMetadata,
+  mergeStaticCssEvalMetadata
+} from "./staticCssEvalMetadata.js";
+import { createStaticCssEvalPrepass } from "./staticCssEvalPrepass.js";
 
 type MaybePromise<T> = T | Promise<T>;
 
-type StaticCssEvalProvider = NonNullable<
-  PluginOptions["staticCssEvalProvider"]
->;
-type StaticCssEvalProviderResult = ReturnType<
-  StaticCssEvalProvider["getResolvedCssValue"]
->;
 type StaticCssEvalMetadataDependency =
   MinchoStaticCssEvalMetadata["dependencies"][number];
 type StaticCssEvalMetadataDiagnostic =
   MinchoStaticCssEvalMetadata["diagnostics"][number];
 type StaticCssEvalMetadataCacheKey =
   MinchoStaticCssEvalMetadata["cacheKeys"][number];
-type StaticCssEvalProviderMetadataSource = {
-  dependencies?: readonly unknown[];
-  diagnostics?: readonly StaticCssEvalMetadataDiagnostic[];
-  diagnostic?: StaticCssEvalMetadataDiagnostic;
-  cacheKey?: StaticCssEvalMetadataCacheKey;
-};
-
 export type StaticCssEvalResolverKind =
   | "source-provider"
   | "filesystem"
@@ -114,31 +104,6 @@ export interface StaticCssEvalResolvedDependency {
 
 export interface StaticCssEvalTransformResult
   extends StaticCssEvalPrepassResult, MinchoStaticCssEvalMetadata {}
-
-interface NormalizedStaticCssEvalSourceResolution {
-  resolvedFile: string;
-  canonicalModuleId: string;
-  normalizedPathKey: string;
-  resolverKind: StaticCssEvalResolverKind;
-  realpath?: string;
-  sourceIdentity?: StaticCssEvalSourceIdentity;
-}
-
-interface PreparedStaticCssEvalPrepass {
-  provider: StaticCssEvalProvider;
-  result: StaticCssEvalPrepassResult;
-}
-
-interface StaticCssEvalPrepassState {
-  loadedModules: ImportedStaticCssEvalLoadedModule[];
-  importResolutions: ImportedStaticCssEvalImportResolution[];
-  resolvedModuleCache: Map<string, ImportedStaticCssEvalModuleRecord>;
-  ownerDependencies: string[];
-  dependencyToOwners: Map<string, string[]>;
-  resolvedDependencies: StaticCssEvalResolvedDependency[];
-  resolvedImports: Map<string, NormalizedStaticCssEvalSourceResolution | null>;
-  loadedDependencyIds: Set<string>;
-}
 
 export class BabelTransformError extends Error {
   readonly file: string;
@@ -262,667 +227,6 @@ export async function babelTransform(
     jsxCssPropTransformed: options.jsxCssPropTransformed === true,
     ...(staticCssEval ? { staticCssEval } : {})
   };
-}
-
-async function createStaticCssEvalPrepass(
-  ownerId: string,
-  sourceProvider: StaticCssEvalSourceProvider
-): Promise<PreparedStaticCssEvalPrepass> {
-  const ownerSource = await sourceProvider.load(ownerId);
-
-  if (!ownerSource) {
-    throw new Error(`Failed to load static css eval owner source ${ownerId}`);
-  }
-
-  const ownerModule = createLoadedModule(ownerId, ownerSource);
-  const ownerRecord = createImportedStaticCssEvalModuleRecord(ownerModule);
-  const candidates = collectJsxCssPropStaticCssEvalCandidates(
-    ownerRecord.programPath,
-    { importerId: ownerId }
-  );
-  const prepassState: StaticCssEvalPrepassState = {
-    loadedModules: [ownerModule],
-    importResolutions: [],
-    resolvedModuleCache: new Map([[ownerRecord.id, ownerRecord]]),
-    ownerDependencies: [],
-    dependencyToOwners: new Map(),
-    resolvedDependencies: [],
-    resolvedImports: new Map(),
-    loadedDependencyIds: new Set([ownerId])
-  };
-
-  for (const candidate of candidates) {
-    const importBinding = candidate.bindingName
-      ? ownerRecord.imports.get(candidate.bindingName)
-      : undefined;
-
-    if (!importBinding) {
-      continue;
-    }
-
-    const moduleRecord = await loadStaticCssEvalPrepassDependency(
-      ownerId,
-      importBinding.importPath,
-      sourceProvider,
-      prepassState
-    );
-
-    if (!moduleRecord) {
-      continue;
-    }
-
-    if (importBinding.kind !== "namespace") {
-      await loadDirectReexportDependencies(
-        moduleRecord,
-        importBinding.importedName,
-        sourceProvider,
-        prepassState
-      );
-    }
-  }
-
-  const ownerToDependencies = new Map<string, string[]>([
-    [ownerId, prepassState.ownerDependencies]
-  ]);
-  const provider = createImportedStaticCssEvalProvider({
-    modules: prepassState.loadedModules,
-    importResolutions: prepassState.importResolutions,
-    moduleRecords: [...prepassState.resolvedModuleCache.values()]
-  });
-
-  return {
-    provider,
-    result: {
-      dependencyFiles: [...prepassState.ownerDependencies],
-      ownerToDependencies,
-      dependencyToOwners: prepassState.dependencyToOwners,
-      resolvedModuleCache: prepassState.resolvedModuleCache,
-      resolvedDependencies: prepassState.resolvedDependencies
-    }
-  };
-}
-
-async function loadStaticCssEvalPrepassDependency(
-  importerId: string,
-  importPath: string,
-  sourceProvider: StaticCssEvalSourceProvider,
-  prepassState: StaticCssEvalPrepassState
-): Promise<ImportedStaticCssEvalModuleRecord | undefined> {
-  const resolvedImportKey = `${importerId}\0${importPath}`;
-  let resolution = prepassState.resolvedImports.get(resolvedImportKey);
-
-  if (!prepassState.resolvedImports.has(resolvedImportKey)) {
-    const sourceResolution = await sourceProvider.resolve(
-      importerId,
-      importPath
-    );
-    resolution = sourceResolution
-      ? normalizeStaticCssEvalSourceResolution(sourceResolution)
-      : null;
-    prepassState.resolvedImports.set(resolvedImportKey, resolution ?? null);
-
-    if (resolution) {
-      prepassState.importResolutions.push({
-        importerId,
-        importPath,
-        resolvedId: resolution.resolvedFile
-      });
-      prepassState.resolvedDependencies.push(
-        createStaticCssEvalResolvedDependency(
-          importerId,
-          importPath,
-          resolution,
-          false
-        )
-      );
-    }
-  }
-
-  if (!resolution) {
-    return undefined;
-  }
-
-  addOwnerDependency(
-    prepassState.ownerDependencies,
-    prepassState.dependencyToOwners,
-    prepassState.loadedModules[0]?.id ?? importerId,
-    resolution.resolvedFile
-  );
-
-  const cachedRecord = prepassState.resolvedModuleCache.get(
-    resolution.resolvedFile
-  );
-
-  if (cachedRecord) {
-    return cachedRecord;
-  }
-
-  if (prepassState.loadedDependencyIds.has(resolution.resolvedFile)) {
-    return undefined;
-  }
-
-  prepassState.loadedDependencyIds.add(resolution.resolvedFile);
-  const loadedSource = await sourceProvider.load(resolution.normalizedPathKey);
-
-  if (!loadedSource) {
-    return undefined;
-  }
-
-  markResolvedDependencyLoaded(
-    prepassState.resolvedDependencies,
-    importerId,
-    importPath,
-    resolution,
-    loadedSource
-  );
-
-  const loadedModule = createLoadedModule(
-    resolution.resolvedFile,
-    loadedSource,
-    resolution
-  );
-
-  try {
-    const moduleRecord = createImportedStaticCssEvalModuleRecord(loadedModule);
-    prepassState.resolvedModuleCache.set(moduleRecord.id, moduleRecord);
-    prepassState.loadedModules.push(loadedModule);
-
-    return moduleRecord;
-  } catch {
-    return undefined;
-  }
-}
-
-async function loadDirectReexportDependencies(
-  moduleRecord: ImportedStaticCssEvalModuleRecord,
-  exportName: string,
-  sourceProvider: StaticCssEvalSourceProvider,
-  prepassState: StaticCssEvalPrepassState
-): Promise<void> {
-  let currentRecord: ImportedStaticCssEvalModuleRecord | undefined =
-    moduleRecord;
-  let currentExportName = exportName;
-  const seenReexports = new Set<string>();
-
-  while (currentRecord) {
-    const exportEntry = currentRecord.exports.get(currentExportName);
-
-    if (!exportEntry || exportEntry.kind !== "reexport") {
-      return;
-    }
-
-    const reexportKey = `${currentRecord.id}\0${currentExportName}`;
-
-    if (seenReexports.has(reexportKey)) {
-      return;
-    }
-
-    seenReexports.add(reexportKey);
-
-    currentRecord = await loadStaticCssEvalPrepassDependency(
-      currentRecord.id,
-      exportEntry.source,
-      sourceProvider,
-      prepassState
-    );
-    currentExportName = exportEntry.importedName;
-  }
-}
-
-function createLoadedModule(
-  id: string,
-  loadedSource: StaticCssEvalLoadedSource,
-  resolution?: NormalizedStaticCssEvalSourceResolution
-): ImportedStaticCssEvalLoadedModule {
-  const sourceText = getLoadedSourceText(id, loadedSource);
-  const sourceIdentity = createLoadedSourceIdentity(
-    sourceText,
-    loadedSource,
-    resolution
-  );
-
-  return {
-    id,
-    source: sourceText,
-    realpath: loadedSource.realpath ?? resolution?.realpath,
-    sourceHash: sourceIdentity.sourceHash,
-    version: sourceIdentity.version
-  };
-}
-
-function getLoadedSourceText(
-  id: string,
-  loadedSource: StaticCssEvalLoadedSource
-): string {
-  const sourceText = loadedSource.sourceText ?? loadedSource.source;
-
-  if (sourceText === undefined) {
-    throw new Error(
-      `Static css eval source provider did not return source for ${id}`
-    );
-  }
-
-  return sourceText;
-}
-
-function normalizeStaticCssEvalSourceResolution(
-  resolution: StaticCssEvalSourceResolution
-): NormalizedStaticCssEvalSourceResolution {
-  const resolvedFile = resolution.resolvedFile ?? resolution.id;
-
-  if (!resolvedFile) {
-    throw new Error(
-      "Static css eval source resolution requires resolvedFile or id"
-    );
-  }
-
-  const canonicalModuleId =
-    resolution.canonicalModuleId ?? resolution.id ?? resolvedFile;
-  const normalizedPathKey =
-    resolution.normalizedPathKey ?? canonicalModuleId ?? resolvedFile;
-
-  return {
-    resolvedFile,
-    canonicalModuleId,
-    normalizedPathKey,
-    resolverKind: resolution.resolverKind ?? "source-provider",
-    realpath: resolution.realpath,
-    sourceIdentity: normalizeStaticCssEvalSourceIdentity(
-      resolution.sourceIdentity,
-      resolution.sourceHash,
-      resolution.version
-    )
-  };
-}
-
-function normalizeStaticCssEvalSourceIdentity(
-  sourceIdentity: StaticCssEvalSourceIdentity | undefined,
-  sourceHash: string | undefined,
-  version: string | number | undefined
-): StaticCssEvalSourceIdentity | undefined {
-  const normalizedSourceHash = sourceIdentity?.sourceHash ?? sourceHash;
-  const normalizedVersion = sourceIdentity?.version ?? version;
-
-  if (normalizedSourceHash === undefined && normalizedVersion === undefined) {
-    return undefined;
-  }
-
-  return {
-    ...(normalizedSourceHash !== undefined
-      ? { sourceHash: normalizedSourceHash }
-      : {}),
-    ...(normalizedVersion !== undefined ? { version: normalizedVersion } : {})
-  };
-}
-
-function createLoadedSourceIdentity(
-  sourceText: string,
-  loadedSource: StaticCssEvalLoadedSource,
-  resolution?: NormalizedStaticCssEvalSourceResolution
-): Required<Pick<StaticCssEvalSourceIdentity, "sourceHash">> &
-  Pick<StaticCssEvalSourceIdentity, "version"> {
-  const sourceIdentity = normalizeStaticCssEvalSourceIdentity(
-    loadedSource.sourceIdentity,
-    loadedSource.sourceHash,
-    loadedSource.version
-  );
-  const sourceHash =
-    sourceIdentity?.sourceHash ??
-    resolution?.sourceIdentity?.sourceHash ??
-    createStaticCssEvalSourceTextHash(sourceText);
-  const version =
-    sourceIdentity?.version ?? resolution?.sourceIdentity?.version;
-
-  return {
-    sourceHash,
-    ...(version !== undefined ? { version } : {})
-  };
-}
-
-function createStaticCssEvalResolvedDependency(
-  importerId: string,
-  specifier: string,
-  resolution: NormalizedStaticCssEvalSourceResolution,
-  loaded: boolean,
-  loadedSource?: StaticCssEvalLoadedSource
-): StaticCssEvalResolvedDependency {
-  const sourceText = loadedSource
-    ? getLoadedSourceText(resolution.normalizedPathKey, loadedSource)
-    : undefined;
-  const sourceIdentity = loadedSource
-    ? createLoadedSourceIdentity(sourceText ?? "", loadedSource, resolution)
-    : resolution.sourceIdentity;
-
-  return {
-    importerId,
-    specifier,
-    resolvedFile: resolution.resolvedFile,
-    canonicalModuleId: resolution.canonicalModuleId,
-    normalizedPathKey: resolution.normalizedPathKey,
-    resolverKind: resolution.resolverKind,
-    loaded,
-    ...(sourceIdentity ? { sourceIdentity } : {})
-  };
-}
-
-function markResolvedDependencyLoaded(
-  resolvedDependencies: StaticCssEvalResolvedDependency[],
-  importerId: string,
-  specifier: string,
-  resolution: NormalizedStaticCssEvalSourceResolution,
-  loadedSource: StaticCssEvalLoadedSource
-): void {
-  const resolvedDependencyIndex = resolvedDependencies.findIndex(
-    (dependency) =>
-      dependency.importerId === importerId &&
-      dependency.specifier === specifier &&
-      dependency.resolvedFile === resolution.resolvedFile
-  );
-  const loadedDependency = createStaticCssEvalResolvedDependency(
-    importerId,
-    specifier,
-    resolution,
-    true,
-    loadedSource
-  );
-
-  if (resolvedDependencyIndex === -1) {
-    resolvedDependencies.push(loadedDependency);
-    return;
-  }
-
-  resolvedDependencies[resolvedDependencyIndex] = loadedDependency;
-}
-
-function createStaticCssEvalSourceTextHash(sourceText: string): string {
-  let hash = 0x811c9dc5;
-
-  for (let index = 0; index < sourceText.length; index += 1) {
-    hash ^= sourceText.charCodeAt(index);
-    hash = Math.imul(hash, 0x01000193);
-  }
-
-  return `fnv1a:${(hash >>> 0).toString(16).padStart(8, "0")}:${sourceText.length}`;
-}
-
-function createObservingStaticCssEvalProvider(
-  provider: StaticCssEvalProvider,
-  metadata: MinchoStaticCssEvalMetadata
-): StaticCssEvalProvider {
-  return {
-    getResolvedCssValue(query): StaticCssEvalProviderResult {
-      const result = provider.getResolvedCssValue(query);
-      appendStaticCssEvalResultMetadata(metadata, result);
-      return result;
-    }
-  };
-}
-
-function appendStaticCssEvalResultMetadata(
-  metadata: MinchoStaticCssEvalMetadata,
-  result: StaticCssEvalProviderResult
-): void {
-  const metadataSource = result as StaticCssEvalProviderMetadataSource;
-  const dependencies = (metadataSource.dependencies ?? []).filter(
-    isStaticCssEvalResolutionDependency
-  );
-  const diagnostics =
-    metadataSource.diagnostics ??
-    (metadataSource.diagnostic ? [metadataSource.diagnostic] : []);
-  const cacheKeys = metadataSource.cacheKey ? [metadataSource.cacheKey] : [];
-
-  appendUniqueMetadataItems(
-    metadata.dependencies,
-    dependencies,
-    createStaticCssEvalDependencyKey
-  );
-  appendUniqueMetadataItems(
-    metadata.diagnostics,
-    diagnostics,
-    createStaticCssEvalDiagnosticKey
-  );
-  appendUniqueMetadataItems(
-    metadata.cacheKeys,
-    cacheKeys,
-    createStaticCssEvalCacheKeyKey
-  );
-  appendUniqueMetadataItems(
-    metadata.resolvedModuleIds,
-    [
-      ...cacheKeys.flatMap((cacheKey) => cacheKey.resolvedId ?? []),
-      ...dependencies.flatMap((dependency) =>
-        dependency.kind !== "local" &&
-        dependency.kind !== "unresolved" &&
-        dependency.inspected
-          ? [dependency.file]
-          : []
-      )
-    ],
-    (moduleId) => moduleId
-  );
-}
-
-function isStaticCssEvalResolutionDependency(
-  dependency: unknown
-): dependency is StaticCssEvalMetadataDependency {
-  return typeof dependency === "object" && dependency !== null;
-}
-
-function getStaticCssEvalMetadata(
-  metadata: unknown
-): MinchoStaticCssEvalMetadata | undefined {
-  const staticCssEval = (
-    metadata as { minchoStaticCssEval?: MinchoStaticCssEvalMetadata } | null
-  )?.minchoStaticCssEval;
-
-  if (!staticCssEval) {
-    return undefined;
-  }
-
-  return cloneStaticCssEvalMetadata(staticCssEval);
-}
-
-function createStaticCssEvalTransformResult(
-  prepassResult: StaticCssEvalPrepassResult | undefined,
-  metadata: MinchoStaticCssEvalMetadata | undefined
-): StaticCssEvalTransformResult | undefined {
-  const staticCssEvalMetadata = metadata
-    ? cloneStaticCssEvalMetadata(metadata)
-    : createEmptyStaticCssEvalMetadata();
-  const hasMetadata =
-    staticCssEvalMetadata.dependencies.length > 0 ||
-    staticCssEvalMetadata.diagnostics.length > 0 ||
-    staticCssEvalMetadata.cacheKeys.length > 0 ||
-    staticCssEvalMetadata.resolvedModuleIds.length > 0;
-
-  if (!prepassResult && !hasMetadata) {
-    return undefined;
-  }
-
-  return {
-    dependencyFiles: prepassResult?.dependencyFiles ?? [],
-    ownerToDependencies: prepassResult?.ownerToDependencies ?? new Map(),
-    dependencyToOwners: prepassResult?.dependencyToOwners ?? new Map(),
-    resolvedModuleCache: prepassResult?.resolvedModuleCache ?? new Map(),
-    resolvedDependencies: prepassResult?.resolvedDependencies ?? [],
-    ...staticCssEvalMetadata
-  };
-}
-
-function mergeStaticCssEvalMetadata(
-  ...metadataItems: Array<MinchoStaticCssEvalMetadata | undefined>
-): MinchoStaticCssEvalMetadata {
-  const mergedMetadata = createEmptyStaticCssEvalMetadata();
-
-  for (const metadata of metadataItems) {
-    if (!metadata) {
-      continue;
-    }
-
-    appendUniqueMetadataItems(
-      mergedMetadata.dependencies,
-      metadata.dependencies,
-      createStaticCssEvalDependencyKey
-    );
-    appendUniqueMetadataItems(
-      mergedMetadata.diagnostics,
-      metadata.diagnostics,
-      createStaticCssEvalDiagnosticKey
-    );
-    appendUniqueMetadataItems(
-      mergedMetadata.cacheKeys,
-      metadata.cacheKeys,
-      createStaticCssEvalCacheKeyKey
-    );
-    appendUniqueMetadataItems(
-      mergedMetadata.resolvedModuleIds,
-      metadata.resolvedModuleIds,
-      (moduleId) => moduleId
-    );
-  }
-
-  return mergedMetadata;
-}
-
-function createEmptyStaticCssEvalMetadata(): MinchoStaticCssEvalMetadata {
-  return {
-    dependencies: [],
-    diagnostics: [],
-    cacheKeys: [],
-    resolvedModuleIds: []
-  };
-}
-
-function cloneStaticCssEvalMetadata(
-  metadata: MinchoStaticCssEvalMetadata
-): MinchoStaticCssEvalMetadata {
-  return {
-    dependencies: metadata.dependencies.map((dependency) => ({
-      ...dependency,
-      memberPath: [...dependency.memberPath]
-    })),
-    diagnostics: metadata.diagnostics.map((diagnostic) => ({
-      ...diagnostic,
-      owner: { ...diagnostic.owner },
-      ...(diagnostic.dependency
-        ? { dependency: { ...diagnostic.dependency } }
-        : {}),
-      ...(diagnostic.memberPath
-        ? { memberPath: [...diagnostic.memberPath] }
-        : {}),
-      ...(diagnostic.importChain
-        ? { importChain: [...diagnostic.importChain] }
-        : {})
-    })),
-    cacheKeys: metadata.cacheKeys.map((cacheKey) => ({
-      ...cacheKey,
-      memberPath: [...cacheKey.memberPath],
-      ...(cacheKey.parserOptions
-        ? {
-            parserOptions: {
-              ...cacheKey.parserOptions,
-              plugins: [...cacheKey.parserOptions.plugins]
-            }
-          }
-        : {}),
-      ...(cacheKey.projectLocalBoundary
-        ? { projectLocalBoundary: { ...cacheKey.projectLocalBoundary } }
-        : {})
-    })),
-    resolvedModuleIds: [...metadata.resolvedModuleIds]
-  };
-}
-
-function appendUniqueMetadataItems<T>(
-  target: T[],
-  items: readonly T[],
-  createKey: (item: T) => string
-): void {
-  const existingKeys = new Set(target.map(createKey));
-
-  for (const item of items) {
-    const key = createKey(item);
-
-    if (existingKeys.has(key)) {
-      continue;
-    }
-
-    existingKeys.add(key);
-    target.push(item);
-  }
-}
-
-function createStaticCssEvalDependencyKey(
-  dependency: StaticCssEvalMetadataDependency
-): string {
-  return JSON.stringify([
-    dependency.file,
-    dependency.kind,
-    dependency.importer,
-    dependency.specifier,
-    dependency.exportName,
-    dependency.memberPath,
-    dependency.inspected,
-    dependency.contributed
-  ]);
-}
-
-function createStaticCssEvalDiagnosticKey(
-  diagnostic: StaticCssEvalMetadataDiagnostic
-): string {
-  return JSON.stringify([
-    diagnostic.id,
-    diagnostic.code,
-    diagnostic.reason,
-    diagnostic.message,
-    diagnostic.owner.file,
-    diagnostic.owner.start,
-    diagnostic.owner.end,
-    diagnostic.dependency?.file,
-    diagnostic.importPath,
-    diagnostic.exportName,
-    diagnostic.memberPath,
-    diagnostic.importChain
-  ]);
-}
-
-function createStaticCssEvalCacheKeyKey(
-  cacheKey: StaticCssEvalMetadataCacheKey
-): string {
-  return JSON.stringify([
-    cacheKey.importerFile,
-    cacheKey.resolvedFile,
-    cacheKey.exportName,
-    cacheKey.memberPath,
-    cacheKey.sourceHash,
-    cacheKey.sourceVersion,
-    cacheKey.pluginOptionsVersion,
-    cacheKey.resolverOptionsVersion,
-    cacheKey.staticEvalSupportVersion,
-    cacheKey.resolvedId
-  ]);
-}
-
-function addOwnerDependency(
-  ownerDependencies: string[],
-  dependencyToOwners: Map<string, string[]>,
-  ownerId: string,
-  dependencyId: string
-): void {
-  if (!ownerDependencies.includes(dependencyId)) {
-    ownerDependencies.push(dependencyId);
-  }
-
-  const owners = dependencyToOwners.get(dependencyId);
-
-  if (!owners) {
-    dependencyToOwners.set(dependencyId, [ownerId]);
-    return;
-  }
-
-  if (!owners.includes(ownerId)) {
-    owners.push(ownerId);
-  }
 }
 
 // == Tests ====================================================================
@@ -1380,6 +684,91 @@ if (import.meta.vitest) {
       expect(code).not.toContain("_cx(styles.button.primary)");
     });
 
+    it("static css eval metadata dedupes dependency diagnostics and resolved module ids", async () => {
+      const fixturePath = await createBabelFixture(
+        `
+          import { button } from "./styles";
+
+          function App() {
+            return <div css={button} />;
+          }
+        `,
+        "css-prop-metadata-dedupe"
+      );
+      const dependency = {
+        file: "/provider/styles.ts",
+        kind: "imported",
+        importer: fixturePath,
+        specifier: "./styles",
+        exportName: "button",
+        memberPath: [],
+        inspected: true,
+        contributed: true
+      } satisfies StaticCssEvalMetadataDependency;
+      const diagnostic = {
+        id: "STATIC_CSS_EVAL_UNRESOLVED_EXPORT",
+        code: "unsupported-source",
+        message: "test static css eval metadata diagnostic",
+        reason: "reexport-or-barrel",
+        owner: { file: fixturePath, start: 0, end: 1 },
+        dependency: { file: dependency.file },
+        importPath: "./styles",
+        exportName: "button",
+        memberPath: [],
+        importChain: [fixturePath, dependency.file]
+      } satisfies StaticCssEvalMetadataDiagnostic;
+      const cacheKey = {
+        importerFile: fixturePath,
+        resolvedFile: dependency.file,
+        resolvedId: dependency.file,
+        exportName: "button",
+        memberPath: [],
+        sourceHash: "test:metadata-dedupe",
+        pluginOptionsVersion: "test-plugin-options",
+        resolverOptionsVersion: "test-resolver-options",
+        staticEvalSupportVersion: "test-static-eval"
+      } satisfies StaticCssEvalMetadataCacheKey;
+      const provider: StaticCssEvalProvider = {
+        getResolvedCssValue(): StaticCssEvalProviderResult {
+          return {
+            kind: "resolved",
+            value: { color: "red" },
+            dependencies: [dependency, { ...dependency }],
+            diagnostics: [diagnostic, { ...diagnostic }],
+            cacheKey
+          } as unknown as StaticCssEvalProviderResult;
+        }
+      };
+
+      const { result, code, staticCssEval } = await babelTransform(
+        fixturePath,
+        {
+          jsxCssProp: true,
+          staticCssEvalProvider: provider
+        }
+      );
+      const [, sidecarSource] = result;
+
+      expect(sidecarSource).toContain('color: "red"');
+      expect(code).not.toContain("_cx(button)");
+      expect(
+        staticCssEval?.dependencies.filter(
+          (item) => item.file === dependency.file && item.kind === "imported"
+        )
+      ).toHaveLength(1);
+      expect(
+        staticCssEval?.diagnostics.filter((item) => item.id === diagnostic.id)
+      ).toHaveLength(1);
+      expect(staticCssEval?.cacheKeys).toEqual(
+        expect.arrayContaining([expect.objectContaining(cacheKey)])
+      );
+      expect(
+        staticCssEval?.resolvedModuleIds.filter(
+          (moduleId) => moduleId === dependency.file
+        )
+      ).toHaveLength(1);
+    });
+
     it("runs async prepass only for css-prop-reachable imports", async () => {
       const path = await import("node:path");
       const ownerSource = `
@@ -1441,7 +830,7 @@ if (import.meta.vitest) {
       expect(staticCssEval?.resolvedModuleCache.has(unusedId)).toBe(false);
     });
 
-    it("uses imported source identity when only the imported style file changes", async () => {
+    it("static css eval metadata preserves dependency files resolved dependencies cache keys and source identity", async () => {
       const fs = await import("node:fs/promises");
       const componentSource = `
         import { button } from "./styles";
@@ -1597,7 +986,7 @@ if (import.meta.vitest) {
       ]);
     });
 
-    it("attaches deterministic imported failure context to transform errors", async () => {
+    it("BabelTransformError preserves static css eval metadata and deterministic imported failure context", async () => {
       const componentSource = `
         import { button } from "./styles";
 
@@ -1775,6 +1164,60 @@ if (import.meta.vitest) {
       );
     });
 
+    it("excludes failed dependency parses from async prepass caches", async () => {
+      const path = await import("node:path");
+      const ownerSource = `
+        import { button } from "./styles";
+
+        function App() {
+          return <div css={button} />;
+        }
+      `;
+      const fixturePath = await createBabelFixture(
+        ownerSource,
+        "css-prop-async-prepass-parse-failure"
+      );
+      const fixtureRoot = path.dirname(fixturePath);
+      const stylesId = path.join(fixtureRoot, "styles.ts");
+      const { provider, calls } = createFakeStaticCssEvalSourceProvider({
+        sources: {
+          [fixturePath]: ownerSource,
+          [stylesId]: `export const button = ;`
+        },
+        resolutions: {
+          [`${fixturePath}\0./styles`]: stylesId
+        }
+      });
+      const prepass = await createStaticCssEvalPrepass(fixturePath, provider);
+      const resolution = prepass.provider.getResolvedCssValue({
+        importerId: fixturePath,
+        expressionStart: 0,
+        expressionEnd: "button".length,
+        bindingName: "button"
+      });
+
+      expect(calls.resolved).toEqual([
+        { importerId: fixturePath, importPath: "./styles" }
+      ]);
+      expect(calls.loaded).toEqual([fixturePath, stylesId]);
+      expect(prepass.result.dependencyFiles).toEqual([stylesId]);
+      expect(prepass.result.resolvedModuleCache.has(fixturePath)).toBe(true);
+      expect(prepass.result.resolvedModuleCache.has(stylesId)).toBe(false);
+      expect(resolution.kind).toBe("error");
+
+      if (resolution.kind !== "error") {
+        throw new Error("Expected failed dependency resolution");
+      }
+
+      expect(resolution.dependencies).toEqual([stylesId]);
+      expect(resolution.diagnostic.code).toBe(
+        "failed-project-local-dependency"
+      );
+      expect(resolution.diagnostic.message).toContain(
+        `failed to load project-local dependency ${stylesId}`
+      );
+    });
+
     it("resolves namespace members from the async source-provider prepass", async () => {
       const path = await import("node:path");
       const ownerSource = `
@@ -1852,60 +1295,6 @@ if (import.meta.vitest) {
         memberPath: ["primary"]
       });
       expect(staticCssEval?.resolvedModuleIds).toContain(stylesId);
-    });
-
-    it("excludes failed dependency parses from async prepass caches", async () => {
-      const path = await import("node:path");
-      const ownerSource = `
-        import { button } from "./styles";
-
-        function App() {
-          return <div css={button} />;
-        }
-      `;
-      const fixturePath = await createBabelFixture(
-        ownerSource,
-        "css-prop-async-prepass-parse-failure"
-      );
-      const fixtureRoot = path.dirname(fixturePath);
-      const stylesId = path.join(fixtureRoot, "styles.ts");
-      const { provider, calls } = createFakeStaticCssEvalSourceProvider({
-        sources: {
-          [fixturePath]: ownerSource,
-          [stylesId]: `export const button = ;`
-        },
-        resolutions: {
-          [`${fixturePath}\0./styles`]: stylesId
-        }
-      });
-      const prepass = await createStaticCssEvalPrepass(fixturePath, provider);
-      const resolution = prepass.provider.getResolvedCssValue({
-        importerId: fixturePath,
-        expressionStart: 0,
-        expressionEnd: "button".length,
-        bindingName: "button"
-      });
-
-      expect(calls.resolved).toEqual([
-        { importerId: fixturePath, importPath: "./styles" }
-      ]);
-      expect(calls.loaded).toEqual([fixturePath, stylesId]);
-      expect(prepass.result.dependencyFiles).toEqual([stylesId]);
-      expect(prepass.result.resolvedModuleCache.has(fixturePath)).toBe(true);
-      expect(prepass.result.resolvedModuleCache.has(stylesId)).toBe(false);
-      expect(resolution.kind).toBe("error");
-
-      if (resolution.kind !== "error") {
-        throw new Error("Expected failed dependency resolution");
-      }
-
-      expect(resolution.dependencies).toEqual([stylesId]);
-      expect(resolution.diagnostic.code).toBe(
-        "failed-project-local-dependency"
-      );
-      expect(resolution.diagnostic.message).toContain(
-        `failed to load project-local dependency ${stylesId}`
-      );
     });
 
     it("preserves whole-expression reexport fallback but rejects reexports inside static css rules", async () => {

--- a/packages/integration/src/babel.ts
+++ b/packages/integration/src/babel.ts
@@ -6,6 +6,7 @@ import {
   type InternalImportedStaticCssEvalImportResolution as ImportedStaticCssEvalImportResolution,
   type InternalImportedStaticCssEvalLoadedModule as ImportedStaticCssEvalLoadedModule,
   type InternalImportedStaticCssEvalModuleRecord as ImportedStaticCssEvalModuleRecord,
+  type MinchoStaticCssEvalMetadata,
   type PluginOptions,
   minchoBabelPlugin,
   minchoStyledComponentPlugin
@@ -13,18 +14,74 @@ import {
 
 type MaybePromise<T> = T | Promise<T>;
 
-export interface StaticCssEvalSourceResolution {
-  id: string;
-  realpath?: string;
+type StaticCssEvalProvider = NonNullable<
+  PluginOptions["staticCssEvalProvider"]
+>;
+type StaticCssEvalProviderResult = ReturnType<
+  StaticCssEvalProvider["getResolvedCssValue"]
+>;
+type StaticCssEvalMetadataDependency =
+  MinchoStaticCssEvalMetadata["dependencies"][number];
+type StaticCssEvalMetadataDiagnostic =
+  MinchoStaticCssEvalMetadata["diagnostics"][number];
+type StaticCssEvalMetadataCacheKey =
+  MinchoStaticCssEvalMetadata["cacheKeys"][number];
+type StaticCssEvalProviderMetadataSource = {
+  dependencies?: readonly unknown[];
+  diagnostics?: readonly StaticCssEvalMetadataDiagnostic[];
+  diagnostic?: StaticCssEvalMetadataDiagnostic;
+  cacheKey?: StaticCssEvalMetadataCacheKey;
+};
+
+export type StaticCssEvalResolverKind =
+  | "source-provider"
+  | "filesystem"
+  | "vite"
+  | "esbuild"
+  | "test"
+  | (string & {});
+
+export interface StaticCssEvalSourceIdentity {
   sourceHash?: string;
   version?: string | number;
 }
 
-export interface StaticCssEvalLoadedSource {
-  source: string;
+// Integration supplies bundler-aware identity/source freshness; Babel static
+// eval remains the only owner of css value and symbol provenance.
+export interface StaticCssEvalSourceResolution {
+  /**
+   * Legacy alias. When newer fields are absent, this is treated as the
+   * resolved file, canonical module id, and normalized load key.
+   */
+  id?: string;
+  /** File path used by Babel/static eval diagnostics, dependency files, and cache keys. */
+  resolvedFile?: string;
+  /** Bundler graph id that should be preserved for callers, even when it differs from the file path. */
+  canonicalModuleId?: string;
+  /** Stable provider load/cache key; integration passes this value back to `load()`. */
+  normalizedPathKey?: string;
   realpath?: string;
   sourceHash?: string;
   version?: string | number;
+  /** Source identity from the bundler; loaded source identity takes precedence. */
+  sourceIdentity?: StaticCssEvalSourceIdentity;
+  /** Identifies which resolver produced this source for downstream cache/debug consumers. */
+  resolverKind?: StaticCssEvalResolverKind;
+}
+
+export interface StaticCssEvalLoadedSource {
+  /** Preferred loaded module text. */
+  sourceText?: string;
+  /** Legacy alias for `sourceText`. */
+  source?: string;
+  resolvedFile?: string;
+  canonicalModuleId?: string;
+  normalizedPathKey?: string;
+  realpath?: string;
+  sourceHash?: string;
+  version?: string | number;
+  sourceIdentity?: StaticCssEvalSourceIdentity;
+  resolverKind?: StaticCssEvalResolverKind;
 }
 
 /** @internal Async owner/dependency source provider for bundler prepasses. */
@@ -41,11 +98,64 @@ export interface StaticCssEvalPrepassResult {
   ownerToDependencies: ReadonlyMap<string, string[]>;
   dependencyToOwners: ReadonlyMap<string, string[]>;
   resolvedModuleCache: ReadonlyMap<string, ImportedStaticCssEvalModuleRecord>;
+  resolvedDependencies: StaticCssEvalResolvedDependency[];
+}
+
+export interface StaticCssEvalResolvedDependency {
+  importerId: string;
+  specifier: string;
+  resolvedFile: string;
+  canonicalModuleId: string;
+  normalizedPathKey: string;
+  resolverKind: StaticCssEvalResolverKind;
+  loaded: boolean;
+  sourceIdentity?: StaticCssEvalSourceIdentity;
+}
+
+export interface StaticCssEvalTransformResult
+  extends StaticCssEvalPrepassResult, MinchoStaticCssEvalMetadata {}
+
+interface NormalizedStaticCssEvalSourceResolution {
+  resolvedFile: string;
+  canonicalModuleId: string;
+  normalizedPathKey: string;
+  resolverKind: StaticCssEvalResolverKind;
+  realpath?: string;
+  sourceIdentity?: StaticCssEvalSourceIdentity;
 }
 
 interface PreparedStaticCssEvalPrepass {
-  provider: NonNullable<PluginOptions["staticCssEvalProvider"]>;
+  provider: StaticCssEvalProvider;
   result: StaticCssEvalPrepassResult;
+}
+
+interface StaticCssEvalPrepassState {
+  loadedModules: ImportedStaticCssEvalLoadedModule[];
+  importResolutions: ImportedStaticCssEvalImportResolution[];
+  resolvedModuleCache: Map<string, ImportedStaticCssEvalModuleRecord>;
+  ownerDependencies: string[];
+  dependencyToOwners: Map<string, string[]>;
+  resolvedDependencies: StaticCssEvalResolvedDependency[];
+  resolvedImports: Map<string, NormalizedStaticCssEvalSourceResolution | null>;
+  loadedDependencyIds: Set<string>;
+}
+
+export class BabelTransformError extends Error {
+  readonly file: string;
+  readonly staticCssEval?: StaticCssEvalTransformResult;
+  override cause: unknown;
+
+  constructor(
+    file: string,
+    cause: unknown,
+    staticCssEval?: StaticCssEvalTransformResult
+  ) {
+    super(cause instanceof Error ? cause.message : String(cause));
+    this.name = "BabelTransformError";
+    this.file = file;
+    this.cause = cause;
+    this.staticCssEval = staticCssEval;
+  }
 }
 
 export type BabelOptions = Omit<
@@ -67,7 +177,7 @@ export type BabelTransformResult = {
   code: string;
   readonly jsxCssPropTransformed?: boolean;
   result: [string, string];
-  readonly staticCssEval?: StaticCssEvalPrepassResult;
+  readonly staticCssEval?: StaticCssEvalTransformResult;
 };
 
 export async function babelTransform(
@@ -84,44 +194,73 @@ export async function babelTransform(
     jsxCssProp === true && staticCssEvalSourceProvider
       ? await createStaticCssEvalPrepass(path, staticCssEvalSourceProvider)
       : undefined;
+  const observedStaticCssEvalMetadata = createEmptyStaticCssEvalMetadata();
   const preparedStaticCssEvalProvider =
     staticCssEvalProvider ?? staticCssEvalPrepass?.provider;
+  const observedStaticCssEvalProvider = preparedStaticCssEvalProvider
+    ? createObservingStaticCssEvalProvider(
+        preparedStaticCssEvalProvider,
+        observedStaticCssEvalMetadata
+      )
+    : undefined;
   const options: PluginOptions & {
     jsxCssProp?: boolean;
   } = {
     result: ["", ""],
     jsxCssProp,
-    staticCssEvalProvider: preparedStaticCssEvalProvider
+    staticCssEvalProvider: observedStaticCssEvalProvider
   };
-  const result = await transformFileAsync(path, {
-    ...babelCoreOptions,
-    plugins: [
-      ...(Array.isArray(babelCoreOptions.plugins)
-        ? babelCoreOptions.plugins
-        : []),
-      minchoStyledComponentPlugin(),
-      [minchoBabelPlugin(), options]
-    ],
-    presets: [
-      ...(Array.isArray(babelCoreOptions.presets)
-        ? babelCoreOptions.presets
-        : []),
-      "@babel/preset-typescript"
-    ],
-    sourceMaps: false
-  });
+  let result;
+
+  try {
+    result = await transformFileAsync(path, {
+      ...babelCoreOptions,
+      plugins: [
+        ...(Array.isArray(babelCoreOptions.plugins)
+          ? babelCoreOptions.plugins
+          : []),
+        minchoStyledComponentPlugin(),
+        [minchoBabelPlugin(), options]
+      ],
+      presets: [
+        ...(Array.isArray(babelCoreOptions.presets)
+          ? babelCoreOptions.presets
+          : []),
+        "@babel/preset-typescript"
+      ],
+      sourceMaps: false
+    });
+  } catch (error) {
+    const staticCssEval = createStaticCssEvalTransformResult(
+      staticCssEvalPrepass?.result,
+      observedStaticCssEvalMetadata
+    );
+
+    if (staticCssEval) {
+      throw new BabelTransformError(path, error, staticCssEval);
+    }
+
+    throw error;
+  }
 
   if (result === null || result.code == null) {
     throw new Error(`Failed to transform ${path}`);
   }
 
+  const staticCssEvalMetadata = mergeStaticCssEvalMetadata(
+    getStaticCssEvalMetadata(result.metadata),
+    observedStaticCssEvalMetadata
+  );
+  const staticCssEval = createStaticCssEvalTransformResult(
+    staticCssEvalPrepass?.result,
+    staticCssEvalMetadata
+  );
+
   return {
     result: options.result,
     code: result.code,
     jsxCssPropTransformed: options.jsxCssPropTransformed === true,
-    ...(staticCssEvalPrepass
-      ? { staticCssEval: staticCssEvalPrepass.result }
-      : {})
+    ...(staticCssEval ? { staticCssEval } : {})
   };
 }
 
@@ -141,115 +280,627 @@ async function createStaticCssEvalPrepass(
     ownerRecord.programPath,
     { importerId: ownerId }
   );
-  const loadedModules: ImportedStaticCssEvalLoadedModule[] = [ownerModule];
-  const importResolutions: ImportedStaticCssEvalImportResolution[] = [];
-  const resolvedModuleCache = new Map<
-    string,
-    ImportedStaticCssEvalModuleRecord
-  >([[ownerRecord.id, ownerRecord]]);
-  const ownerDependencies: string[] = [];
-  const dependencyToOwners = new Map<string, string[]>();
-  const resolvedImports = new Map<
-    string,
-    StaticCssEvalSourceResolution | null
-  >();
-  const loadedDependencyIds = new Set<string>([ownerId]);
+  const prepassState: StaticCssEvalPrepassState = {
+    loadedModules: [ownerModule],
+    importResolutions: [],
+    resolvedModuleCache: new Map([[ownerRecord.id, ownerRecord]]),
+    ownerDependencies: [],
+    dependencyToOwners: new Map(),
+    resolvedDependencies: [],
+    resolvedImports: new Map(),
+    loadedDependencyIds: new Set([ownerId])
+  };
 
   for (const candidate of candidates) {
     const importBinding = candidate.bindingName
       ? ownerRecord.imports.get(candidate.bindingName)
       : undefined;
 
-    if (!importBinding || importBinding.kind === "namespace") {
+    if (!importBinding) {
       continue;
     }
 
-    const importPath = importBinding.importPath;
-    let resolution = resolvedImports.get(importPath);
-
-    if (!resolvedImports.has(importPath)) {
-      resolution = await sourceProvider.resolve(ownerId, importPath);
-      resolvedImports.set(importPath, resolution ?? null);
-
-      if (resolution) {
-        importResolutions.push({
-          importerId: ownerId,
-          importPath,
-          resolvedId: resolution.id
-        });
-      }
-    }
-
-    if (!resolution) {
-      continue;
-    }
-
-    addOwnerDependency(
-      ownerDependencies,
-      dependencyToOwners,
+    const moduleRecord = await loadStaticCssEvalPrepassDependency(
       ownerId,
-      resolution.id
+      importBinding.importPath,
+      sourceProvider,
+      prepassState
     );
 
-    if (loadedDependencyIds.has(resolution.id)) {
+    if (!moduleRecord) {
       continue;
     }
 
-    loadedDependencyIds.add(resolution.id);
-    const loadedSource = await sourceProvider.load(resolution.id);
-
-    if (!loadedSource) {
-      continue;
-    }
-
-    const loadedModule = createLoadedModule(
-      resolution.id,
-      loadedSource,
-      resolution
-    );
-
-    try {
-      const moduleRecord =
-        createImportedStaticCssEvalModuleRecord(loadedModule);
-      resolvedModuleCache.set(moduleRecord.id, moduleRecord);
-      loadedModules.push(loadedModule);
-    } catch {
-      continue;
+    if (importBinding.kind !== "namespace") {
+      await loadDirectReexportDependencies(
+        moduleRecord,
+        importBinding.importedName,
+        sourceProvider,
+        prepassState
+      );
     }
   }
 
   const ownerToDependencies = new Map<string, string[]>([
-    [ownerId, ownerDependencies]
+    [ownerId, prepassState.ownerDependencies]
   ]);
   const provider = createImportedStaticCssEvalProvider({
-    modules: loadedModules,
-    importResolutions,
-    moduleRecords: [...resolvedModuleCache.values()]
+    modules: prepassState.loadedModules,
+    importResolutions: prepassState.importResolutions,
+    moduleRecords: [...prepassState.resolvedModuleCache.values()]
   });
 
   return {
     provider,
     result: {
-      dependencyFiles: [...ownerDependencies],
+      dependencyFiles: [...prepassState.ownerDependencies],
       ownerToDependencies,
-      dependencyToOwners,
-      resolvedModuleCache
+      dependencyToOwners: prepassState.dependencyToOwners,
+      resolvedModuleCache: prepassState.resolvedModuleCache,
+      resolvedDependencies: prepassState.resolvedDependencies
     }
   };
+}
+
+async function loadStaticCssEvalPrepassDependency(
+  importerId: string,
+  importPath: string,
+  sourceProvider: StaticCssEvalSourceProvider,
+  prepassState: StaticCssEvalPrepassState
+): Promise<ImportedStaticCssEvalModuleRecord | undefined> {
+  const resolvedImportKey = `${importerId}\0${importPath}`;
+  let resolution = prepassState.resolvedImports.get(resolvedImportKey);
+
+  if (!prepassState.resolvedImports.has(resolvedImportKey)) {
+    const sourceResolution = await sourceProvider.resolve(
+      importerId,
+      importPath
+    );
+    resolution = sourceResolution
+      ? normalizeStaticCssEvalSourceResolution(sourceResolution)
+      : null;
+    prepassState.resolvedImports.set(resolvedImportKey, resolution ?? null);
+
+    if (resolution) {
+      prepassState.importResolutions.push({
+        importerId,
+        importPath,
+        resolvedId: resolution.resolvedFile
+      });
+      prepassState.resolvedDependencies.push(
+        createStaticCssEvalResolvedDependency(
+          importerId,
+          importPath,
+          resolution,
+          false
+        )
+      );
+    }
+  }
+
+  if (!resolution) {
+    return undefined;
+  }
+
+  addOwnerDependency(
+    prepassState.ownerDependencies,
+    prepassState.dependencyToOwners,
+    prepassState.loadedModules[0]?.id ?? importerId,
+    resolution.resolvedFile
+  );
+
+  const cachedRecord = prepassState.resolvedModuleCache.get(
+    resolution.resolvedFile
+  );
+
+  if (cachedRecord) {
+    return cachedRecord;
+  }
+
+  if (prepassState.loadedDependencyIds.has(resolution.resolvedFile)) {
+    return undefined;
+  }
+
+  prepassState.loadedDependencyIds.add(resolution.resolvedFile);
+  const loadedSource = await sourceProvider.load(resolution.normalizedPathKey);
+
+  if (!loadedSource) {
+    return undefined;
+  }
+
+  markResolvedDependencyLoaded(
+    prepassState.resolvedDependencies,
+    importerId,
+    importPath,
+    resolution,
+    loadedSource
+  );
+
+  const loadedModule = createLoadedModule(
+    resolution.resolvedFile,
+    loadedSource,
+    resolution
+  );
+
+  try {
+    const moduleRecord = createImportedStaticCssEvalModuleRecord(loadedModule);
+    prepassState.resolvedModuleCache.set(moduleRecord.id, moduleRecord);
+    prepassState.loadedModules.push(loadedModule);
+
+    return moduleRecord;
+  } catch {
+    return undefined;
+  }
+}
+
+async function loadDirectReexportDependencies(
+  moduleRecord: ImportedStaticCssEvalModuleRecord,
+  exportName: string,
+  sourceProvider: StaticCssEvalSourceProvider,
+  prepassState: StaticCssEvalPrepassState
+): Promise<void> {
+  let currentRecord: ImportedStaticCssEvalModuleRecord | undefined =
+    moduleRecord;
+  let currentExportName = exportName;
+  const seenReexports = new Set<string>();
+
+  while (currentRecord) {
+    const exportEntry = currentRecord.exports.get(currentExportName);
+
+    if (!exportEntry || exportEntry.kind !== "reexport") {
+      return;
+    }
+
+    const reexportKey = `${currentRecord.id}\0${currentExportName}`;
+
+    if (seenReexports.has(reexportKey)) {
+      return;
+    }
+
+    seenReexports.add(reexportKey);
+
+    currentRecord = await loadStaticCssEvalPrepassDependency(
+      currentRecord.id,
+      exportEntry.source,
+      sourceProvider,
+      prepassState
+    );
+    currentExportName = exportEntry.importedName;
+  }
 }
 
 function createLoadedModule(
   id: string,
   loadedSource: StaticCssEvalLoadedSource,
-  resolution?: StaticCssEvalSourceResolution
+  resolution?: NormalizedStaticCssEvalSourceResolution
 ): ImportedStaticCssEvalLoadedModule {
+  const sourceText = getLoadedSourceText(id, loadedSource);
+  const sourceIdentity = createLoadedSourceIdentity(
+    sourceText,
+    loadedSource,
+    resolution
+  );
+
   return {
     id,
-    source: loadedSource.source,
+    source: sourceText,
     realpath: loadedSource.realpath ?? resolution?.realpath,
-    sourceHash: loadedSource.sourceHash ?? resolution?.sourceHash,
-    version: loadedSource.version ?? resolution?.version
+    sourceHash: sourceIdentity.sourceHash,
+    version: sourceIdentity.version
   };
+}
+
+function getLoadedSourceText(
+  id: string,
+  loadedSource: StaticCssEvalLoadedSource
+): string {
+  const sourceText = loadedSource.sourceText ?? loadedSource.source;
+
+  if (sourceText === undefined) {
+    throw new Error(
+      `Static css eval source provider did not return source for ${id}`
+    );
+  }
+
+  return sourceText;
+}
+
+function normalizeStaticCssEvalSourceResolution(
+  resolution: StaticCssEvalSourceResolution
+): NormalizedStaticCssEvalSourceResolution {
+  const resolvedFile = resolution.resolvedFile ?? resolution.id;
+
+  if (!resolvedFile) {
+    throw new Error(
+      "Static css eval source resolution requires resolvedFile or id"
+    );
+  }
+
+  const canonicalModuleId =
+    resolution.canonicalModuleId ?? resolution.id ?? resolvedFile;
+  const normalizedPathKey =
+    resolution.normalizedPathKey ?? canonicalModuleId ?? resolvedFile;
+
+  return {
+    resolvedFile,
+    canonicalModuleId,
+    normalizedPathKey,
+    resolverKind: resolution.resolverKind ?? "source-provider",
+    realpath: resolution.realpath,
+    sourceIdentity: normalizeStaticCssEvalSourceIdentity(
+      resolution.sourceIdentity,
+      resolution.sourceHash,
+      resolution.version
+    )
+  };
+}
+
+function normalizeStaticCssEvalSourceIdentity(
+  sourceIdentity: StaticCssEvalSourceIdentity | undefined,
+  sourceHash: string | undefined,
+  version: string | number | undefined
+): StaticCssEvalSourceIdentity | undefined {
+  const normalizedSourceHash = sourceIdentity?.sourceHash ?? sourceHash;
+  const normalizedVersion = sourceIdentity?.version ?? version;
+
+  if (normalizedSourceHash === undefined && normalizedVersion === undefined) {
+    return undefined;
+  }
+
+  return {
+    ...(normalizedSourceHash !== undefined
+      ? { sourceHash: normalizedSourceHash }
+      : {}),
+    ...(normalizedVersion !== undefined ? { version: normalizedVersion } : {})
+  };
+}
+
+function createLoadedSourceIdentity(
+  sourceText: string,
+  loadedSource: StaticCssEvalLoadedSource,
+  resolution?: NormalizedStaticCssEvalSourceResolution
+): Required<Pick<StaticCssEvalSourceIdentity, "sourceHash">> &
+  Pick<StaticCssEvalSourceIdentity, "version"> {
+  const sourceIdentity = normalizeStaticCssEvalSourceIdentity(
+    loadedSource.sourceIdentity,
+    loadedSource.sourceHash,
+    loadedSource.version
+  );
+  const sourceHash =
+    sourceIdentity?.sourceHash ??
+    resolution?.sourceIdentity?.sourceHash ??
+    createStaticCssEvalSourceTextHash(sourceText);
+  const version =
+    sourceIdentity?.version ?? resolution?.sourceIdentity?.version;
+
+  return {
+    sourceHash,
+    ...(version !== undefined ? { version } : {})
+  };
+}
+
+function createStaticCssEvalResolvedDependency(
+  importerId: string,
+  specifier: string,
+  resolution: NormalizedStaticCssEvalSourceResolution,
+  loaded: boolean,
+  loadedSource?: StaticCssEvalLoadedSource
+): StaticCssEvalResolvedDependency {
+  const sourceText = loadedSource
+    ? getLoadedSourceText(resolution.normalizedPathKey, loadedSource)
+    : undefined;
+  const sourceIdentity = loadedSource
+    ? createLoadedSourceIdentity(sourceText ?? "", loadedSource, resolution)
+    : resolution.sourceIdentity;
+
+  return {
+    importerId,
+    specifier,
+    resolvedFile: resolution.resolvedFile,
+    canonicalModuleId: resolution.canonicalModuleId,
+    normalizedPathKey: resolution.normalizedPathKey,
+    resolverKind: resolution.resolverKind,
+    loaded,
+    ...(sourceIdentity ? { sourceIdentity } : {})
+  };
+}
+
+function markResolvedDependencyLoaded(
+  resolvedDependencies: StaticCssEvalResolvedDependency[],
+  importerId: string,
+  specifier: string,
+  resolution: NormalizedStaticCssEvalSourceResolution,
+  loadedSource: StaticCssEvalLoadedSource
+): void {
+  const resolvedDependencyIndex = resolvedDependencies.findIndex(
+    (dependency) =>
+      dependency.importerId === importerId &&
+      dependency.specifier === specifier &&
+      dependency.resolvedFile === resolution.resolvedFile
+  );
+  const loadedDependency = createStaticCssEvalResolvedDependency(
+    importerId,
+    specifier,
+    resolution,
+    true,
+    loadedSource
+  );
+
+  if (resolvedDependencyIndex === -1) {
+    resolvedDependencies.push(loadedDependency);
+    return;
+  }
+
+  resolvedDependencies[resolvedDependencyIndex] = loadedDependency;
+}
+
+function createStaticCssEvalSourceTextHash(sourceText: string): string {
+  let hash = 0x811c9dc5;
+
+  for (let index = 0; index < sourceText.length; index += 1) {
+    hash ^= sourceText.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+
+  return `fnv1a:${(hash >>> 0).toString(16).padStart(8, "0")}:${sourceText.length}`;
+}
+
+function createObservingStaticCssEvalProvider(
+  provider: StaticCssEvalProvider,
+  metadata: MinchoStaticCssEvalMetadata
+): StaticCssEvalProvider {
+  return {
+    getResolvedCssValue(query): StaticCssEvalProviderResult {
+      const result = provider.getResolvedCssValue(query);
+      appendStaticCssEvalResultMetadata(metadata, result);
+      return result;
+    }
+  };
+}
+
+function appendStaticCssEvalResultMetadata(
+  metadata: MinchoStaticCssEvalMetadata,
+  result: StaticCssEvalProviderResult
+): void {
+  const metadataSource = result as StaticCssEvalProviderMetadataSource;
+  const dependencies = (metadataSource.dependencies ?? []).filter(
+    isStaticCssEvalResolutionDependency
+  );
+  const diagnostics =
+    metadataSource.diagnostics ??
+    (metadataSource.diagnostic ? [metadataSource.diagnostic] : []);
+  const cacheKeys = metadataSource.cacheKey ? [metadataSource.cacheKey] : [];
+
+  appendUniqueMetadataItems(
+    metadata.dependencies,
+    dependencies,
+    createStaticCssEvalDependencyKey
+  );
+  appendUniqueMetadataItems(
+    metadata.diagnostics,
+    diagnostics,
+    createStaticCssEvalDiagnosticKey
+  );
+  appendUniqueMetadataItems(
+    metadata.cacheKeys,
+    cacheKeys,
+    createStaticCssEvalCacheKeyKey
+  );
+  appendUniqueMetadataItems(
+    metadata.resolvedModuleIds,
+    [
+      ...cacheKeys.flatMap((cacheKey) => cacheKey.resolvedId ?? []),
+      ...dependencies.flatMap((dependency) =>
+        dependency.kind !== "local" &&
+        dependency.kind !== "unresolved" &&
+        dependency.inspected
+          ? [dependency.file]
+          : []
+      )
+    ],
+    (moduleId) => moduleId
+  );
+}
+
+function isStaticCssEvalResolutionDependency(
+  dependency: unknown
+): dependency is StaticCssEvalMetadataDependency {
+  return typeof dependency === "object" && dependency !== null;
+}
+
+function getStaticCssEvalMetadata(
+  metadata: unknown
+): MinchoStaticCssEvalMetadata | undefined {
+  const staticCssEval = (
+    metadata as { minchoStaticCssEval?: MinchoStaticCssEvalMetadata } | null
+  )?.minchoStaticCssEval;
+
+  if (!staticCssEval) {
+    return undefined;
+  }
+
+  return cloneStaticCssEvalMetadata(staticCssEval);
+}
+
+function createStaticCssEvalTransformResult(
+  prepassResult: StaticCssEvalPrepassResult | undefined,
+  metadata: MinchoStaticCssEvalMetadata | undefined
+): StaticCssEvalTransformResult | undefined {
+  const staticCssEvalMetadata = metadata
+    ? cloneStaticCssEvalMetadata(metadata)
+    : createEmptyStaticCssEvalMetadata();
+  const hasMetadata =
+    staticCssEvalMetadata.dependencies.length > 0 ||
+    staticCssEvalMetadata.diagnostics.length > 0 ||
+    staticCssEvalMetadata.cacheKeys.length > 0 ||
+    staticCssEvalMetadata.resolvedModuleIds.length > 0;
+
+  if (!prepassResult && !hasMetadata) {
+    return undefined;
+  }
+
+  return {
+    dependencyFiles: prepassResult?.dependencyFiles ?? [],
+    ownerToDependencies: prepassResult?.ownerToDependencies ?? new Map(),
+    dependencyToOwners: prepassResult?.dependencyToOwners ?? new Map(),
+    resolvedModuleCache: prepassResult?.resolvedModuleCache ?? new Map(),
+    resolvedDependencies: prepassResult?.resolvedDependencies ?? [],
+    ...staticCssEvalMetadata
+  };
+}
+
+function mergeStaticCssEvalMetadata(
+  ...metadataItems: Array<MinchoStaticCssEvalMetadata | undefined>
+): MinchoStaticCssEvalMetadata {
+  const mergedMetadata = createEmptyStaticCssEvalMetadata();
+
+  for (const metadata of metadataItems) {
+    if (!metadata) {
+      continue;
+    }
+
+    appendUniqueMetadataItems(
+      mergedMetadata.dependencies,
+      metadata.dependencies,
+      createStaticCssEvalDependencyKey
+    );
+    appendUniqueMetadataItems(
+      mergedMetadata.diagnostics,
+      metadata.diagnostics,
+      createStaticCssEvalDiagnosticKey
+    );
+    appendUniqueMetadataItems(
+      mergedMetadata.cacheKeys,
+      metadata.cacheKeys,
+      createStaticCssEvalCacheKeyKey
+    );
+    appendUniqueMetadataItems(
+      mergedMetadata.resolvedModuleIds,
+      metadata.resolvedModuleIds,
+      (moduleId) => moduleId
+    );
+  }
+
+  return mergedMetadata;
+}
+
+function createEmptyStaticCssEvalMetadata(): MinchoStaticCssEvalMetadata {
+  return {
+    dependencies: [],
+    diagnostics: [],
+    cacheKeys: [],
+    resolvedModuleIds: []
+  };
+}
+
+function cloneStaticCssEvalMetadata(
+  metadata: MinchoStaticCssEvalMetadata
+): MinchoStaticCssEvalMetadata {
+  return {
+    dependencies: metadata.dependencies.map((dependency) => ({
+      ...dependency,
+      memberPath: [...dependency.memberPath]
+    })),
+    diagnostics: metadata.diagnostics.map((diagnostic) => ({
+      ...diagnostic,
+      owner: { ...diagnostic.owner },
+      ...(diagnostic.dependency
+        ? { dependency: { ...diagnostic.dependency } }
+        : {}),
+      ...(diagnostic.memberPath
+        ? { memberPath: [...diagnostic.memberPath] }
+        : {}),
+      ...(diagnostic.importChain
+        ? { importChain: [...diagnostic.importChain] }
+        : {})
+    })),
+    cacheKeys: metadata.cacheKeys.map((cacheKey) => ({
+      ...cacheKey,
+      memberPath: [...cacheKey.memberPath],
+      ...(cacheKey.parserOptions
+        ? {
+            parserOptions: {
+              ...cacheKey.parserOptions,
+              plugins: [...cacheKey.parserOptions.plugins]
+            }
+          }
+        : {}),
+      ...(cacheKey.projectLocalBoundary
+        ? { projectLocalBoundary: { ...cacheKey.projectLocalBoundary } }
+        : {})
+    })),
+    resolvedModuleIds: [...metadata.resolvedModuleIds]
+  };
+}
+
+function appendUniqueMetadataItems<T>(
+  target: T[],
+  items: readonly T[],
+  createKey: (item: T) => string
+): void {
+  const existingKeys = new Set(target.map(createKey));
+
+  for (const item of items) {
+    const key = createKey(item);
+
+    if (existingKeys.has(key)) {
+      continue;
+    }
+
+    existingKeys.add(key);
+    target.push(item);
+  }
+}
+
+function createStaticCssEvalDependencyKey(
+  dependency: StaticCssEvalMetadataDependency
+): string {
+  return JSON.stringify([
+    dependency.file,
+    dependency.kind,
+    dependency.importer,
+    dependency.specifier,
+    dependency.exportName,
+    dependency.memberPath,
+    dependency.inspected,
+    dependency.contributed
+  ]);
+}
+
+function createStaticCssEvalDiagnosticKey(
+  diagnostic: StaticCssEvalMetadataDiagnostic
+): string {
+  return JSON.stringify([
+    diagnostic.id,
+    diagnostic.code,
+    diagnostic.reason,
+    diagnostic.message,
+    diagnostic.owner.file,
+    diagnostic.owner.start,
+    diagnostic.owner.end,
+    diagnostic.dependency?.file,
+    diagnostic.importPath,
+    diagnostic.exportName,
+    diagnostic.memberPath,
+    diagnostic.importChain
+  ]);
+}
+
+function createStaticCssEvalCacheKeyKey(
+  cacheKey: StaticCssEvalMetadataCacheKey
+): string {
+  return JSON.stringify([
+    cacheKey.importerFile,
+    cacheKey.resolvedFile,
+    cacheKey.exportName,
+    cacheKey.memberPath,
+    cacheKey.sourceHash,
+    cacheKey.sourceVersion,
+    cacheKey.pluginOptionsVersion,
+    cacheKey.resolverOptionsVersion,
+    cacheKey.staticEvalSupportVersion,
+    cacheKey.resolvedId
+  ]);
 }
 
 function addOwnerDependency(
@@ -303,6 +954,30 @@ if (import.meta.vitest) {
     return fixturePath;
   }
 
+  async function createBabelFixtureFiles<
+    FixtureFiles extends Record<string, string>
+  >(files: FixtureFiles, label: string) {
+    const fs = await import("node:fs/promises");
+    const path = await import("node:path");
+    fixtureIndex += 1;
+    const fixtureRoot = path.join(
+      process.env.TMPDIR ?? `${process.cwd()}/temps`,
+      `mincho-babel-css-prop-${fixtureIndex}-${label}`
+    );
+    const filePaths = {} as Record<keyof FixtureFiles, string>;
+
+    fixtureRoots.push(fixtureRoot);
+
+    for (const fileName of Object.keys(files) as Array<keyof FixtureFiles>) {
+      const fixturePath = path.join(fixtureRoot, String(fileName));
+      filePaths[fileName] = fixturePath;
+      await fs.mkdir(path.dirname(fixturePath), { recursive: true });
+      await fs.writeFile(fixturePath, files[fileName], "utf8");
+    }
+
+    return { fixtureRoot, filePaths };
+  }
+
   afterEach(async () => {
     const fs = await import("node:fs/promises");
 
@@ -317,6 +992,56 @@ if (import.meta.vitest) {
 
   function escapeRegExp(input: string) {
     return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+
+  function createTestSourceIdentity(
+    sourceText: string
+  ): StaticCssEvalSourceIdentity {
+    const colorTag = sourceText.includes('color: "blue"')
+      ? "blue"
+      : sourceText.includes('color: "red"')
+        ? "red"
+        : "source";
+
+    return { sourceHash: `test:${sourceText.length}:${colorTag}` };
+  }
+
+  function createFileBackedStaticCssEvalSourceProvider(options: {
+    resolutions: Record<string, string>;
+    resolverKind?: StaticCssEvalResolverKind;
+  }): StaticCssEvalSourceProvider {
+    return {
+      resolve(importerId, importPath) {
+        const resolvedFile =
+          options.resolutions[`${importerId}\0${importPath}`];
+
+        if (!resolvedFile) {
+          return null;
+        }
+
+        return {
+          resolvedFile,
+          canonicalModuleId: `test:${resolvedFile}`,
+          normalizedPathKey: resolvedFile,
+          resolverKind: options.resolverKind ?? "test"
+        };
+      },
+      async load(id) {
+        const fs = await import("node:fs/promises");
+
+        try {
+          const sourceText = await fs.readFile(id, "utf8");
+
+          return {
+            sourceText,
+            sourceIdentity: createTestSourceIdentity(sourceText),
+            resolverKind: options.resolverKind ?? "test"
+          };
+        } catch {
+          return null;
+        }
+      }
+    };
   }
 
   type StaticCssEvalProvider = NonNullable<
@@ -716,7 +1441,254 @@ if (import.meta.vitest) {
       expect(staticCssEval?.resolvedModuleCache.has(unusedId)).toBe(false);
     });
 
-    it("reports dependency maps for unsupported reexport fallback from async prepass", async () => {
+    it("uses imported source identity when only the imported style file changes", async () => {
+      const fs = await import("node:fs/promises");
+      const componentSource = `
+        import { button } from "./styles";
+
+        function App() {
+          return <div css={button} />;
+        }
+      `;
+      const redStylesSource = `export const button = { color: "red" } as const;`;
+      const blueStylesSource = `export const button = { color: "blue" } as const;`;
+      const { filePaths } = await createBabelFixtureFiles(
+        {
+          "component.tsx": componentSource,
+          "styles.ts": redStylesSource
+        },
+        "css-prop-imported-cache-invalidation"
+      );
+      const componentId = filePaths["component.tsx"];
+      const stylesId = filePaths["styles.ts"];
+      const provider = createFileBackedStaticCssEvalSourceProvider({
+        resolutions: {
+          [`${componentId}\0./styles`]: stylesId
+        }
+      });
+
+      const firstTransform = await babelTransform(componentId, {
+        jsxCssProp: true,
+        staticCssEvalSourceProvider: provider
+      });
+      await fs.writeFile(stylesId, blueStylesSource, "utf8");
+      const secondTransform = await babelTransform(componentId, {
+        jsxCssProp: true,
+        staticCssEvalSourceProvider: provider
+      });
+
+      expect(firstTransform.result[1]).toContain('color: "red"');
+      expect(firstTransform.result[1]).not.toContain('color: "blue"');
+      expect(secondTransform.result[1]).toContain('color: "blue"');
+      expect(secondTransform.result[1]).not.toContain('color: "red"');
+      expect(firstTransform.staticCssEval?.dependencyFiles).toEqual([stylesId]);
+      expect(secondTransform.staticCssEval?.dependencyFiles).toEqual([
+        stylesId
+      ]);
+      expect(firstTransform.staticCssEval?.cacheKeys[0]?.sourceHash).toBe(
+        createTestSourceIdentity(redStylesSource).sourceHash
+      );
+      expect(secondTransform.staticCssEval?.cacheKeys[0]?.sourceHash).toBe(
+        createTestSourceIdentity(blueStylesSource).sourceHash
+      );
+      expect(firstTransform.staticCssEval?.cacheKeys[0]?.sourceHash).not.toBe(
+        secondTransform.staticCssEval?.cacheKeys[0]?.sourceHash
+      );
+      expect(secondTransform.staticCssEval?.resolvedDependencies).toEqual([
+        expect.objectContaining({
+          importerId: componentId,
+          specifier: "./styles",
+          resolvedFile: stylesId,
+          canonicalModuleId: `test:${stylesId}`,
+          normalizedPathKey: stylesId,
+          resolverKind: "test",
+          loaded: true,
+          sourceIdentity: createTestSourceIdentity(blueStylesSource)
+        })
+      ]);
+      expect(secondTransform.staticCssEval?.resolvedModuleIds).toContain(
+        stylesId
+      );
+    });
+
+    it("does not reuse an unresolved export result after imported source content changes", async () => {
+      const fs = await import("node:fs/promises");
+      const componentSource = `
+        import { button } from "./styles";
+
+        function App() {
+          return <div css={button} />;
+        }
+      `;
+      const missingExportStylesSource = `export const card = { color: "red" } as const;`;
+      const fixedStylesSource = `export const button = { color: "blue" } as const;`;
+      const { filePaths } = await createBabelFixtureFiles(
+        {
+          "component.tsx": componentSource,
+          "styles.ts": missingExportStylesSource
+        },
+        "css-prop-imported-unresolved-cache-invalidation"
+      );
+      const componentId = filePaths["component.tsx"];
+      const stylesId = filePaths["styles.ts"];
+      const provider = createFileBackedStaticCssEvalSourceProvider({
+        resolutions: {
+          [`${componentId}\0./styles`]: stylesId
+        }
+      });
+      let firstError: unknown;
+
+      try {
+        await babelTransform(componentId, {
+          jsxCssProp: true,
+          staticCssEvalSourceProvider: provider
+        });
+      } catch (error) {
+        firstError = error;
+      }
+
+      expect(firstError).toBeInstanceOf(BabelTransformError);
+
+      const transformError = firstError as BabelTransformError;
+      const firstStaticCssEval = transformError.staticCssEval;
+
+      expect(firstStaticCssEval?.diagnostics[0]).toMatchObject({
+        id: "STATIC_CSS_EVAL_UNRESOLVED_EXPORT",
+        owner: { file: componentId },
+        dependency: { file: stylesId },
+        importPath: "./styles",
+        exportName: "button"
+      });
+      expect(firstStaticCssEval?.cacheKeys[0]).toMatchObject({
+        importerFile: componentId,
+        resolvedFile: stylesId,
+        sourceHash: createTestSourceIdentity(missingExportStylesSource)
+          .sourceHash
+      });
+
+      await fs.writeFile(stylesId, fixedStylesSource, "utf8");
+
+      const secondTransform = await babelTransform(componentId, {
+        jsxCssProp: true,
+        staticCssEvalSourceProvider: provider
+      });
+
+      expect(secondTransform.result[1]).toContain('color: "blue"');
+      expect(secondTransform.result[1]).not.toContain('color: "red"');
+      expect(secondTransform.code).not.toContain("_cx(button)");
+      expect(secondTransform.staticCssEval?.diagnostics).toEqual([]);
+      expect(secondTransform.staticCssEval?.cacheKeys[0]).toMatchObject({
+        importerFile: componentId,
+        resolvedFile: stylesId,
+        sourceHash: createTestSourceIdentity(fixedStylesSource).sourceHash
+      });
+      expect(firstStaticCssEval?.cacheKeys[0]?.sourceHash).not.toBe(
+        secondTransform.staticCssEval?.cacheKeys[0]?.sourceHash
+      );
+      expect(secondTransform.staticCssEval?.resolvedDependencies).toEqual([
+        expect.objectContaining({
+          importerId: componentId,
+          specifier: "./styles",
+          resolvedFile: stylesId,
+          normalizedPathKey: stylesId,
+          loaded: true,
+          sourceIdentity: createTestSourceIdentity(fixedStylesSource)
+        })
+      ]);
+    });
+
+    it("attaches deterministic imported failure context to transform errors", async () => {
+      const componentSource = `
+        import { button } from "./styles";
+
+        function App() {
+          return <div css={button} />;
+        }
+      `;
+      const stylesSource = `export const card = { color: "red" } as const;`;
+      const { filePaths } = await createBabelFixtureFiles(
+        {
+          "component.tsx": componentSource,
+          "styles.ts": stylesSource
+        },
+        "css-prop-imported-failure-context"
+      );
+      const componentId = filePaths["component.tsx"];
+      const stylesId = filePaths["styles.ts"];
+      const provider = createFileBackedStaticCssEvalSourceProvider({
+        resolutions: {
+          [`${componentId}\0./styles`]: stylesId
+        }
+      });
+      let thrownError: unknown;
+
+      try {
+        await babelTransform(componentId, {
+          jsxCssProp: true,
+          staticCssEvalSourceProvider: provider
+        });
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBeInstanceOf(BabelTransformError);
+
+      const transformError = thrownError as BabelTransformError;
+      const staticCssEval = transformError.staticCssEval;
+      const diagnostic = staticCssEval?.diagnostics[0];
+
+      expect(transformError.file).toBe(componentId);
+      expect(transformError.message).toContain(
+        "Cannot statically evaluate css prop value"
+      );
+      expect(staticCssEval?.dependencyFiles).toEqual([stylesId]);
+      expect(staticCssEval?.resolvedDependencies).toEqual([
+        expect.objectContaining({
+          importerId: componentId,
+          specifier: "./styles",
+          resolvedFile: stylesId,
+          canonicalModuleId: `test:${stylesId}`,
+          normalizedPathKey: stylesId,
+          resolverKind: "test",
+          loaded: true,
+          sourceIdentity: createTestSourceIdentity(stylesSource)
+        })
+      ]);
+      expect(staticCssEval?.dependencies[0]).toMatchObject({
+        file: stylesId,
+        kind: "imported",
+        importer: componentId,
+        specifier: "./styles",
+        exportName: "button",
+        memberPath: [],
+        inspected: true,
+        contributed: false
+      });
+      expect(diagnostic).toMatchObject({
+        id: "STATIC_CSS_EVAL_UNRESOLVED_EXPORT",
+        owner: { file: componentId },
+        dependency: { file: stylesId },
+        importPath: "./styles",
+        exportName: "button",
+        memberPath: []
+      });
+      expect(diagnostic?.importChain).toEqual([
+        componentId,
+        `${stylesId}#button`,
+        stylesId
+      ]);
+      expect(staticCssEval?.cacheKeys[0]).toMatchObject({
+        importerFile: componentId,
+        resolvedFile: stylesId,
+        resolvedId: stylesId,
+        exportName: "button",
+        memberPath: [],
+        sourceHash: createTestSourceIdentity(stylesSource).sourceHash
+      });
+      expect(staticCssEval?.resolvedModuleIds).toContain(stylesId);
+    });
+
+    it("resolves direct named reexports from the async source-provider prepass", async () => {
       const path = await import("node:path");
       const ownerSource = `
         import { button } from "./barrel";
@@ -750,23 +1722,136 @@ if (import.meta.vitest) {
           staticCssEvalSourceProvider: provider
         }
       );
+      const [, sidecarSource] = result;
 
-      expect(result[1]).toBe("");
-      expect(code).toContain("className={_cx(button)}");
       expect(calls.resolved).toEqual([
-        { importerId: fixturePath, importPath: "./barrel" }
+        { importerId: fixturePath, importPath: "./barrel" },
+        { importerId: barrelId, importPath: "./styles" }
       ]);
-      expect(calls.loaded).toEqual([fixturePath, barrelId]);
-      expect(staticCssEval?.dependencyFiles).toEqual([barrelId]);
+      expect(calls.loaded).toEqual([fixturePath, barrelId, stylesId]);
+      expect(sidecarSource).toContain('color: "red"');
+      expect(code).not.toContain("_cx(button)");
+      expect(staticCssEval?.dependencyFiles).toEqual([barrelId, stylesId]);
       expect(staticCssEval?.ownerToDependencies.get(fixturePath)).toEqual([
-        barrelId
+        barrelId,
+        stylesId
       ]);
       expect(staticCssEval?.dependencyToOwners.get(barrelId)).toEqual([
         fixturePath
       ]);
+      expect(staticCssEval?.dependencyToOwners.get(stylesId)).toEqual([
+        fixturePath
+      ]);
       expect(staticCssEval?.resolvedModuleCache.has(fixturePath)).toBe(true);
       expect(staticCssEval?.resolvedModuleCache.has(barrelId)).toBe(true);
-      expect(staticCssEval?.resolvedModuleCache.has(stylesId)).toBe(false);
+      expect(staticCssEval?.resolvedModuleCache.has(stylesId)).toBe(true);
+      expect(staticCssEval?.resolvedDependencies).toEqual([
+        expect.objectContaining({
+          importerId: fixturePath,
+          specifier: "./barrel",
+          resolvedFile: barrelId,
+          loaded: true
+        }),
+        expect.objectContaining({
+          importerId: barrelId,
+          specifier: "./styles",
+          resolvedFile: stylesId,
+          loaded: true
+        })
+      ]);
+      expect(staticCssEval?.dependencies).toEqual([
+        expect.objectContaining({ file: barrelId, kind: "reexported" }),
+        expect.objectContaining({ file: stylesId, kind: "reexported" })
+      ]);
+      expect(staticCssEval?.cacheKeys[0]).toMatchObject({
+        importerFile: fixturePath,
+        resolvedFile: stylesId,
+        resolvedId: stylesId,
+        exportName: "button",
+        memberPath: []
+      });
+      expect(staticCssEval?.resolvedModuleIds).toEqual(
+        expect.arrayContaining([barrelId, stylesId])
+      );
+    });
+
+    it("resolves namespace members from the async source-provider prepass", async () => {
+      const path = await import("node:path");
+      const ownerSource = `
+        import * as styles from "./styles";
+
+        function App() {
+          return <div css={styles.button.primary} />;
+        }
+      `;
+      const stylesSource = `export const button = { primary: { color: "red" } } as const;`;
+      const fixturePath = await createBabelFixture(
+        ownerSource,
+        "css-prop-async-prepass-namespace-member"
+      );
+      const fixtureRoot = path.dirname(fixturePath);
+      const stylesId = path.join(fixtureRoot, "styles.ts");
+      const { provider, calls } = createFakeStaticCssEvalSourceProvider({
+        sources: {
+          [fixturePath]: ownerSource,
+          [stylesId]: stylesSource
+        },
+        resolutions: {
+          [`${fixturePath}\0./styles`]: stylesId
+        }
+      });
+      const { result, code, staticCssEval } = await babelTransform(
+        fixturePath,
+        {
+          jsxCssProp: true,
+          staticCssEvalSourceProvider: provider
+        }
+      );
+      const [, sidecarSource] = result;
+
+      expect(calls.resolved).toEqual([
+        { importerId: fixturePath, importPath: "./styles" }
+      ]);
+      expect(calls.loaded).toEqual([fixturePath, stylesId]);
+      expect(sidecarSource).toContain('color: "red"');
+      expect(code).not.toContain("_cx(styles.button.primary)");
+      expect(staticCssEval?.dependencyFiles).toEqual([stylesId]);
+      expect(staticCssEval?.ownerToDependencies.get(fixturePath)).toEqual([
+        stylesId
+      ]);
+      expect(staticCssEval?.dependencyToOwners.get(stylesId)).toEqual([
+        fixturePath
+      ]);
+      expect(staticCssEval?.resolvedModuleCache.has(fixturePath)).toBe(true);
+      expect(staticCssEval?.resolvedModuleCache.has(stylesId)).toBe(true);
+      expect(staticCssEval?.resolvedDependencies).toEqual([
+        expect.objectContaining({
+          importerId: fixturePath,
+          specifier: "./styles",
+          resolvedFile: stylesId,
+          loaded: true
+        })
+      ]);
+      expect(staticCssEval?.dependencies).toEqual([
+        expect.objectContaining({
+          file: stylesId,
+          kind: "namespace-member",
+          importer: fixturePath,
+          specifier: "./styles",
+          exportName: "button",
+          memberPath: ["primary"],
+          inspected: true,
+          contributed: true
+        })
+      ]);
+      expect(staticCssEval?.cacheKeys[0]).toMatchObject({
+        importerFile: fixturePath,
+        resolvedFile: stylesId,
+        resolvedId: stylesId,
+        exportName: "button",
+        memberPath: ["primary"]
+      });
+      expect(staticCssEval?.resolvedModuleIds).toContain(stylesId);
     });
 
     it("excludes failed dependency parses from async prepass caches", async () => {

--- a/packages/integration/src/babel.ts
+++ b/packages/integration/src/babel.ts
@@ -36,6 +36,36 @@ export interface StaticCssEvalSourceIdentity {
   version?: string | number;
 }
 
+export const STATIC_CSS_EVAL_SOURCE_KINDS = [
+  "project-source",
+  "package-source",
+  "provider-virtual",
+  "static-data",
+  "external-no-source",
+  "unresolved",
+  "unsupported-source-shape"
+] as const;
+
+export type StaticCssEvalSourceKind =
+  (typeof STATIC_CSS_EVAL_SOURCE_KINDS)[number];
+
+export const STATIC_CSS_EVAL_SOURCE_ORIGINS = [
+  "project",
+  "package",
+  "provider",
+  "data",
+  "external",
+  "unresolved",
+  "unsupported"
+] as const;
+
+export type StaticCssEvalSourceOrigin =
+  (typeof STATIC_CSS_EVAL_SOURCE_ORIGINS)[number];
+
+export type StaticCssEvalSourceUnsupportedReason = NonNullable<
+  StaticCssEvalMetadataDependency["unsupportedReason"]
+>;
+
 // Integration supplies bundler-aware identity/source freshness; Babel static
 // eval remains the only owner of css value and symbol provenance.
 export interface StaticCssEvalSourceResolution {
@@ -55,6 +85,10 @@ export interface StaticCssEvalSourceResolution {
   version?: string | number;
   /** Source identity from the bundler; loaded source identity takes precedence. */
   sourceIdentity?: StaticCssEvalSourceIdentity;
+  readonly sourceKind?: StaticCssEvalSourceKind;
+  readonly sourceOrigin?: StaticCssEvalSourceOrigin;
+  readonly unsupportedReason?: StaticCssEvalSourceUnsupportedReason;
+  readonly watchFiles?: readonly string[];
   /** Identifies which resolver produced this source for downstream cache/debug consumers. */
   resolverKind?: StaticCssEvalResolverKind;
 }
@@ -71,6 +105,10 @@ export interface StaticCssEvalLoadedSource {
   sourceHash?: string;
   version?: string | number;
   sourceIdentity?: StaticCssEvalSourceIdentity;
+  readonly sourceKind?: StaticCssEvalSourceKind;
+  readonly sourceOrigin?: StaticCssEvalSourceOrigin;
+  readonly unsupportedReason?: StaticCssEvalSourceUnsupportedReason;
+  readonly watchFiles?: readonly string[];
   resolverKind?: StaticCssEvalResolverKind;
 }
 
@@ -100,6 +138,10 @@ export interface StaticCssEvalResolvedDependency {
   resolverKind: StaticCssEvalResolverKind;
   loaded: boolean;
   sourceIdentity?: StaticCssEvalSourceIdentity;
+  readonly sourceKind?: StaticCssEvalSourceKind;
+  readonly sourceOrigin?: StaticCssEvalSourceOrigin;
+  readonly unsupportedReason?: StaticCssEvalSourceUnsupportedReason;
+  readonly watchFiles?: readonly string[];
 }
 
 export interface StaticCssEvalTransformResult
@@ -690,7 +732,10 @@ if (import.meta.vitest) {
           import { button } from "./styles";
 
           function App() {
-            return <div css={button} />;
+            return <>
+              <div css={button} />
+              <span css={button} />
+            </>;
           }
         `,
         "css-prop-metadata-dedupe"
@@ -728,14 +773,34 @@ if (import.meta.vitest) {
         resolverOptionsVersion: "test-resolver-options",
         staticEvalSupportVersion: "test-static-eval"
       } satisfies StaticCssEvalMetadataCacheKey;
+      const packageCacheKey = {
+        ...cacheKey,
+        canonicalModuleId: "pkg:@scope/styles",
+        normalizedPathKey: "pkg:@scope/styles?condition=import",
+        sourceKind: "package-source",
+        sourceOrigin: "package",
+        watchFiles: ["/project/.pnp.cjs"],
+        parserVersion: "test-parser-v1",
+        parserOptions: {
+          plugins: ["jsx", "typescript"],
+          sourceType: "module",
+          jsx: true,
+          typescript: true
+        }
+      } satisfies StaticCssEvalMetadataCacheKey;
+      const cacheKeys = [cacheKey, packageCacheKey] as const;
+      let cacheKeyIndex = 0;
       const provider: StaticCssEvalProvider = {
         getResolvedCssValue(): StaticCssEvalProviderResult {
+          const currentCacheKey = cacheKeys[cacheKeyIndex] ?? packageCacheKey;
+          cacheKeyIndex += 1;
+
           return {
             kind: "resolved",
             value: { color: "red" },
             dependencies: [dependency, { ...dependency }],
             diagnostics: [diagnostic, { ...diagnostic }],
-            cacheKey
+            cacheKey: currentCacheKey
           } as unknown as StaticCssEvalProviderResult;
         }
       };
@@ -760,8 +825,12 @@ if (import.meta.vitest) {
         staticCssEval?.diagnostics.filter((item) => item.id === diagnostic.id)
       ).toHaveLength(1);
       expect(staticCssEval?.cacheKeys).toEqual(
-        expect.arrayContaining([expect.objectContaining(cacheKey)])
+        expect.arrayContaining([
+          expect.objectContaining(cacheKey),
+          expect.objectContaining(packageCacheKey)
+        ])
       );
+      expect(staticCssEval?.cacheKeys).toHaveLength(2);
       expect(
         staticCssEval?.resolvedModuleIds.filter(
           (moduleId) => moduleId === dependency.file
@@ -897,6 +966,180 @@ if (import.meta.vitest) {
       ]);
       expect(secondTransform.staticCssEval?.resolvedModuleIds).toContain(
         stylesId
+      );
+    });
+
+    it("static css eval cache keys include source provider package data and virtual identity metadata", async () => {
+      const componentSource = `
+        import { button } from "@scope/styles";
+        import { token } from "@scope/styles/tokens.json";
+        import { virtualButton } from "virtual:mincho/styles";
+
+        function App() {
+          return <>
+            <div css={button} />
+            <div css={token} />
+            <div css={virtualButton} />
+          </>;
+        }
+      `;
+      const { filePaths } = await createBabelFixtureFiles(
+        {
+          "component.tsx": componentSource
+        },
+        "css-prop-source-provider-cache-metadata"
+      );
+      const componentId = filePaths["component.tsx"];
+      const packageId = "pkg:@scope/styles/index.ts";
+      const packageLoadId = `${packageId}?condition=import`;
+      const dataId = "pkg:@scope/styles/tokens.json?import";
+      const virtualId = "\0virtual:mincho/styles";
+      const pnpWatchFile = "/project/.pnp.cjs";
+      const dataWatchFile = "/project/node_modules/@scope/styles/tokens.json";
+      const resolutions = new Map<string, StaticCssEvalSourceResolution>([
+        [
+          `${componentId}\0@scope/styles`,
+          {
+            resolvedFile: packageId,
+            canonicalModuleId: "pkg:@scope/styles",
+            normalizedPathKey: packageLoadId,
+            sourceKind: "package-source",
+            sourceIdentity: { version: "package-resolution-v1" },
+            watchFiles: [pnpWatchFile],
+            resolverKind: "test"
+          }
+        ],
+        [
+          `${componentId}\0@scope/styles/tokens.json`,
+          {
+            resolvedFile: dataId,
+            canonicalModuleId: dataId,
+            normalizedPathKey: dataId,
+            sourceKind: "static-data",
+            watchFiles: [dataWatchFile],
+            resolverKind: "test"
+          }
+        ],
+        [
+          `${componentId}\0virtual:mincho/styles`,
+          {
+            resolvedFile: virtualId,
+            canonicalModuleId: virtualId,
+            normalizedPathKey: virtualId,
+            sourceKind: "provider-virtual",
+            sourceIdentity: { version: "virtual-resolution-v1" },
+            resolverKind: "test"
+          }
+        ]
+      ]);
+      const loadedSources = new Map<string, StaticCssEvalLoadedSource>([
+        [componentId, { source: componentSource }],
+        [
+          packageLoadId,
+          {
+            sourceText: `export const button = { color: "red" } as const;`,
+            sourceKind: "package-source",
+            sourceIdentity: { sourceHash: "package-source-v1" },
+            watchFiles: [pnpWatchFile],
+            resolverKind: "test"
+          }
+        ],
+        [
+          dataId,
+          {
+            sourceText: JSON.stringify({ token: { color: "green" } }),
+            sourceKind: "static-data",
+            sourceIdentity: { sourceHash: "data-source-v1" },
+            watchFiles: [dataWatchFile],
+            resolverKind: "test"
+          }
+        ],
+        [
+          virtualId,
+          {
+            sourceText: `export const virtualButton = { color: "blue" } as const;`,
+            sourceKind: "provider-virtual",
+            sourceIdentity: {
+              sourceHash: "virtual-source-v1",
+              version: "virtual-loaded-v1"
+            },
+            resolverKind: "test"
+          }
+        ]
+      ]);
+      const provider: StaticCssEvalSourceProvider = {
+        resolve(importerId, importPath) {
+          return resolutions.get(`${importerId}\0${importPath}`) ?? null;
+        },
+        load(id) {
+          return loadedSources.get(id) ?? null;
+        }
+      };
+
+      const { code, result, staticCssEval } = await babelTransform(
+        componentId,
+        {
+          jsxCssProp: true,
+          staticCssEvalSourceProvider: provider
+        }
+      );
+
+      expect(result[1]).toContain('color: "red"');
+      expect(result[1]).toContain('color: "green"');
+      expect(result[1]).toContain('color: "blue"');
+      expect(code).not.toContain("_cx(button)");
+      expect(staticCssEval?.cacheKeys).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            resolvedFile: packageId,
+            resolvedId: packageId,
+            canonicalModuleId: "pkg:@scope/styles",
+            normalizedPathKey: packageLoadId,
+            sourceKind: "package-source",
+            sourceOrigin: "package",
+            sourceHash: "package-source-v1",
+            sourceVersion: "package-resolution-v1",
+            watchFiles: [pnpWatchFile]
+          }),
+          expect.objectContaining({
+            resolvedFile: dataId,
+            resolvedId: dataId,
+            canonicalModuleId: dataId,
+            normalizedPathKey: dataId,
+            sourceKind: "static-data",
+            sourceOrigin: "data",
+            sourceHash: "data-source-v1",
+            watchFiles: [dataWatchFile]
+          }),
+          expect.objectContaining({
+            resolvedFile: virtualId,
+            resolvedId: virtualId,
+            canonicalModuleId: virtualId,
+            normalizedPathKey: virtualId,
+            sourceKind: "provider-virtual",
+            sourceOrigin: "provider",
+            sourceHash: "virtual-source-v1",
+            sourceVersion: "virtual-loaded-v1"
+          })
+        ])
+      );
+      expect(staticCssEval?.resolvedDependencies).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            resolvedFile: packageId,
+            sourceKind: "package-source",
+            watchFiles: [pnpWatchFile]
+          }),
+          expect.objectContaining({
+            resolvedFile: dataId,
+            sourceKind: "static-data",
+            watchFiles: [dataWatchFile]
+          }),
+          expect.objectContaining({
+            resolvedFile: virtualId,
+            sourceKind: "provider-virtual"
+          })
+        ])
       );
     });
 
@@ -1077,6 +1320,108 @@ if (import.meta.vitest) {
       expect(staticCssEval?.resolvedModuleIds).toContain(stylesId);
     });
 
+    it("reports prepared unsupported static-data reasons in transform diagnostics", async () => {
+      const cases = [
+        {
+          label: "wasm-init",
+          importPath: "@scope/styles/icon.wasm?init",
+          resolvedId: "pkg:@scope/styles/icon.wasm?init",
+          sourceText: `export default function init() {}`,
+          unsupportedReason: "runtime-wasm-init"
+        },
+        {
+          label: "invalid-json",
+          importPath: "@scope/styles/broken.json",
+          resolvedId: "pkg:@scope/styles/broken.json?import",
+          sourceText: `{ "button": `,
+          unsupportedReason: "invalid-json-data"
+        }
+      ] as const;
+
+      for (const testCase of cases) {
+        const componentSource = `
+          import unsupported from "${testCase.importPath}";
+
+          function App() {
+            return <div css={unsupported} />;
+          }
+        `;
+        const componentId = await createBabelFixture(
+          componentSource,
+          `css-prop-static-data-${testCase.label}`
+        );
+        const provider: StaticCssEvalSourceProvider = {
+          resolve(importerId, importPath) {
+            if (
+              importerId !== componentId ||
+              importPath !== testCase.importPath
+            ) {
+              return null;
+            }
+
+            return {
+              resolvedFile: testCase.resolvedId,
+              canonicalModuleId: testCase.resolvedId,
+              normalizedPathKey: testCase.resolvedId,
+              sourceKind: "static-data",
+              resolverKind: "test"
+            };
+          },
+          load(id) {
+            if (id === componentId) {
+              return { sourceText: componentSource, resolverKind: "test" };
+            }
+
+            if (id === testCase.resolvedId) {
+              return {
+                sourceText: testCase.sourceText,
+                sourceKind: "static-data",
+                sourceIdentity: { version: testCase.label },
+                resolverKind: "test"
+              };
+            }
+
+            return null;
+          }
+        };
+        let thrownError: unknown;
+
+        try {
+          await babelTransform(componentId, {
+            jsxCssProp: true,
+            staticCssEvalSourceProvider: provider
+          });
+        } catch (error) {
+          thrownError = error;
+        }
+
+        expect(thrownError).toBeInstanceOf(BabelTransformError);
+
+        if (!(thrownError instanceof BabelTransformError)) {
+          throw new Error(
+            "Expected BabelTransformError for static data source"
+          );
+        }
+
+        expect(thrownError.staticCssEval?.diagnostics[0]).toMatchObject({
+          id: "STATIC_CSS_EVAL_PROVIDER_SOURCE_UNSUPPORTED",
+          reason: testCase.unsupportedReason,
+          dependency: { file: testCase.resolvedId },
+          importPath: testCase.importPath,
+          exportName: "default"
+        });
+        expect(thrownError.staticCssEval?.resolvedDependencies).toEqual([
+          expect.objectContaining({
+            resolvedFile: testCase.resolvedId,
+            sourceKind: "unsupported-source-shape",
+            sourceOrigin: "unsupported",
+            unsupportedReason: testCase.unsupportedReason,
+            loaded: true
+          })
+        ]);
+      }
+    });
+
     it("resolves direct named reexports from the async source-provider prepass", async () => {
       const path = await import("node:path");
       const ownerSource = `
@@ -1209,13 +1554,21 @@ if (import.meta.vitest) {
         throw new Error("Expected failed dependency resolution");
       }
 
-      expect(resolution.dependencies).toEqual([stylesId]);
-      expect(resolution.diagnostic.code).toBe(
-        "failed-project-local-dependency"
-      );
-      expect(resolution.diagnostic.message).toContain(
-        `failed to load project-local dependency ${stylesId}`
-      );
+      expect(resolution.dependencies).toMatchObject([
+        {
+          file: stylesId,
+          inspected: true,
+          contributed: false,
+          sourceKind: "unsupported-source-shape",
+          unsupportedReason: "unsupported-source-shape"
+        }
+      ]);
+      expect(resolution.diagnostic).toMatchObject({
+        id: "STATIC_CSS_EVAL_PROVIDER_SOURCE_UNSUPPORTED",
+        code: "unsupported-source",
+        reason: "unsupported-source-shape",
+        dependency: { file: stylesId }
+      });
     });
 
     it("resolves namespace members from the async source-provider prepass", async () => {
@@ -1683,14 +2036,15 @@ if (import.meta.vitest) {
       }
 
       expect(calls.resolved).toEqual([
-        { importerId: fixturePath, importPath: "./barrel" }
+        { importerId: fixturePath, importPath: "./barrel" },
+        { importerId: barrelId, importPath: "@scope/styles" }
       ]);
       expect(calls.loaded).toEqual([fixturePath, barrelId]);
       expect(thrownError.staticCssEval?.dependencyFiles).toEqual([barrelId]);
       expect(thrownError.staticCssEval?.diagnostics[0]).toMatchObject({
-        id: "STATIC_CSS_EVAL_PACKAGE_IMPORT_UNSUPPORTED",
+        id: "STATIC_CSS_EVAL_UNRESOLVED_IMPORT",
         owner: { file: fixturePath },
-        dependency: { file: barrelId },
+        dependency: { file: "@scope/styles" },
         importPath: "@scope/styles",
         exportName: "button"
       });

--- a/packages/integration/src/compile.ts
+++ b/packages/integration/src/compile.ts
@@ -1,7 +1,7 @@
 import { basename, dirname, join } from "node:path";
 import * as fs from "node:fs";
 import { addFileScope, getPackageInfo } from "@vanilla-extract/integration";
-import defaultEsbuild, { type PluginBuild } from "esbuild";
+import defaultEsbuild, { type BuildOptions, type PluginBuild } from "esbuild";
 import { transformSync } from "@babel/core";
 import { minchoStyledComponentPlugin } from "@mincho-js/babel";
 
@@ -15,6 +15,107 @@ interface CompileOptions {
   originalPath: string;
 }
 
+function getScopedSourceWithCache({
+  cwd,
+  contents,
+  originalPath,
+  packageName,
+  resolverCache
+}: {
+  cwd: string;
+  contents: string;
+  originalPath: string;
+  packageName: string;
+  resolverCache: Map<string, string>;
+}) {
+  if (resolverCache.has(originalPath)) {
+    return resolverCache.get(originalPath)!;
+  }
+
+  const source = addFileScope({
+    source: contents,
+    filePath: originalPath,
+    rootPath: cwd,
+    packageName
+  });
+
+  resolverCache.set(originalPath, source);
+
+  return source;
+}
+
+function transformScopedDependencySource({
+  contents,
+  filePath,
+  packageName,
+  rootPath
+}: {
+  contents: string;
+  filePath: string;
+  packageName: string;
+  rootPath: string;
+}) {
+  let source = addFileScope({
+    source: contents,
+    filePath,
+    rootPath,
+    packageName
+  });
+
+  source = transformSync(source, {
+    filename: filePath,
+    plugins: [minchoStyledComponentPlugin()],
+    presets: ["@babel/preset-typescript"],
+    sourceMaps: false
+  })!.code!;
+
+  return source;
+}
+
+function createScopedOnLoadPlugin(packageName: string) {
+  return {
+    name: "mincho:custom-extract-scope",
+    setup(build: PluginBuild) {
+      build.onLoad(
+        { filter: /\.(t|j)sx?$/ },
+        async (args: { path: string }) => {
+          const contents = await fs.promises.readFile(args.path, "utf-8");
+
+          return {
+            contents: transformScopedDependencySource({
+              contents,
+              filePath: args.path,
+              rootPath: build.initialOptions.absWorkingDir!,
+              packageName
+            }),
+            loader: "tsx",
+            resolveDir: dirname(args.path)
+          };
+        }
+      );
+    }
+  };
+}
+
+function assertSingleChildCompilationOutput(
+  outputFiles?: Array<{ text: string }>
+) {
+  if (!outputFiles || outputFiles.length !== 1) {
+    throw new Error("Invalid child compilation result");
+  }
+
+  return outputFiles[0].text;
+}
+
+function getWatchFiles(
+  cwd: string,
+  metafile?: { inputs?: Record<string, unknown> }
+) {
+  return Object.keys(metafile?.inputs || {}).map((filePath) =>
+    join(cwd, filePath)
+  );
+}
+
 export async function compile({
   esbuild = defaultEsbuild,
   filePath,
@@ -25,20 +126,13 @@ export async function compile({
   originalPath
 }: CompileOptions) {
   const packageInfo = getPackageInfo(cwd);
-  let source: string;
-
-  if (resolverCache.has(originalPath)) {
-    source = resolverCache.get(originalPath)!;
-  } else {
-    source = addFileScope({
-      source: contents,
-      filePath: originalPath,
-      rootPath: cwd,
-      packageName: packageInfo.name
-    });
-
-    resolverCache.set(originalPath, source);
-  }
+  const source = getScopedSourceWithCache({
+    cwd,
+    contents,
+    originalPath,
+    packageName: packageInfo.name,
+    resolverCache
+  });
 
   const result = await esbuild.build({
     stdin: {
@@ -53,47 +147,143 @@ export async function compile({
     platform: "node",
     write: false,
     absWorkingDir: cwd,
-    plugins: [
-      {
-        name: "mincho:custom-extract-scope",
-        setup(build) {
-          build.onLoad({ filter: /\.(t|j)sx?$/ }, async (args) => {
-            const contents = await fs.promises.readFile(args.path, "utf-8");
-            let source = addFileScope({
-              source: contents,
-              filePath: args.path,
-              rootPath: build.initialOptions.absWorkingDir!,
-              packageName: packageInfo.name
-            });
-
-            source = transformSync(source, {
-              filename: args.path,
-              plugins: [minchoStyledComponentPlugin()],
-              presets: ["@babel/preset-typescript"],
-              sourceMaps: false
-            })!.code!;
-
-            return {
-              contents: source,
-              loader: "tsx",
-              resolveDir: dirname(args.path)
-            };
-          });
-        }
-      }
-    ]
+    plugins: [createScopedOnLoadPlugin(packageInfo.name)]
   });
 
-  const { outputFiles, metafile } = result;
-
-  if (!outputFiles || outputFiles.length !== 1) {
-    throw new Error("Invalid child compilation result");
-  }
+  const compiledSource = assertSingleChildCompilationOutput(result.outputFiles);
 
   return {
-    source: outputFiles[0].text,
-    watchFiles: Object.keys(metafile?.inputs || {}).map((filePath) =>
-      join(cwd, filePath)
-    )
+    source: compiledSource,
+    watchFiles: getWatchFiles(cwd, result.metafile)
   };
+}
+
+// @ts-expect-error error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+  const { afterEach, describe, expect, it, vi } = import.meta.vitest;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function createChildEsbuildStub(
+    options: {
+      metafileInputs?: Record<string, unknown>;
+      outputFiles?: Array<{ text: string }>;
+      onLoadPath?: string;
+    } = {}
+  ) {
+    const buildCalls: Array<BuildOptions> = [];
+
+    const esbuild = {
+      async build(buildOptions: BuildOptions) {
+        buildCalls.push(buildOptions);
+
+        const onLoadHandlers: Array<{
+          callback: (args: { path: string }) => Promise<{ contents: string }>;
+        }> = [];
+
+        const pluginBuild = {
+          initialOptions: {
+            absWorkingDir: buildOptions.absWorkingDir
+          },
+          onLoad(
+            _options: unknown,
+            callback: (args: { path: string }) => Promise<{ contents: string }>
+          ) {
+            onLoadHandlers.push({ callback });
+          }
+        };
+
+        for (const plugin of buildOptions.plugins ?? []) {
+          plugin.setup(pluginBuild as PluginBuild);
+        }
+
+        if (onLoadHandlers[0]) {
+          await onLoadHandlers[0].callback({
+            path: options.onLoadPath ?? "/workspace/scoped-dependency.tsx"
+          });
+        }
+
+        return {
+          outputFiles: options.outputFiles ?? [
+            { text: buildOptions.stdin!.contents! }
+          ],
+          metafile: { inputs: options.metafileInputs ?? {} }
+        };
+      }
+    };
+
+    return { buildCalls, esbuild: esbuild as PluginBuild["esbuild"] };
+  }
+
+  describe("compile", () => {
+    it("compile reuses resolver cache and returns watch files", async () => {
+      vi.spyOn(fs.promises, "readFile").mockResolvedValue(
+        'export const child = "ok";'
+      );
+
+      const { buildCalls, esbuild } = createChildEsbuildStub({
+        metafileInputs: {
+          "src/dependency.tsx": {},
+          "nested/child.ts": {}
+        }
+      });
+      const resolverCache = new Map<string, string>();
+      const cwd = process.cwd();
+      const originalPath = `${cwd}/source.css.ts`;
+
+      const first = await compile({
+        esbuild,
+        filePath: `${cwd}/child.tsx`,
+        contents: "export const one = 1;",
+        cwd,
+        resolverCache,
+        originalPath
+      });
+      const second = await compile({
+        esbuild,
+        filePath: `${cwd}/child.tsx`,
+        contents: "export const two = 2;",
+        cwd,
+        resolverCache,
+        originalPath
+      });
+
+      expect(buildCalls).toHaveLength(2);
+      expect(buildCalls[0]!.stdin!.contents).toBe(
+        buildCalls[1]!.stdin!.contents
+      );
+      expect(first.source).toBe(second.source);
+      expect(resolverCache.get(originalPath)).toBe(first.source);
+      expect(first.watchFiles).toEqual([
+        join(cwd, "src/dependency.tsx"),
+        join(cwd, "nested/child.ts")
+      ]);
+    });
+
+    it("compile throws Invalid child compilation result", async () => {
+      vi.spyOn(fs.promises, "readFile").mockResolvedValue(
+        'export const child = "ok";'
+      );
+
+      const { esbuild } = createChildEsbuildStub({
+        outputFiles: []
+      });
+      const cwd = process.cwd();
+
+      await expect(
+        compile({
+          esbuild,
+          filePath: `${cwd}/child.tsx`,
+          contents: "export const value = 1;",
+          cwd,
+          resolverCache: new Map(),
+          originalPath: `${cwd}/source.css.ts`
+        })
+      ).rejects.toThrow("Invalid child compilation result");
+    });
+  });
 }

--- a/packages/integration/src/defineRulesPreset.ts
+++ b/packages/integration/src/defineRulesPreset.ts
@@ -5,11 +5,10 @@ import {
   type DefineRulesRegistrySession
 } from "@mincho-js/css/defineRules/registry";
 import { processVanillaFile } from "@vanilla-extract/integration";
-
-const DEFINE_RULES_REGISTRY_SERIALIZABLE_CONFIG_DIAGNOSTIC =
-  "defineRules registry serialization does not support function-valued conditions, properties, or shortcuts";
-const DEFINE_RULES_REGISTRY_SERIALIZABLE_CONTEXT_DIAGNOSTIC =
-  "defineRules registry serialization does not support non-serializable context";
+import {
+  getConfigEntry,
+  validateSerializableConfigEntry
+} from "./defineRulesPresetValidation.js";
 
 type Awaitable<Value> = Value | PromiseLike<Value>;
 
@@ -88,160 +87,6 @@ export function validateDefineRulesRegistrySession(
       { validatePlainSerializableValues: true }
     );
   }
-}
-
-interface DefineRulesRegistryDiagnosticContext {
-  fileScope: DefineRulesRegistrySession["instances"][number]["fileScope"];
-  registrationIndex: number;
-}
-
-function formatDefineRulesRegistryDiagnosticContext(
-  diagnosticContext: DefineRulesRegistryDiagnosticContext
-): string {
-  const packageName = diagnosticContext.fileScope.packageName ?? "<root>";
-
-  return `fileScope: ${packageName}:${diagnosticContext.fileScope.filePath}, registrationIndex: ${diagnosticContext.registrationIndex}`;
-}
-
-function getConfigEntry(
-  config: unknown,
-  key: "conditions" | "context" | "properties" | "shortcuts"
-): unknown {
-  if (config == null || typeof config !== "object") {
-    return undefined;
-  }
-
-  return (config as Record<string, unknown>)[key];
-}
-
-interface SerializableConfigEntryValidationOptions {
-  validatePlainSerializableValues?: boolean;
-}
-
-function validateSerializableConfigEntry(
-  entry: unknown,
-  path: string,
-  diagnosticContext: DefineRulesRegistryDiagnosticContext,
-  options: SerializableConfigEntryValidationOptions = {},
-  seenEntries: WeakSet<object> = new WeakSet()
-): void {
-  if (
-    entry == null ||
-    typeof entry === "string" ||
-    typeof entry === "number" ||
-    typeof entry === "boolean" ||
-    typeof entry === "undefined"
-  ) {
-    return;
-  }
-
-  if (typeof entry === "function") {
-    throwSerializableConfigEntryDiagnostic(path, diagnosticContext, options);
-  }
-
-  if (
-    options.validatePlainSerializableValues === true &&
-    (typeof entry === "symbol" || typeof entry === "bigint")
-  ) {
-    throwSerializableConfigEntryDiagnostic(path, diagnosticContext, options);
-  }
-
-  if (typeof entry !== "object") {
-    return;
-  }
-
-  if (seenEntries.has(entry)) {
-    if (options.validatePlainSerializableValues === true) {
-      throwSerializableConfigEntryDiagnostic(path, diagnosticContext, options);
-    }
-    return;
-  }
-  seenEntries.add(entry);
-
-  try {
-    if (Array.isArray(entry)) {
-      for (let index = 0; index < entry.length; index += 1) {
-        validateSerializableConfigEntry(
-          entry[index],
-          `${path}[${index}]`,
-          diagnosticContext,
-          options,
-          seenEntries
-        );
-      }
-      return;
-    }
-
-    if (
-      options.validatePlainSerializableValues === true &&
-      !isPlainSerializableConfigObject(entry)
-    ) {
-      throwSerializableConfigEntryDiagnostic(path, diagnosticContext, options);
-    }
-
-    for (const [key, value] of Object.entries(entry)) {
-      validateSerializableConfigEntry(
-        value,
-        `${path}${formatConfigPathSegment(key)}`,
-        diagnosticContext,
-        options,
-        seenEntries
-      );
-    }
-  } finally {
-    if (options.validatePlainSerializableValues === true) {
-      seenEntries.delete(entry);
-    }
-  }
-}
-
-function throwSerializableConfigEntryDiagnostic(
-  path: string,
-  diagnosticContext: DefineRulesRegistryDiagnosticContext,
-  options: SerializableConfigEntryValidationOptions
-): never {
-  const diagnosticMessage =
-    options.validatePlainSerializableValues === true
-      ? DEFINE_RULES_REGISTRY_SERIALIZABLE_CONTEXT_DIAGNOSTIC
-      : DEFINE_RULES_REGISTRY_SERIALIZABLE_CONFIG_DIAGNOSTIC;
-
-  throw new Error(
-    `${diagnosticMessage} at ${path} (${formatDefineRulesRegistryDiagnosticContext(diagnosticContext)})`
-  );
-}
-
-function isPlainSerializableConfigObject(entry: object): boolean {
-  const prototype = Object.getPrototypeOf(entry);
-
-  return prototype === null || isObjectPrototype(prototype);
-}
-
-function isObjectPrototype(prototype: object): boolean {
-  if (Object.getPrototypeOf(prototype) !== null) {
-    return false;
-  }
-
-  if (!Object.prototype.hasOwnProperty.call(prototype, "constructor")) {
-    return false;
-  }
-
-  const objectConstructor = (prototype as { constructor?: unknown })
-    .constructor;
-
-  return (
-    typeof objectConstructor === "function" &&
-    objectConstructor.prototype === prototype &&
-    Function.prototype.toString.call(objectConstructor) ===
-      Function.prototype.toString.call(Object)
-  );
-}
-
-function formatConfigPathSegment(key: string): string {
-  if (/^[A-Za-z_$][\w$]*$/.test(key)) {
-    return `.${key}`;
-  }
-
-  return `[${JSON.stringify(key)}]`;
 }
 
 // == Tests ====================================================================

--- a/packages/integration/src/defineRulesPresetValidation.ts
+++ b/packages/integration/src/defineRulesPresetValidation.ts
@@ -1,0 +1,160 @@
+import type { DefineRulesRegistrySession } from "@mincho-js/css/defineRules/registry";
+
+const DEFINE_RULES_REGISTRY_SERIALIZABLE_CONFIG_DIAGNOSTIC =
+  "defineRules registry serialization does not support function-valued conditions, properties, or shortcuts";
+const DEFINE_RULES_REGISTRY_SERIALIZABLE_CONTEXT_DIAGNOSTIC =
+  "defineRules registry serialization does not support non-serializable context";
+
+export interface DefineRulesRegistryDiagnosticContext {
+  fileScope: DefineRulesRegistrySession["instances"][number]["fileScope"];
+  registrationIndex: number;
+}
+
+export function getConfigEntry(
+  config: unknown,
+  key: "conditions" | "context" | "properties" | "shortcuts"
+): unknown {
+  if (config == null || typeof config !== "object") {
+    return undefined;
+  }
+
+  return (config as Record<string, unknown>)[key];
+}
+
+interface SerializableConfigEntryValidationOptions {
+  validatePlainSerializableValues?: boolean;
+}
+
+export function validateSerializableConfigEntry(
+  entry: unknown,
+  path: string,
+  diagnosticContext: DefineRulesRegistryDiagnosticContext,
+  options: SerializableConfigEntryValidationOptions = {},
+  seenEntries: WeakSet<object> = new WeakSet()
+): void {
+  if (
+    entry == null ||
+    typeof entry === "string" ||
+    typeof entry === "number" ||
+    typeof entry === "boolean" ||
+    typeof entry === "undefined"
+  ) {
+    return;
+  }
+
+  if (typeof entry === "function") {
+    throwSerializableConfigEntryDiagnostic(path, diagnosticContext, options);
+  }
+
+  if (
+    options.validatePlainSerializableValues === true &&
+    (typeof entry === "symbol" || typeof entry === "bigint")
+  ) {
+    throwSerializableConfigEntryDiagnostic(path, diagnosticContext, options);
+  }
+
+  if (typeof entry !== "object") {
+    return;
+  }
+
+  if (seenEntries.has(entry)) {
+    if (options.validatePlainSerializableValues === true) {
+      throwSerializableConfigEntryDiagnostic(path, diagnosticContext, options);
+    }
+    return;
+  }
+  seenEntries.add(entry);
+
+  try {
+    if (Array.isArray(entry)) {
+      for (let index = 0; index < entry.length; index += 1) {
+        validateSerializableConfigEntry(
+          entry[index],
+          `${path}[${index}]`,
+          diagnosticContext,
+          options,
+          seenEntries
+        );
+      }
+      return;
+    }
+
+    if (
+      options.validatePlainSerializableValues === true &&
+      !isPlainSerializableConfigObject(entry)
+    ) {
+      throwSerializableConfigEntryDiagnostic(path, diagnosticContext, options);
+    }
+
+    for (const [key, value] of Object.entries(entry)) {
+      validateSerializableConfigEntry(
+        value,
+        `${path}${formatConfigPathSegment(key)}`,
+        diagnosticContext,
+        options,
+        seenEntries
+      );
+    }
+  } finally {
+    if (options.validatePlainSerializableValues === true) {
+      seenEntries.delete(entry);
+    }
+  }
+}
+
+function throwSerializableConfigEntryDiagnostic(
+  path: string,
+  diagnosticContext: DefineRulesRegistryDiagnosticContext,
+  options: SerializableConfigEntryValidationOptions
+): never {
+  const diagnosticMessage =
+    options.validatePlainSerializableValues === true
+      ? DEFINE_RULES_REGISTRY_SERIALIZABLE_CONTEXT_DIAGNOSTIC
+      : DEFINE_RULES_REGISTRY_SERIALIZABLE_CONFIG_DIAGNOSTIC;
+
+  throw new Error(
+    `${diagnosticMessage} at ${path} (${formatDefineRulesRegistryDiagnosticContext(diagnosticContext)})`
+  );
+}
+
+function formatDefineRulesRegistryDiagnosticContext(
+  diagnosticContext: DefineRulesRegistryDiagnosticContext
+): string {
+  const packageName = diagnosticContext.fileScope.packageName ?? "<root>";
+
+  return `fileScope: ${packageName}:${diagnosticContext.fileScope.filePath}, registrationIndex: ${diagnosticContext.registrationIndex}`;
+}
+
+function isPlainSerializableConfigObject(entry: object): boolean {
+  const prototype = Object.getPrototypeOf(entry);
+
+  return prototype === null || isObjectPrototype(prototype);
+}
+
+function isObjectPrototype(prototype: object): boolean {
+  if (Object.getPrototypeOf(prototype) !== null) {
+    return false;
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(prototype, "constructor")) {
+    return false;
+  }
+
+  const objectConstructor = (prototype as { constructor?: unknown })
+    .constructor;
+
+  return (
+    typeof objectConstructor === "function" &&
+    objectConstructor.prototype === prototype &&
+    Function.prototype.toString.call(objectConstructor) ===
+      Function.prototype.toString.call(Object)
+  );
+}
+
+function formatConfigPathSegment(key: string): string {
+  if (/^[A-Za-z_$][\w$]*$/.test(key)) {
+    return `.${key}`;
+  }
+
+  return `[${JSON.stringify(key)}]`;
+}

--- a/packages/integration/src/index.ts
+++ b/packages/integration/src/index.ts
@@ -24,3 +24,19 @@ export {
   trimTrailingSlash,
   unsupportedStaticCssEvalResolutionPrefix
 } from "./staticCssEval.js";
+export {
+  internalCollectStaticCssEvalDependencyIds,
+  internalCreateStaticCssEvalSourceHash,
+  internalCreateStaticCssEvalSourceIdentity,
+  internalGetExistingStaticCssEvalRealpath,
+  internalGetExistingStaticCssEvalStat,
+  internalGetStaticCssEvalRealpathOrResolvedPath,
+  internalHasStaticCssEvalNodeModulesSegment,
+  internalIsProjectLocalStaticCssEvalImportPath,
+  internalIsStaticCssEvalPathInsideRoot,
+  internalIsVirtualStaticCssEvalId,
+  internalNormalizeStaticCssEvalPathSyntax,
+  normalizeStaticCssEvalFileId as internalNormalizeStaticCssEvalFileId,
+  type InternalStaticCssEvalMetadataLike,
+  type InternalStaticCssEvalSourceIdentity
+} from "./staticCssEvalUtils.js";

--- a/packages/integration/src/index.ts
+++ b/packages/integration/src/index.ts
@@ -33,9 +33,13 @@ export {
   internalGetStaticCssEvalRealpathOrResolvedPath,
   internalHasStaticCssEvalNodeModulesSegment,
   internalIsProjectLocalStaticCssEvalImportPath,
+  internalIsMissingStaticCssEvalFileSystemEntryError,
+  internalIsStaticCssEvalStaticDataFile,
   internalIsStaticCssEvalPathInsideRoot,
   internalIsVirtualStaticCssEvalId,
   internalNormalizeStaticCssEvalPathSyntax,
+  internalPrepareStaticCssEvalStaticDataSource,
+  internalStaticCssEvalExternalResolutionPrefix,
   normalizeStaticCssEvalFileId as internalNormalizeStaticCssEvalFileId,
   type InternalStaticCssEvalMetadataLike,
   type InternalStaticCssEvalSourceIdentity

--- a/packages/integration/src/staticCssEvalMetadata.ts
+++ b/packages/integration/src/staticCssEvalMetadata.ts
@@ -1,0 +1,285 @@
+import {
+  type MinchoStaticCssEvalMetadata,
+  type PluginOptions
+} from "@mincho-js/babel";
+import type {
+  StaticCssEvalPrepassResult,
+  StaticCssEvalTransformResult
+} from "./babel.js";
+
+type StaticCssEvalProvider = NonNullable<
+  PluginOptions["staticCssEvalProvider"]
+>;
+type StaticCssEvalProviderResult = ReturnType<
+  StaticCssEvalProvider["getResolvedCssValue"]
+>;
+type StaticCssEvalMetadataDependency =
+  MinchoStaticCssEvalMetadata["dependencies"][number];
+type StaticCssEvalMetadataDiagnostic =
+  MinchoStaticCssEvalMetadata["diagnostics"][number];
+type StaticCssEvalMetadataCacheKey =
+  MinchoStaticCssEvalMetadata["cacheKeys"][number];
+type StaticCssEvalProviderMetadataSource = {
+  dependencies?: readonly unknown[];
+  diagnostics?: readonly StaticCssEvalMetadataDiagnostic[];
+  diagnostic?: StaticCssEvalMetadataDiagnostic;
+  cacheKey?: StaticCssEvalMetadataCacheKey;
+};
+
+export function createObservingStaticCssEvalProvider(
+  provider: StaticCssEvalProvider,
+  metadata: MinchoStaticCssEvalMetadata
+): StaticCssEvalProvider {
+  return {
+    getResolvedCssValue(query): StaticCssEvalProviderResult {
+      const result = provider.getResolvedCssValue(query);
+      appendStaticCssEvalResultMetadata(metadata, result);
+      return result;
+    }
+  };
+}
+
+function appendStaticCssEvalResultMetadata(
+  metadata: MinchoStaticCssEvalMetadata,
+  result: StaticCssEvalProviderResult
+): void {
+  const metadataSource = result as StaticCssEvalProviderMetadataSource;
+  const dependencies = (metadataSource.dependencies ?? []).filter(
+    isStaticCssEvalResolutionDependency
+  );
+  const diagnostics =
+    metadataSource.diagnostics ??
+    (metadataSource.diagnostic ? [metadataSource.diagnostic] : []);
+  const cacheKeys = metadataSource.cacheKey ? [metadataSource.cacheKey] : [];
+
+  appendUniqueMetadataItems(
+    metadata.dependencies,
+    dependencies,
+    createStaticCssEvalDependencyKey
+  );
+  appendUniqueMetadataItems(
+    metadata.diagnostics,
+    diagnostics,
+    createStaticCssEvalDiagnosticKey
+  );
+  appendUniqueMetadataItems(
+    metadata.cacheKeys,
+    cacheKeys,
+    createStaticCssEvalCacheKeyKey
+  );
+  appendUniqueMetadataItems(
+    metadata.resolvedModuleIds,
+    [
+      ...cacheKeys.flatMap((cacheKey) => cacheKey.resolvedId ?? []),
+      ...dependencies.flatMap((dependency) =>
+        dependency.kind !== "local" &&
+        dependency.kind !== "unresolved" &&
+        dependency.inspected
+          ? [dependency.file]
+          : []
+      )
+    ],
+    (moduleId) => moduleId
+  );
+}
+
+function isStaticCssEvalResolutionDependency(
+  dependency: unknown
+): dependency is StaticCssEvalMetadataDependency {
+  return typeof dependency === "object" && dependency !== null;
+}
+
+export function getStaticCssEvalMetadata(
+  metadata: unknown
+): MinchoStaticCssEvalMetadata | undefined {
+  const staticCssEval = (
+    metadata as { minchoStaticCssEval?: MinchoStaticCssEvalMetadata } | null
+  )?.minchoStaticCssEval;
+
+  if (!staticCssEval) {
+    return undefined;
+  }
+
+  return cloneStaticCssEvalMetadata(staticCssEval);
+}
+
+export function createStaticCssEvalTransformResult(
+  prepassResult: StaticCssEvalPrepassResult | undefined,
+  metadata: MinchoStaticCssEvalMetadata | undefined
+): StaticCssEvalTransformResult | undefined {
+  const staticCssEvalMetadata = metadata
+    ? cloneStaticCssEvalMetadata(metadata)
+    : createEmptyStaticCssEvalMetadata();
+  const hasMetadata =
+    staticCssEvalMetadata.dependencies.length > 0 ||
+    staticCssEvalMetadata.diagnostics.length > 0 ||
+    staticCssEvalMetadata.cacheKeys.length > 0 ||
+    staticCssEvalMetadata.resolvedModuleIds.length > 0;
+
+  if (!prepassResult && !hasMetadata) {
+    return undefined;
+  }
+
+  return {
+    dependencyFiles: prepassResult?.dependencyFiles ?? [],
+    ownerToDependencies: prepassResult?.ownerToDependencies ?? new Map(),
+    dependencyToOwners: prepassResult?.dependencyToOwners ?? new Map(),
+    resolvedModuleCache: prepassResult?.resolvedModuleCache ?? new Map(),
+    resolvedDependencies: prepassResult?.resolvedDependencies ?? [],
+    ...staticCssEvalMetadata
+  };
+}
+
+export function mergeStaticCssEvalMetadata(
+  ...metadataItems: Array<MinchoStaticCssEvalMetadata | undefined>
+): MinchoStaticCssEvalMetadata {
+  const mergedMetadata = createEmptyStaticCssEvalMetadata();
+
+  for (const metadata of metadataItems) {
+    if (!metadata) {
+      continue;
+    }
+
+    appendUniqueMetadataItems(
+      mergedMetadata.dependencies,
+      metadata.dependencies,
+      createStaticCssEvalDependencyKey
+    );
+    appendUniqueMetadataItems(
+      mergedMetadata.diagnostics,
+      metadata.diagnostics,
+      createStaticCssEvalDiagnosticKey
+    );
+    appendUniqueMetadataItems(
+      mergedMetadata.cacheKeys,
+      metadata.cacheKeys,
+      createStaticCssEvalCacheKeyKey
+    );
+    appendUniqueMetadataItems(
+      mergedMetadata.resolvedModuleIds,
+      metadata.resolvedModuleIds,
+      (moduleId) => moduleId
+    );
+  }
+
+  return mergedMetadata;
+}
+
+export function createEmptyStaticCssEvalMetadata(): MinchoStaticCssEvalMetadata {
+  return {
+    dependencies: [],
+    diagnostics: [],
+    cacheKeys: [],
+    resolvedModuleIds: []
+  };
+}
+
+function cloneStaticCssEvalMetadata(
+  metadata: MinchoStaticCssEvalMetadata
+): MinchoStaticCssEvalMetadata {
+  return {
+    dependencies: metadata.dependencies.map((dependency) => ({
+      ...dependency,
+      memberPath: [...dependency.memberPath]
+    })),
+    diagnostics: metadata.diagnostics.map((diagnostic) => ({
+      ...diagnostic,
+      owner: { ...diagnostic.owner },
+      ...(diagnostic.dependency
+        ? { dependency: { ...diagnostic.dependency } }
+        : {}),
+      ...(diagnostic.memberPath
+        ? { memberPath: [...diagnostic.memberPath] }
+        : {}),
+      ...(diagnostic.importChain
+        ? { importChain: [...diagnostic.importChain] }
+        : {})
+    })),
+    cacheKeys: metadata.cacheKeys.map((cacheKey) => ({
+      ...cacheKey,
+      memberPath: [...cacheKey.memberPath],
+      ...(cacheKey.parserOptions
+        ? {
+            parserOptions: {
+              ...cacheKey.parserOptions,
+              plugins: [...cacheKey.parserOptions.plugins]
+            }
+          }
+        : {}),
+      ...(cacheKey.projectLocalBoundary
+        ? { projectLocalBoundary: { ...cacheKey.projectLocalBoundary } }
+        : {})
+    })),
+    resolvedModuleIds: [...metadata.resolvedModuleIds]
+  };
+}
+
+function appendUniqueMetadataItems<T>(
+  target: T[],
+  items: readonly T[],
+  createKey: (item: T) => string
+): void {
+  const existingKeys = new Set(target.map(createKey));
+
+  for (const item of items) {
+    const key = createKey(item);
+
+    if (existingKeys.has(key)) {
+      continue;
+    }
+
+    existingKeys.add(key);
+    target.push(item);
+  }
+}
+
+function createStaticCssEvalDependencyKey(
+  dependency: StaticCssEvalMetadataDependency
+): string {
+  return JSON.stringify([
+    dependency.file,
+    dependency.kind,
+    dependency.importer,
+    dependency.specifier,
+    dependency.exportName,
+    dependency.memberPath,
+    dependency.inspected,
+    dependency.contributed
+  ]);
+}
+
+function createStaticCssEvalDiagnosticKey(
+  diagnostic: StaticCssEvalMetadataDiagnostic
+): string {
+  return JSON.stringify([
+    diagnostic.id,
+    diagnostic.code,
+    diagnostic.reason,
+    diagnostic.message,
+    diagnostic.owner.file,
+    diagnostic.owner.start,
+    diagnostic.owner.end,
+    diagnostic.dependency?.file,
+    diagnostic.importPath,
+    diagnostic.exportName,
+    diagnostic.memberPath,
+    diagnostic.importChain
+  ]);
+}
+
+function createStaticCssEvalCacheKeyKey(
+  cacheKey: StaticCssEvalMetadataCacheKey
+): string {
+  return JSON.stringify([
+    cacheKey.importerFile,
+    cacheKey.resolvedFile,
+    cacheKey.exportName,
+    cacheKey.memberPath,
+    cacheKey.sourceHash,
+    cacheKey.sourceVersion,
+    cacheKey.pluginOptionsVersion,
+    cacheKey.resolverOptionsVersion,
+    cacheKey.staticEvalSupportVersion,
+    cacheKey.resolvedId
+  ]);
+}

--- a/packages/integration/src/staticCssEvalMetadata.ts
+++ b/packages/integration/src/staticCssEvalMetadata.ts
@@ -1,4 +1,9 @@
 import {
+  internalAppendUniqueStaticCssEvalMetadataItems as appendUniqueMetadataItems,
+  internalAppendUniqueStaticCssEvalResolvedModuleIds as appendUniqueResolvedModuleIds,
+  internalCreateStaticCssEvalCacheKeyMetadataKey as createStaticCssEvalCacheKeyKey,
+  internalCreateStaticCssEvalDependencyMetadataKey as createStaticCssEvalDependencyKey,
+  internalCreateStaticCssEvalDiagnosticMetadataKey as createStaticCssEvalDiagnosticKey,
   type MinchoStaticCssEvalMetadata,
   type PluginOptions
 } from "@mincho-js/babel";
@@ -67,20 +72,7 @@ function appendStaticCssEvalResultMetadata(
     cacheKeys,
     createStaticCssEvalCacheKeyKey
   );
-  appendUniqueMetadataItems(
-    metadata.resolvedModuleIds,
-    [
-      ...cacheKeys.flatMap((cacheKey) => cacheKey.resolvedId ?? []),
-      ...dependencies.flatMap((dependency) =>
-        dependency.kind !== "local" &&
-        dependency.kind !== "unresolved" &&
-        dependency.inspected
-          ? [dependency.file]
-          : []
-      )
-    ],
-    (moduleId) => moduleId
-  );
+  appendUniqueResolvedModuleIds(metadata, dependencies, cacheKeys);
 }
 
 function isStaticCssEvalResolutionDependency(
@@ -180,7 +172,10 @@ function cloneStaticCssEvalMetadata(
   return {
     dependencies: metadata.dependencies.map((dependency) => ({
       ...dependency,
-      memberPath: [...dependency.memberPath]
+      memberPath: [...dependency.memberPath],
+      ...(dependency.watchFiles
+        ? { watchFiles: [...dependency.watchFiles] }
+        : {})
     })),
     diagnostics: metadata.diagnostics.map((diagnostic) => ({
       ...diagnostic,
@@ -198,6 +193,7 @@ function cloneStaticCssEvalMetadata(
     cacheKeys: metadata.cacheKeys.map((cacheKey) => ({
       ...cacheKey,
       memberPath: [...cacheKey.memberPath],
+      ...(cacheKey.watchFiles ? { watchFiles: [...cacheKey.watchFiles] } : {}),
       ...(cacheKey.parserOptions
         ? {
             parserOptions: {
@@ -212,74 +208,4 @@ function cloneStaticCssEvalMetadata(
     })),
     resolvedModuleIds: [...metadata.resolvedModuleIds]
   };
-}
-
-function appendUniqueMetadataItems<T>(
-  target: T[],
-  items: readonly T[],
-  createKey: (item: T) => string
-): void {
-  const existingKeys = new Set(target.map(createKey));
-
-  for (const item of items) {
-    const key = createKey(item);
-
-    if (existingKeys.has(key)) {
-      continue;
-    }
-
-    existingKeys.add(key);
-    target.push(item);
-  }
-}
-
-function createStaticCssEvalDependencyKey(
-  dependency: StaticCssEvalMetadataDependency
-): string {
-  return JSON.stringify([
-    dependency.file,
-    dependency.kind,
-    dependency.importer,
-    dependency.specifier,
-    dependency.exportName,
-    dependency.memberPath,
-    dependency.inspected,
-    dependency.contributed
-  ]);
-}
-
-function createStaticCssEvalDiagnosticKey(
-  diagnostic: StaticCssEvalMetadataDiagnostic
-): string {
-  return JSON.stringify([
-    diagnostic.id,
-    diagnostic.code,
-    diagnostic.reason,
-    diagnostic.message,
-    diagnostic.owner.file,
-    diagnostic.owner.start,
-    diagnostic.owner.end,
-    diagnostic.dependency?.file,
-    diagnostic.importPath,
-    diagnostic.exportName,
-    diagnostic.memberPath,
-    diagnostic.importChain
-  ]);
-}
-
-function createStaticCssEvalCacheKeyKey(
-  cacheKey: StaticCssEvalMetadataCacheKey
-): string {
-  return JSON.stringify([
-    cacheKey.importerFile,
-    cacheKey.resolvedFile,
-    cacheKey.exportName,
-    cacheKey.memberPath,
-    cacheKey.sourceHash,
-    cacheKey.sourceVersion,
-    cacheKey.pluginOptionsVersion,
-    cacheKey.resolverOptionsVersion,
-    cacheKey.staticEvalSupportVersion,
-    cacheKey.resolvedId
-  ]);
 }

--- a/packages/integration/src/staticCssEvalPrepass.ts
+++ b/packages/integration/src/staticCssEvalPrepass.ts
@@ -46,6 +46,44 @@ interface StaticCssEvalPrepassState {
   loadedDependencyIds: Set<string>;
 }
 
+interface StaticCssEvalPrepassContext {
+  sourceProvider: StaticCssEvalSourceProvider;
+  state: StaticCssEvalPrepassState;
+}
+
+type StaticCssEvalPrepassImportBinding =
+  ImportedStaticCssEvalModuleRecord["imports"] extends ReadonlyMap<
+    string,
+    infer ImportBinding
+  >
+    ? ImportBinding
+    : never;
+type StaticCssEvalPrepassExportName = string | null;
+type StaticCssEvalPrepassExportEntry =
+  ImportedStaticCssEvalModuleRecord["exports"] extends ReadonlyMap<
+    StaticCssEvalPrepassExportName,
+    infer ExportEntry
+  >
+    ? ExportEntry
+    : never;
+
+interface StaticCssEvalPrepassExportRequest {
+  exportName: StaticCssEvalPrepassExportName;
+  memberPath: readonly string[];
+  wholeNamespace: boolean;
+}
+
+interface StaticCssEvalPrepassExportWalk {
+  exportName: string;
+  memberPath: readonly string[];
+  seen: Set<string>;
+}
+
+interface StaticCssEvalPrepassWholeNamespaceWalk {
+  includeDefaultExport: boolean;
+  seen: Set<string>;
+}
+
 export async function createStaticCssEvalPrepass(
   ownerId: string,
   sourceProvider: StaticCssEvalSourceProvider
@@ -72,6 +110,10 @@ export async function createStaticCssEvalPrepass(
     resolvedImports: new Map(),
     loadedDependencyIds: new Set([ownerId])
   };
+  const prepassContext: StaticCssEvalPrepassContext = {
+    sourceProvider,
+    state: prepassState
+  };
 
   for (const candidate of candidates) {
     const importBinding = candidate.bindingName
@@ -85,20 +127,23 @@ export async function createStaticCssEvalPrepass(
     const moduleRecord = await loadStaticCssEvalPrepassDependency(
       ownerId,
       importBinding.importPath,
-      sourceProvider,
-      prepassState
+      prepassContext
     );
 
     if (!moduleRecord) {
       continue;
     }
 
-    if (importBinding.kind !== "namespace") {
-      await loadDirectReexportDependencies(
+    const request = createStaticCssEvalPrepassExportRequest(
+      importBinding,
+      candidate.memberPath ?? []
+    );
+
+    if (request) {
+      await loadStaticCssEvalPrepassGraphDependencies(
         moduleRecord,
-        importBinding.importedName,
-        sourceProvider,
-        prepassState
+        request,
+        prepassContext
       );
     }
   }
@@ -127,13 +172,17 @@ export async function createStaticCssEvalPrepass(
 async function loadStaticCssEvalPrepassDependency(
   importerId: string,
   importPath: string,
-  sourceProvider: StaticCssEvalSourceProvider,
-  prepassState: StaticCssEvalPrepassState
+  context: StaticCssEvalPrepassContext
 ): Promise<ImportedStaticCssEvalModuleRecord | undefined> {
-  const resolvedImportKey = `${importerId}\0${importPath}`;
-  let resolution = prepassState.resolvedImports.get(resolvedImportKey);
+  if (!isProjectLocalStaticCssEvalImportSpecifier(importPath)) {
+    return undefined;
+  }
 
-  if (!prepassState.resolvedImports.has(resolvedImportKey)) {
+  const { sourceProvider, state } = context;
+  const resolvedImportKey = `${importerId}\0${importPath}`;
+  let resolution = state.resolvedImports.get(resolvedImportKey);
+
+  if (!state.resolvedImports.has(resolvedImportKey)) {
     const sourceResolution = await sourceProvider.resolve(
       importerId,
       importPath
@@ -141,15 +190,15 @@ async function loadStaticCssEvalPrepassDependency(
     resolution = sourceResolution
       ? normalizeStaticCssEvalSourceResolution(sourceResolution)
       : null;
-    prepassState.resolvedImports.set(resolvedImportKey, resolution ?? null);
+    state.resolvedImports.set(resolvedImportKey, resolution ?? null);
 
     if (resolution) {
-      prepassState.importResolutions.push({
+      state.importResolutions.push({
         importerId,
         importPath,
         resolvedId: resolution.resolvedFile
       });
-      prepassState.resolvedDependencies.push(
+      state.resolvedDependencies.push(
         createStaticCssEvalResolvedDependency(
           importerId,
           importPath,
@@ -165,25 +214,23 @@ async function loadStaticCssEvalPrepassDependency(
   }
 
   addOwnerDependency(
-    prepassState.ownerDependencies,
-    prepassState.dependencyToOwners,
-    prepassState.loadedModules[0]?.id ?? importerId,
+    state.ownerDependencies,
+    state.dependencyToOwners,
+    state.loadedModules[0]?.id ?? importerId,
     resolution.resolvedFile
   );
 
-  const cachedRecord = prepassState.resolvedModuleCache.get(
-    resolution.resolvedFile
-  );
+  const cachedRecord = state.resolvedModuleCache.get(resolution.resolvedFile);
 
   if (cachedRecord) {
     return cachedRecord;
   }
 
-  if (prepassState.loadedDependencyIds.has(resolution.resolvedFile)) {
+  if (state.loadedDependencyIds.has(resolution.resolvedFile)) {
     return undefined;
   }
 
-  prepassState.loadedDependencyIds.add(resolution.resolvedFile);
+  state.loadedDependencyIds.add(resolution.resolvedFile);
   const loadedSource = await sourceProvider.load(resolution.normalizedPathKey);
 
   if (!loadedSource) {
@@ -191,7 +238,7 @@ async function loadStaticCssEvalPrepassDependency(
   }
 
   markResolvedDependencyLoaded(
-    prepassState.resolvedDependencies,
+    state.resolvedDependencies,
     importerId,
     importPath,
     resolution,
@@ -203,11 +250,10 @@ async function loadStaticCssEvalPrepassDependency(
     loadedSource,
     resolution
   );
-
   try {
     const moduleRecord = createImportedStaticCssEvalModuleRecord(loadedModule);
-    prepassState.resolvedModuleCache.set(moduleRecord.id, moduleRecord);
-    prepassState.loadedModules.push(loadedModule);
+    state.resolvedModuleCache.set(moduleRecord.id, moduleRecord);
+    state.loadedModules.push(loadedModule);
 
     return moduleRecord;
   } catch {
@@ -215,40 +261,217 @@ async function loadStaticCssEvalPrepassDependency(
   }
 }
 
-async function loadDirectReexportDependencies(
-  moduleRecord: ImportedStaticCssEvalModuleRecord,
-  exportName: string,
-  sourceProvider: StaticCssEvalSourceProvider,
-  prepassState: StaticCssEvalPrepassState
-): Promise<void> {
-  let currentRecord: ImportedStaticCssEvalModuleRecord | undefined =
-    moduleRecord;
-  let currentExportName = exportName;
-  const seenReexports = new Set<string>();
+function createStaticCssEvalPrepassExportRequest(
+  importBinding: StaticCssEvalPrepassImportBinding,
+  memberPath: readonly string[]
+): StaticCssEvalPrepassExportRequest | null {
+  switch (importBinding.kind) {
+    case "default":
+    case "named":
+      return {
+        exportName: importBinding.importedName,
+        memberPath: [...memberPath],
+        wholeNamespace: false
+      };
+    case "namespace": {
+      const [exportName, ...remainingMemberPath] = memberPath;
 
-  while (currentRecord) {
-    const exportEntry = currentRecord.exports.get(currentExportName);
+      if (exportName === undefined) {
+        return {
+          exportName: null,
+          memberPath: [],
+          wholeNamespace: true
+        };
+      }
 
-    if (!exportEntry || exportEntry.kind !== "reexport") {
-      return;
+      return {
+        exportName,
+        memberPath: remainingMemberPath,
+        wholeNamespace: false
+      };
     }
-
-    const reexportKey = `${currentRecord.id}\0${currentExportName}`;
-
-    if (seenReexports.has(reexportKey)) {
-      return;
-    }
-
-    seenReexports.add(reexportKey);
-
-    currentRecord = await loadStaticCssEvalPrepassDependency(
-      currentRecord.id,
-      exportEntry.source,
-      sourceProvider,
-      prepassState
-    );
-    currentExportName = exportEntry.importedName;
+    default:
+      return assertNever(importBinding);
   }
+}
+
+async function loadStaticCssEvalPrepassGraphDependencies(
+  moduleRecord: ImportedStaticCssEvalModuleRecord,
+  request: StaticCssEvalPrepassExportRequest,
+  context: StaticCssEvalPrepassContext
+): Promise<void> {
+  if (request.wholeNamespace) {
+    await loadWholeNamespacePrepassDependencies(
+      moduleRecord,
+      { includeDefaultExport: true, seen: new Set() },
+      context
+    );
+    return;
+  }
+
+  if (request.exportName === null) {
+    return;
+  }
+
+  await loadExportNamePrepassDependencies(
+    moduleRecord,
+    {
+      exportName: request.exportName,
+      memberPath: request.memberPath,
+      seen: new Set()
+    },
+    context
+  );
+}
+
+async function loadExportNamePrepassDependencies(
+  moduleRecord: ImportedStaticCssEvalModuleRecord,
+  walk: StaticCssEvalPrepassExportWalk,
+  context: StaticCssEvalPrepassContext
+): Promise<void> {
+  const walkKey = createStaticCssEvalPrepassWalkKey(
+    moduleRecord.id,
+    walk.exportName,
+    walk.memberPath
+  );
+
+  if (walk.seen.has(walkKey)) {
+    return;
+  }
+
+  walk.seen.add(walkKey);
+
+  const exportEntry = moduleRecord.exports.get(walk.exportName);
+
+  if (exportEntry) {
+    await loadExplicitExportEntryPrepassDependencies(
+      moduleRecord,
+      exportEntry,
+      walk,
+      context
+    );
+    return;
+  }
+
+  if (walk.exportName === "default") {
+    return;
+  }
+
+  for (const starEntry of moduleRecord.parsedModule.exportStarReexports) {
+    const dependencyRecord = await loadStaticCssEvalPrepassDependency(
+      moduleRecord.id,
+      starEntry.source,
+      context
+    );
+
+    if (!dependencyRecord) {
+      continue;
+    }
+
+    await loadExportNamePrepassDependencies(dependencyRecord, walk, context);
+  }
+}
+
+async function loadWholeNamespacePrepassDependencies(
+  moduleRecord: ImportedStaticCssEvalModuleRecord,
+  walk: StaticCssEvalPrepassWholeNamespaceWalk,
+  context: StaticCssEvalPrepassContext
+): Promise<void> {
+  const walkKey = createStaticCssEvalPrepassWalkKey(
+    moduleRecord.id,
+    walk.includeDefaultExport ? "<namespace-with-default>" : "<namespace>",
+    []
+  );
+
+  if (walk.seen.has(walkKey)) {
+    return;
+  }
+
+  walk.seen.add(walkKey);
+
+  for (const [exportName, exportEntry] of moduleRecord.exports) {
+    if (exportName === null) {
+      continue;
+    }
+
+    if (!walk.includeDefaultExport && exportName === "default") {
+      continue;
+    }
+
+    await loadExplicitExportEntryPrepassDependencies(
+      moduleRecord,
+      exportEntry,
+      { exportName, memberPath: [], seen: walk.seen },
+      context
+    );
+  }
+
+  for (const starEntry of moduleRecord.parsedModule.exportStarReexports) {
+    const dependencyRecord = await loadStaticCssEvalPrepassDependency(
+      moduleRecord.id,
+      starEntry.source,
+      context
+    );
+
+    if (!dependencyRecord) {
+      continue;
+    }
+
+    await loadWholeNamespacePrepassDependencies(
+      dependencyRecord,
+      { includeDefaultExport: false, seen: walk.seen },
+      context
+    );
+  }
+}
+
+async function loadExplicitExportEntryPrepassDependencies(
+  moduleRecord: ImportedStaticCssEvalModuleRecord,
+  exportEntry: StaticCssEvalPrepassExportEntry,
+  walk: StaticCssEvalPrepassExportWalk,
+  context: StaticCssEvalPrepassContext
+): Promise<void> {
+  if (exportEntry.kind !== "reexport") {
+    return;
+  }
+
+  const dependencyRecord = await loadStaticCssEvalPrepassDependency(
+    moduleRecord.id,
+    exportEntry.source,
+    context
+  );
+
+  if (!dependencyRecord) {
+    return;
+  }
+
+  await loadExportNamePrepassDependencies(
+    dependencyRecord,
+    {
+      exportName: exportEntry.importedName,
+      memberPath: walk.memberPath,
+      seen: walk.seen
+    },
+    context
+  );
+}
+
+function createStaticCssEvalPrepassWalkKey(
+  file: string,
+  exportName: string,
+  memberPath: readonly string[]
+): string {
+  return `${file}\0${exportName}\0${memberPath.join(".")}`;
+}
+
+function isProjectLocalStaticCssEvalImportSpecifier(
+  importPath: string
+): boolean {
+  return importPath.startsWith(".") || importPath.startsWith("/");
+}
+
+function assertNever(value: never): never {
+  throw new TypeError(`Unexpected static css eval prepass value: ${value}`);
 }
 
 function createLoadedModule(

--- a/packages/integration/src/staticCssEvalPrepass.ts
+++ b/packages/integration/src/staticCssEvalPrepass.ts
@@ -13,8 +13,11 @@ import type {
   StaticCssEvalResolvedDependency,
   StaticCssEvalResolverKind,
   StaticCssEvalSourceIdentity,
+  StaticCssEvalSourceKind,
+  StaticCssEvalSourceOrigin,
   StaticCssEvalSourceProvider,
-  StaticCssEvalSourceResolution
+  StaticCssEvalSourceResolution,
+  StaticCssEvalSourceUnsupportedReason
 } from "./babel.js";
 
 type StaticCssEvalProvider = NonNullable<
@@ -28,6 +31,10 @@ interface NormalizedStaticCssEvalSourceResolution {
   resolverKind: StaticCssEvalResolverKind;
   realpath?: string;
   sourceIdentity?: StaticCssEvalSourceIdentity;
+  sourceKind: StaticCssEvalSourceKind;
+  sourceOrigin: StaticCssEvalSourceOrigin;
+  unsupportedReason?: StaticCssEvalSourceUnsupportedReason;
+  watchFiles?: readonly string[];
 }
 
 interface PreparedStaticCssEvalPrepass {
@@ -83,6 +90,61 @@ interface StaticCssEvalPrepassWholeNamespaceWalk {
   includeDefaultExport: boolean;
   seen: Set<string>;
 }
+
+interface CreateLoadedModuleOptions {
+  resolution?: NormalizedStaticCssEvalSourceResolution;
+  sourceText?: string;
+}
+
+type PreparedStaticCssEvalLoadedSource =
+  | {
+      kind: "source";
+      sourceText: string;
+      loadedSource: StaticCssEvalLoadedSource;
+    }
+  | {
+      kind: "unsupported";
+      loadedSource: StaticCssEvalLoadedSource;
+    };
+
+const STATIC_CSS_EVAL_PREPASS_MAX_SOURCE_BYTES = 1024 * 1024;
+
+const STATIC_CSS_EVAL_PREPASS_RESERVED_EXPORT_NAMES = new Set([
+  "await",
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "default",
+  "delete",
+  "do",
+  "else",
+  "export",
+  "extends",
+  "finally",
+  "for",
+  "function",
+  "if",
+  "import",
+  "in",
+  "instanceof",
+  "new",
+  "return",
+  "super",
+  "switch",
+  "this",
+  "throw",
+  "try",
+  "typeof",
+  "var",
+  "void",
+  "while",
+  "with",
+  "yield"
+]);
 
 export async function createStaticCssEvalPrepass(
   ownerId: string,
@@ -174,10 +236,6 @@ async function loadStaticCssEvalPrepassDependency(
   importPath: string,
   context: StaticCssEvalPrepassContext
 ): Promise<ImportedStaticCssEvalModuleRecord | undefined> {
-  if (!isProjectLocalStaticCssEvalImportSpecifier(importPath)) {
-    return undefined;
-  }
-
   const { sourceProvider, state } = context;
   const resolvedImportKey = `${importerId}\0${importPath}`;
   let resolution = state.resolvedImports.get(resolvedImportKey);
@@ -193,11 +251,13 @@ async function loadStaticCssEvalPrepassDependency(
     state.resolvedImports.set(resolvedImportKey, resolution ?? null);
 
     if (resolution) {
-      state.importResolutions.push({
-        importerId,
-        importPath,
-        resolvedId: resolution.resolvedFile
-      });
+      state.importResolutions.push(
+        createStaticCssEvalPrepassImportResolution(
+          importerId,
+          importPath,
+          resolution
+        )
+      );
       state.resolvedDependencies.push(
         createStaticCssEvalResolvedDependency(
           importerId,
@@ -237,28 +297,84 @@ async function loadStaticCssEvalPrepassDependency(
     return undefined;
   }
 
+  const preparedSource = prepareStaticCssEvalLoadedSource(
+    resolution.resolvedFile,
+    loadedSource,
+    resolution
+  );
+
+  if (preparedSource.kind === "unsupported") {
+    markPrepassImportResolutionLoaded(
+      state.importResolutions,
+      importerId,
+      importPath,
+      resolution,
+      preparedSource.loadedSource
+    );
+    markResolvedDependencyLoaded(
+      state.resolvedDependencies,
+      importerId,
+      importPath,
+      resolution,
+      preparedSource.loadedSource
+    );
+    return undefined;
+  }
+
+  const loadedModule = createLoadedModule(
+    resolution.resolvedFile,
+    preparedSource.loadedSource,
+    { resolution, sourceText: preparedSource.sourceText }
+  );
+
+  let moduleRecord: ImportedStaticCssEvalModuleRecord;
+
+  try {
+    moduleRecord = createImportedStaticCssEvalModuleRecord(loadedModule);
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error;
+    }
+
+    const unsupportedSource = createUnsupportedStaticCssEvalLoadedSource(
+      loadedSource,
+      "unsupported-source-shape"
+    );
+    markResolvedDependencyLoaded(
+      state.resolvedDependencies,
+      importerId,
+      importPath,
+      resolution,
+      unsupportedSource
+    );
+    markPrepassImportResolutionLoaded(
+      state.importResolutions,
+      importerId,
+      importPath,
+      resolution,
+      unsupportedSource
+    );
+    return undefined;
+  }
+
+  markPrepassImportResolutionLoaded(
+    state.importResolutions,
+    importerId,
+    importPath,
+    resolution,
+    preparedSource.loadedSource
+  );
   markResolvedDependencyLoaded(
     state.resolvedDependencies,
     importerId,
     importPath,
     resolution,
-    loadedSource
+    preparedSource.loadedSource
   );
+  state.resolvedModuleCache.set(moduleRecord.id, moduleRecord);
+  state.loadedModules.push(loadedModule);
 
-  const loadedModule = createLoadedModule(
-    resolution.resolvedFile,
-    loadedSource,
-    resolution
-  );
-  try {
-    const moduleRecord = createImportedStaticCssEvalModuleRecord(loadedModule);
-    state.resolvedModuleCache.set(moduleRecord.id, moduleRecord);
-    state.loadedModules.push(loadedModule);
-
-    return moduleRecord;
-  } catch {
-    return undefined;
-  }
+  return moduleRecord;
 }
 
 function createStaticCssEvalPrepassExportRequest(
@@ -464,12 +580,6 @@ function createStaticCssEvalPrepassWalkKey(
   return `${file}\0${exportName}\0${memberPath.join(".")}`;
 }
 
-function isProjectLocalStaticCssEvalImportSpecifier(
-  importPath: string
-): boolean {
-  return importPath.startsWith(".") || importPath.startsWith("/");
-}
-
 function assertNever(value: never): never {
   throw new TypeError(`Unexpected static css eval prepass value: ${value}`);
 }
@@ -477,22 +587,403 @@ function assertNever(value: never): never {
 function createLoadedModule(
   id: string,
   loadedSource: StaticCssEvalLoadedSource,
-  resolution?: NormalizedStaticCssEvalSourceResolution
+  options: CreateLoadedModuleOptions = {}
 ): ImportedStaticCssEvalLoadedModule {
-  const sourceText = getLoadedSourceText(id, loadedSource);
+  const sourceText =
+    options.sourceText ?? getLoadedSourceText(id, loadedSource);
   const sourceIdentity = createLoadedSourceIdentity(
     sourceText,
     loadedSource,
-    resolution
+    options.resolution
   );
 
   return {
     id,
     source: sourceText,
-    realpath: loadedSource.realpath ?? resolution?.realpath,
+    realpath: loadedSource.realpath ?? options.resolution?.realpath,
     sourceHash: sourceIdentity.sourceHash,
-    version: sourceIdentity.version
+    version: sourceIdentity.version,
+    ...createLoadedModuleSourceMetadata(loadedSource, options.resolution)
   };
+}
+
+function createStaticCssEvalPrepassImportResolution(
+  importerId: string,
+  importPath: string,
+  resolution: NormalizedStaticCssEvalSourceResolution,
+  loadedSource?: StaticCssEvalLoadedSource
+): ImportedStaticCssEvalImportResolution {
+  const canonicalModuleId =
+    loadedSource?.canonicalModuleId ?? resolution.canonicalModuleId;
+  const normalizedPathKey =
+    loadedSource?.normalizedPathKey ?? resolution.normalizedPathKey;
+  const sourceKind = loadedSource?.sourceKind ?? resolution.sourceKind;
+  const sourceOrigin =
+    loadedSource?.sourceOrigin ??
+    (loadedSource?.sourceKind
+      ? getStaticCssEvalSourceOrigin(loadedSource.sourceKind)
+      : resolution.sourceOrigin);
+  const unsupportedReason =
+    loadedSource?.unsupportedReason ?? resolution.unsupportedReason;
+  const watchFiles = loadedSource?.watchFiles ?? resolution.watchFiles;
+
+  return {
+    importerId,
+    importPath,
+    resolvedId: resolution.resolvedFile,
+    canonicalModuleId,
+    normalizedPathKey,
+    sourceKind,
+    sourceOrigin,
+    ...(unsupportedReason ? { unsupportedReason } : {}),
+    ...(watchFiles ? { watchFiles: [...watchFiles] } : {})
+  };
+}
+
+function markPrepassImportResolutionLoaded(
+  importResolutions: ImportedStaticCssEvalImportResolution[],
+  importerId: string,
+  importPath: string,
+  resolution: NormalizedStaticCssEvalSourceResolution,
+  loadedSource: StaticCssEvalLoadedSource
+): void {
+  const importResolutionIndex = importResolutions.findIndex(
+    (importResolution) =>
+      importResolution.importerId === importerId &&
+      importResolution.importPath === importPath &&
+      importResolution.resolvedId === resolution.resolvedFile
+  );
+  const loadedImportResolution = createStaticCssEvalPrepassImportResolution(
+    importerId,
+    importPath,
+    resolution,
+    loadedSource
+  );
+
+  if (importResolutionIndex === -1) {
+    importResolutions.push(loadedImportResolution);
+    return;
+  }
+
+  importResolutions[importResolutionIndex] = loadedImportResolution;
+}
+
+function createLoadedModuleSourceMetadata(
+  loadedSource: StaticCssEvalLoadedSource,
+  resolution: NormalizedStaticCssEvalSourceResolution | undefined
+): Pick<
+  ImportedStaticCssEvalLoadedModule,
+  | "canonicalModuleId"
+  | "normalizedPathKey"
+  | "sourceKind"
+  | "sourceOrigin"
+  | "unsupportedReason"
+  | "watchFiles"
+> {
+  const sourceKind = loadedSource.sourceKind ?? resolution?.sourceKind;
+  const sourceOrigin =
+    loadedSource.sourceOrigin ??
+    (loadedSource.sourceKind
+      ? getStaticCssEvalSourceOrigin(loadedSource.sourceKind)
+      : resolution?.sourceOrigin);
+  const canonicalModuleId =
+    loadedSource.canonicalModuleId ?? resolution?.canonicalModuleId;
+  const normalizedPathKey =
+    loadedSource.normalizedPathKey ?? resolution?.normalizedPathKey;
+  const unsupportedReason =
+    loadedSource.unsupportedReason ?? resolution?.unsupportedReason;
+  const watchFiles = loadedSource.watchFiles ?? resolution?.watchFiles;
+
+  return {
+    ...(canonicalModuleId ? { canonicalModuleId } : {}),
+    ...(normalizedPathKey ? { normalizedPathKey } : {}),
+    ...(sourceKind ? { sourceKind } : {}),
+    ...(sourceOrigin ? { sourceOrigin } : {}),
+    ...(unsupportedReason ? { unsupportedReason } : {}),
+    ...(watchFiles ? { watchFiles: [...watchFiles] } : {})
+  };
+}
+
+function prepareStaticCssEvalLoadedSource(
+  id: string,
+  loadedSource: StaticCssEvalLoadedSource,
+  resolution: NormalizedStaticCssEvalSourceResolution
+): PreparedStaticCssEvalLoadedSource {
+  const sourceKind = loadedSource.sourceKind ?? resolution.sourceKind;
+  const sourceText = loadedSource.sourceText ?? loadedSource.source;
+
+  if (sourceKind === "unsupported-source-shape") {
+    return {
+      kind: "unsupported",
+      loadedSource: createUnsupportedStaticCssEvalLoadedSource(
+        loadedSource,
+        loadedSource.unsupportedReason ?? "unsupported-source-shape"
+      )
+    };
+  }
+
+  if (sourceText === undefined) {
+    return {
+      kind: "unsupported",
+      loadedSource: createUnsupportedStaticCssEvalLoadedSource(
+        loadedSource,
+        "unsupported-source-shape"
+      )
+    };
+  }
+
+  if (sourceKind === "static-data") {
+    return prepareStaticCssEvalStaticDataSource({
+      id,
+      sourceText,
+      loadedSource,
+      resolution
+    });
+  }
+
+  return prepareStaticCssEvalSourceText(sourceText, loadedSource);
+}
+
+function prepareStaticCssEvalSourceText(
+  sourceText: string,
+  loadedSource: StaticCssEvalLoadedSource
+): PreparedStaticCssEvalLoadedSource {
+  if (isStaticCssEvalSourceOverByteLimit(sourceText)) {
+    return {
+      kind: "unsupported",
+      loadedSource: createUnsupportedStaticCssEvalLoadedSource(
+        loadedSource,
+        "source-size-limit-exceeded"
+      )
+    };
+  }
+
+  return { kind: "source", sourceText, loadedSource };
+}
+
+function prepareStaticCssEvalStaticDataSource(options: {
+  id: string;
+  sourceText: string;
+  loadedSource: StaticCssEvalLoadedSource;
+  resolution: NormalizedStaticCssEvalSourceResolution;
+}): PreparedStaticCssEvalLoadedSource {
+  const sourceIds = createStaticCssEvalSourceIds(
+    options.id,
+    options.resolution
+  );
+
+  if (isStaticCssEvalWasmRuntimeSource(sourceIds)) {
+    return {
+      kind: "unsupported",
+      loadedSource: createUnsupportedStaticCssEvalLoadedSource(
+        options.loadedSource,
+        hasStaticCssEvalQueryFlag(sourceIds, "init")
+          ? "runtime-wasm-init"
+          : "runtime-wasm-module"
+      )
+    };
+  }
+
+  if (isStaticCssEvalStringDataSource(sourceIds)) {
+    const esmSource = createStaticCssEvalStringDataModuleSource(
+      options.sourceText
+    );
+
+    return prepareStaticCssEvalSourceText(esmSource, {
+      ...options.loadedSource,
+      sourceText: esmSource
+    });
+  }
+
+  if (isStaticCssEvalJsonSource(sourceIds)) {
+    return prepareStaticCssEvalJsonDataSource(
+      options.sourceText,
+      options.loadedSource
+    );
+  }
+
+  return prepareStaticCssEvalSourceText(
+    options.sourceText,
+    options.loadedSource
+  );
+}
+
+function prepareStaticCssEvalJsonDataSource(
+  sourceText: string,
+  loadedSource: StaticCssEvalLoadedSource
+): PreparedStaticCssEvalLoadedSource {
+  let value: unknown;
+
+  try {
+    value = JSON.parse(sourceText);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return {
+        kind: "unsupported",
+        loadedSource: createUnsupportedStaticCssEvalLoadedSource(
+          loadedSource,
+          "invalid-json-data"
+        )
+      };
+    }
+
+    throw error;
+  }
+
+  const esmSource = createStaticCssEvalJsonDataModuleSource(value);
+
+  if (!esmSource) {
+    return {
+      kind: "unsupported",
+      loadedSource: createUnsupportedStaticCssEvalLoadedSource(
+        loadedSource,
+        "non-literal-loader-output"
+      )
+    };
+  }
+
+  return prepareStaticCssEvalSourceText(esmSource, {
+    ...loadedSource,
+    sourceText: esmSource
+  });
+}
+
+function createStaticCssEvalJsonDataModuleSource(
+  value: unknown
+): string | null {
+  const defaultLiteral = JSON.stringify(value);
+
+  if (typeof defaultLiteral !== "string") {
+    return null;
+  }
+
+  const declarations = [`export default ${defaultLiteral};`];
+
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    for (const [key, itemValue] of Object.entries(value)) {
+      if (!isStaticCssEvalValidNamedExport(key)) {
+        continue;
+      }
+
+      const itemLiteral = JSON.stringify(itemValue);
+
+      if (typeof itemLiteral === "string") {
+        declarations.push(`export const ${key} = ${itemLiteral};`);
+      }
+    }
+  }
+
+  return `${declarations.join("\n")}\n`;
+}
+
+function createStaticCssEvalStringDataModuleSource(value: string): string {
+  return `export default ${JSON.stringify(value)};\n`;
+}
+
+function createUnsupportedStaticCssEvalLoadedSource(
+  loadedSource: StaticCssEvalLoadedSource,
+  unsupportedReason: StaticCssEvalSourceUnsupportedReason
+): StaticCssEvalLoadedSource {
+  return {
+    ...loadedSource,
+    sourceKind: "unsupported-source-shape",
+    sourceOrigin: "unsupported",
+    unsupportedReason: loadedSource.unsupportedReason ?? unsupportedReason
+  };
+}
+
+function createStaticCssEvalSourceIds(
+  id: string,
+  resolution: NormalizedStaticCssEvalSourceResolution
+): string[] {
+  return [
+    ...new Set([
+      id,
+      resolution.resolvedFile,
+      resolution.canonicalModuleId,
+      resolution.normalizedPathKey
+    ])
+  ];
+}
+
+function isStaticCssEvalJsonSource(sourceIds: readonly string[]): boolean {
+  return sourceIds.some((sourceId) =>
+    stripStaticCssEvalQuery(sourceId).endsWith(".json")
+  );
+}
+
+function isStaticCssEvalStringDataSource(
+  sourceIds: readonly string[]
+): boolean {
+  return (
+    hasStaticCssEvalQueryFlag(sourceIds, "raw") ||
+    hasStaticCssEvalQueryFlag(sourceIds, "url")
+  );
+}
+
+function isStaticCssEvalWasmRuntimeSource(
+  sourceIds: readonly string[]
+): boolean {
+  return sourceIds.some(
+    (sourceId) =>
+      stripStaticCssEvalQuery(sourceId).endsWith(".wasm") &&
+      !hasStaticCssEvalQueryFlag([sourceId], "raw") &&
+      !hasStaticCssEvalQueryFlag([sourceId], "url")
+  );
+}
+
+function hasStaticCssEvalQueryFlag(
+  sourceIds: readonly string[],
+  flag: string
+): boolean {
+  return sourceIds.some((sourceId) =>
+    getStaticCssEvalQueryFlags(sourceId).includes(flag)
+  );
+}
+
+function getStaticCssEvalQueryFlags(sourceId: string): string[] {
+  const queryIndex = sourceId.indexOf("?");
+
+  if (queryIndex === -1) {
+    return [];
+  }
+
+  const hashIndex = sourceId.indexOf("#", queryIndex);
+  const query = sourceId.slice(
+    queryIndex + 1,
+    hashIndex === -1 ? undefined : hashIndex
+  );
+
+  const flags: string[] = [];
+
+  for (const part of query.split("&")) {
+    const flag = part.split("=")[0];
+
+    if (flag) {
+      flags.push(flag);
+    }
+  }
+
+  return flags;
+}
+
+function stripStaticCssEvalQuery(sourceId: string): string {
+  const queryIndex = sourceId.search(/[?#]/);
+  return queryIndex === -1 ? sourceId : sourceId.slice(0, queryIndex);
+}
+
+function isStaticCssEvalValidNamedExport(name: string): boolean {
+  return (
+    /^[A-Za-z_$][0-9A-Za-z_$]*$/.test(name) &&
+    !STATIC_CSS_EVAL_PREPASS_RESERVED_EXPORT_NAMES.has(name)
+  );
+}
+
+function isStaticCssEvalSourceOverByteLimit(sourceText: string): boolean {
+  return (
+    new TextEncoder().encode(sourceText).byteLength >
+    STATIC_CSS_EVAL_PREPASS_MAX_SOURCE_BYTES
+  );
 }
 
 function getLoadedSourceText(
@@ -525,6 +1016,7 @@ function normalizeStaticCssEvalSourceResolution(
     resolution.canonicalModuleId ?? resolution.id ?? resolvedFile;
   const normalizedPathKey =
     resolution.normalizedPathKey ?? canonicalModuleId ?? resolvedFile;
+  const sourceKind = resolution.sourceKind ?? "project-source";
 
   return {
     resolvedFile,
@@ -536,8 +1028,36 @@ function normalizeStaticCssEvalSourceResolution(
       resolution.sourceIdentity,
       resolution.sourceHash,
       resolution.version
-    )
+    ),
+    sourceKind,
+    sourceOrigin:
+      resolution.sourceOrigin ?? getStaticCssEvalSourceOrigin(sourceKind),
+    unsupportedReason: resolution.unsupportedReason,
+    ...(resolution.watchFiles ? { watchFiles: [...resolution.watchFiles] } : {})
   };
+}
+
+function getStaticCssEvalSourceOrigin(
+  sourceKind: StaticCssEvalSourceKind
+): StaticCssEvalSourceOrigin {
+  switch (sourceKind) {
+    case "project-source":
+      return "project";
+    case "package-source":
+      return "package";
+    case "provider-virtual":
+      return "provider";
+    case "static-data":
+      return "data";
+    case "external-no-source":
+      return "external";
+    case "unresolved":
+      return "unresolved";
+    case "unsupported-source-shape":
+      return "unsupported";
+    default:
+      return assertNever(sourceKind);
+  }
 }
 
 function normalizeStaticCssEvalSourceIdentity(
@@ -592,11 +1112,20 @@ function createStaticCssEvalResolvedDependency(
   loadedSource?: StaticCssEvalLoadedSource
 ): StaticCssEvalResolvedDependency {
   const sourceText = loadedSource
-    ? getLoadedSourceText(resolution.normalizedPathKey, loadedSource)
+    ? (loadedSource.sourceText ?? loadedSource.source)
     : undefined;
   const sourceIdentity = loadedSource
     ? createLoadedSourceIdentity(sourceText ?? "", loadedSource, resolution)
     : resolution.sourceIdentity;
+  const sourceKind = loadedSource?.sourceKind ?? resolution.sourceKind;
+  const sourceOrigin =
+    loadedSource?.sourceOrigin ??
+    (loadedSource?.sourceKind
+      ? getStaticCssEvalSourceOrigin(loadedSource.sourceKind)
+      : resolution.sourceOrigin);
+  const unsupportedReason =
+    loadedSource?.unsupportedReason ?? resolution.unsupportedReason;
+  const watchFiles = loadedSource?.watchFiles ?? resolution.watchFiles;
 
   return {
     importerId,
@@ -606,7 +1135,11 @@ function createStaticCssEvalResolvedDependency(
     normalizedPathKey: resolution.normalizedPathKey,
     resolverKind: resolution.resolverKind,
     loaded,
-    ...(sourceIdentity ? { sourceIdentity } : {})
+    ...(sourceIdentity ? { sourceIdentity } : {}),
+    sourceKind,
+    sourceOrigin,
+    ...(unsupportedReason ? { unsupportedReason } : {}),
+    ...(watchFiles ? { watchFiles: [...watchFiles] } : {})
   };
 }
 
@@ -670,4 +1203,1089 @@ function addOwnerDependency(
   if (!owners.includes(ownerId)) {
     owners.push(ownerId);
   }
+}
+
+// Ignore errors when compiling to CommonJS.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+  const { describe, expect, it } = import.meta.vitest;
+
+  const YARN_NODE_LINKERS = ["pnp", "pnpm", "node-modules"] as const;
+
+  type YarnNodeLinker = (typeof YARN_NODE_LINKERS)[number];
+
+  type YarnNodeLinkerFixtureSourceEntry = {
+    readonly kind: "source";
+    readonly resolvedFile: string;
+    readonly canonicalModuleId: string;
+    readonly normalizedPathKey: string;
+    readonly sourcePath: string;
+    readonly realpath: string;
+    readonly sourceKind: StaticCssEvalSourceKind;
+    readonly sourceOrigin: StaticCssEvalSourceOrigin;
+    readonly sourceIdentity: StaticCssEvalSourceIdentity;
+    readonly watchFiles: readonly string[];
+  };
+
+  type YarnNodeLinkerFixtureExternalEntry = {
+    readonly kind: "external-no-source";
+    readonly resolvedFile: string;
+    readonly canonicalModuleId: string;
+    readonly normalizedPathKey: string;
+    readonly sourceKind: "external-no-source";
+    readonly sourceOrigin: "external";
+    readonly unsupportedReason: "external-no-source";
+    readonly sourceIdentity: StaticCssEvalSourceIdentity;
+    readonly watchFiles: readonly string[];
+  };
+
+  type YarnNodeLinkerFixtureLoadEntry =
+    | YarnNodeLinkerFixtureSourceEntry
+    | YarnNodeLinkerFixtureExternalEntry;
+
+  type YarnNodeLinkerFixture = {
+    readonly nodeLinker: YarnNodeLinker;
+    readonly rootDir: string;
+    readonly yarnrcPath: string;
+    readonly yarnrcValue: string;
+    readonly ownerId: string;
+    readonly unsupportedOwnerId: string;
+    readonly packageJsonPath: string;
+    readonly provider: StaticCssEvalSourceProvider;
+    readonly moduleIds: {
+      readonly direct: string;
+      readonly defaultExport: string;
+      readonly barrel: string;
+      readonly starSource: string;
+      readonly json: string;
+      readonly raw: string;
+      readonly external: string;
+      readonly supported: readonly string[];
+    };
+    readonly dispose: () => Promise<void>;
+  };
+
+  async function withYarnNodeLinkerFixtures(
+    run: (fixtures: readonly YarnNodeLinkerFixture[]) => Promise<void>
+  ): Promise<void> {
+    const fixtures = await Promise.all(
+      YARN_NODE_LINKERS.map((nodeLinker) =>
+        createYarnNodeLinkerFixture(nodeLinker)
+      )
+    );
+
+    try {
+      await run(fixtures);
+    } finally {
+      await Promise.all(fixtures.map((fixture) => fixture.dispose()));
+      await removeYarnNodeLinkerFixtureParent();
+    }
+  }
+
+  async function removeYarnNodeLinkerFixtureParent(): Promise<void> {
+    const { rm } = await import("node:fs/promises");
+    const { join } = await import("node:path");
+
+    await rm(join(process.cwd(), ".tmp", "static-css-eval-node-linkers"), {
+      recursive: true,
+      force: true
+    });
+  }
+
+  async function createYarnNodeLinkerFixture(
+    nodeLinker: YarnNodeLinker
+  ): Promise<YarnNodeLinkerFixture> {
+    const { mkdir, mkdtemp, readFile, rm, writeFile } =
+      await import("node:fs/promises");
+    const { join } = await import("node:path");
+    const tempParent = join(
+      process.cwd(),
+      ".tmp",
+      "static-css-eval-node-linkers"
+    );
+
+    await mkdir(tempParent, { recursive: true });
+
+    const rootDir = await mkdtemp(join(tempParent, `${nodeLinker}-`));
+    const srcDir = join(rootDir, "src");
+    const packageRoot = join(
+      rootDir,
+      ".yarn",
+      "provider-store",
+      nodeLinker,
+      "@fixture",
+      "styles"
+    );
+    const ownerId = join(srcDir, "App.tsx");
+    const unsupportedOwnerId = join(srcDir, "Unsupported.tsx");
+    const yarnrcPath = join(rootDir, ".yarnrc.yml");
+    const yarnrcValue = `nodeLinker: ${nodeLinker}`;
+    const packageJsonPath = join(packageRoot, "package.json");
+    const packageId = `yarn:${nodeLinker}:@fixture/styles`;
+    const directId = `${packageId}/index.ts`;
+    const defaultId = `${packageId}/default.ts`;
+    const barrelId = `${packageId}/barrel.ts`;
+    const starSourceId = `${packageId}/star-source.ts`;
+    const jsonId = `${packageId}/theme.json?import`;
+    const rawId = `${packageId}/tokens.css?raw`;
+    const externalId = `yarn:${nodeLinker}:external:@fixture/no-source`;
+    const directPath = join(packageRoot, "index.ts");
+    const defaultPath = join(packageRoot, "default.ts");
+    const barrelPath = join(packageRoot, "barrel.ts");
+    const starSourcePath = join(packageRoot, "star-source.ts");
+    const jsonPath = join(packageRoot, "theme.json");
+    const rawPath = join(packageRoot, "tokens.css");
+    const watchFiles = [packageJsonPath, yarnrcPath];
+
+    await mkdir(srcDir, { recursive: true });
+    await mkdir(packageRoot, { recursive: true });
+    await Promise.all([
+      writeFile(yarnrcPath, `${yarnrcValue}\n`),
+      writeFile(
+        join(rootDir, "package.json"),
+        `${JSON.stringify(
+          {
+            name: `linker-${nodeLinker}-consumer`,
+            packageManager: "yarn@4.14.1",
+            private: true,
+            type: "module",
+            dependencies: { "@fixture/styles": "workspace:." }
+          },
+          null,
+          2
+        )}\n`
+      ),
+      writeFile(
+        packageJsonPath,
+        `${JSON.stringify(
+          {
+            name: "@fixture/styles",
+            version: "1.0.0",
+            type: "module",
+            exports: {
+              ".": "./index.ts",
+              "./default": "./default.ts",
+              "./barrel": "./barrel.ts",
+              "./theme.json": "./theme.json",
+              "./tokens.css?raw": "./tokens.css?raw"
+            }
+          },
+          null,
+          2
+        )}\n`
+      ),
+      writeFile(ownerId, createYarnNodeLinkerConsumerSource()),
+      writeFile(unsupportedOwnerId, createYarnNodeLinkerUnsupportedSource()),
+      writeFile(
+        directPath,
+        `export const directButton = { color: "crimson" } as const;\n`
+      ),
+      writeFile(
+        defaultPath,
+        `const defaultButton = { color: "navy" } as const;\nexport default defaultButton;\n`
+      ),
+      writeFile(barrelPath, `export * from "./star-source";\n`),
+      writeFile(
+        starSourcePath,
+        `export const barrelButton = { color: "forestgreen" } as const;\n`
+      ),
+      writeFile(
+        jsonPath,
+        `${JSON.stringify({
+          jsonButton: { color: "rebeccapurple" },
+          jsonDefaultButton: { color: "goldenrod" }
+        })}\n`
+      ),
+      writeFile(rawPath, `:root { --fixture-token: tomato; }\n`)
+    ]);
+
+    const entries = [
+      {
+        kind: "source",
+        resolvedFile: ownerId,
+        canonicalModuleId: ownerId,
+        normalizedPathKey: ownerId,
+        sourcePath: ownerId,
+        realpath: ownerId,
+        sourceKind: "project-source",
+        sourceOrigin: "project",
+        sourceIdentity: { version: `${nodeLinker}:consumer` },
+        watchFiles: [ownerId]
+      },
+      {
+        kind: "source",
+        resolvedFile: unsupportedOwnerId,
+        canonicalModuleId: unsupportedOwnerId,
+        normalizedPathKey: unsupportedOwnerId,
+        sourcePath: unsupportedOwnerId,
+        realpath: unsupportedOwnerId,
+        sourceKind: "project-source",
+        sourceOrigin: "project",
+        sourceIdentity: { version: `${nodeLinker}:unsupported-consumer` },
+        watchFiles: [unsupportedOwnerId]
+      },
+      {
+        kind: "source",
+        resolvedFile: directId,
+        canonicalModuleId: `${packageId}:root`,
+        normalizedPathKey: `${directId}?conditions=import`,
+        sourcePath: directPath,
+        realpath: directPath,
+        sourceKind: "package-source",
+        sourceOrigin: "package",
+        sourceIdentity: { version: `${nodeLinker}:direct` },
+        watchFiles
+      },
+      {
+        kind: "source",
+        resolvedFile: defaultId,
+        canonicalModuleId: `${packageId}:default`,
+        normalizedPathKey: `${defaultId}?conditions=import`,
+        sourcePath: defaultPath,
+        realpath: defaultPath,
+        sourceKind: "package-source",
+        sourceOrigin: "package",
+        sourceIdentity: { version: `${nodeLinker}:default` },
+        watchFiles
+      },
+      {
+        kind: "source",
+        resolvedFile: barrelId,
+        canonicalModuleId: `${packageId}:barrel`,
+        normalizedPathKey: `${barrelId}?conditions=import`,
+        sourcePath: barrelPath,
+        realpath: barrelPath,
+        sourceKind: "package-source",
+        sourceOrigin: "package",
+        sourceIdentity: { version: `${nodeLinker}:barrel` },
+        watchFiles
+      },
+      {
+        kind: "source",
+        resolvedFile: starSourceId,
+        canonicalModuleId: `${packageId}:star-source`,
+        normalizedPathKey: `${starSourceId}?conditions=import`,
+        sourcePath: starSourcePath,
+        realpath: starSourcePath,
+        sourceKind: "package-source",
+        sourceOrigin: "package",
+        sourceIdentity: { version: `${nodeLinker}:star-source` },
+        watchFiles
+      },
+      {
+        kind: "source",
+        resolvedFile: jsonId,
+        canonicalModuleId: `${packageId}:theme-json`,
+        normalizedPathKey: jsonId,
+        sourcePath: jsonPath,
+        realpath: jsonPath,
+        sourceKind: "static-data",
+        sourceOrigin: "data",
+        sourceIdentity: { version: `${nodeLinker}:json` },
+        watchFiles
+      },
+      {
+        kind: "source",
+        resolvedFile: rawId,
+        canonicalModuleId: `${packageId}:tokens-raw`,
+        normalizedPathKey: rawId,
+        sourcePath: rawPath,
+        realpath: rawPath,
+        sourceKind: "static-data",
+        sourceOrigin: "data",
+        sourceIdentity: { version: `${nodeLinker}:raw` },
+        watchFiles
+      },
+      {
+        kind: "external-no-source",
+        resolvedFile: externalId,
+        canonicalModuleId: `${packageId}:external-no-source`,
+        normalizedPathKey: externalId,
+        sourceKind: "external-no-source",
+        sourceOrigin: "external",
+        unsupportedReason: "external-no-source",
+        sourceIdentity: { version: `${nodeLinker}:external-no-source` },
+        watchFiles
+      }
+    ] satisfies readonly YarnNodeLinkerFixtureLoadEntry[];
+    const loadEntries = new Map(
+      entries.map((entry) => [entry.normalizedPathKey, entry])
+    );
+    const resolutions = new Map<string, YarnNodeLinkerFixtureLoadEntry>([
+      [createFixtureResolutionKey(ownerId, "@fixture/styles"), entries[2]],
+      [
+        createFixtureResolutionKey(ownerId, "@fixture/styles/default"),
+        entries[3]
+      ],
+      [
+        createFixtureResolutionKey(ownerId, "@fixture/styles/barrel"),
+        entries[4]
+      ],
+      [
+        createFixtureResolutionKey(ownerId, "@fixture/styles/theme.json"),
+        entries[6]
+      ],
+      [
+        createFixtureResolutionKey(ownerId, "@fixture/styles/tokens.css?raw"),
+        entries[7]
+      ],
+      [createFixtureResolutionKey(barrelId, "./star-source"), entries[5]],
+      [
+        createFixtureResolutionKey(unsupportedOwnerId, "@fixture/no-source"),
+        entries[8]
+      ]
+    ]);
+    const provider: StaticCssEvalSourceProvider = {
+      resolve(importerId, importPath) {
+        const entry = resolutions.get(
+          createFixtureResolutionKey(importerId, importPath)
+        );
+
+        return entry ? createYarnNodeLinkerResolution(entry, nodeLinker) : null;
+      },
+      async load(id) {
+        const entry = loadEntries.get(id);
+
+        if (!entry) {
+          return null;
+        }
+
+        switch (entry.kind) {
+          case "source":
+            return {
+              sourceText: await readFile(entry.sourcePath, "utf8"),
+              resolvedFile: entry.resolvedFile,
+              canonicalModuleId: entry.canonicalModuleId,
+              normalizedPathKey: entry.normalizedPathKey,
+              realpath: entry.realpath,
+              sourceKind: entry.sourceKind,
+              sourceOrigin: entry.sourceOrigin,
+              sourceIdentity: entry.sourceIdentity,
+              watchFiles: entry.watchFiles
+            };
+          case "external-no-source":
+            return null;
+          default:
+            return assertNever(entry);
+        }
+      }
+    };
+
+    return {
+      nodeLinker,
+      rootDir,
+      yarnrcPath,
+      yarnrcValue,
+      ownerId,
+      unsupportedOwnerId,
+      packageJsonPath,
+      provider,
+      moduleIds: {
+        direct: directId,
+        defaultExport: defaultId,
+        barrel: barrelId,
+        starSource: starSourceId,
+        json: jsonId,
+        raw: rawId,
+        external: externalId,
+        supported: [directId, defaultId, barrelId, starSourceId, jsonId, rawId]
+      },
+      dispose: () => rm(rootDir, { recursive: true, force: true })
+    };
+  }
+
+  function createYarnNodeLinkerConsumerSource(): string {
+    return `
+      import { directButton } from "@fixture/styles";
+      import defaultButton from "@fixture/styles/default";
+      import { barrelButton } from "@fixture/styles/barrel";
+      import theme, { jsonButton } from "@fixture/styles/theme.json";
+      import rawTokens from "@fixture/styles/tokens.css?raw";
+
+      function App() {
+        return <>
+          <div css={directButton} />
+          <div css={defaultButton} />
+          <div css={barrelButton} />
+          <div css={jsonButton} />
+          <div css={theme.jsonDefaultButton} />
+          <div css={rawTokens} />
+        </>;
+      }
+    `;
+  }
+
+  function createYarnNodeLinkerUnsupportedSource(): string {
+    return `
+      import { externalButton } from "@fixture/no-source";
+
+      function App() {
+        return <div css={externalButton} />;
+      }
+    `;
+  }
+
+  function createFixtureResolutionKey(
+    importerId: string,
+    importPath: string
+  ): string {
+    return `${importerId}\0${importPath}`;
+  }
+
+  function createYarnNodeLinkerResolution(
+    entry: YarnNodeLinkerFixtureLoadEntry,
+    nodeLinker: YarnNodeLinker
+  ): StaticCssEvalSourceResolution {
+    return {
+      resolvedFile: entry.resolvedFile,
+      canonicalModuleId: entry.canonicalModuleId,
+      normalizedPathKey: entry.normalizedPathKey,
+      sourceKind: entry.sourceKind,
+      sourceOrigin: entry.sourceOrigin,
+      sourceIdentity: entry.sourceIdentity,
+      watchFiles: entry.watchFiles,
+      resolverKind: `yarn-${nodeLinker}-provider`,
+      ...(entry.kind === "source" ? { realpath: entry.realpath } : {}),
+      ...(entry.kind === "external-no-source"
+        ? { unsupportedReason: entry.unsupportedReason }
+        : {})
+    };
+  }
+
+  describe("static css eval prepass source provider metadata", () => {
+    it("preserves legacy id/source provider metadata", async () => {
+      const ownerId = "/project/src/App.tsx";
+      const stylesId = "/project/src/styles.ts";
+      const ownerSource = `
+        import { button } from "./styles";
+
+        function App() {
+          return <div css={button} />;
+        }
+      `;
+      const stylesSource = `export const button = { color: "red" } as const;`;
+      const sources: Record<string, string> = {
+        [ownerId]: ownerSource,
+        [stylesId]: stylesSource
+      };
+      const provider: StaticCssEvalSourceProvider = {
+        resolve(importerId, importPath) {
+          expect({ importerId, importPath }).toEqual({
+            importerId: ownerId,
+            importPath: "./styles"
+          });
+
+          return { id: stylesId };
+        },
+        load(id) {
+          const source = sources[id];
+
+          return source === undefined ? null : { source };
+        }
+      };
+
+      const { result } = await createStaticCssEvalPrepass(ownerId, provider);
+
+      expect(result.dependencyFiles).toEqual([stylesId]);
+      expect(result.resolvedDependencies).toEqual([
+        expect.objectContaining({
+          importerId: ownerId,
+          specifier: "./styles",
+          resolvedFile: stylesId,
+          canonicalModuleId: stylesId,
+          normalizedPathKey: stylesId,
+          resolverKind: "source-provider",
+          loaded: true
+        })
+      ]);
+      expect(result.resolvedModuleCache.has(stylesId)).toBe(true);
+    });
+
+    it("records external-no-source provider metadata without filesystem fallback", async () => {
+      const ownerId = "/project/src/App.tsx";
+      const externalId = "external:@scope/styles";
+      const ownerSource = `
+        import { button } from "./external";
+
+        function App() {
+          return <div css={button} />;
+        }
+      `;
+      const loadedIds: string[] = [];
+      const provider: StaticCssEvalSourceProvider = {
+        resolve(importerId, importPath) {
+          expect({ importerId, importPath }).toEqual({
+            importerId: ownerId,
+            importPath: "./external"
+          });
+
+          return {
+            resolvedFile: externalId,
+            canonicalModuleId: "pkg:@scope/styles",
+            normalizedPathKey: externalId,
+            sourceKind: "external-no-source",
+            sourceOrigin: "external",
+            unsupportedReason: "external-no-source",
+            sourceIdentity: { version: "externalized-v1" },
+            watchFiles: ["/project/package.json"]
+          };
+        },
+        load(id) {
+          loadedIds.push(id);
+
+          return id === ownerId ? { source: ownerSource } : null;
+        }
+      };
+
+      const { result } = await createStaticCssEvalPrepass(ownerId, provider);
+
+      expect(loadedIds).toEqual([ownerId, externalId]);
+      expect(result.resolvedModuleCache.has(externalId)).toBe(false);
+      expect(result.resolvedDependencies).toEqual([
+        expect.objectContaining({
+          importerId: ownerId,
+          specifier: "./external",
+          resolvedFile: externalId,
+          canonicalModuleId: "pkg:@scope/styles",
+          normalizedPathKey: externalId,
+          sourceKind: "external-no-source",
+          sourceOrigin: "external",
+          unsupportedReason: "external-no-source",
+          resolverKind: "source-provider",
+          loaded: false,
+          sourceIdentity: { version: "externalized-v1" },
+          watchFiles: ["/project/package.json"]
+        })
+      ]);
+    });
+
+    it("uses loaded source metadata over resolution metadata", async () => {
+      const ownerId = "/project/src/App.tsx";
+      const stylesId = "/project/node_modules/@scope/styles/index.ts";
+      const stylesSource = `export const button = { color: "red" } as const;`;
+      const ownerSource = `
+        import { button } from "./styles";
+
+        function App() {
+          return <div css={button} />;
+        }
+      `;
+      const provider: StaticCssEvalSourceProvider = {
+        resolve() {
+          return {
+            id: stylesId,
+            canonicalModuleId: "pkg:@scope/styles",
+            normalizedPathKey: stylesId,
+            sourceKind: "package-source",
+            sourceOrigin: "package",
+            sourceIdentity: { version: "resolution-v1" },
+            watchFiles: ["/project/node_modules/@scope/styles/package.json"]
+          };
+        },
+        load(id) {
+          if (id === ownerId) {
+            return { source: ownerSource };
+          }
+
+          return {
+            source: stylesSource,
+            sourceKind: "static-data",
+            sourceIdentity: { sourceHash: "loaded-static-data" },
+            watchFiles: ["/project/node_modules/@scope/styles/styles.json"]
+          };
+        }
+      };
+
+      const { result } = await createStaticCssEvalPrepass(ownerId, provider);
+
+      expect(result.resolvedDependencies).toEqual([
+        expect.objectContaining({
+          resolvedFile: stylesId,
+          canonicalModuleId: "pkg:@scope/styles",
+          normalizedPathKey: stylesId,
+          sourceKind: "static-data",
+          sourceOrigin: "data",
+          loaded: true,
+          sourceIdentity: {
+            sourceHash: "loaded-static-data",
+            version: "resolution-v1"
+          },
+          watchFiles: ["/project/node_modules/@scope/styles/styles.json"]
+        })
+      ]);
+    });
+
+    it("resolves package and virtual source provider edges", async () => {
+      const ownerId = "/project/src/App.tsx";
+      const packageId = "pkg:@scope/styles/index.ts";
+      const virtualId = "\0virtual:mincho/styles";
+      const ownerSource = `
+        import { button } from "@scope/styles";
+        import { virtualButton } from "virtual:mincho/styles";
+
+        function App() {
+          return <>
+            <div css={button} />
+            <div css={virtualButton} />
+          </>;
+        }
+      `;
+      const calls: Array<{ importerId: string; importPath: string }> = [];
+      const provider: StaticCssEvalSourceProvider = {
+        resolve(importerId, importPath) {
+          calls.push({ importerId, importPath });
+
+          if (importPath === "@scope/styles") {
+            return {
+              resolvedFile: packageId,
+              canonicalModuleId: "pkg:@scope/styles",
+              normalizedPathKey: "pkg:@scope/styles/index.ts?condition=import",
+              realpath: "/project/.yarn/cache/@scope-styles/index.ts",
+              sourceKind: "package-source",
+              watchFiles: ["/project/.pnp.cjs"]
+            };
+          }
+
+          if (importPath === "virtual:mincho/styles") {
+            return {
+              id: virtualId,
+              canonicalModuleId: virtualId,
+              normalizedPathKey: virtualId,
+              sourceKind: "provider-virtual",
+              sourceIdentity: { version: "virtual-v1" }
+            };
+          }
+
+          return null;
+        },
+        load(id) {
+          if (id === ownerId) {
+            return { source: ownerSource };
+          }
+
+          if (id === "pkg:@scope/styles/index.ts?condition=import") {
+            return {
+              sourceText: `export const button = { color: "red" } as const;`,
+              sourceKind: "package-source",
+              sourceIdentity: { sourceHash: "pkg-styles-v1" }
+            };
+          }
+
+          if (id === virtualId) {
+            return {
+              sourceText: `export const virtualButton = { color: "blue" } as const;`,
+              sourceKind: "provider-virtual",
+              sourceIdentity: { sourceHash: "virtual-styles-v1" }
+            };
+          }
+
+          return null;
+        }
+      };
+
+      const { result } = await createStaticCssEvalPrepass(ownerId, provider);
+
+      expect(calls).toEqual([
+        { importerId: ownerId, importPath: "@scope/styles" },
+        { importerId: ownerId, importPath: "virtual:mincho/styles" }
+      ]);
+      expect(result.dependencyFiles).toEqual([packageId, virtualId]);
+      expect(result.resolvedModuleCache.has(packageId)).toBe(true);
+      expect(result.resolvedModuleCache.has(virtualId)).toBe(true);
+      expect(result.resolvedDependencies).toEqual([
+        expect.objectContaining({
+          specifier: "@scope/styles",
+          resolvedFile: packageId,
+          canonicalModuleId: "pkg:@scope/styles",
+          normalizedPathKey: "pkg:@scope/styles/index.ts?condition=import",
+          sourceKind: "package-source",
+          sourceOrigin: "package",
+          loaded: true,
+          sourceIdentity: { sourceHash: "pkg-styles-v1" },
+          watchFiles: ["/project/.pnp.cjs"]
+        }),
+        expect.objectContaining({
+          specifier: "virtual:mincho/styles",
+          resolvedFile: virtualId,
+          canonicalModuleId: virtualId,
+          normalizedPathKey: virtualId,
+          sourceKind: "provider-virtual",
+          sourceOrigin: "provider",
+          loaded: true,
+          sourceIdentity: {
+            sourceHash: "virtual-styles-v1",
+            version: "virtual-v1"
+          }
+        })
+      ]);
+    });
+
+    it("synthesizes json raw and wasm static data modules as literal ESM", async () => {
+      const ownerId = "/project/src/App.tsx";
+      const jsonId = "pkg:@scope/styles/styles.json?import";
+      const rawId = "pkg:@scope/styles/tokens.css?raw";
+      const wasmUrlId = "pkg:@scope/styles/icon.wasm?url";
+      const ownerSource = `
+        import { button } from "@scope/styles/styles.json";
+        import tokens from "@scope/styles/tokens.css?raw";
+        import wasmUrl from "@scope/styles/icon.wasm?url";
+
+        function App() {
+          return <>
+            <div css={button} />
+            <div css={tokens} />
+            <div css={wasmUrl} />
+          </>;
+        }
+      `;
+      const resolutions: Record<string, string> = {
+        [`${ownerId}\0@scope/styles/styles.json`]: jsonId,
+        [`${ownerId}\0@scope/styles/tokens.css?raw`]: rawId,
+        [`${ownerId}\0@scope/styles/icon.wasm?url`]: wasmUrlId
+      };
+      const provider: StaticCssEvalSourceProvider = {
+        resolve(importerId, importPath) {
+          const resolvedId = resolutions[`${importerId}\0${importPath}`];
+
+          return resolvedId
+            ? {
+                resolvedFile: resolvedId,
+                canonicalModuleId: resolvedId,
+                normalizedPathKey: resolvedId,
+                sourceKind: "static-data"
+              }
+            : null;
+        },
+        load(id) {
+          if (id === ownerId) {
+            return { source: ownerSource };
+          }
+
+          if (id === jsonId) {
+            return {
+              sourceText: JSON.stringify({
+                button: { color: "red" },
+                card: { color: "blue" },
+                "invalid-key": { color: "orange" }
+              }),
+              sourceKind: "static-data",
+              sourceIdentity: { version: "json-v1" }
+            };
+          }
+
+          if (id === rawId) {
+            return {
+              sourceText: ".button { color: red; }",
+              sourceKind: "static-data",
+              sourceIdentity: { version: "raw-v1" }
+            };
+          }
+
+          if (id === wasmUrlId) {
+            return {
+              sourceText: "/assets/icon.abc123.wasm",
+              sourceKind: "static-data",
+              sourceIdentity: { version: "wasm-url-v1" }
+            };
+          }
+
+          return null;
+        }
+      };
+
+      const { result } = await createStaticCssEvalPrepass(ownerId, provider);
+      const jsonRecord = result.resolvedModuleCache.get(jsonId);
+      const rawRecord = result.resolvedModuleCache.get(rawId);
+      const wasmUrlRecord = result.resolvedModuleCache.get(wasmUrlId);
+
+      if (!jsonRecord || !rawRecord || !wasmUrlRecord) {
+        throw new TypeError("expected synthesized data module records");
+      }
+
+      expect(jsonRecord.source).toContain(
+        `export default {"button":{"color":"red"},"card":{"color":"blue"},"invalid-key":{"color":"orange"}};`
+      );
+      expect(jsonRecord.source).toContain(
+        `export const button = {"color":"red"};`
+      );
+      expect(jsonRecord.source).toContain(
+        `export const card = {"color":"blue"};`
+      );
+      expect(jsonRecord.exports.has("button")).toBe(true);
+      expect(jsonRecord.exports.has("card")).toBe(true);
+      expect(jsonRecord.exports.has("invalid-key")).toBe(false);
+      expect(rawRecord.source).toBe(
+        `export default ".button { color: red; }";\n`
+      );
+      expect(wasmUrlRecord.source).toBe(
+        `export default "/assets/icon.abc123.wasm";\n`
+      );
+      expect(result.resolvedDependencies).toEqual([
+        expect.objectContaining({
+          specifier: "@scope/styles/styles.json",
+          sourceKind: "static-data",
+          sourceOrigin: "data",
+          loaded: true,
+          sourceIdentity: expect.objectContaining({ version: "json-v1" })
+        }),
+        expect.objectContaining({
+          specifier: "@scope/styles/tokens.css?raw",
+          sourceKind: "static-data",
+          sourceOrigin: "data",
+          loaded: true,
+          sourceIdentity: expect.objectContaining({ version: "raw-v1" })
+        }),
+        expect.objectContaining({
+          specifier: "@scope/styles/icon.wasm?url",
+          sourceKind: "static-data",
+          sourceOrigin: "data",
+          loaded: true,
+          sourceIdentity: expect.objectContaining({ version: "wasm-url-v1" })
+        })
+      ]);
+    });
+
+    it("records unsupported wasm init, oversized data, and missing source payloads without parsing", async () => {
+      const ownerId = "/project/src/App.tsx";
+      const wasmInitId = "pkg:@scope/styles/icon.wasm?init";
+      const oversizedRawId = "pkg:@scope/styles/huge.css?raw";
+      const missingSourceId = "pkg:@scope/styles/missing.css?raw";
+      const ownerSource = `
+        import initWasm from "@scope/styles/icon.wasm?init";
+        import huge from "@scope/styles/huge.css?raw";
+        import missing from "@scope/styles/missing.css?raw";
+
+        function App() {
+          return <>
+            <div css={initWasm} />
+            <div css={huge} />
+            <div css={missing} />
+          </>;
+        }
+      `;
+      const resolutions: Record<string, string> = {
+        [`${ownerId}\0@scope/styles/icon.wasm?init`]: wasmInitId,
+        [`${ownerId}\0@scope/styles/huge.css?raw`]: oversizedRawId,
+        [`${ownerId}\0@scope/styles/missing.css?raw`]: missingSourceId
+      };
+      const provider: StaticCssEvalSourceProvider = {
+        resolve(importerId, importPath) {
+          const resolvedId = resolutions[`${importerId}\0${importPath}`];
+
+          return resolvedId
+            ? {
+                resolvedFile: resolvedId,
+                canonicalModuleId: resolvedId,
+                normalizedPathKey: resolvedId,
+                sourceKind: "static-data"
+              }
+            : null;
+        },
+        load(id) {
+          if (id === ownerId) {
+            return { source: ownerSource };
+          }
+
+          if (id === wasmInitId) {
+            return {
+              sourceText: `export default function init() {}`,
+              sourceKind: "static-data",
+              sourceIdentity: { version: "wasm-init-v1" }
+            };
+          }
+
+          if (id === oversizedRawId) {
+            return {
+              sourceText: "a".repeat(1024 * 1024 + 1),
+              sourceKind: "static-data",
+              sourceIdentity: { version: "oversized-raw-v1" }
+            };
+          }
+
+          if (id === missingSourceId) {
+            return {
+              sourceKind: "static-data",
+              sourceIdentity: { version: "missing-source-v1" }
+            };
+          }
+
+          return null;
+        }
+      };
+
+      const { result } = await createStaticCssEvalPrepass(ownerId, provider);
+
+      expect(result.resolvedModuleCache.has(wasmInitId)).toBe(false);
+      expect(result.resolvedModuleCache.has(oversizedRawId)).toBe(false);
+      expect(result.resolvedModuleCache.has(missingSourceId)).toBe(false);
+      expect(result.resolvedDependencies).toEqual([
+        expect.objectContaining({
+          specifier: "@scope/styles/icon.wasm?init",
+          resolvedFile: wasmInitId,
+          loaded: true,
+          sourceKind: "unsupported-source-shape",
+          sourceOrigin: "unsupported",
+          unsupportedReason: "runtime-wasm-init",
+          sourceIdentity: expect.objectContaining({ version: "wasm-init-v1" })
+        }),
+        expect.objectContaining({
+          specifier: "@scope/styles/huge.css?raw",
+          resolvedFile: oversizedRawId,
+          loaded: true,
+          sourceKind: "unsupported-source-shape",
+          sourceOrigin: "unsupported",
+          unsupportedReason: "source-size-limit-exceeded",
+          sourceIdentity: expect.objectContaining({
+            version: "oversized-raw-v1"
+          })
+        }),
+        expect.objectContaining({
+          specifier: "@scope/styles/missing.css?raw",
+          resolvedFile: missingSourceId,
+          loaded: true,
+          sourceKind: "unsupported-source-shape",
+          sourceOrigin: "unsupported",
+          unsupportedReason: "unsupported-source-shape",
+          sourceIdentity: expect.objectContaining({
+            version: "missing-source-v1"
+          })
+        })
+      ]);
+    });
+
+    it("resolves Yarn nodeLinker pnp pnpm node-modules package fixtures through provider metadata", async () => {
+      const { readFile } = await import("node:fs/promises");
+
+      await withYarnNodeLinkerFixtures(async (fixtures) => {
+        for (const fixture of fixtures) {
+          const yarnrcValue = (
+            await readFile(fixture.yarnrcPath, "utf8")
+          ).trim();
+
+          expect(yarnrcValue).toBe(fixture.yarnrcValue);
+
+          const { result } = await createStaticCssEvalPrepass(
+            fixture.ownerId,
+            fixture.provider
+          );
+          const jsonRecord = result.resolvedModuleCache.get(
+            fixture.moduleIds.json
+          );
+          const rawRecord = result.resolvedModuleCache.get(
+            fixture.moduleIds.raw
+          );
+
+          if (!jsonRecord || !rawRecord) {
+            throw new TypeError("expected linker data module records");
+          }
+
+          for (const moduleId of fixture.moduleIds.supported) {
+            expect(result.resolvedModuleCache.has(moduleId)).toBe(true);
+          }
+
+          expect(result.dependencyFiles).toEqual(
+            expect.arrayContaining([...fixture.moduleIds.supported])
+          );
+          expect(jsonRecord.source).toContain(
+            `export default {"jsonButton":{"color":"rebeccapurple"},"jsonDefaultButton":{"color":"goldenrod"}};`
+          );
+          expect(jsonRecord.source).toContain(
+            `export const jsonButton = {"color":"rebeccapurple"};`
+          );
+          expect(jsonRecord.exports.has("default")).toBe(true);
+          expect(jsonRecord.exports.has("jsonButton")).toBe(true);
+          expect(rawRecord.source).toBe(
+            `export default ":root { --fixture-token: tomato; }\\n";\n`
+          );
+          expect(result.resolvedDependencies).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                specifier: "@fixture/styles",
+                resolvedFile: fixture.moduleIds.direct,
+                sourceKind: "package-source",
+                sourceOrigin: "package",
+                resolverKind: `yarn-${fixture.nodeLinker}-provider`,
+                loaded: true,
+                watchFiles: [fixture.packageJsonPath, fixture.yarnrcPath]
+              }),
+              expect.objectContaining({
+                specifier: "@fixture/styles/default",
+                resolvedFile: fixture.moduleIds.defaultExport,
+                sourceKind: "package-source",
+                sourceOrigin: "package",
+                resolverKind: `yarn-${fixture.nodeLinker}-provider`,
+                loaded: true
+              }),
+              expect.objectContaining({
+                specifier: "@fixture/styles/barrel",
+                resolvedFile: fixture.moduleIds.barrel,
+                sourceKind: "package-source",
+                sourceOrigin: "package",
+                resolverKind: `yarn-${fixture.nodeLinker}-provider`,
+                loaded: true
+              }),
+              expect.objectContaining({
+                importerId: fixture.moduleIds.barrel,
+                specifier: "./star-source",
+                resolvedFile: fixture.moduleIds.starSource,
+                sourceKind: "package-source",
+                sourceOrigin: "package",
+                resolverKind: `yarn-${fixture.nodeLinker}-provider`,
+                loaded: true
+              }),
+              expect.objectContaining({
+                specifier: "@fixture/styles/theme.json",
+                resolvedFile: fixture.moduleIds.json,
+                sourceKind: "static-data",
+                sourceOrigin: "data",
+                resolverKind: `yarn-${fixture.nodeLinker}-provider`,
+                loaded: true
+              }),
+              expect.objectContaining({
+                specifier: "@fixture/styles/tokens.css?raw",
+                resolvedFile: fixture.moduleIds.raw,
+                sourceKind: "static-data",
+                sourceOrigin: "data",
+                resolverKind: `yarn-${fixture.nodeLinker}-provider`,
+                loaded: true
+              })
+            ])
+          );
+        }
+      });
+    });
+
+    it("records external-no-source diagnostics for Yarn nodeLinker pnp pnpm node-modules fixtures", async () => {
+      await withYarnNodeLinkerFixtures(async (fixtures) => {
+        for (const fixture of fixtures) {
+          const { result } = await createStaticCssEvalPrepass(
+            fixture.unsupportedOwnerId,
+            fixture.provider
+          );
+
+          expect(
+            result.resolvedModuleCache.has(fixture.moduleIds.external)
+          ).toBe(false);
+          expect(result.resolvedDependencies).toEqual([
+            expect.objectContaining({
+              specifier: "@fixture/no-source",
+              resolvedFile: fixture.moduleIds.external,
+              sourceKind: "external-no-source",
+              sourceOrigin: "external",
+              unsupportedReason: "external-no-source",
+              resolverKind: `yarn-${fixture.nodeLinker}-provider`,
+              loaded: false,
+              sourceIdentity: {
+                version: `${fixture.nodeLinker}:external-no-source`
+              },
+              watchFiles: [fixture.packageJsonPath, fixture.yarnrcPath]
+            })
+          ]);
+        }
+      });
+    });
+  });
 }

--- a/packages/integration/src/staticCssEvalPrepass.ts
+++ b/packages/integration/src/staticCssEvalPrepass.ts
@@ -1,0 +1,450 @@
+import {
+  internalCollectJsxCssPropStaticCssEvalCandidates as collectJsxCssPropStaticCssEvalCandidates,
+  internalCreateImportedStaticCssEvalModuleRecord as createImportedStaticCssEvalModuleRecord,
+  internalCreateImportedStaticCssEvalProvider as createImportedStaticCssEvalProvider,
+  type InternalImportedStaticCssEvalImportResolution as ImportedStaticCssEvalImportResolution,
+  type InternalImportedStaticCssEvalLoadedModule as ImportedStaticCssEvalLoadedModule,
+  type InternalImportedStaticCssEvalModuleRecord as ImportedStaticCssEvalModuleRecord,
+  type PluginOptions
+} from "@mincho-js/babel";
+import type {
+  StaticCssEvalLoadedSource,
+  StaticCssEvalPrepassResult,
+  StaticCssEvalResolvedDependency,
+  StaticCssEvalResolverKind,
+  StaticCssEvalSourceIdentity,
+  StaticCssEvalSourceProvider,
+  StaticCssEvalSourceResolution
+} from "./babel.js";
+
+type StaticCssEvalProvider = NonNullable<
+  PluginOptions["staticCssEvalProvider"]
+>;
+
+interface NormalizedStaticCssEvalSourceResolution {
+  resolvedFile: string;
+  canonicalModuleId: string;
+  normalizedPathKey: string;
+  resolverKind: StaticCssEvalResolverKind;
+  realpath?: string;
+  sourceIdentity?: StaticCssEvalSourceIdentity;
+}
+
+interface PreparedStaticCssEvalPrepass {
+  provider: StaticCssEvalProvider;
+  result: StaticCssEvalPrepassResult;
+}
+
+interface StaticCssEvalPrepassState {
+  loadedModules: ImportedStaticCssEvalLoadedModule[];
+  importResolutions: ImportedStaticCssEvalImportResolution[];
+  resolvedModuleCache: Map<string, ImportedStaticCssEvalModuleRecord>;
+  ownerDependencies: string[];
+  dependencyToOwners: Map<string, string[]>;
+  resolvedDependencies: StaticCssEvalResolvedDependency[];
+  resolvedImports: Map<string, NormalizedStaticCssEvalSourceResolution | null>;
+  loadedDependencyIds: Set<string>;
+}
+
+export async function createStaticCssEvalPrepass(
+  ownerId: string,
+  sourceProvider: StaticCssEvalSourceProvider
+): Promise<PreparedStaticCssEvalPrepass> {
+  const ownerSource = await sourceProvider.load(ownerId);
+
+  if (!ownerSource) {
+    throw new Error(`Failed to load static css eval owner source ${ownerId}`);
+  }
+
+  const ownerModule = createLoadedModule(ownerId, ownerSource);
+  const ownerRecord = createImportedStaticCssEvalModuleRecord(ownerModule);
+  const candidates = collectJsxCssPropStaticCssEvalCandidates(
+    ownerRecord.programPath,
+    { importerId: ownerId }
+  );
+  const prepassState: StaticCssEvalPrepassState = {
+    loadedModules: [ownerModule],
+    importResolutions: [],
+    resolvedModuleCache: new Map([[ownerRecord.id, ownerRecord]]),
+    ownerDependencies: [],
+    dependencyToOwners: new Map(),
+    resolvedDependencies: [],
+    resolvedImports: new Map(),
+    loadedDependencyIds: new Set([ownerId])
+  };
+
+  for (const candidate of candidates) {
+    const importBinding = candidate.bindingName
+      ? ownerRecord.imports.get(candidate.bindingName)
+      : undefined;
+
+    if (!importBinding) {
+      continue;
+    }
+
+    const moduleRecord = await loadStaticCssEvalPrepassDependency(
+      ownerId,
+      importBinding.importPath,
+      sourceProvider,
+      prepassState
+    );
+
+    if (!moduleRecord) {
+      continue;
+    }
+
+    if (importBinding.kind !== "namespace") {
+      await loadDirectReexportDependencies(
+        moduleRecord,
+        importBinding.importedName,
+        sourceProvider,
+        prepassState
+      );
+    }
+  }
+
+  const ownerToDependencies = new Map<string, string[]>([
+    [ownerId, prepassState.ownerDependencies]
+  ]);
+  const provider = createImportedStaticCssEvalProvider({
+    modules: prepassState.loadedModules,
+    importResolutions: prepassState.importResolutions,
+    moduleRecords: [...prepassState.resolvedModuleCache.values()]
+  });
+
+  return {
+    provider,
+    result: {
+      dependencyFiles: [...prepassState.ownerDependencies],
+      ownerToDependencies,
+      dependencyToOwners: prepassState.dependencyToOwners,
+      resolvedModuleCache: prepassState.resolvedModuleCache,
+      resolvedDependencies: prepassState.resolvedDependencies
+    }
+  };
+}
+
+async function loadStaticCssEvalPrepassDependency(
+  importerId: string,
+  importPath: string,
+  sourceProvider: StaticCssEvalSourceProvider,
+  prepassState: StaticCssEvalPrepassState
+): Promise<ImportedStaticCssEvalModuleRecord | undefined> {
+  const resolvedImportKey = `${importerId}\0${importPath}`;
+  let resolution = prepassState.resolvedImports.get(resolvedImportKey);
+
+  if (!prepassState.resolvedImports.has(resolvedImportKey)) {
+    const sourceResolution = await sourceProvider.resolve(
+      importerId,
+      importPath
+    );
+    resolution = sourceResolution
+      ? normalizeStaticCssEvalSourceResolution(sourceResolution)
+      : null;
+    prepassState.resolvedImports.set(resolvedImportKey, resolution ?? null);
+
+    if (resolution) {
+      prepassState.importResolutions.push({
+        importerId,
+        importPath,
+        resolvedId: resolution.resolvedFile
+      });
+      prepassState.resolvedDependencies.push(
+        createStaticCssEvalResolvedDependency(
+          importerId,
+          importPath,
+          resolution,
+          false
+        )
+      );
+    }
+  }
+
+  if (!resolution) {
+    return undefined;
+  }
+
+  addOwnerDependency(
+    prepassState.ownerDependencies,
+    prepassState.dependencyToOwners,
+    prepassState.loadedModules[0]?.id ?? importerId,
+    resolution.resolvedFile
+  );
+
+  const cachedRecord = prepassState.resolvedModuleCache.get(
+    resolution.resolvedFile
+  );
+
+  if (cachedRecord) {
+    return cachedRecord;
+  }
+
+  if (prepassState.loadedDependencyIds.has(resolution.resolvedFile)) {
+    return undefined;
+  }
+
+  prepassState.loadedDependencyIds.add(resolution.resolvedFile);
+  const loadedSource = await sourceProvider.load(resolution.normalizedPathKey);
+
+  if (!loadedSource) {
+    return undefined;
+  }
+
+  markResolvedDependencyLoaded(
+    prepassState.resolvedDependencies,
+    importerId,
+    importPath,
+    resolution,
+    loadedSource
+  );
+
+  const loadedModule = createLoadedModule(
+    resolution.resolvedFile,
+    loadedSource,
+    resolution
+  );
+
+  try {
+    const moduleRecord = createImportedStaticCssEvalModuleRecord(loadedModule);
+    prepassState.resolvedModuleCache.set(moduleRecord.id, moduleRecord);
+    prepassState.loadedModules.push(loadedModule);
+
+    return moduleRecord;
+  } catch {
+    return undefined;
+  }
+}
+
+async function loadDirectReexportDependencies(
+  moduleRecord: ImportedStaticCssEvalModuleRecord,
+  exportName: string,
+  sourceProvider: StaticCssEvalSourceProvider,
+  prepassState: StaticCssEvalPrepassState
+): Promise<void> {
+  let currentRecord: ImportedStaticCssEvalModuleRecord | undefined =
+    moduleRecord;
+  let currentExportName = exportName;
+  const seenReexports = new Set<string>();
+
+  while (currentRecord) {
+    const exportEntry = currentRecord.exports.get(currentExportName);
+
+    if (!exportEntry || exportEntry.kind !== "reexport") {
+      return;
+    }
+
+    const reexportKey = `${currentRecord.id}\0${currentExportName}`;
+
+    if (seenReexports.has(reexportKey)) {
+      return;
+    }
+
+    seenReexports.add(reexportKey);
+
+    currentRecord = await loadStaticCssEvalPrepassDependency(
+      currentRecord.id,
+      exportEntry.source,
+      sourceProvider,
+      prepassState
+    );
+    currentExportName = exportEntry.importedName;
+  }
+}
+
+function createLoadedModule(
+  id: string,
+  loadedSource: StaticCssEvalLoadedSource,
+  resolution?: NormalizedStaticCssEvalSourceResolution
+): ImportedStaticCssEvalLoadedModule {
+  const sourceText = getLoadedSourceText(id, loadedSource);
+  const sourceIdentity = createLoadedSourceIdentity(
+    sourceText,
+    loadedSource,
+    resolution
+  );
+
+  return {
+    id,
+    source: sourceText,
+    realpath: loadedSource.realpath ?? resolution?.realpath,
+    sourceHash: sourceIdentity.sourceHash,
+    version: sourceIdentity.version
+  };
+}
+
+function getLoadedSourceText(
+  id: string,
+  loadedSource: StaticCssEvalLoadedSource
+): string {
+  const sourceText = loadedSource.sourceText ?? loadedSource.source;
+
+  if (sourceText === undefined) {
+    throw new Error(
+      `Static css eval source provider did not return source for ${id}`
+    );
+  }
+
+  return sourceText;
+}
+
+function normalizeStaticCssEvalSourceResolution(
+  resolution: StaticCssEvalSourceResolution
+): NormalizedStaticCssEvalSourceResolution {
+  const resolvedFile = resolution.resolvedFile ?? resolution.id;
+
+  if (!resolvedFile) {
+    throw new Error(
+      "Static css eval source resolution requires resolvedFile or id"
+    );
+  }
+
+  const canonicalModuleId =
+    resolution.canonicalModuleId ?? resolution.id ?? resolvedFile;
+  const normalizedPathKey =
+    resolution.normalizedPathKey ?? canonicalModuleId ?? resolvedFile;
+
+  return {
+    resolvedFile,
+    canonicalModuleId,
+    normalizedPathKey,
+    resolverKind: resolution.resolverKind ?? "source-provider",
+    realpath: resolution.realpath,
+    sourceIdentity: normalizeStaticCssEvalSourceIdentity(
+      resolution.sourceIdentity,
+      resolution.sourceHash,
+      resolution.version
+    )
+  };
+}
+
+function normalizeStaticCssEvalSourceIdentity(
+  sourceIdentity: StaticCssEvalSourceIdentity | undefined,
+  sourceHash: string | undefined,
+  version: string | number | undefined
+): StaticCssEvalSourceIdentity | undefined {
+  const normalizedSourceHash = sourceIdentity?.sourceHash ?? sourceHash;
+  const normalizedVersion = sourceIdentity?.version ?? version;
+
+  if (normalizedSourceHash === undefined && normalizedVersion === undefined) {
+    return undefined;
+  }
+
+  return {
+    ...(normalizedSourceHash !== undefined
+      ? { sourceHash: normalizedSourceHash }
+      : {}),
+    ...(normalizedVersion !== undefined ? { version: normalizedVersion } : {})
+  };
+}
+
+function createLoadedSourceIdentity(
+  sourceText: string,
+  loadedSource: StaticCssEvalLoadedSource,
+  resolution?: NormalizedStaticCssEvalSourceResolution
+): Required<Pick<StaticCssEvalSourceIdentity, "sourceHash">> &
+  Pick<StaticCssEvalSourceIdentity, "version"> {
+  const sourceIdentity = normalizeStaticCssEvalSourceIdentity(
+    loadedSource.sourceIdentity,
+    loadedSource.sourceHash,
+    loadedSource.version
+  );
+  const sourceHash =
+    sourceIdentity?.sourceHash ??
+    resolution?.sourceIdentity?.sourceHash ??
+    createStaticCssEvalSourceTextHash(sourceText);
+  const version =
+    sourceIdentity?.version ?? resolution?.sourceIdentity?.version;
+
+  return {
+    sourceHash,
+    ...(version !== undefined ? { version } : {})
+  };
+}
+
+function createStaticCssEvalResolvedDependency(
+  importerId: string,
+  specifier: string,
+  resolution: NormalizedStaticCssEvalSourceResolution,
+  loaded: boolean,
+  loadedSource?: StaticCssEvalLoadedSource
+): StaticCssEvalResolvedDependency {
+  const sourceText = loadedSource
+    ? getLoadedSourceText(resolution.normalizedPathKey, loadedSource)
+    : undefined;
+  const sourceIdentity = loadedSource
+    ? createLoadedSourceIdentity(sourceText ?? "", loadedSource, resolution)
+    : resolution.sourceIdentity;
+
+  return {
+    importerId,
+    specifier,
+    resolvedFile: resolution.resolvedFile,
+    canonicalModuleId: resolution.canonicalModuleId,
+    normalizedPathKey: resolution.normalizedPathKey,
+    resolverKind: resolution.resolverKind,
+    loaded,
+    ...(sourceIdentity ? { sourceIdentity } : {})
+  };
+}
+
+function markResolvedDependencyLoaded(
+  resolvedDependencies: StaticCssEvalResolvedDependency[],
+  importerId: string,
+  specifier: string,
+  resolution: NormalizedStaticCssEvalSourceResolution,
+  loadedSource: StaticCssEvalLoadedSource
+): void {
+  const resolvedDependencyIndex = resolvedDependencies.findIndex(
+    (dependency) =>
+      dependency.importerId === importerId &&
+      dependency.specifier === specifier &&
+      dependency.resolvedFile === resolution.resolvedFile
+  );
+  const loadedDependency = createStaticCssEvalResolvedDependency(
+    importerId,
+    specifier,
+    resolution,
+    true,
+    loadedSource
+  );
+
+  if (resolvedDependencyIndex === -1) {
+    resolvedDependencies.push(loadedDependency);
+    return;
+  }
+
+  resolvedDependencies[resolvedDependencyIndex] = loadedDependency;
+}
+
+function createStaticCssEvalSourceTextHash(sourceText: string): string {
+  let hash = 0x811c9dc5;
+
+  for (let index = 0; index < sourceText.length; index += 1) {
+    hash ^= sourceText.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+
+  return `fnv1a:${(hash >>> 0).toString(16).padStart(8, "0")}:${sourceText.length}`;
+}
+
+function addOwnerDependency(
+  ownerDependencies: string[],
+  dependencyToOwners: Map<string, string[]>,
+  ownerId: string,
+  dependencyId: string
+): void {
+  if (!ownerDependencies.includes(dependencyId)) {
+    ownerDependencies.push(dependencyId);
+  }
+
+  const owners = dependencyToOwners.get(dependencyId);
+
+  if (!owners) {
+    dependencyToOwners.set(dependencyId, [ownerId]);
+    return;
+  }
+
+  if (!owners.includes(ownerId)) {
+    owners.push(ownerId);
+  }
+}

--- a/packages/integration/src/staticCssEvalUtils.ts
+++ b/packages/integration/src/staticCssEvalUtils.ts
@@ -1,0 +1,217 @@
+import * as fs from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface InternalStaticCssEvalSourceIdentity {
+  sourceHash?: string;
+  version?: string | number;
+}
+
+interface InternalStaticCssEvalDependency {
+  file: string;
+  kind?: string;
+}
+
+interface InternalStaticCssEvalResolvedDependency {
+  resolvedFile: string;
+  canonicalModuleId?: string;
+  normalizedPathKey?: string;
+}
+
+interface InternalStaticCssEvalCacheKey {
+  resolvedFile?: string;
+  resolvedId?: string;
+}
+
+export interface InternalStaticCssEvalMetadataLike {
+  cacheKeys?: readonly InternalStaticCssEvalCacheKey[];
+  dependencies?: readonly InternalStaticCssEvalDependency[];
+  dependencyFiles?: readonly string[];
+  resolvedDependencies?: readonly InternalStaticCssEvalResolvedDependency[];
+  resolvedModuleIds?: readonly string[];
+}
+
+export function internalCollectStaticCssEvalDependencyIds(
+  staticCssEval: InternalStaticCssEvalMetadataLike | undefined
+): string[] {
+  if (!staticCssEval) {
+    return [];
+  }
+
+  return internalDedupeStaticCssEvalStrings([
+    ...(staticCssEval.dependencyFiles ?? []),
+    ...(staticCssEval.dependencies ?? [])
+      .filter((dependency) => dependency.kind !== "local")
+      .map((dependency) => dependency.file),
+    ...(staticCssEval.resolvedDependencies ?? []).flatMap((dependency) => [
+      dependency.resolvedFile,
+      dependency.canonicalModuleId,
+      dependency.normalizedPathKey
+    ]),
+    ...(staticCssEval.cacheKeys ?? []).flatMap((cacheKey) => [
+      cacheKey.resolvedFile,
+      cacheKey.resolvedId
+    ]),
+    ...(staticCssEval.resolvedModuleIds ?? [])
+  ]);
+}
+
+export function normalizeStaticCssEvalFileId(
+  id: string,
+  rootPath = ""
+): string {
+  const filePath = internalNormalizeStaticCssEvalPathSyntax(id);
+  const normalizedRoot = rootPath
+    ? internalNormalizeStaticCssEvalPathSyntax(rootPath)
+    : "";
+
+  if (
+    normalizedRoot &&
+    filePath.startsWith("/") &&
+    !internalIsStaticCssEvalPathInsideRoot(normalizedRoot, filePath) &&
+    !fs.existsSync(filePath)
+  ) {
+    return `${internalTrimStaticCssEvalTrailingSlash(normalizedRoot)}/${filePath.replace(/^\/+/, "")}`;
+  }
+
+  return filePath;
+}
+
+export function internalNormalizeStaticCssEvalPathSyntax(id: string): string {
+  const strippedId = internalStripStaticCssEvalRequestQuery(
+    internalStripStaticCssEvalSsrPrefix(id)
+  );
+
+  if (strippedId.startsWith("file://")) {
+    try {
+      return internalNormalizePathSyntax(fileURLToPath(strippedId));
+    } catch {
+      return internalNormalizePathSyntax(strippedId);
+    }
+  }
+
+  const normalizedId = internalNormalizePathSyntax(strippedId);
+
+  if (normalizedId.startsWith("/@fs/")) {
+    return normalizedId.slice("/@fs".length);
+  }
+
+  return normalizedId;
+}
+
+export function internalIsProjectLocalStaticCssEvalImportPath(
+  importPath: string
+): boolean {
+  return importPath.startsWith(".") || importPath.startsWith("/");
+}
+
+export function internalIsVirtualStaticCssEvalId(id: string): boolean {
+  return (
+    id.startsWith("\0") ||
+    id.includes("\0") ||
+    id.startsWith("virtual:") ||
+    id.includes("__x00__")
+  );
+}
+
+export function internalHasStaticCssEvalNodeModulesSegment(
+  filePath: string
+): boolean {
+  return normalizeStaticCssEvalFileId(filePath)
+    .split("/")
+    .includes("node_modules");
+}
+
+export function internalIsStaticCssEvalPathInsideRoot(
+  rootPath: string,
+  filePath: string
+): boolean {
+  const normalizedRoot = internalTrimStaticCssEvalTrailingSlash(
+    internalNormalizeStaticCssEvalPathSyntax(rootPath)
+  );
+  const normalizedFilePath = internalTrimStaticCssEvalTrailingSlash(
+    internalNormalizeStaticCssEvalPathSyntax(filePath)
+  );
+
+  return (
+    normalizedFilePath === normalizedRoot ||
+    normalizedFilePath.startsWith(`${normalizedRoot}/`)
+  );
+}
+
+export async function internalGetStaticCssEvalRealpathOrResolvedPath(
+  filePath: string
+): Promise<string> {
+  return (
+    (await internalGetExistingStaticCssEvalRealpath(filePath)) ??
+    normalizeStaticCssEvalFileId(resolve(filePath))
+  );
+}
+
+export async function internalGetExistingStaticCssEvalRealpath(
+  filePath: string
+): Promise<string | null> {
+  try {
+    return normalizeStaticCssEvalFileId(await fs.promises.realpath(filePath));
+  } catch {
+    return null;
+  }
+}
+
+export async function internalGetExistingStaticCssEvalStat(
+  filePath: string
+): Promise<fs.Stats | null> {
+  try {
+    return await fs.promises.stat(filePath);
+  } catch {
+    return null;
+  }
+}
+
+export function internalCreateStaticCssEvalSourceHash(stat: fs.Stats): string {
+  return `mtime:${stat.mtimeMs}:size:${stat.size}`;
+}
+
+export function internalCreateStaticCssEvalSourceIdentity(
+  stat: fs.Stats
+): InternalStaticCssEvalSourceIdentity {
+  return {
+    sourceHash: internalCreateStaticCssEvalSourceHash(stat),
+    version: stat.mtimeMs
+  };
+}
+
+function internalStripStaticCssEvalSsrPrefix(id: string): string {
+  let normalizedId = id;
+
+  while (normalizedId.startsWith("ssr:")) {
+    normalizedId = normalizedId.slice("ssr:".length);
+  }
+
+  return normalizedId;
+}
+
+function internalStripStaticCssEvalRequestQuery(id: string): string {
+  const queryIndex = id.search(/[?#]/);
+  return queryIndex === -1 ? id : id.slice(0, queryIndex);
+}
+
+function internalTrimStaticCssEvalTrailingSlash(filePath: string): string {
+  return filePath.length > 1 ? filePath.replace(/\/+$/g, "") : filePath;
+}
+
+function internalNormalizePathSyntax(filePath: string): string {
+  return filePath.replace(/\\/g, "/");
+}
+
+function internalDedupeStaticCssEvalStrings(
+  values: readonly (string | undefined)[]
+): string[] {
+  return [...new Set(values.filter(internalIsStaticCssEvalStringValue))];
+}
+
+function internalIsStaticCssEvalStringValue(
+  value: string | undefined
+): value is string {
+  return typeof value === "string" && value !== "";
+}

--- a/packages/integration/src/staticCssEvalUtils.ts
+++ b/packages/integration/src/staticCssEvalUtils.ts
@@ -2,6 +2,9 @@ import * as fs from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+export const internalStaticCssEvalExternalResolutionPrefix =
+  "external:mincho-static-css-eval:";
+
 export interface InternalStaticCssEvalSourceIdentity {
   sourceHash?: string;
   version?: string | number;
@@ -10,17 +13,22 @@ export interface InternalStaticCssEvalSourceIdentity {
 interface InternalStaticCssEvalDependency {
   file: string;
   kind?: string;
+  watchFiles?: readonly string[];
 }
 
 interface InternalStaticCssEvalResolvedDependency {
   resolvedFile: string;
   canonicalModuleId?: string;
   normalizedPathKey?: string;
+  watchFiles?: readonly string[];
 }
 
 interface InternalStaticCssEvalCacheKey {
   resolvedFile?: string;
   resolvedId?: string;
+  canonicalModuleId?: string;
+  normalizedPathKey?: string;
+  watchFiles?: readonly string[];
 }
 
 export interface InternalStaticCssEvalMetadataLike {
@@ -42,18 +50,26 @@ export function internalCollectStaticCssEvalDependencyIds(
     ...(staticCssEval.dependencyFiles ?? []),
     ...(staticCssEval.dependencies ?? [])
       .filter((dependency) => dependency.kind !== "local")
-      .map((dependency) => dependency.file),
+      .flatMap((dependency) => [dependency.file, ...getWatchFiles(dependency)]),
     ...(staticCssEval.resolvedDependencies ?? []).flatMap((dependency) => [
       dependency.resolvedFile,
       dependency.canonicalModuleId,
-      dependency.normalizedPathKey
+      dependency.normalizedPathKey,
+      ...getWatchFiles(dependency)
     ]),
     ...(staticCssEval.cacheKeys ?? []).flatMap((cacheKey) => [
       cacheKey.resolvedFile,
-      cacheKey.resolvedId
+      cacheKey.resolvedId,
+      cacheKey.canonicalModuleId,
+      cacheKey.normalizedPathKey,
+      ...getWatchFiles(cacheKey)
     ]),
     ...(staticCssEval.resolvedModuleIds ?? [])
   ]);
+}
+
+function getWatchFiles(value: { watchFiles?: readonly string[] }): string[] {
+  return [...(value.watchFiles ?? [])];
 }
 
 export function normalizeStaticCssEvalFileId(
@@ -174,11 +190,47 @@ export function internalCreateStaticCssEvalSourceHash(stat: fs.Stats): string {
 
 export function internalCreateStaticCssEvalSourceIdentity(
   stat: fs.Stats
-): InternalStaticCssEvalSourceIdentity {
+): Required<InternalStaticCssEvalSourceIdentity> {
   return {
     sourceHash: internalCreateStaticCssEvalSourceHash(stat),
     version: stat.mtimeMs
   };
+}
+
+export function internalIsMissingStaticCssEvalFileSystemEntryError(
+  error: unknown
+): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error.code === "ENOENT" || error.code === "ENOTDIR")
+  );
+}
+
+export function internalIsStaticCssEvalStaticDataFile(
+  sourceId: string,
+  realpath: string
+): boolean {
+  const flags = internalGetStaticCssEvalQueryFlags(sourceId);
+
+  return (
+    realpath.endsWith(".json") ||
+    realpath.endsWith(".wasm") ||
+    flags.some((flag) =>
+      ["raw", "url", "text", "string", "init"].includes(flag)
+    )
+  );
+}
+
+export function internalPrepareStaticCssEvalStaticDataSource(
+  sourceId: string,
+  source: string
+): string {
+  const flags = internalGetStaticCssEvalQueryFlags(sourceId);
+
+  return flags.includes("text") || flags.includes("string")
+    ? `export default ${JSON.stringify(source)};\n`
+    : source;
 }
 
 function internalStripStaticCssEvalSsrPrefix(id: string): string {
@@ -197,7 +249,17 @@ function internalStripStaticCssEvalRequestQuery(id: string): string {
 }
 
 function internalTrimStaticCssEvalTrailingSlash(filePath: string): string {
-  return filePath.length > 1 ? filePath.replace(/\/+$/g, "") : filePath;
+  if (filePath.length <= 1) {
+    return filePath;
+  }
+
+  let end = filePath.length;
+
+  while (end > 0 && filePath.charAt(end - 1) === "/") {
+    end -= 1;
+  }
+
+  return filePath.slice(0, end);
 }
 
 function internalNormalizePathSyntax(filePath: string): string {
@@ -214,4 +276,23 @@ function internalIsStaticCssEvalStringValue(
   value: string | undefined
 ): value is string {
   return typeof value === "string" && value !== "";
+}
+
+function internalGetStaticCssEvalQueryFlags(sourceId: string): string[] {
+  const queryIndex = sourceId.indexOf("?");
+
+  if (queryIndex === -1) {
+    return [];
+  }
+
+  const hashIndex = sourceId.indexOf("#", queryIndex);
+  const query = sourceId.slice(
+    queryIndex + 1,
+    hashIndex === -1 ? undefined : hashIndex
+  );
+
+  return query
+    .split("&")
+    .map((part) => part.split("=")[0])
+    .filter(internalIsStaticCssEvalStringValue);
 }

--- a/packages/react/src/jsx-dev-runtime.ts
+++ b/packages/react/src/jsx-dev-runtime.ts
@@ -22,7 +22,13 @@ export function jsxDEV(
   return reactJsxDEV(type, props, key, isStatic, source, self);
 }
 
+// == Tests ====================================================================
+// Ignore errors when compiling to CommonJS.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
 if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
   const { describe, it, expect } = import.meta.vitest;
 
   describe("Mincho development JSX runtime", () => {

--- a/packages/react/src/jsx-dev-runtime.ts
+++ b/packages/react/src/jsx-dev-runtime.ts
@@ -1,12 +1,13 @@
 import type { ElementType, Key, ReactElement } from "react";
 import type { JSXSource } from "react/jsx-dev-runtime";
 import { Fragment, jsxDEV as reactJsxDEV } from "react/jsx-dev-runtime";
+import {
+  missedTransformErrorMessage,
+  throwForOwnCssProp
+} from "./jsxCssPropRuntimeGuard.js";
 
 export { Fragment };
 export type { JSX } from "./jsx-namespace.js";
-
-const missedTransformErrorMessage =
-  "Mincho JSX css prop was not compiled. Enable the Mincho transform with jsxCssProp: true and ensure it runs before React JSX transform.";
 
 export function jsxDEV(
   type: ElementType,
@@ -16,19 +17,9 @@ export function jsxDEV(
   source?: JSXSource,
   self?: unknown
 ): ReactElement {
-  if (hasOwnCssProp(props)) {
-    throw new Error(missedTransformErrorMessage);
-  }
+  throwForOwnCssProp(props);
 
   return reactJsxDEV(type, props, key, isStatic, source, self);
-}
-
-function hasOwnCssProp(props: unknown): boolean {
-  return (
-    typeof props === "object" &&
-    props !== null &&
-    Object.prototype.hasOwnProperty.call(props, "css")
-  );
 }
 
 if (import.meta.vitest) {

--- a/packages/react/src/jsx-namespace.ts
+++ b/packages/react/src/jsx-namespace.ts
@@ -48,7 +48,13 @@ export declare namespace JSX {
   type IntrinsicElements = MinchoIntrinsicElements;
 }
 
+// == Tests ====================================================================
+// Ignore errors when compiling to CommonJS.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
 if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
   const { describe, it, assertType, expectTypeOf } = import.meta.vitest;
 
   describe("scoped Mincho JSX namespace", () => {

--- a/packages/react/src/jsx-namespace.ts
+++ b/packages/react/src/jsx-namespace.ts
@@ -146,15 +146,9 @@ if (import.meta.vitest) {
       assertType<MinchoCssPropValue>([["base", false]]);
       // @ts-expect-error Recursive arrays with numeric leaves are ClassValue-only.
       assertType<MinchoCssPropValue>([[1]]);
-      // @ts-expect-error TypeScript rejects always-truthy object literal logical left operands before Mincho css prop typing.
-      // eslint-disable-next-line no-constant-binary-expression -- The constant operand is the TypeScript error under test.
-      assertType<MinchoCssPropValue>({ color: "red" } || providedClass);
-      // @ts-expect-error TypeScript rejects never-nullish object literal nullish left operands before Mincho css prop typing.
-      // eslint-disable-next-line no-constant-binary-expression -- The constant operand is the TypeScript error under test.
-      assertType<MinchoCssPropValue>({ color: "red" } ?? providedClass);
-      // @ts-expect-error TypeScript rejects always-truthy object literal logical left operands before Mincho css prop typing.
-      // eslint-disable-next-line no-constant-binary-expression -- The constant operand is the TypeScript error under test.
-      assertType<MinchoCssPropValue>({ color: "red" } && providedClass);
+      assertType<MinchoCssPropValue>(cssRule || providedClass);
+      assertType<MinchoCssPropValue>(cssRule ?? providedClass);
+      assertType<MinchoCssPropValue>(cssRule && providedClass);
     });
 
     it("adds css to string-compatible intrinsic className props", () => {
@@ -317,21 +311,15 @@ if (import.meta.vitest) {
       });
 
       assertType<JSX.IntrinsicElements["div"]>({
-        // @ts-expect-error TypeScript rejects always-truthy object literal logical left operands before Mincho css prop typing.
-        // eslint-disable-next-line no-constant-binary-expression -- The constant operand is the TypeScript error under test.
-        css: { color: "red" } || providedClass
+        css: cssRule || providedClass
       });
 
       assertType<JSX.IntrinsicElements["div"]>({
-        // @ts-expect-error TypeScript rejects never-nullish object literal nullish left operands before Mincho css prop typing.
-        // eslint-disable-next-line no-constant-binary-expression -- The constant operand is the TypeScript error under test.
-        css: { color: "red" } ?? providedClass
+        css: cssRule ?? providedClass
       });
 
       assertType<JSX.IntrinsicElements["div"]>({
-        // @ts-expect-error TypeScript rejects always-truthy object literal logical left operands before Mincho css prop typing.
-        // eslint-disable-next-line no-constant-binary-expression -- The constant operand is the TypeScript error under test.
-        css: { color: "red" } && providedClass
+        css: cssRule && providedClass
       });
 
       assertType<ReactJSX.IntrinsicElements["div"]>({
@@ -389,10 +377,10 @@ if (import.meta.vitest) {
         Props
       >;
 
-      const condition: boolean = Math.random() > 0.5;
       const functionCss = () => "base";
       const maybeClass: string | null = Math.random() > 0.5 ? null : "base";
       const getClassName = () => "base";
+      const condition = true as boolean;
 
       assertType<ManagedProps<{ className?: string; label: string }>>({
         css: "base",

--- a/packages/react/src/jsx-runtime.ts
+++ b/packages/react/src/jsx-runtime.ts
@@ -32,7 +32,13 @@ export function jsxs(
   return reactJsxs(type, props, key);
 }
 
+// == Tests ====================================================================
+// Ignore errors when compiling to CommonJS.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
 if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
   const { describe, it, expect } = import.meta.vitest;
 
   describe("Mincho production JSX runtime", () => {

--- a/packages/react/src/jsx-runtime.ts
+++ b/packages/react/src/jsx-runtime.ts
@@ -4,12 +4,13 @@ import {
   jsx as reactJsx,
   jsxs as reactJsxs
 } from "react/jsx-runtime";
+import {
+  missedTransformErrorMessage,
+  throwForOwnCssProp
+} from "./jsxCssPropRuntimeGuard.js";
 
 export { Fragment };
 export type { JSX } from "./jsx-namespace.js";
-
-const missedTransformErrorMessage =
-  "Mincho JSX css prop was not compiled. Enable the Mincho transform with jsxCssProp: true and ensure it runs before React JSX transform.";
 
 export function jsx(
   type: ElementType,
@@ -29,20 +30,6 @@ export function jsxs(
   throwForOwnCssProp(props);
 
   return reactJsxs(type, props, key);
-}
-
-function throwForOwnCssProp(props: unknown) {
-  if (hasOwnCssProp(props)) {
-    throw new Error(missedTransformErrorMessage);
-  }
-}
-
-function hasOwnCssProp(props: unknown): boolean {
-  return (
-    typeof props === "object" &&
-    props !== null &&
-    Object.prototype.hasOwnProperty.call(props, "css")
-  );
 }
 
 if (import.meta.vitest) {

--- a/packages/react/src/jsxCssPropRuntimeGuard.ts
+++ b/packages/react/src/jsxCssPropRuntimeGuard.ts
@@ -1,0 +1,18 @@
+const missedTransformErrorMessage =
+  "Mincho JSX css prop was not compiled. Enable the Mincho transform with jsxCssProp: true and ensure it runs before React JSX transform.";
+
+export { missedTransformErrorMessage };
+
+export function throwForOwnCssProp(props: unknown) {
+  if (hasOwnCssProp(props)) {
+    throw new Error(missedTransformErrorMessage);
+  }
+}
+
+export function hasOwnCssProp(props: unknown): boolean {
+  return (
+    typeof props === "object" &&
+    props !== null &&
+    Object.prototype.hasOwnProperty.call(props, "css")
+  );
+}

--- a/packages/react/src/runtime.ts
+++ b/packages/react/src/runtime.ts
@@ -102,7 +102,13 @@ function splitVariantProps(
 //   return component.displayName || component.name || "Component";
 // }
 
+// == Tests ====================================================================
+// Ignore errors when compiling to CommonJS.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
 if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
   const { describe, it, expect } = import.meta.vitest;
 
   type TestStyleFn = RuntimeFn<

--- a/packages/react/src/runtime.ts
+++ b/packages/react/src/runtime.ts
@@ -28,25 +28,15 @@ export function $$styled<T extends ComponentType<unknown>>(
     [key: string]: unknown;
   };
 
+  const variantKeys = getVariantKeys(styles);
+
   const StyledComponent = forwardRef<unknown, Props>(
     ({ as, className: classNameProp, ...props }, ref) => {
       const componentToRender = as ?? component;
 
-      // More efficient variant/props separation using predefined variant keys
       const [variantSelection, otherProps] = useMemo(() => {
-        const variantSelection: VariantObjectSelection<VariantGroups> = {};
-        const otherProps: Record<string, unknown> = {};
-
-        for (const [key, value] of Object.entries(props)) {
-          if (styles.variants().includes(key)) {
-            variantSelection[key] = value;
-          } else {
-            otherProps[key] = value;
-          }
-        }
-
-        return [variantSelection, otherProps];
-      }, [props]);
+        return splitVariantProps(props, variantKeys);
+      }, [props, variantKeys]);
 
       const className = [styles(variantSelection), classNameProp].join(" ");
 
@@ -80,7 +70,131 @@ export function $$styled<T extends ComponentType<unknown>>(
   return StyledComponent;
 }
 
+function getVariantKeys(
+  styles: RuntimeFn<
+    VariantGroups,
+    ComplexPropDefinitions<PropTarget | undefined>
+  >
+) {
+  return new Set(styles.variants());
+}
+
+function splitVariantProps(
+  props: Record<string, unknown>,
+  variantKeys: ReadonlySet<string>
+): [VariantObjectSelection<VariantGroups>, Record<string, unknown>] {
+  const variantSelection: VariantObjectSelection<VariantGroups> = {};
+  const otherProps: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(props)) {
+    if (variantKeys.has(key)) {
+      variantSelection[key] = value as string | undefined;
+    } else {
+      otherProps[key] = value;
+    }
+  }
+
+  return [variantSelection, otherProps];
+}
+
 // Helper function to get display name
 // function getDisplayName(component: ComponentType<unknown>): string {
 //   return component.displayName || component.name || "Component";
 // }
+
+if (import.meta.vitest) {
+  const { describe, it, expect } = import.meta.vitest;
+
+  type TestStyleFn = RuntimeFn<
+    VariantGroups,
+    ComplexPropDefinitions<PropTarget | undefined>
+  >;
+
+  function createTestStyles(
+    variantKeys: string[],
+    classByVariant: Record<string, Record<string, string>> = {}
+  ) {
+    const selections: Array<VariantObjectSelection<VariantGroups>> = [];
+    const styles = ((selection: VariantObjectSelection<VariantGroups>) => {
+      selections.push({ ...selection });
+
+      const variantClassNames = Object.entries(selection)
+        .map(([key, value]) => classByVariant[key]?.[String(value)])
+        .filter(Boolean);
+
+      return ["base", ...variantClassNames].join(" ");
+    }) as TestStyleFn;
+
+    styles.props = () => ({});
+    styles.variants = () => variantKeys;
+    styles.classNames = {
+      base: "base",
+      variants: {}
+    };
+
+    return { styles, selections };
+  }
+
+  describe("styled runtime", () => {
+    it("styled runtime splits variants forwards props and preserves className order", async () => {
+      const { renderToStaticMarkup } = await import("react-dom/server");
+      const { styles, selections } = createTestStyles(["color", "size"], {
+        color: { brand: "color-brand" },
+        size: { small: "size-small" }
+      });
+      const Button = $$styled(
+        "button" as unknown as ComponentType<unknown>,
+        styles
+      );
+
+      const markup = renderToStaticMarkup(
+        createElement(Button, {
+          children: "Buy",
+          className: "explicit",
+          color: "brand",
+          id: "cta",
+          size: "small",
+          type: "button"
+        })
+      );
+
+      expect(markup).toContain('class="base color-brand size-small explicit"');
+      expect(markup).toContain('id="cta"');
+      expect(markup).toContain('type="button"');
+      expect(markup).not.toContain('color="brand"');
+      expect(markup).not.toContain('size="small"');
+      expect(selections).toEqual([{ color: "brand", size: "small" }]);
+    });
+
+    it("styled runtime handles missing falsey and as override props", async () => {
+      const { renderToStaticMarkup } = await import("react-dom/server");
+      const { styles, selections } = createTestStyles(["disabled"], {
+        disabled: { false: "disabled-false" }
+      });
+      const Panel = $$styled(
+        "section" as unknown as ComponentType<unknown>,
+        styles
+      );
+
+      const markup = renderToStaticMarkup(
+        createElement(Panel, {
+          as: "a",
+          children: "Edge",
+          "data-count": 0,
+          disabled: false,
+          href: "/edge",
+          title: null
+        })
+      );
+
+      expect(markup).toContain("<a ");
+      expect(markup).toContain('class="base disabled-false "');
+      expect(markup).toContain('data-count="0"');
+      expect(markup).toContain('href="/edge"');
+      expect(markup).not.toContain("<section");
+      expect(markup).not.toContain("disabled=");
+      expect(markup).not.toContain("title=");
+      expect(selections).toEqual([{ disabled: false }]);
+    });
+  });
+}

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1595,6 +1595,21 @@ if (import.meta.vitest) {
     `;
   }
 
+  function createNamespaceCssPropEntrySource(
+    importPath = "./barrel",
+    cssExpression = "styles.button.primary"
+  ): string {
+    return `
+      import * as styles from "${importPath}";
+
+      function App() {
+        return <div css={${cssExpression}} />;
+      }
+
+      export { App };
+    `;
+  }
+
   function createImportedCssPropStaticRuleEntrySource(
     importPath = "./styles"
   ): string {
@@ -1634,6 +1649,44 @@ if (import.meta.vitest) {
         }
       ],
       resolvedModuleIds: [`ssr:/@fs${filePath}?module#hash`]
+    };
+  }
+
+  function createExportStarStaticCssEvalMetadata({
+    barrelPath,
+    explicitDefaultPath,
+    terminalLeafPath
+  }: {
+    readonly barrelPath: string;
+    readonly explicitDefaultPath?: string;
+    readonly terminalLeafPath: string;
+  }): StaticCssEvalMetadata {
+    const dependencyPaths = [
+      barrelPath,
+      ...(explicitDefaultPath ? [explicitDefaultPath] : []),
+      terminalLeafPath
+    ];
+
+    return {
+      dependencyFiles: dependencyPaths.map(
+        (filePath) => `/@fs${filePath}?import#dep`
+      ),
+      dependencies: dependencyPaths.map((filePath) => ({
+        file: `ssr:/@fs${filePath}?dep#hash`,
+        kind: "reexported"
+      })),
+      resolvedDependencies: dependencyPaths.map((filePath) => ({
+        resolvedFile: `/@fs${filePath}?resolved#hash`,
+        canonicalModuleId: `ssr:/@fs${filePath}?canonical#hash`,
+        normalizedPathKey: `/@fs${filePath}?normalized#hash`
+      })),
+      cacheKeys: dependencyPaths.map((filePath) => ({
+        resolvedFile: `/@fs${filePath}?cache#hash`,
+        resolvedId: `ssr:/@fs${filePath}?cache-id#hash`
+      })),
+      resolvedModuleIds: dependencyPaths.map(
+        (filePath) => `ssr:/@fs${filePath}?module#hash`
+      )
     };
   }
 
@@ -2548,22 +2601,159 @@ if (import.meta.vitest) {
       }
     });
 
-    it("fails closed for export-star static css evaluation with bounded watches", async () => {
+    it("refreshes export-star namespace member watch dependencies when leaf and barrel targets change", async () => {
       const fixture = await createImportedCssPropViteFixture(
-        "jsx-css-prop-imported-export-star-",
+        "jsx-css-prop-imported-export-star-namespace-watch-",
         {
-          entrySource: createImportedCssPropEntrySource("./barrel")
+          entrySource: createNamespaceCssPropEntrySource()
         }
       );
       const barrelPath = join(fixture.srcRoot, "barrel.ts");
       const buttonPath = join(fixture.srcRoot, "button.ts");
+      const primaryButtonPath = join(fixture.srcRoot, "primaryButton.ts");
 
       try {
         await spyOnSourceBabelTransform();
         await fs.promises.writeFile(barrelPath, 'export * from "./button";');
         await fs.promises.writeFile(
           buttonPath,
+          'export const button = { primary: { color: "red" } } as const;'
+        );
+        await fs.promises.writeFile(
+          primaryButtonPath,
+          'export const button = { primary: { color: "green" } } as const;'
+        );
+
+        const harness = await createViteHarness({
+          configOverrides: {
+            command: "serve",
+            mode: "development",
+            root: fixture.root
+          },
+          pluginOptions: {
+            jsxCssProp: true
+          }
+        });
+
+        const barrelRealpath = normalizePath(
+          await fs.promises.realpath(barrelPath)
+        );
+        const buttonRealpath = normalizePath(
+          await fs.promises.realpath(buttonPath)
+        );
+        const primaryButtonRealpath = normalizePath(
+          await fs.promises.realpath(primaryButtonPath)
+        );
+        const redArtifact = await transformImportedCssPropToVirtualCss(
+          harness,
+          fixture.entryPath,
+          fixture.entrySource
+        );
+
+        expect(redArtifact.virtualCss).toContain("color: red;");
+        expect(new Set(harness.watchFiles)).toEqual(
+          new Set([barrelRealpath, buttonRealpath])
+        );
+
+        await fs.promises.writeFile(
+          buttonPath,
+          'export const button = { primary: { color: "blue" } } as const;'
+        );
+        await harness.transform(
+          buttonPath,
+          await fs.promises.readFile(buttonPath, "utf8")
+        );
+        expect(await harness.load(redArtifact.resolvedVirtualId)).toBeNull();
+        harness.watchFiles.length = 0;
+
+        const blueArtifact = await transformImportedCssPropToVirtualCss(
+          harness,
+          fixture.entryPath,
+          fixture.entrySource
+        );
+        expect(blueArtifact.virtualCss).toContain("color: blue;");
+        expect(new Set(harness.watchFiles)).toEqual(
+          new Set([barrelRealpath, buttonRealpath])
+        );
+
+        await fs.promises.writeFile(
+          barrelPath,
+          'export * from "./primaryButton";'
+        );
+        await harness.transform(
+          barrelPath,
+          await fs.promises.readFile(barrelPath, "utf8")
+        );
+        expect(await harness.load(blueArtifact.resolvedVirtualId)).toBeNull();
+
+        const greenArtifact = await transformImportedCssPropToVirtualCss(
+          harness,
+          fixture.entryPath,
+          fixture.entrySource
+        );
+        expect(greenArtifact.virtualCss).toContain("color: green;");
+        expect(new Set(harness.watchFiles)).toEqual(
+          new Set([barrelRealpath, buttonRealpath, primaryButtonRealpath])
+        );
+
+        await harness.transform(
+          buttonPath,
+          await fs.promises.readFile(buttonPath, "utf8")
+        );
+        expect(await harness.load(greenArtifact.resolvedVirtualId)).toContain(
+          "color: green;"
+        );
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("registers whole namespace export-star watch metadata from Babel integration", async () => {
+      const fixture = await createImportedCssPropViteFixture(
+        "jsx-css-prop-whole-namespace-export-star-watch-",
+        {
+          entrySource: createNamespaceCssPropEntrySource("./barrel", "styles")
+        }
+      );
+      const barrelPath = join(fixture.srcRoot, "barrel.ts");
+      const resetPath = join(fixture.srcRoot, "reset.ts");
+      const buttonPath = join(fixture.srcRoot, "button.ts");
+
+      try {
+        const integrationModule = await import("@mincho-js/integration");
+        await fs.promises.writeFile(
+          barrelPath,
+          'export { default } from "./reset"; export * from "./button";'
+        );
+        await fs.promises.writeFile(
+          resetPath,
+          "export default { margin: 0 } as const;"
+        );
+        await fs.promises.writeFile(
+          buttonPath,
           'export const button = { color: "red" } as const;'
+        );
+
+        const barrelRealpath = normalizePath(
+          await fs.promises.realpath(barrelPath)
+        );
+        const resetRealpath = normalizePath(
+          await fs.promises.realpath(resetPath)
+        );
+        const buttonRealpath = normalizePath(
+          await fs.promises.realpath(buttonPath)
+        );
+        const transformResult: BabelTransformResult = {
+          code: fixture.entrySource,
+          result: ["", ""],
+          staticCssEval: createExportStarStaticCssEvalMetadata({
+            barrelPath: barrelRealpath,
+            explicitDefaultPath: resetRealpath,
+            terminalLeafPath: buttonRealpath
+          })
+        };
+        vi.spyOn(integrationModule, "babelTransform").mockResolvedValue(
+          transformResult
         );
 
         const harness = await createViteHarness({
@@ -2575,33 +2765,11 @@ if (import.meta.vitest) {
           }
         });
 
-        let thrownError: unknown;
+        await harness.transform(fixture.entryPath, fixture.entrySource);
 
-        try {
-          await harness.transform(fixture.entryPath, fixture.entrySource);
-        } catch (error) {
-          thrownError = error;
-        }
-
-        expect(thrownError).toBeInstanceOf(Error);
-        expect((thrownError as Error).message).toContain(
-          'export * from "./button" is unsupported'
+        expect(new Set(harness.watchFiles)).toEqual(
+          new Set([barrelRealpath, resetRealpath, buttonRealpath])
         );
-        expect(
-          getStaticCssEvalFromTransformError(thrownError)?.diagnostics?.map(
-            (diagnostic) => diagnostic.id
-          )
-        ).toContain("STATIC_CSS_EVAL_EXPORT_STAR_UNSUPPORTED");
-
-        const barrelRealpath = normalizePath(
-          await fs.promises.realpath(barrelPath)
-        );
-        const buttonRealpath = normalizePath(
-          await fs.promises.realpath(buttonPath)
-        );
-
-        expect(harness.watchFiles).toEqual([barrelRealpath]);
-        expect(harness.watchFiles).not.toContain(buttonRealpath);
       } finally {
         await fs.promises.rm(fixture.root, { force: true, recursive: true });
       }

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -877,12 +877,24 @@ if (import.meta.vitest) {
   function getDefineRulesPresetSerializationManifestUrl(): string {
     return new URL(
       "../../integration/src/__fixtures__/defineRules-preset-serialization/manifest.ts",
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
       import.meta.url
     ).href;
   }
 
   function createViteFixtureCacheRoot(): string {
-    return join(fileURLToPath(new URL("..", import.meta.url)), ".cache");
+    return join(
+      fileURLToPath(
+        new URL(
+          "..",
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+          import.meta.url
+        )
+      ),
+      ".cache"
+    );
   }
 
   async function loadDefineRulesPresetSerializationManifest(): Promise<DefineRulesPresetSerializationManifest> {
@@ -1717,6 +1729,8 @@ if (import.meta.vitest) {
   async function spyOnSourceBabelTransform() {
     const sourceIntegrationUrl = new URL(
       "../../integration/src/babel" + ".ts",
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
       import.meta.url
     ).href;
     const [integrationModule, sourceIntegrationModule] = await Promise.all([

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -2,8 +2,6 @@ import {
   type BabelOptions,
   babelTransform,
   compile,
-  createUnsupportedStaticCssEvalResolution as createSharedUnsupportedStaticCssEvalResolution,
-  isUnsupportedStaticCssEvalResolutionId as sharedIsUnsupportedStaticCssEvalResolutionId,
   internalCollectStaticCssEvalDependencyIds as collectStaticCssEvalDependencyIds,
   internalCreateStaticCssEvalSourceHash as createStaticCssEvalSourceHash,
   internalCreateStaticCssEvalSourceIdentity as createStaticCssEvalSourceIdentity,
@@ -11,16 +9,21 @@ import {
   internalGetExistingStaticCssEvalStat as getExistingStat,
   internalGetStaticCssEvalRealpathOrResolvedPath as getRealpathOrResolvedPath,
   internalHasStaticCssEvalNodeModulesSegment as hasNodeModulesSegment,
+  internalIsMissingStaticCssEvalFileSystemEntryError as isMissingFileSystemEntryError,
   internalIsProjectLocalStaticCssEvalImportPath as isProjectLocalImportPath,
+  internalIsStaticCssEvalStaticDataFile as isStaticCssEvalStaticDataFile,
   internalIsStaticCssEvalPathInsideRoot as isPathInsideRoot,
   internalIsVirtualStaticCssEvalId as isVirtualStaticCssEvalId,
   internalNormalizeStaticCssEvalFileId as normalizeStaticCssEvalFileId,
+  internalPrepareStaticCssEvalStaticDataSource as prepareStaticCssEvalStaticDataSource,
+  internalStaticCssEvalExternalResolutionPrefix as externalStaticCssEvalResolutionPrefix,
   processDefineRulesPresetRegistryFile,
   runDefineRulesPresetRegistryStep
 } from "@mincho-js/integration";
 import { normalizePath } from "@rollup/pluginutils";
 import { dirname, join, resolve } from "node:path";
 import * as fs from "node:fs";
+import { fileURLToPath } from "node:url";
 
 interface Module {
   lastHMRTimestamp?: number;
@@ -34,6 +37,10 @@ interface ViteDevServer {
     getModulesByFile?: (file: string) => Set<Module> | undefined;
     invalidateModule: (module: Module) => void;
   };
+  transformRequest?: (
+    url: string,
+    options?: { ssr?: boolean }
+  ) => Promise<{ code?: string } | null>;
 }
 
 interface ResolvedConfig {
@@ -47,6 +54,9 @@ interface ResolvedConfig {
 
 interface PluginContext {
   addWatchFile: (id: string) => void;
+  load?: (options: {
+    id: string;
+  }) => Promise<{ code?: string } | null> | { code?: string } | null;
   resolve?: (
     source: string,
     importer?: string,
@@ -111,11 +121,15 @@ interface StaticCssEvalSourceResolution {
   sourceHash?: string;
   version?: string | number;
   sourceIdentity?: StaticCssEvalSourceIdentity;
+  sourceKind?: StaticCssEvalSourceKind;
+  sourceOrigin?: StaticCssEvalSourceOrigin;
+  unsupportedReason?: StaticCssEvalSourceUnsupportedReason;
+  watchFiles?: readonly string[];
   resolverKind?: StaticCssEvalResolverKind;
 }
 
 interface StaticCssEvalLoadedSource {
-  source: string;
+  source?: string;
   sourceText?: string;
   resolvedFile?: string;
   canonicalModuleId?: string;
@@ -124,6 +138,10 @@ interface StaticCssEvalLoadedSource {
   sourceHash?: string;
   version?: string | number;
   sourceIdentity?: StaticCssEvalSourceIdentity;
+  sourceKind?: StaticCssEvalSourceKind;
+  sourceOrigin?: StaticCssEvalSourceOrigin;
+  unsupportedReason?: StaticCssEvalSourceUnsupportedReason;
+  watchFiles?: readonly string[];
   resolverKind?: StaticCssEvalResolverKind;
 }
 
@@ -139,6 +157,29 @@ type StaticCssEvalResolverKind =
   | "esbuild"
   | "test"
   | (string & {});
+
+type StaticCssEvalSourceKind =
+  | "project-source"
+  | "package-source"
+  | "provider-virtual"
+  | "static-data"
+  | "external-no-source"
+  | "unresolved"
+  | "unsupported-source-shape";
+
+type StaticCssEvalSourceOrigin =
+  | "project"
+  | "package"
+  | "provider"
+  | "data"
+  | "external"
+  | "unresolved"
+  | "unsupported";
+
+type StaticCssEvalSourceUnsupportedReason =
+  | "external-no-source"
+  | "unresolved"
+  | "unsupported-source-shape";
 
 interface StaticCssEvalSourceProvider {
   resolve(
@@ -182,12 +223,20 @@ interface StaticCssEvalMetadata {
 interface StaticCssEvalResolutionDependency {
   file: string;
   kind?: string;
+  sourceKind?: StaticCssEvalSourceKind;
+  sourceOrigin?: StaticCssEvalSourceOrigin;
+  unsupportedReason?: StaticCssEvalSourceUnsupportedReason;
+  watchFiles?: readonly string[];
 }
 
 interface StaticCssEvalResolvedDependency {
   resolvedFile: string;
   canonicalModuleId?: string;
   normalizedPathKey?: string;
+  sourceKind?: StaticCssEvalSourceKind;
+  sourceOrigin?: StaticCssEvalSourceOrigin;
+  unsupportedReason?: StaticCssEvalSourceUnsupportedReason;
+  watchFiles?: readonly string[];
 }
 
 interface StaticCssEvalDiagnostic {
@@ -201,6 +250,13 @@ interface StaticCssEvalCacheKey {
   importerFile?: string;
   resolvedFile?: string;
   resolvedId?: string;
+  canonicalModuleId?: string;
+  normalizedPathKey?: string;
+  sourceKind?: StaticCssEvalSourceKind;
+  sourceOrigin?: StaticCssEvalSourceOrigin;
+  unsupportedReason?: StaticCssEvalSourceUnsupportedReason;
+  watchFiles?: readonly string[];
+  parserVersion?: string | number;
 }
 
 interface MinchoVitePluginOptions {
@@ -369,12 +425,7 @@ export function minchoVitePlugin(
   }
 
   function isWatchableStaticCssEvalDependency(id: string): boolean {
-    return (
-      rootRealpath !== "" &&
-      !isVirtualStaticCssEvalId(id) &&
-      !hasNodeModulesSegment(id) &&
-      isPathInsideRoot(rootRealpath, id)
-    );
+    return rootRealpath !== "" && fs.existsSync(id);
   }
 
   return {
@@ -562,7 +613,8 @@ export function minchoVitePlugin(
                     this,
                     fileId,
                     code,
-                    rootRealpath
+                    rootRealpath,
+                    server
                   )
               }
             : babelOptions;
@@ -670,42 +722,37 @@ function createViteStaticCssEvalSourceProvider(
   pluginContext: PluginContext,
   ownerId: string,
   ownerSource: string,
-  rootRealpath: string
+  rootRealpath: string,
+  serverInstance?: ViteDevServer
 ): StaticCssEvalSourceProvider {
   return {
     async resolve(importerId: string, importPath: string) {
-      if (!isProjectLocalImportPath(importPath)) {
-        return createUnsupportedStaticCssEvalResolution(importPath);
-      }
-
       const resolved = await pluginContext.resolve?.(importPath, importerId, {
         skipSelf: true
       });
 
-      if (!resolved || resolved.external) {
+      if (!resolved) {
         return null;
+      }
+
+      if (resolved.external) {
+        return createExternalStaticCssEvalResolution(resolved.id);
       }
 
       if (isVirtualStaticCssEvalId(resolved.id)) {
-        return createUnsupportedStaticCssEvalResolution(importPath);
+        return canLoadViteStaticCssEvalVirtualSource(
+          pluginContext,
+          serverInstance
+        )
+          ? createViteStaticCssEvalVirtualResolution(resolved.id)
+          : createUnsupportedStaticCssEvalResolution(importPath);
       }
 
-      const canonicalModuleId = normalizeStaticCssEvalFileId(
-        resolved.id,
-        rootRealpath
-      );
-      const resolvedId = canonicalModuleId;
-      const resolvedRealpath = await getExistingRealpath(resolvedId);
+      const fileId = normalizeStaticCssEvalFileId(resolved.id, rootRealpath);
+      const resolvedRealpath = await getExistingRealpath(fileId);
 
       if (!resolvedRealpath) {
         return null;
-      }
-
-      if (
-        hasNodeModulesSegment(resolvedRealpath) ||
-        !isPathInsideRoot(rootRealpath, resolvedRealpath)
-      ) {
-        return createUnsupportedStaticCssEvalResolution(importPath);
       }
 
       let stat: fs.Stats;
@@ -719,19 +766,15 @@ function createViteStaticCssEvalSourceProvider(
 
         throw error;
       }
-      const sourceIdentity = createStaticCssEvalSourceIdentity(stat);
 
-      return {
-        id: resolvedRealpath,
-        resolvedFile: resolvedRealpath,
-        canonicalModuleId,
-        normalizedPathKey: resolvedRealpath,
+      const metadata = createViteStaticCssEvalFileMetadata({
+        id: resolved.id,
         realpath: resolvedRealpath,
-        sourceHash: sourceIdentity.sourceHash,
-        version: sourceIdentity.version,
-        sourceIdentity,
-        resolverKind: "vite"
-      };
+        rootRealpath,
+        stat
+      });
+
+      return { id: metadata.resolvedFile, ...metadata };
     },
     async load(id: string) {
       const fileId = normalizeStaticCssEvalFileId(id, rootRealpath);
@@ -752,32 +795,59 @@ function createViteStaticCssEvalSourceProvider(
           normalizedPathKey: ownerId,
           ...(ownerRealpath ? { realpath: ownerRealpath } : {}),
           ...(sourceIdentity ? { sourceIdentity } : {}),
+          sourceKind: "project-source",
+          sourceOrigin: "project",
+          ...(ownerRealpath ? { watchFiles: [ownerRealpath] } : {}),
           resolverKind: "vite"
         };
       }
 
       if (isUnsupportedStaticCssEvalResolutionId(id)) {
-        return { sourceText: "export {};", source: "export {};" };
+        return {
+          sourceText: "export {};",
+          source: "export {};",
+          sourceKind: "unsupported-source-shape",
+          sourceOrigin: "unsupported",
+          unsupportedReason: "unsupported-source-shape",
+          resolverKind: "vite"
+        };
       }
 
-      if (isVirtualStaticCssEvalId(id) || hasNodeModulesSegment(fileId)) {
+      if (isExternalStaticCssEvalResolutionId(id)) {
         return null;
+      }
+
+      if (isVirtualStaticCssEvalId(id)) {
+        const virtualSource = await loadViteStaticCssEvalVirtualSource(
+          id,
+          pluginContext,
+          serverInstance
+        );
+
+        return virtualSource
+          ? {
+              sourceText: virtualSource,
+              source: virtualSource,
+              resolvedFile: id,
+              canonicalModuleId: id,
+              normalizedPathKey: id,
+              sourceKind: "provider-virtual",
+              sourceOrigin: "provider",
+              resolverKind: "vite"
+            }
+          : null;
       }
 
       const realpath = await getExistingRealpath(fileId);
-      if (
-        !realpath ||
-        hasNodeModulesSegment(realpath) ||
-        !isPathInsideRoot(rootRealpath, realpath)
-      ) {
+      if (!realpath) {
         return null;
       }
 
-      let source: string;
+      let fileSource: string;
       let stat: fs.Stats;
 
       try {
-        [source, stat] = await Promise.all([
+        [fileSource, stat] = await Promise.all([
           fs.promises.readFile(realpath, "utf8"),
           fs.promises.stat(realpath)
         ]);
@@ -788,29 +858,275 @@ function createViteStaticCssEvalSourceProvider(
 
         throw error;
       }
-
+      const metadata = createViteStaticCssEvalFileMetadata({
+        id,
+        realpath,
+        rootRealpath,
+        stat
+      });
+      const source = getViteStaticCssEvalStaticDataSource({
+        id,
+        realpath,
+        rootRealpath,
+        source: fileSource
+      });
       return {
         sourceText: source,
         source,
-        resolvedFile: realpath,
-        canonicalModuleId: fileId,
-        normalizedPathKey: realpath,
-        realpath,
-        sourceHash: createStaticCssEvalSourceHash(stat),
-        version: stat.mtimeMs,
-        sourceIdentity: createStaticCssEvalSourceIdentity(stat),
-        resolverKind: "vite"
+        ...metadata
       };
     }
   };
 }
 
-function createUnsupportedStaticCssEvalResolution(importPath: string) {
-  return createSharedUnsupportedStaticCssEvalResolution(importPath);
+interface ViteStaticCssEvalFileMetadataOptions {
+  id: string;
+  realpath: string;
+  rootRealpath: string;
+  stat: fs.Stats;
+}
+
+function createViteStaticCssEvalFileMetadata({
+  id,
+  realpath,
+  rootRealpath,
+  stat
+}: ViteStaticCssEvalFileMetadataOptions): Required<
+  Pick<
+    StaticCssEvalSourceResolution,
+    | "canonicalModuleId"
+    | "normalizedPathKey"
+    | "realpath"
+    | "resolvedFile"
+    | "resolverKind"
+    | "sourceHash"
+    | "sourceIdentity"
+    | "sourceKind"
+    | "sourceOrigin"
+    | "version"
+    | "watchFiles"
+  >
+> {
+  const sourceHash = createStaticCssEvalSourceHash(stat);
+  const version = stat.mtimeMs;
+  const sourceIdentity: Required<
+    Pick<StaticCssEvalSourceIdentity, "sourceHash" | "version">
+  > = {
+    sourceHash,
+    version
+  };
+  const sourceKind = getViteStaticCssEvalFileSourceKind({
+    id,
+    realpath,
+    rootRealpath
+  });
+  const querySuffix =
+    sourceKind === "static-data" ? getViteStaticCssEvalQuerySuffix(id) : "";
+  const resolvedFile = `${realpath}${querySuffix}`;
+
+  return {
+    resolvedFile,
+    canonicalModuleId: resolvedFile,
+    normalizedPathKey: resolvedFile,
+    realpath,
+    sourceHash: sourceIdentity.sourceHash,
+    version: sourceIdentity.version,
+    sourceIdentity,
+    sourceKind,
+    sourceOrigin: getViteStaticCssEvalSourceOrigin(sourceKind),
+    watchFiles: [realpath],
+    resolverKind: "vite"
+  };
+}
+
+function getViteStaticCssEvalFileSourceKind({
+  id,
+  realpath,
+  rootRealpath
+}: Pick<
+  ViteStaticCssEvalFileMetadataOptions,
+  "id" | "realpath" | "rootRealpath"
+>): StaticCssEvalSourceKind {
+  if (isStaticCssEvalStaticDataFile(id, realpath)) {
+    return "static-data";
+  }
+
+  return hasNodeModulesSegment(realpath) ||
+    !isPathInsideRoot(rootRealpath, realpath)
+    ? "package-source"
+    : "project-source";
+}
+
+function getViteStaticCssEvalSourceOrigin(
+  sourceKind: StaticCssEvalSourceKind
+): StaticCssEvalSourceOrigin {
+  switch (sourceKind) {
+    case "project-source":
+      return "project";
+    case "package-source":
+      return "package";
+    case "provider-virtual":
+      return "provider";
+    case "static-data":
+      return "data";
+    case "external-no-source":
+      return "external";
+    case "unresolved":
+      return "unresolved";
+    case "unsupported-source-shape":
+      return "unsupported";
+    default:
+      return assertNeverStaticCssEvalSourceKind(sourceKind);
+  }
+}
+
+function getViteStaticCssEvalQueryFlags(id: string): string[] {
+  const querySuffix = getViteStaticCssEvalQuerySuffix(id);
+
+  if (querySuffix === "") {
+    return [];
+  }
+
+  return querySuffix
+    .slice(1)
+    .split("&")
+    .map((part) => part.split("=")[0])
+    .filter((flag) => flag !== "");
+}
+
+function getViteStaticCssEvalQuerySuffix(id: string): string {
+  const queryStart = id.indexOf("?");
+
+  if (queryStart === -1) {
+    return "";
+  }
+
+  const hashStart = id.indexOf("#", queryStart);
+
+  return id.slice(queryStart, hashStart === -1 ? undefined : hashStart);
+}
+
+function getViteStaticCssEvalStaticDataSource(options: {
+  id: string;
+  realpath: string;
+  rootRealpath: string;
+  source: string;
+}): string {
+  const flags = getViteStaticCssEvalQueryFlags(options.id);
+
+  if (flags.includes("url")) {
+    const assetUrl = getViteStaticCssEvalUrlSource(
+      options.realpath,
+      options.rootRealpath
+    );
+
+    return `export default ${JSON.stringify(assetUrl)};\n`;
+  }
+
+  return prepareStaticCssEvalStaticDataSource(options.id, options.source);
+}
+
+function getViteStaticCssEvalUrlSource(
+  realpath: string,
+  rootRealpath: string
+): string {
+  const normalizedRealpath = normalizePath(realpath);
+  const normalizedRootRealpath = normalizePath(rootRealpath);
+
+  if (isPathInsideRoot(normalizedRootRealpath, normalizedRealpath)) {
+    return `/${customNormalize(normalizedRealpath.slice(normalizedRootRealpath.length))}`;
+  }
+
+  return `/@fs/${customNormalize(normalizedRealpath)}`;
+}
+
+function createViteStaticCssEvalVirtualResolution(
+  id: string
+): StaticCssEvalSourceResolution {
+  return {
+    id,
+    resolvedFile: id,
+    canonicalModuleId: id,
+    normalizedPathKey: id,
+    sourceKind: "provider-virtual",
+    sourceOrigin: "provider",
+    resolverKind: "vite"
+  };
+}
+
+function canLoadViteStaticCssEvalVirtualSource(
+  pluginContext: PluginContext,
+  serverInstance: ViteDevServer | undefined
+): boolean {
+  return Boolean(serverInstance?.transformRequest || pluginContext.load);
+}
+
+async function loadViteStaticCssEvalVirtualSource(
+  id: string,
+  pluginContext: PluginContext,
+  serverInstance: ViteDevServer | undefined
+): Promise<string | null> {
+  const transformed = await serverInstance?.transformRequest?.(id, {
+    ssr: true
+  });
+
+  if (typeof transformed?.code === "string") {
+    return transformed.code;
+  }
+
+  const loaded = await pluginContext.load?.({ id });
+
+  return typeof loaded?.code === "string" ? loaded.code : null;
+}
+
+function createExternalStaticCssEvalResolution(
+  id: string
+): StaticCssEvalSourceResolution {
+  const resolvedId = `${externalStaticCssEvalResolutionPrefix}${encodeURIComponent(
+    id
+  )}`;
+
+  return {
+    id: resolvedId,
+    resolvedFile: resolvedId,
+    canonicalModuleId: id,
+    normalizedPathKey: resolvedId,
+    sourceKind: "external-no-source",
+    sourceOrigin: "external",
+    unsupportedReason: "external-no-source",
+    resolverKind: "vite"
+  };
+}
+
+function createUnsupportedStaticCssEvalResolution(
+  importPath: string
+): StaticCssEvalSourceResolution {
+  const id = `virtual:mincho-static-css-eval-unsupported:${encodeURIComponent(
+    importPath
+  )}`;
+
+  return {
+    id,
+    resolvedFile: id,
+    canonicalModuleId: id,
+    normalizedPathKey: id,
+    sourceKind: "unsupported-source-shape",
+    sourceOrigin: "unsupported",
+    unsupportedReason: "unsupported-source-shape",
+    resolverKind: "vite"
+  };
 }
 
 function isUnsupportedStaticCssEvalResolutionId(id: string): boolean {
-  return sharedIsUnsupportedStaticCssEvalResolutionId(id);
+  return id.startsWith("virtual:mincho-static-css-eval-unsupported:");
+}
+
+function isExternalStaticCssEvalResolutionId(id: string): boolean {
+  return id.startsWith(externalStaticCssEvalResolutionPrefix);
+}
+
+function assertNeverStaticCssEvalSourceKind(value: never): never {
+  throw new TypeError(`Unexpected static css eval source kind: ${value}`);
 }
 
 function getStaticCssEvalFromTransformError(
@@ -819,6 +1135,7 @@ function getStaticCssEvalFromTransformError(
   return (error as { staticCssEval?: StaticCssEvalMetadata } | null)
     ?.staticCssEval;
 }
+
 // == Tests ====================================================================
 // Ignore errors when compiling to CommonJS.
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -2022,21 +2339,27 @@ if (import.meta.vitest) {
       }
     });
 
-    it("static css eval shared helpers ignore virtual node_modules and outside-root dependencies for Vite", async () => {
+    it("static css eval watch files include real package and outside-root dependencies for Vite", async () => {
       const fixture = await createImportedCssPropViteFixture(
         "static-css-eval-shared-helper-boundary-"
       );
 
       try {
         const integrationModule = await import("@mincho-js/integration");
-        const rootRealpath = normalizePath(
-          await fs.promises.realpath(fixture.root)
-        );
         const stylesRealpath = normalizePath(
           await fs.promises.realpath(fixture.stylesPath)
         );
         const outsideRootFile = normalizePath(
           join(process.cwd(), "package.json")
+        );
+        const packagePath = join(fixture.root, "node_modules/pkg/styles.ts");
+        await fs.promises.mkdir(dirname(packagePath), { recursive: true });
+        await fs.promises.writeFile(
+          packagePath,
+          createImportedStyleSource("blue")
+        );
+        const packageRealpath = normalizePath(
+          await fs.promises.realpath(packagePath)
         );
 
         vi.spyOn(integrationModule, "babelTransform").mockResolvedValue({
@@ -2046,8 +2369,15 @@ if (import.meta.vitest) {
             dependencyFiles: [
               stylesRealpath,
               "virtual:mincho-static-css-eval-test",
-              `${rootRealpath}/node_modules/pkg/styles.ts`,
               outsideRootFile
+            ],
+            resolvedDependencies: [
+              {
+                resolvedFile: "virtual:mincho-static-css-eval-provider",
+                canonicalModuleId: "virtual:mincho-static-css-eval-provider",
+                normalizedPathKey: "virtual:mincho-static-css-eval-provider",
+                watchFiles: [packageRealpath]
+              }
             ]
           }
         } as unknown as BabelTransformResult);
@@ -2063,7 +2393,9 @@ if (import.meta.vitest) {
 
         await harness.transform(fixture.entryPath, fixture.entrySource);
 
-        expect(harness.watchFiles).toEqual([stylesRealpath]);
+        expect(new Set(harness.watchFiles)).toEqual(
+          new Set([stylesRealpath, packageRealpath, outsideRootFile])
+        );
       } finally {
         await fs.promises.rm(fixture.root, { force: true, recursive: true });
       }
@@ -2489,6 +2821,407 @@ if (import.meta.vitest) {
       }
     });
 
+    it("supplies Vite package data virtual and unsupported source records to static css eval", async () => {
+      const fixture = await createJsxCssPropViteFixture(
+        "static-css-eval-provider-package-data-virtual-",
+        `
+          import { button } from "@pkg/styles";
+          import { token } from "@pkg/styles/styles.json";
+          import rawTokens from "@pkg/styles/tokens.css?raw";
+          import textToken from "@pkg/styles/token.txt?text";
+          import assetUrl from "@pkg/styles/asset.svg?url";
+          import wasmUrl from "@pkg/styles/icon.wasm?url";
+          import initWasm from "@pkg/styles/icon.wasm?init";
+          import { virtualButton } from "virtual:mincho-test-styles";
+          import { externalButton } from "@pkg/external";
+
+          function App() {
+            return <>
+              <div css={button} />
+              <div css={token} />
+              <div css={rawTokens} />
+              <div css={textToken} />
+              <div css={assetUrl} />
+              <div css={wasmUrl} />
+              <div css={initWasm} />
+              <div css={virtualButton} />
+              <div css={externalButton} />
+            </>;
+          }
+
+          export { App };
+        `
+      );
+      const packageRoot = join(fixture.root, "node_modules/@pkg/styles");
+      const packageIndexPath = join(packageRoot, "index.ts");
+      const packageJsonPath = join(packageRoot, "styles.json");
+      const rawTokensPath = join(packageRoot, "tokens.css");
+      const textTokenPath = join(packageRoot, "token.txt");
+      const assetPath = join(packageRoot, "asset.svg");
+      const wasmPath = join(packageRoot, "icon.wasm");
+      const virtualId = "\0virtual:mincho-test-styles";
+      const captured: {
+        loaded: Record<string, StaticCssEvalLoadedSource | null | undefined>;
+        resolved: Record<
+          string,
+          StaticCssEvalSourceResolution | null | undefined
+        >;
+      } = { loaded: {}, resolved: {} };
+
+      try {
+        const integrationModule = await import("@mincho-js/integration");
+        await fs.promises.mkdir(packageRoot, { recursive: true });
+        await fs.promises.writeFile(
+          packageIndexPath,
+          'export const button = { color: "red" } as const;',
+          "utf8"
+        );
+        await fs.promises.writeFile(
+          packageJsonPath,
+          JSON.stringify({ token: { color: "green" } }),
+          "utf8"
+        );
+        await fs.promises.writeFile(
+          rawTokensPath,
+          ".token { color: blue; }",
+          "utf8"
+        );
+        await fs.promises.writeFile(textTokenPath, "purple", "utf8");
+        await fs.promises.writeFile(assetPath, "<svg></svg>", "utf8");
+        await fs.promises.writeFile(wasmPath, "wasm-init", "utf8");
+
+        vi.spyOn(integrationModule, "babelTransform").mockImplementation(
+          async (
+            _path: string,
+            options: MinchoBabelOptionsWithStaticCssEval = {}
+          ) => {
+            const sourceProvider = options.staticCssEvalSourceProvider;
+
+            if (!sourceProvider) {
+              throw new Error("Expected Vite static css eval source provider");
+            }
+
+            const importPaths = [
+              "@pkg/styles",
+              "@pkg/styles/styles.json",
+              "@pkg/styles/tokens.css?raw",
+              "@pkg/styles/token.txt?text",
+              "@pkg/styles/asset.svg?url",
+              "@pkg/styles/icon.wasm?url",
+              "@pkg/styles/icon.wasm?init",
+              "virtual:mincho-test-styles",
+              "@pkg/external"
+            ] as const;
+
+            for (const importPath of importPaths) {
+              const resolution = await sourceProvider.resolve(
+                fixture.entryPath,
+                importPath
+              );
+              captured.resolved[importPath] = resolution;
+              captured.loaded[importPath] = resolution?.normalizedPathKey
+                ? await sourceProvider.load(resolution.normalizedPathKey)
+                : undefined;
+            }
+
+            return {
+              code: fixture.source,
+              result: ["", ""]
+            } as unknown as BabelTransformResult;
+          }
+        );
+
+        const virtualTransform = vi.fn(async (id: string) =>
+          id === virtualId
+            ? {
+                code: 'export const virtualButton = { color: "blue" } as const;'
+              }
+            : null
+        );
+        const harness = await createViteHarness({
+          configOverrides: {
+            root: fixture.root
+          },
+          pluginOptions: {
+            jsxCssProp: true
+          },
+          resolve(source) {
+            if (source === "@pkg/styles") {
+              return { id: `/@fs${packageIndexPath}?import` };
+            }
+            if (source === "@pkg/styles/styles.json") {
+              return { id: `/@fs${packageJsonPath}?import` };
+            }
+            if (source === "@pkg/styles/tokens.css?raw") {
+              return { id: `/@fs${rawTokensPath}?raw` };
+            }
+            if (source === "@pkg/styles/token.txt?text") {
+              return { id: `/@fs${textTokenPath}?text` };
+            }
+            if (source === "@pkg/styles/asset.svg?url") {
+              return { id: `/@fs${assetPath}?url` };
+            }
+            if (source === "@pkg/styles/icon.wasm?url") {
+              return { id: `/@fs${wasmPath}?url` };
+            }
+            if (source === "@pkg/styles/icon.wasm?init") {
+              return { id: `/@fs${wasmPath}?init` };
+            }
+            if (source === "virtual:mincho-test-styles") {
+              return { id: virtualId };
+            }
+            if (source === "@pkg/external") {
+              return { id: source, external: true };
+            }
+
+            return null;
+          },
+          server: {
+            moduleGraph: {
+              getModuleById: () => undefined,
+              invalidateModule: vi.fn()
+            },
+            transformRequest: virtualTransform
+          }
+        });
+
+        await harness.transform(fixture.entryPath, fixture.source);
+
+        const packageRealpath = normalizePath(
+          await fs.promises.realpath(packageIndexPath)
+        );
+        const jsonRealpath = normalizePath(
+          await fs.promises.realpath(packageJsonPath)
+        );
+        const rawRealpath = normalizePath(
+          await fs.promises.realpath(rawTokensPath)
+        );
+        const textRealpath = normalizePath(
+          await fs.promises.realpath(textTokenPath)
+        );
+        const assetRealpath = normalizePath(
+          await fs.promises.realpath(assetPath)
+        );
+        const wasmRealpath = normalizePath(
+          await fs.promises.realpath(wasmPath)
+        );
+        const assetUrl = "/node_modules/@pkg/styles/asset.svg";
+        const wasmUrl = "/node_modules/@pkg/styles/icon.wasm";
+
+        expect(captured.resolved["@pkg/styles"]).toMatchObject({
+          resolvedFile: packageRealpath,
+          normalizedPathKey: packageRealpath,
+          realpath: packageRealpath,
+          sourceKind: "package-source",
+          sourceOrigin: "package",
+          watchFiles: [packageRealpath],
+          resolverKind: "vite"
+        });
+        expect(captured.loaded["@pkg/styles"]).toMatchObject({
+          sourceText: 'export const button = { color: "red" } as const;',
+          resolvedFile: packageRealpath,
+          sourceKind: "package-source",
+          sourceOrigin: "package",
+          watchFiles: [packageRealpath],
+          resolverKind: "vite"
+        });
+        expect(captured.resolved["@pkg/styles/styles.json"]).toMatchObject({
+          resolvedFile: `${jsonRealpath}?import`,
+          normalizedPathKey: `${jsonRealpath}?import`,
+          realpath: jsonRealpath,
+          sourceKind: "static-data",
+          sourceOrigin: "data",
+          watchFiles: [jsonRealpath]
+        });
+        expect(captured.loaded["@pkg/styles/styles.json"]).toMatchObject({
+          sourceText: JSON.stringify({ token: { color: "green" } }),
+          sourceKind: "static-data",
+          sourceOrigin: "data",
+          watchFiles: [jsonRealpath]
+        });
+        expect(captured.resolved["@pkg/styles/tokens.css?raw"]).toMatchObject({
+          resolvedFile: `${rawRealpath}?raw`,
+          normalizedPathKey: `${rawRealpath}?raw`,
+          realpath: rawRealpath,
+          sourceKind: "static-data",
+          sourceOrigin: "data",
+          watchFiles: [rawRealpath]
+        });
+        expect(captured.resolved["@pkg/styles/token.txt?text"]).toMatchObject({
+          resolvedFile: `${textRealpath}?text`,
+          normalizedPathKey: `${textRealpath}?text`,
+          realpath: textRealpath,
+          sourceKind: "static-data",
+          sourceOrigin: "data",
+          watchFiles: [textRealpath]
+        });
+        expect(captured.loaded["@pkg/styles/token.txt?text"]).toMatchObject({
+          sourceText: `export default "purple";\n`,
+          sourceKind: "static-data",
+          sourceOrigin: "data",
+          watchFiles: [textRealpath]
+        });
+        expect(captured.resolved["@pkg/styles/asset.svg?url"]).toMatchObject({
+          resolvedFile: `${assetRealpath}?url`,
+          normalizedPathKey: `${assetRealpath}?url`,
+          realpath: assetRealpath,
+          sourceKind: "static-data",
+          sourceOrigin: "data",
+          watchFiles: [assetRealpath]
+        });
+        expect(captured.loaded["@pkg/styles/asset.svg?url"]).toMatchObject({
+          sourceText: `export default ${JSON.stringify(assetUrl)};\n`,
+          sourceKind: "static-data",
+          sourceOrigin: "data",
+          watchFiles: [assetRealpath]
+        });
+        expect(captured.resolved["@pkg/styles/icon.wasm?url"]).toMatchObject({
+          resolvedFile: `${wasmRealpath}?url`,
+          normalizedPathKey: `${wasmRealpath}?url`,
+          realpath: wasmRealpath,
+          sourceKind: "static-data",
+          sourceOrigin: "data",
+          watchFiles: [wasmRealpath]
+        });
+        expect(captured.loaded["@pkg/styles/icon.wasm?url"]).toMatchObject({
+          sourceText: `export default ${JSON.stringify(wasmUrl)};\n`,
+          sourceKind: "static-data",
+          sourceOrigin: "data",
+          watchFiles: [wasmRealpath]
+        });
+        expect(captured.resolved["@pkg/styles/icon.wasm?init"]).toMatchObject({
+          resolvedFile: `${wasmRealpath}?init`,
+          normalizedPathKey: `${wasmRealpath}?init`,
+          realpath: wasmRealpath,
+          sourceKind: "static-data",
+          sourceOrigin: "data",
+          watchFiles: [wasmRealpath]
+        });
+        expect(captured.resolved["virtual:mincho-test-styles"]).toMatchObject({
+          resolvedFile: virtualId,
+          canonicalModuleId: virtualId,
+          normalizedPathKey: virtualId,
+          sourceKind: "provider-virtual",
+          sourceOrigin: "provider"
+        });
+        expect(captured.loaded["virtual:mincho-test-styles"]).toMatchObject({
+          sourceText:
+            'export const virtualButton = { color: "blue" } as const;',
+          sourceKind: "provider-virtual",
+          sourceOrigin: "provider"
+        });
+        expect(virtualTransform).toHaveBeenCalledWith(virtualId, { ssr: true });
+        expect(captured.resolved["@pkg/external"]).toMatchObject({
+          resolvedFile: "external:mincho-static-css-eval:%40pkg%2Fexternal",
+          sourceKind: "external-no-source",
+          sourceOrigin: "external",
+          unsupportedReason: "external-no-source"
+        });
+        expect(captured.loaded["@pkg/external"]).toBeNull();
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("statically evaluates Vite static css eval package url wasm and provider virtual css prop imports", async () => {
+      const fixture = await createJsxCssPropViteFixture(
+        "static-css-eval-package-virtual-transform-",
+        `
+          import defaultButton, { button } from "@pkg/styles";
+          import * as styles from "@pkg/styles";
+          import assetUrl from "@pkg/styles/asset.svg?url";
+          import wasmUrl from "@pkg/styles/icon.wasm?url";
+          import { virtualButton } from "virtual:mincho-test-styles";
+
+          function App() {
+            return <>
+              <div css={button} />
+              <div css={defaultButton} />
+              <div css={styles.card} />
+              <div css={assetUrl} />
+              <div css={wasmUrl} />
+              <div css={virtualButton} />
+            </>;
+          }
+
+          export { App };
+        `
+      );
+      const packageRoot = join(fixture.root, "node_modules/@pkg/styles");
+      const packageIndexPath = join(packageRoot, "index.ts");
+      const assetPath = join(packageRoot, "asset.svg");
+      const wasmPath = join(packageRoot, "icon.wasm");
+      const virtualId = "\0virtual:mincho-test-styles";
+
+      try {
+        await fs.promises.mkdir(packageRoot, { recursive: true });
+        await fs.promises.writeFile(
+          packageIndexPath,
+          `
+            export const button = { color: "red" } as const;
+            export const card = { color: "green" } as const;
+            export default { color: "orange" } as const;
+          `,
+          "utf8"
+        );
+        await fs.promises.writeFile(assetPath, "<svg></svg>", "utf8");
+        await fs.promises.writeFile(wasmPath, "wasm-binary", "utf8");
+        await spyOnSourceBabelTransform();
+
+        const harness = await createViteHarness({
+          configOverrides: {
+            root: fixture.root
+          },
+          pluginOptions: {
+            jsxCssProp: true
+          },
+          resolve(source) {
+            if (source === "@pkg/styles") {
+              return { id: `/@fs${packageIndexPath}?import` };
+            }
+            if (source === "@pkg/styles/asset.svg?url") {
+              return { id: `/@fs${assetPath}?url` };
+            }
+            if (source === "@pkg/styles/icon.wasm?url") {
+              return { id: `/@fs${wasmPath}?url` };
+            }
+            if (source === "virtual:mincho-test-styles") {
+              return { id: virtualId };
+            }
+
+            return null;
+          },
+          server: {
+            moduleGraph: {
+              getModuleById: () => undefined,
+              invalidateModule: vi.fn()
+            },
+            async transformRequest(id) {
+              return id === virtualId
+                ? {
+                    code: 'export const virtualButton = { color: "blue" } as const;'
+                  }
+                : null;
+            }
+          }
+        });
+        const artifact = await transformImportedCssPropToVirtualCss(
+          harness,
+          fixture.entryPath,
+          fixture.source
+        );
+
+        expect(artifact.virtualCss).toContain("color: red;");
+        expect(artifact.virtualCss).toContain("color: orange;");
+        expect(artifact.virtualCss).toContain("color: green;");
+        expect(artifact.virtualCss).not.toContain("<svg></svg>");
+        expect(artifact.virtualCss).not.toContain("wasm-binary");
+        expect(artifact.virtualCss).toContain("color: blue;");
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
     it("registers dependency files for successful imported evaluations", async () => {
       const supportedFixture = await createImportedCssPropViteFixture(
         "jsx-css-prop-imported-watch-supported-"
@@ -2799,12 +3532,25 @@ if (import.meta.vitest) {
 
       try {
         await spyOnSourceBabelTransform();
+        const missingVirtualId = "\0virtual:styles";
         const fallbackHarness = await createViteHarness({
           configOverrides: {
             root: fallbackFixture.root
           },
           pluginOptions: {
             jsxCssProp: true
+          },
+          resolve(source) {
+            return source === "virtual:styles"
+              ? { id: missingVirtualId }
+              : null;
+          },
+          server: {
+            moduleGraph: {
+              getModuleById: () => undefined,
+              invalidateModule: vi.fn()
+            },
+            transformRequest: vi.fn(async () => null)
           }
         });
         await expect(
@@ -2812,7 +3558,9 @@ if (import.meta.vitest) {
             fallbackFixture.entryPath,
             fallbackFixture.source
           )
-        ).rejects.toThrow('package import "virtual:styles" is unsupported');
+        ).rejects.toThrow(
+          "Cannot statically evaluate css prop value: provider virtual module"
+        );
         expect(fallbackHarness.watchFiles).toEqual([]);
 
         const staticRuleHarness = await createViteHarness({
@@ -2841,45 +3589,6 @@ if (import.meta.vitest) {
             recursive: true
           })
         ]);
-      }
-    });
-
-    it("refuses symlinked node_modules sources in static css eval load", async () => {
-      const cacheRoot = createViteFixtureCacheRoot();
-      await fs.promises.mkdir(cacheRoot, { recursive: true });
-      const root = await fs.promises.mkdtemp(
-        join(cacheRoot, "jsx-css-prop-imported-boundary-symlink-")
-      );
-      const srcRoot = join(root, "src");
-      const stylesPath = join(srcRoot, "styles.ts");
-      const nodeModulesStylesPath = join(root, "node_modules/pkg/styles.ts");
-
-      try {
-        await Promise.all([
-          fs.promises.mkdir(srcRoot, { recursive: true }),
-          fs.promises.mkdir(dirname(nodeModulesStylesPath), {
-            recursive: true
-          })
-        ]);
-        await fs.promises.writeFile(
-          nodeModulesStylesPath,
-          createImportedStyleSource("red"),
-          "utf8"
-        );
-        await fs.promises.symlink(nodeModulesStylesPath, stylesPath);
-
-        const sourceProvider = createViteStaticCssEvalSourceProvider(
-          {
-            addWatchFile() {}
-          },
-          join(srcRoot, "entry.tsx"),
-          'export const owner = "ignored";',
-          await getRealpathOrResolvedPath(root)
-        );
-
-        await expect(sourceProvider.load(stylesPath)).resolves.toBeNull();
-      } finally {
-        await fs.promises.rm(root, { force: true, recursive: true });
       }
     });
 

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -28,6 +28,7 @@ interface Module {
 interface ViteDevServer {
   moduleGraph: {
     getModuleById: (id: string) => Module | undefined;
+    getModulesByFile?: (file: string) => Set<Module> | undefined;
     invalidateModule: (module: Module) => void;
   };
 }
@@ -99,17 +100,42 @@ type MinchoBabelOptions = BabelOptions & { jsxCssProp?: boolean };
 
 interface StaticCssEvalSourceResolution {
   id: string;
+  resolvedFile?: string;
+  canonicalModuleId?: string;
+  normalizedPathKey?: string;
   realpath?: string;
+  sourceText?: string;
   sourceHash?: string;
   version?: string | number;
+  sourceIdentity?: StaticCssEvalSourceIdentity;
+  resolverKind?: StaticCssEvalResolverKind;
 }
 
 interface StaticCssEvalLoadedSource {
   source: string;
+  sourceText?: string;
+  resolvedFile?: string;
+  canonicalModuleId?: string;
+  normalizedPathKey?: string;
   realpath?: string;
   sourceHash?: string;
   version?: string | number;
+  sourceIdentity?: StaticCssEvalSourceIdentity;
+  resolverKind?: StaticCssEvalResolverKind;
 }
+
+interface StaticCssEvalSourceIdentity {
+  sourceHash?: string;
+  version?: string | number;
+}
+
+type StaticCssEvalResolverKind =
+  | "source-provider"
+  | "filesystem"
+  | "vite"
+  | "esbuild"
+  | "test"
+  | (string & {});
 
 interface StaticCssEvalSourceProvider {
   resolve(
@@ -127,15 +153,52 @@ interface StaticCssEvalSourceProvider {
     | null;
 }
 
-type MinchoBabelOptionsWithStaticCssEval = MinchoBabelOptions & {
+type MinchoBabelOptionsWithStaticCssEval = Omit<
+  MinchoBabelOptions,
+  "staticCssEvalSourceProvider"
+> & {
   staticCssEvalSourceProvider?: StaticCssEvalSourceProvider;
 };
 
-type BabelTransformResult = Awaited<ReturnType<typeof babelTransform>> & {
-  staticCssEval?: {
-    dependencyFiles: string[];
-  };
+type BabelTransformResult = Omit<
+  Awaited<ReturnType<typeof babelTransform>>,
+  "staticCssEval"
+> & {
+  staticCssEval?: StaticCssEvalMetadata;
 };
+
+interface StaticCssEvalMetadata {
+  dependencyFiles?: readonly string[];
+  dependencies?: readonly StaticCssEvalResolutionDependency[];
+  resolvedDependencies?: readonly StaticCssEvalResolvedDependency[];
+  diagnostics?: readonly StaticCssEvalDiagnostic[];
+  cacheKeys?: readonly StaticCssEvalCacheKey[];
+  resolvedModuleIds?: readonly string[];
+}
+
+interface StaticCssEvalResolutionDependency {
+  file: string;
+  kind?: string;
+}
+
+interface StaticCssEvalResolvedDependency {
+  resolvedFile: string;
+  canonicalModuleId?: string;
+  normalizedPathKey?: string;
+}
+
+interface StaticCssEvalDiagnostic {
+  id?: string;
+  dependency?: {
+    file: string;
+  };
+}
+
+interface StaticCssEvalCacheKey {
+  importerFile?: string;
+  resolvedFile?: string;
+  resolvedId?: string;
+}
 
 interface MinchoVitePluginOptions {
   babel?: MinchoBabelOptions;
@@ -254,14 +317,22 @@ export function minchoVitePlugin(
   function replaceStaticCssEvalDependenciesForOwner(
     pluginContext: PluginContext,
     ownerId: string,
-    dependencyFiles: readonly string[]
+    staticCssEval: StaticCssEvalMetadata | undefined
   ): void {
+    // Vite invalidation consumes shared Babel/integration metadata as truth.
+    // This layer normalizes watch ids; it does not infer css symbol provenance.
     removeStaticCssEvalDependenciesForOwner(ownerId);
 
     const dependencies = new Set(
-      dependencyFiles
-        .map(normalizeStaticCssEvalFileId)
-        .filter(isWatchableStaticCssEvalDependency)
+      collectStaticCssEvalDependencyIds(staticCssEval)
+        .map((dependency) =>
+          normalizeStaticCssEvalFileId(dependency, rootRealpath)
+        )
+        .filter(
+          (dependency) =>
+            dependency !== ownerId &&
+            isWatchableStaticCssEvalDependency(dependency)
+        )
     );
 
     if (dependencies.size === 0) {
@@ -383,7 +454,7 @@ export function minchoVitePlugin(
     },
     async transform(this: PluginContext, code: string, id: string) {
       if (id.startsWith("\0")) return;
-      const fileId = normalizeStaticCssEvalFileId(id);
+      const fileId = normalizeStaticCssEvalFileId(id, rootRealpath);
       invalidateStaticCssEvalDependency(fileId);
 
       const moduleInfo = idToPluginData.get(id);
@@ -470,9 +541,7 @@ export function minchoVitePlugin(
           _options?.jsxCssProp === undefined
             ? _options?.babel
             : { ..._options.babel, jsxCssProp: _options.jsxCssProp };
-        const transformBabelOptions:
-          | MinchoBabelOptionsWithStaticCssEval
-          | undefined =
+        const transformBabelOptions: MinchoBabelOptions | undefined =
           babelOptions?.jsxCssProp === true
             ? {
                 ...babelOptions,
@@ -485,10 +554,21 @@ export function minchoVitePlugin(
                   )
               }
             : babelOptions;
-        const transformResult = (await babelTransform(
-          fileId,
-          transformBabelOptions
-        )) as BabelTransformResult;
+        let transformResult: BabelTransformResult;
+
+        try {
+          transformResult = (await babelTransform(
+            fileId,
+            transformBabelOptions
+          )) as BabelTransformResult;
+        } catch (error) {
+          replaceStaticCssEvalDependenciesForOwner(
+            this,
+            fileId,
+            getStaticCssEvalFromTransformError(error)
+          );
+          throw error;
+        }
         const {
           code: transformedCode,
           jsxCssPropTransformed,
@@ -496,11 +576,7 @@ export function minchoVitePlugin(
           staticCssEval
         } = transformResult;
 
-        replaceStaticCssEvalDependenciesForOwner(
-          this,
-          fileId,
-          staticCssEval?.dependencyFiles ?? []
-        );
+        replaceStaticCssEvalDependenciesForOwner(this, fileId, staticCssEval);
 
         if (!cssExtract || !file) {
           if (
@@ -602,7 +678,11 @@ function createViteStaticCssEvalSourceProvider(
         return createUnsupportedStaticCssEvalResolution(importPath);
       }
 
-      const resolvedId = normalizeStaticCssEvalFileId(resolved.id);
+      const canonicalModuleId = normalizeStaticCssEvalFileId(
+        resolved.id,
+        rootRealpath
+      );
+      const resolvedId = canonicalModuleId;
       const resolvedRealpath = await getExistingRealpath(resolvedId);
 
       if (!resolvedRealpath) {
@@ -627,27 +707,45 @@ function createViteStaticCssEvalSourceProvider(
 
         throw error;
       }
+      const sourceIdentity = createStaticCssEvalSourceIdentity(stat);
 
       return {
         id: resolvedRealpath,
+        resolvedFile: resolvedRealpath,
+        canonicalModuleId,
+        normalizedPathKey: resolvedRealpath,
         realpath: resolvedRealpath,
-        sourceHash: createStaticCssEvalSourceHash(stat),
-        version: stat.mtimeMs
+        sourceHash: sourceIdentity.sourceHash,
+        version: sourceIdentity.version,
+        sourceIdentity,
+        resolverKind: "vite"
       };
     },
     async load(id: string) {
-      const fileId = normalizeStaticCssEvalFileId(id);
+      const fileId = normalizeStaticCssEvalFileId(id, rootRealpath);
 
       if (fileId === ownerId) {
         const ownerRealpath = await getExistingRealpath(fileId);
+        const stat = ownerRealpath
+          ? await getExistingStat(ownerRealpath)
+          : null;
+        const sourceIdentity = stat
+          ? createStaticCssEvalSourceIdentity(stat)
+          : undefined;
         return {
+          sourceText: ownerSource,
           source: ownerSource,
-          ...(ownerRealpath ? { realpath: ownerRealpath } : {})
+          resolvedFile: ownerRealpath ?? ownerId,
+          canonicalModuleId: ownerId,
+          normalizedPathKey: ownerId,
+          ...(ownerRealpath ? { realpath: ownerRealpath } : {}),
+          ...(sourceIdentity ? { sourceIdentity } : {}),
+          resolverKind: "vite"
         };
       }
 
       if (isUnsupportedStaticCssEvalResolutionId(id)) {
-        return { source: "export {};" };
+        return { sourceText: "export {};", source: "export {};" };
       }
 
       if (isVirtualStaticCssEvalId(id) || hasNodeModulesSegment(fileId)) {
@@ -680,10 +778,16 @@ function createViteStaticCssEvalSourceProvider(
       }
 
       return {
+        sourceText: source,
         source,
+        resolvedFile: realpath,
+        canonicalModuleId: fileId,
+        normalizedPathKey: realpath,
         realpath,
         sourceHash: createStaticCssEvalSourceHash(stat),
-        version: stat.mtimeMs
+        version: stat.mtimeMs,
+        sourceIdentity: createStaticCssEvalSourceIdentity(stat),
+        resolverKind: "vite"
       };
     }
   };
@@ -697,8 +801,89 @@ function isUnsupportedStaticCssEvalResolutionId(id: string): boolean {
   return sharedIsUnsupportedStaticCssEvalResolutionId(id);
 }
 
-function normalizeStaticCssEvalFileId(id: string): string {
-  return normalizePath(stripViteRequestQuery(id));
+function getStaticCssEvalFromTransformError(
+  error: unknown
+): StaticCssEvalMetadata | undefined {
+  return (error as { staticCssEval?: StaticCssEvalMetadata } | null)
+    ?.staticCssEval;
+}
+
+function collectStaticCssEvalDependencyIds(
+  staticCssEval: StaticCssEvalMetadata | undefined
+): string[] {
+  if (!staticCssEval) {
+    return [];
+  }
+
+  return dedupeStrings([
+    ...(staticCssEval.dependencyFiles ?? []),
+    ...(staticCssEval.dependencies ?? [])
+      .filter((dependency) => dependency.kind !== "local")
+      .map((dependency) => dependency.file),
+    ...(staticCssEval.resolvedDependencies ?? []).flatMap((dependency) => [
+      dependency.resolvedFile,
+      dependency.canonicalModuleId,
+      dependency.normalizedPathKey
+    ]),
+    ...(staticCssEval.cacheKeys ?? []).flatMap((cacheKey) => [
+      cacheKey.resolvedFile,
+      cacheKey.resolvedId
+    ]),
+    ...(staticCssEval.resolvedModuleIds ?? [])
+  ]);
+}
+
+function dedupeStrings(values: readonly (string | undefined)[]): string[] {
+  return [...new Set(values.filter(isStringValue))];
+}
+
+function isStringValue(value: string | undefined): value is string {
+  return typeof value === "string" && value !== "";
+}
+
+function normalizeStaticCssEvalFileId(id: string, rootPath = ""): string {
+  const strippedId = stripViteRequestQuery(stripViteSsrPrefix(id));
+  const filePath = normalizeViteFilePath(strippedId);
+  const normalizedRoot = rootPath ? normalizePath(rootPath) : "";
+
+  if (
+    normalizedRoot &&
+    filePath.startsWith("/") &&
+    !isPathInsideRoot(normalizedRoot, filePath) &&
+    !fs.existsSync(filePath)
+  ) {
+    return normalizePath(join(normalizedRoot, filePath.slice(1)));
+  }
+
+  return filePath;
+}
+
+function stripViteSsrPrefix(id: string): string {
+  let normalizedId = id;
+
+  while (normalizedId.startsWith("ssr:")) {
+    normalizedId = normalizedId.slice("ssr:".length);
+  }
+
+  return normalizedId;
+}
+
+function normalizeViteFilePath(id: string): string {
+  if (id.startsWith("file://")) {
+    try {
+      return normalizePath(fileURLToPath(id));
+    } catch {
+      return normalizePath(id);
+    }
+  }
+
+  const normalizedId = normalizePath(id);
+
+  if (normalizedId.startsWith("/@fs/")) {
+    return normalizePath(normalizedId.slice("/@fs".length));
+  }
+
+  return normalizedId;
 }
 
 function stripViteRequestQuery(id: string): string {
@@ -733,6 +918,14 @@ async function getExistingRealpath(filePath: string): Promise<string | null> {
   return getSharedExistingRealpath(filePath, normalizePath);
 }
 
+async function getExistingStat(filePath: string): Promise<fs.Stats | null> {
+  try {
+    return await fs.promises.stat(filePath);
+  } catch {
+    return null;
+  }
+}
+
 function createStaticCssEvalSourceHash(stat: fs.Stats): string {
   return createSharedStaticCssEvalSourceHash(stat);
 }
@@ -743,6 +936,15 @@ function isMissingFileSystemEntryError(error: unknown): boolean {
     "code" in error &&
     (error.code === "ENOENT" || error.code === "ENOTDIR")
   );
+}
+
+function createStaticCssEvalSourceIdentity(
+  stat: fs.Stats
+): StaticCssEvalSourceIdentity {
+  return {
+    sourceHash: createStaticCssEvalSourceHash(stat),
+    version: stat.mtimeMs
+  };
 }
 
 // == Tests ====================================================================
@@ -1527,6 +1729,30 @@ if (import.meta.vitest) {
     return `export const button = { color: "${color}" } as const;`;
   }
 
+  function createDuplicatedStaticCssEvalMetadataVariants(
+    filePath: string,
+    kind = "imported"
+  ): StaticCssEvalMetadata {
+    return {
+      dependencyFiles: [`/@fs${filePath}?import#dep`],
+      dependencies: [{ file: `ssr:/@fs${filePath}?dep#hash`, kind }],
+      resolvedDependencies: [
+        {
+          resolvedFile: `/@fs${filePath}?resolved#hash`,
+          canonicalModuleId: `ssr:/@fs${filePath}?canonical#hash`,
+          normalizedPathKey: `/@fs${filePath}?normalized#hash`
+        }
+      ],
+      cacheKeys: [
+        {
+          resolvedFile: `/@fs${filePath}?cache#hash`,
+          resolvedId: `ssr:/@fs${filePath}?cache-id#hash`
+        }
+      ],
+      resolvedModuleIds: [`ssr:/@fs${filePath}?module#hash`]
+    };
+  }
+
   async function createImportedCssPropViteFixture(
     prefix: string,
     options: {
@@ -1821,6 +2047,61 @@ if (import.meta.vitest) {
   });
 
   describe("minchoVitePlugin", () => {
+    it("normalizes Vite static css dependency ids before cache and watch keys", () => {
+      const root = "/project";
+
+      expect(
+        normalizeStaticCssEvalFileId(
+          "/@fs/project/src/styles.ts?import#hash",
+          root
+        )
+      ).toBe("/project/src/styles.ts");
+      expect(normalizeStaticCssEvalFileId("/src/styles.ts?used", root)).toBe(
+        "/project/src/styles.ts"
+      );
+      expect(
+        normalizeStaticCssEvalFileId("ssr:/src/styles.ts?import", root)
+      ).toBe("/project/src/styles.ts");
+      expect(
+        normalizeStaticCssEvalFileId("C:\\project\\src\\styles.ts?raw#hash")
+      ).toBe("C:/project/src/styles.ts");
+    });
+
+    it("dedupes query, hash, /@fs, and SSR metadata variants to one watch key", async () => {
+      const fixture = await createImportedCssPropViteFixture(
+        "jsx-css-prop-normalized-metadata-"
+      );
+
+      try {
+        const integrationModule = await import("@mincho-js/integration");
+        const stylesRealpath = normalizePath(
+          await fs.promises.realpath(fixture.stylesPath)
+        );
+
+        vi.spyOn(integrationModule, "babelTransform").mockResolvedValue({
+          code: fixture.entrySource,
+          result: ["", ""],
+          staticCssEval:
+            createDuplicatedStaticCssEvalMetadataVariants(stylesRealpath)
+        } as unknown as BabelTransformResult);
+
+        const harness = await createViteHarness({
+          configOverrides: {
+            root: fixture.root
+          },
+          pluginOptions: {
+            jsxCssProp: true
+          }
+        });
+
+        await harness.transform(fixture.entryPath, fixture.entrySource);
+
+        expect(harness.watchFiles).toEqual([stylesRealpath]);
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
     it("lowers enabled jsx css prop before React JSX lowering and serves generated CSS", async () => {
       const fixture = await createJsxCssPropViteFixture(
         "jsx-css-prop-enabled-"
@@ -1993,25 +2274,117 @@ if (import.meta.vitest) {
       }
     });
 
-    it("registers dependency files for successful and failed imported evaluations", async () => {
+    it("supplies Vite canonical resolver fields to the static css eval source provider", async () => {
+      const fixture = await createImportedCssPropViteFixture(
+        "jsx-css-prop-provider-canonical-"
+      );
+      const captured: {
+        loadedSource?: StaticCssEvalLoadedSource | null;
+        resolution?: StaticCssEvalSourceResolution | null;
+      } = {};
+
+      try {
+        const integrationModule = await import("@mincho-js/integration");
+        vi.spyOn(integrationModule, "babelTransform").mockImplementation(
+          async (
+            _path: string,
+            options: MinchoBabelOptionsWithStaticCssEval = {}
+          ) => {
+            const sourceProvider = (
+              options as MinchoBabelOptionsWithStaticCssEval | undefined
+            )?.staticCssEvalSourceProvider;
+
+            if (!sourceProvider) {
+              throw new Error("Expected Vite static css eval source provider");
+            }
+
+            captured.resolution = await sourceProvider.resolve(
+              fixture.entryPath,
+              "./styles"
+            );
+
+            if (!captured.resolution?.normalizedPathKey) {
+              throw new Error("Expected canonical Vite source resolution");
+            }
+
+            captured.loadedSource = await sourceProvider.load(
+              captured.resolution.normalizedPathKey
+            );
+
+            return {
+              code: fixture.entrySource,
+              result: ["", ""],
+              staticCssEval: {
+                dependencyFiles: [
+                  captured.resolution.resolvedFile ?? captured.resolution.id
+                ]
+              }
+            } as unknown as BabelTransformResult;
+          }
+        );
+
+        const harness = await createViteHarness({
+          configOverrides: {
+            root: fixture.root
+          },
+          pluginOptions: {
+            jsxCssProp: true
+          },
+          resolve(source) {
+            return source === "./styles"
+              ? { id: `/@fs${fixture.stylesPath}?import#hmr` }
+              : null;
+          }
+        });
+        await harness.transform(fixture.entryPath, fixture.entrySource);
+
+        const stylesRealpath = normalizePath(
+          await fs.promises.realpath(fixture.stylesPath)
+        );
+        const resolution = captured.resolution;
+        const loadedSource = captured.loadedSource;
+
+        if (!resolution || !loadedSource) {
+          throw new Error(
+            "Expected captured Vite static css provider metadata"
+          );
+        }
+
+        expect(resolution).toMatchObject({
+          id: stylesRealpath,
+          resolvedFile: stylesRealpath,
+          canonicalModuleId: stylesRealpath,
+          normalizedPathKey: stylesRealpath,
+          realpath: stylesRealpath,
+          sourceIdentity: {
+            sourceHash: expect.stringMatching(/^mtime:/)
+          },
+          resolverKind: "vite"
+        });
+        expect(loadedSource).toMatchObject({
+          sourceText: fixture.styleSource,
+          resolvedFile: stylesRealpath,
+          canonicalModuleId: stylesRealpath,
+          normalizedPathKey: stylesRealpath,
+          realpath: stylesRealpath,
+          sourceIdentity: {
+            sourceHash: expect.stringMatching(/^mtime:/)
+          },
+          resolverKind: "vite"
+        });
+        expect(harness.watchFiles).toContain(stylesRealpath);
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("registers dependency files for successful imported evaluations", async () => {
       const supportedFixture = await createImportedCssPropViteFixture(
         "jsx-css-prop-imported-watch-supported-"
       );
-      const reexportFixture = await createImportedCssPropViteFixture(
-        "jsx-css-prop-imported-watch-reexport-",
-        {
-          entrySource: createImportedCssPropEntrySource("./barrel")
-        }
-      );
-      const barrelPath = join(reexportFixture.srcRoot, "barrel.ts");
 
       try {
         await spyOnSourceBabelTransform();
-        await fs.promises.writeFile(
-          barrelPath,
-          'export { button } from "./styles";'
-        );
-
         const supportedHarness = await createViteHarness({
           configOverrides: {
             root: supportedFixture.root
@@ -2028,38 +2401,151 @@ if (import.meta.vitest) {
         expect(supportedHarness.watchFiles).toContain(
           normalizePath(await fs.promises.realpath(supportedFixture.stylesPath))
         );
+      } finally {
+        await fs.promises.rm(supportedFixture.root, {
+          force: true,
+          recursive: true
+        });
+      }
+    });
 
-        const reexportHarness = await createViteHarness({
+    it("registers direct re-export dependency metadata without re-deriving provenance", async () => {
+      const fixture = await createImportedCssPropViteFixture(
+        "jsx-css-prop-imported-watch-reexport-",
+        {
+          entrySource: createImportedCssPropEntrySource("./barrel")
+        }
+      );
+      const barrelPath = join(fixture.srcRoot, "barrel.ts");
+      const buttonPath = join(fixture.srcRoot, "button.ts");
+
+      try {
+        const integrationModule = await import("@mincho-js/integration");
+        await fs.promises.writeFile(
+          barrelPath,
+          'export { button } from "./button";'
+        );
+        await fs.promises.writeFile(
+          buttonPath,
+          'export const button = { color: "red" } as const;'
+        );
+
+        const barrelRealpath = normalizePath(
+          await fs.promises.realpath(barrelPath)
+        );
+        const buttonRealpath = normalizePath(
+          await fs.promises.realpath(buttonPath)
+        );
+
+        vi.spyOn(integrationModule, "babelTransform").mockResolvedValue({
+          code: fixture.entrySource,
+          result: ["", ""],
+          staticCssEval: {
+            dependencyFiles: [barrelRealpath],
+            dependencies: [
+              { file: barrelRealpath, kind: "reexported" },
+              { file: buttonRealpath, kind: "reexported" }
+            ],
+            resolvedDependencies: [
+              {
+                resolvedFile: barrelRealpath,
+                canonicalModuleId: `/@fs${barrelRealpath}?import`,
+                normalizedPathKey: barrelRealpath
+              },
+              {
+                resolvedFile: buttonRealpath,
+                canonicalModuleId: `ssr:/@fs${buttonRealpath}?import`,
+                normalizedPathKey: buttonRealpath
+              }
+            ],
+            cacheKeys: [
+              {
+                resolvedFile: buttonRealpath,
+                resolvedId: `/@fs${buttonRealpath}?import`
+              }
+            ],
+            resolvedModuleIds: [
+              `/@fs${barrelRealpath}?import`,
+              `ssr:/@fs${buttonRealpath}?import`
+            ]
+          }
+        } as unknown as BabelTransformResult);
+
+        const harness = await createViteHarness({
           configOverrides: {
-            root: reexportFixture.root
+            root: fixture.root
           },
           pluginOptions: {
             jsxCssProp: true
           }
         });
-        const reexportCode = extractViteTransformCode(
-          await reexportHarness.transform(
-            reexportFixture.entryPath,
-            reexportFixture.entrySource
-          ),
-          "Expected unsupported reexport fallback transform to return code"
-        );
 
-        expect(reexportCode).toContain("className={_cx(button)}");
-        expect(reexportHarness.watchFiles).toContain(
-          normalizePath(await fs.promises.realpath(barrelPath))
+        await harness.transform(fixture.entryPath, fixture.entrySource);
+
+        expect(new Set(harness.watchFiles)).toEqual(
+          new Set([barrelRealpath, buttonRealpath])
         );
       } finally {
-        await Promise.all([
-          fs.promises.rm(supportedFixture.root, {
-            force: true,
-            recursive: true
-          }),
-          fs.promises.rm(reexportFixture.root, {
-            force: true,
-            recursive: true
-          })
-        ]);
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("fails closed for export-star static css evaluation with bounded watches", async () => {
+      const fixture = await createImportedCssPropViteFixture(
+        "jsx-css-prop-imported-export-star-",
+        {
+          entrySource: createImportedCssPropEntrySource("./barrel")
+        }
+      );
+      const barrelPath = join(fixture.srcRoot, "barrel.ts");
+      const buttonPath = join(fixture.srcRoot, "button.ts");
+
+      try {
+        await spyOnSourceBabelTransform();
+        await fs.promises.writeFile(barrelPath, 'export * from "./button";');
+        await fs.promises.writeFile(
+          buttonPath,
+          'export const button = { color: "red" } as const;'
+        );
+
+        const harness = await createViteHarness({
+          configOverrides: {
+            root: fixture.root
+          },
+          pluginOptions: {
+            jsxCssProp: true
+          }
+        });
+
+        let thrownError: unknown;
+
+        try {
+          await harness.transform(fixture.entryPath, fixture.entrySource);
+        } catch (error) {
+          thrownError = error;
+        }
+
+        expect(thrownError).toBeInstanceOf(Error);
+        expect((thrownError as Error).message).toContain(
+          'export * from "./button" is unsupported'
+        );
+        expect(
+          getStaticCssEvalFromTransformError(thrownError)?.diagnostics?.map(
+            (diagnostic) => diagnostic.id
+          )
+        ).toContain("STATIC_CSS_EVAL_EXPORT_STAR_UNSUPPORTED");
+
+        const barrelRealpath = normalizePath(
+          await fs.promises.realpath(barrelPath)
+        );
+        const buttonRealpath = normalizePath(
+          await fs.promises.realpath(buttonPath)
+        );
+
+        expect(harness.watchFiles).toEqual([barrelRealpath]);
+        expect(harness.watchFiles).not.toContain(buttonRealpath);
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
       }
     });
 
@@ -2095,17 +2581,12 @@ if (import.meta.vitest) {
             jsxCssProp: true
           }
         });
-        const fallbackCode = extractViteTransformCode(
-          await fallbackHarness.transform(
+        await expect(
+          fallbackHarness.transform(
             fallbackFixture.entryPath,
             fallbackFixture.source
-          ),
-          "Expected boundary fallback transform to return code"
-        );
-
-        expect(fallbackCode).toContain("className={_cx(button)}");
-        expect(fallbackCode).toContain("className={_cx(packageButton)}");
-        expect(fallbackCode).not.toContain("extracted_");
+          )
+        ).rejects.toThrow('package import "virtual:styles" is unsupported');
         expect(fallbackHarness.watchFiles).toEqual([]);
 
         const staticRuleHarness = await createViteHarness({
@@ -2207,9 +2688,7 @@ if (import.meta.vitest) {
         expect(await harness.load(redArtifact.resolvedVirtualId)).toBeNull();
         await expect(
           harness.transform(fixture.entryPath, fixture.entrySource)
-        ).rejects.toThrow(
-          "Cannot statically evaluate css prop value: failed to resolve project-local dependency ./styles"
-        );
+        ).rejects.toThrow('import "./styles" could not be resolved');
         expect(await harness.load(redArtifact.extractedId)).toBeNull();
         expect(await harness.load(redArtifact.resolvedVirtualId)).toBeNull();
       } finally {

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -2,22 +2,25 @@ import {
   type BabelOptions,
   babelTransform,
   compile,
-  createStaticCssEvalSourceHash as createSharedStaticCssEvalSourceHash,
   createUnsupportedStaticCssEvalResolution as createSharedUnsupportedStaticCssEvalResolution,
-  getExistingRealpath as getSharedExistingRealpath,
-  getRealpathOrResolvedPath as getSharedRealpathOrResolvedPath,
-  hasNodeModulesSegment as sharedHasNodeModulesSegment,
-  isPathInsideRoot as sharedIsPathInsideRoot,
-  isProjectLocalImportPath as sharedIsProjectLocalImportPath,
   isUnsupportedStaticCssEvalResolutionId as sharedIsUnsupportedStaticCssEvalResolutionId,
-  isVirtualStaticCssEvalId as sharedIsVirtualStaticCssEvalId,
+  internalCollectStaticCssEvalDependencyIds as collectStaticCssEvalDependencyIds,
+  internalCreateStaticCssEvalSourceHash as createStaticCssEvalSourceHash,
+  internalCreateStaticCssEvalSourceIdentity as createStaticCssEvalSourceIdentity,
+  internalGetExistingStaticCssEvalRealpath as getExistingRealpath,
+  internalGetExistingStaticCssEvalStat as getExistingStat,
+  internalGetStaticCssEvalRealpathOrResolvedPath as getRealpathOrResolvedPath,
+  internalHasStaticCssEvalNodeModulesSegment as hasNodeModulesSegment,
+  internalIsProjectLocalStaticCssEvalImportPath as isProjectLocalImportPath,
+  internalIsStaticCssEvalPathInsideRoot as isPathInsideRoot,
+  internalIsVirtualStaticCssEvalId as isVirtualStaticCssEvalId,
+  internalNormalizeStaticCssEvalFileId as normalizeStaticCssEvalFileId,
   processDefineRulesPresetRegistryFile,
   runDefineRulesPresetRegistryStep
 } from "@mincho-js/integration";
 import { normalizePath } from "@rollup/pluginutils";
 import { dirname, join, resolve } from "node:path";
 import * as fs from "node:fs";
-import { fileURLToPath } from "node:url";
 
 interface Module {
   lastHMRTimestamp?: number;
@@ -323,8 +326,11 @@ export function minchoVitePlugin(
     // This layer normalizes watch ids; it does not infer css symbol provenance.
     removeStaticCssEvalDependenciesForOwner(ownerId);
 
-    const dependencies = new Set(
-      collectStaticCssEvalDependencyIds(staticCssEval)
+    const dependencyIds = collectStaticCssEvalDependencyIds(
+      staticCssEval
+    ) as Array<string>;
+    const dependencies = new Set<string>(
+      dependencyIds
         .map((dependency) =>
           normalizeStaticCssEvalFileId(dependency, rootRealpath)
         )
@@ -494,7 +500,13 @@ export function minchoVitePlugin(
             source,
             filePath: moduleInfo.filePath,
             identOption: config.mode === "production" ? "short" : "debug",
-            serializeVirtualCssPath: async ({ fileScope, source }) => {
+            serializeVirtualCssPath: async ({
+              fileScope,
+              source
+            }: {
+              fileScope: { filePath: string };
+              source: string;
+            }) => {
               const id: string = `${fileScope.filePath}${virtualExt}`;
               const cssFileId = normalizePath(resolve(config.root, id));
 
@@ -807,146 +819,6 @@ function getStaticCssEvalFromTransformError(
   return (error as { staticCssEval?: StaticCssEvalMetadata } | null)
     ?.staticCssEval;
 }
-
-function collectStaticCssEvalDependencyIds(
-  staticCssEval: StaticCssEvalMetadata | undefined
-): string[] {
-  if (!staticCssEval) {
-    return [];
-  }
-
-  return dedupeStrings([
-    ...(staticCssEval.dependencyFiles ?? []),
-    ...(staticCssEval.dependencies ?? [])
-      .filter((dependency) => dependency.kind !== "local")
-      .map((dependency) => dependency.file),
-    ...(staticCssEval.resolvedDependencies ?? []).flatMap((dependency) => [
-      dependency.resolvedFile,
-      dependency.canonicalModuleId,
-      dependency.normalizedPathKey
-    ]),
-    ...(staticCssEval.cacheKeys ?? []).flatMap((cacheKey) => [
-      cacheKey.resolvedFile,
-      cacheKey.resolvedId
-    ]),
-    ...(staticCssEval.resolvedModuleIds ?? [])
-  ]);
-}
-
-function dedupeStrings(values: readonly (string | undefined)[]): string[] {
-  return [...new Set(values.filter(isStringValue))];
-}
-
-function isStringValue(value: string | undefined): value is string {
-  return typeof value === "string" && value !== "";
-}
-
-function normalizeStaticCssEvalFileId(id: string, rootPath = ""): string {
-  const strippedId = stripViteRequestQuery(stripViteSsrPrefix(id));
-  const filePath = normalizeViteFilePath(strippedId);
-  const normalizedRoot = rootPath ? normalizePath(rootPath) : "";
-
-  if (
-    normalizedRoot &&
-    filePath.startsWith("/") &&
-    !isPathInsideRoot(normalizedRoot, filePath) &&
-    !fs.existsSync(filePath)
-  ) {
-    return normalizePath(join(normalizedRoot, filePath.slice(1)));
-  }
-
-  return filePath;
-}
-
-function stripViteSsrPrefix(id: string): string {
-  let normalizedId = id;
-
-  while (normalizedId.startsWith("ssr:")) {
-    normalizedId = normalizedId.slice("ssr:".length);
-  }
-
-  return normalizedId;
-}
-
-function normalizeViteFilePath(id: string): string {
-  if (id.startsWith("file://")) {
-    try {
-      return normalizePath(fileURLToPath(id));
-    } catch {
-      return normalizePath(id);
-    }
-  }
-
-  const normalizedId = normalizePath(id);
-
-  if (normalizedId.startsWith("/@fs/")) {
-    return normalizePath(normalizedId.slice("/@fs".length));
-  }
-
-  return normalizedId;
-}
-
-function stripViteRequestQuery(id: string): string {
-  const queryIndex = id.search(/[?#]/);
-  return queryIndex === -1 ? id : id.slice(0, queryIndex);
-}
-
-function isProjectLocalImportPath(importPath: string): boolean {
-  return sharedIsProjectLocalImportPath(importPath);
-}
-
-function isVirtualStaticCssEvalId(id: string): boolean {
-  return sharedIsVirtualStaticCssEvalId(id);
-}
-
-function hasNodeModulesSegment(filePath: string): boolean {
-  return sharedHasNodeModulesSegment(filePath, normalizePath);
-}
-
-function isPathInsideRoot(rootPath: string, filePath: string): boolean {
-  return sharedIsPathInsideRoot(rootPath, filePath, normalizePath);
-}
-
-async function getRealpathOrResolvedPath(filePath: string): Promise<string> {
-  return getSharedRealpathOrResolvedPath(filePath, {
-    normalizeFilePath: normalizePath,
-    resolvePath: resolve
-  });
-}
-
-async function getExistingRealpath(filePath: string): Promise<string | null> {
-  return getSharedExistingRealpath(filePath, normalizePath);
-}
-
-async function getExistingStat(filePath: string): Promise<fs.Stats | null> {
-  try {
-    return await fs.promises.stat(filePath);
-  } catch {
-    return null;
-  }
-}
-
-function createStaticCssEvalSourceHash(stat: fs.Stats): string {
-  return createSharedStaticCssEvalSourceHash(stat);
-}
-
-function isMissingFileSystemEntryError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    "code" in error &&
-    (error.code === "ENOENT" || error.code === "ENOTDIR")
-  );
-}
-
-function createStaticCssEvalSourceIdentity(
-  stat: fs.Stats
-): StaticCssEvalSourceIdentity {
-  return {
-    sourceHash: createStaticCssEvalSourceHash(stat),
-    version: stat.mtimeMs
-  };
-}
-
 // == Tests ====================================================================
 // Ignore errors when compiling to CommonJS.
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -2047,6 +1919,89 @@ if (import.meta.vitest) {
   });
 
   describe("minchoVitePlugin", () => {
+    it("static css eval shared helpers normalize file ids and preserve source identity for Vite", async () => {
+      const fixture = await createImportedCssPropViteFixture(
+        "static-css-eval-shared-helper-identity-"
+      );
+
+      try {
+        const rootRealpath = normalizePath(
+          await fs.promises.realpath(fixture.root)
+        );
+        const stylesRealpath = normalizePath(
+          await fs.promises.realpath(fixture.stylesPath)
+        );
+        const stat = await fs.promises.stat(stylesRealpath);
+        const sourceIdentity = createStaticCssEvalSourceIdentity(stat);
+
+        expect(
+          normalizeStaticCssEvalFileId(
+            `/@fs${stylesRealpath}?import#hash`,
+            rootRealpath
+          )
+        ).toBe(stylesRealpath);
+        expect(
+          normalizeStaticCssEvalFileId(
+            `ssr:/@fs${stylesRealpath}?used#hash`,
+            rootRealpath
+          )
+        ).toBe(stylesRealpath);
+        expect(sourceIdentity).toEqual({
+          sourceHash: `mtime:${stat.mtimeMs}:size:${stat.size}`,
+          version: stat.mtimeMs
+        });
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("static css eval shared helpers ignore virtual node_modules and outside-root dependencies for Vite", async () => {
+      const fixture = await createImportedCssPropViteFixture(
+        "static-css-eval-shared-helper-boundary-"
+      );
+
+      try {
+        const integrationModule = await import("@mincho-js/integration");
+        const rootRealpath = normalizePath(
+          await fs.promises.realpath(fixture.root)
+        );
+        const stylesRealpath = normalizePath(
+          await fs.promises.realpath(fixture.stylesPath)
+        );
+        const outsideRootFile = normalizePath(
+          join(process.cwd(), "package.json")
+        );
+
+        vi.spyOn(integrationModule, "babelTransform").mockResolvedValue({
+          code: fixture.entrySource,
+          result: ["", ""],
+          staticCssEval: {
+            dependencyFiles: [
+              stylesRealpath,
+              "virtual:mincho-static-css-eval-test",
+              `${rootRealpath}/node_modules/pkg/styles.ts`,
+              outsideRootFile
+            ]
+          }
+        } as unknown as BabelTransformResult);
+
+        const harness = await createViteHarness({
+          configOverrides: {
+            root: fixture.root
+          },
+          pluginOptions: {
+            jsxCssProp: true
+          }
+        });
+
+        await harness.transform(fixture.entryPath, fixture.entrySource);
+
+        expect(harness.watchFiles).toEqual([stylesRealpath]);
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
     it("normalizes Vite static css dependency ids before cache and watch keys", () => {
       const root = "/project";
 
@@ -2269,6 +2224,95 @@ if (import.meta.vitest) {
         expect(blueArtifact.extractedSource).not.toContain('color: "red"');
         expect(blueArtifact.virtualCss).toContain("color: blue;");
         expect(blueArtifact.virtualCss).not.toContain("color: red;");
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("static css eval dependency invalidation removes stale owners and virtual css", async () => {
+      const fixture = await createImportedCssPropViteFixture(
+        "static-css-eval-dependency-invalidation-"
+      );
+      const ownerModule: Module = { lastInvalidationTimestamp: 2001 };
+      const sidecarModule: Module = { lastInvalidationTimestamp: 2002 };
+      const virtualModule: Module = { lastInvalidationTimestamp: 2003 };
+      const modules = new Map<string, Module>([
+        [fixture.entryPath, ownerModule]
+      ]);
+      const getModuleById = vi.fn((moduleId: string) => modules.get(moduleId));
+      const invalidateModule = vi.fn();
+
+      try {
+        const babelTransformSpy = await spyOnSourceBabelTransform();
+        const harness = await createViteHarness({
+          configOverrides: {
+            command: "serve",
+            mode: "development",
+            root: fixture.root
+          },
+          pluginOptions: {
+            jsxCssProp: true
+          },
+          server: {
+            moduleGraph: {
+              getModuleById,
+              invalidateModule
+            }
+          }
+        });
+        const redArtifact = await transformImportedCssPropToVirtualCss(
+          harness,
+          fixture.entryPath,
+          fixture.entrySource
+        );
+        modules.set(redArtifact.extractedId, sidecarModule);
+        modules.set(redArtifact.resolvedVirtualId, virtualModule);
+
+        await fs.promises.writeFile(
+          fixture.stylesPath,
+          createImportedStyleSource("blue")
+        );
+        await harness.transform(
+          fixture.stylesPath,
+          await fs.promises.readFile(fixture.stylesPath, "utf8")
+        );
+
+        expect(invalidateModule).toHaveBeenCalledWith(ownerModule);
+        expect(invalidateModule).toHaveBeenCalledWith(sidecarModule);
+        expect(invalidateModule).toHaveBeenCalledWith(virtualModule);
+        expect(ownerModule.lastHMRTimestamp).toBe(2001);
+        expect(await harness.load(redArtifact.extractedId)).toBeNull();
+        expect(await harness.load(redArtifact.resolvedVirtualId)).toBeNull();
+
+        const blueArtifact = await transformImportedCssPropToVirtualCss(
+          harness,
+          fixture.entryPath,
+          fixture.entrySource
+        );
+        modules.set(blueArtifact.extractedId, sidecarModule);
+        modules.set(blueArtifact.resolvedVirtualId, virtualModule);
+        expect(blueArtifact.virtualCss).toContain("color: blue;");
+
+        babelTransformSpy.mockResolvedValue({
+          code: "export const App = () => null;",
+          result: ["", ""],
+          staticCssEval: undefined
+        } as unknown as BabelTransformResult);
+        await harness.transform(
+          fixture.entryPath,
+          "export const App = () => null;"
+        );
+
+        invalidateModule.mockClear();
+        await harness.transform(
+          fixture.stylesPath,
+          await fs.promises.readFile(fixture.stylesPath, "utf8")
+        );
+
+        expect(invalidateModule).not.toHaveBeenCalled();
+        expect(await harness.load(blueArtifact.resolvedVirtualId)).toContain(
+          "color: blue;"
+        );
       } finally {
         await fs.promises.rm(fixture.root, { force: true, recursive: true });
       }
@@ -3126,7 +3170,9 @@ if (import.meta.vitest) {
         result: ["extracted_rules.css.ts", "resolver contents"]
       });
       const compileFixtureSource: typeof compile = integrationModule.compile;
-      const compileLivePresetFixture: typeof compile = (options) =>
+      const compileLivePresetFixture: typeof compile = (
+        options: Parameters<typeof compile>[0]
+      ) =>
         compileFixtureSource({
           ...options,
           contents: livePresetBuildSource

--- a/site/src/content/styled.mdx
+++ b/site/src/content/styled.mdx
@@ -455,4 +455,4 @@ const variant = 'button';
 <div css={styles?.button} />
 ```
 
-These examples fail because v1 does not evaluate identifier object values, object spreads, dynamic member paths, or optional member paths inside static CSS-rule candidates.
+These examples fail because V1 does not evaluate identifier object values, object spreads, dynamic member paths, or optional member paths inside static CSS-rule candidates.

--- a/site/src/content/styled.mdx
+++ b/site/src/content/styled.mdx
@@ -406,7 +406,7 @@ function MyComponent() {
 }
 ```
 
-V1 static evaluation supports direct object/array values, mutation-free same-file `const` object/array values, project local ESM named imports, aliased named imports, default imports/exports, selected namespace members such as `styles.button`, whole namespace objects such as `css={styles}`, direct named reexports, and `export *` barrels:
+Static evaluation supports direct object/array values, mutation-free same-file `const` object/array values, and provider-backed ESM sources. Supported sources include project files, package files such as `@pkg/styles`, package barrels, static data modules, and provider-backed virtual modules when the bundler supplies deterministic source text or a literal payload. Named imports, aliased named imports, default imports/exports, selected namespace members such as `styles.button`, whole namespace objects such as `css={styles}`, direct named reexports, and `export *` barrels use the same ESM rules across all supported source kinds:
 
 ```tsx
 const button = { color: 'blue' } as const;
@@ -449,7 +449,7 @@ import * as styles from './styles';
 <div css={styles} />
 ```
 
-Project local reexport chains are static too. Direct named reexports and star barrels can expose values for named imports and namespace members:
+Provider-backed reexport chains are static too. Direct named reexports and star barrels can expose values for named imports and namespace members from project files or package barrels:
 
 ```tsx
 // primitives.ts
@@ -466,6 +466,27 @@ import * as styles from './styles';
 
 <div css={primaryButton} />
 <div css={styles.button} />
+```
+
+Package, data, and virtual sources are supported only through the source provider. Mincho does not resolve package exports on its own; Vite, esbuild, or another integration must provide the source/literal payload and stable identity metadata:
+
+```tsx
+// App.tsx
+import pkgStyles, { card as packageCard } from '@pkg/styles';
+import { button as packageButton } from '@pkg/styles/barrel';
+import tokens, { brandColor } from '@pkg/styles/tokens.json';
+import rawColor from '@pkg/styles/color.txt?raw';
+import wasmUrl from '@pkg/styles/icon.wasm?url';
+import virtualStyles from 'virtual:mincho-styles';
+
+<div css={packageCard} />
+<div css={pkgStyles.root} />
+<div css={packageButton} />
+<div css={tokens.card} />
+<div css={{ color: brandColor }} />
+<div css={{ color: rawColor }} />
+<div css={{ backgroundImage: wasmUrl }} />
+<div css={virtualStyles.button} />
 ```
 
 `export *` follows ESM semantics and does not forward `default`. Use an explicit default reexport when a barrel should expose a default value:
@@ -487,9 +508,9 @@ import rootDefault, { root } from './styles';
 
 The practical literal grammar is small: string, number, boolean, `null`, unary numeric values, no-expression template literals such as `` `grid` ``, and nested object/array literals.
 
-Bundlers provide source resolution and loading only. Vite and esbuild give Mincho project local source text and dependency edges through the source provider, then Mincho parses that source, reads AST export manifests, and statically evaluates only the supported literal subset. No module execution is used. Mincho never executes user modules to obtain `css` prop values, and it does not use Node, VM, `eval`, `require()`, dynamic import, or bundler runtime execution for static evaluation.
+Bundlers provide source resolution and loading only. Vite and esbuild give Mincho provider-backed project/package/data/virtual source text, literal payloads, identity metadata, and dependency edges through the source provider. Mincho then parses source, reads AST export manifests, and statically evaluates only the supported literal subset. No module execution is used. Mincho never executes user modules to obtain `css` prop values, and it does not use Node, VM, `eval`, `require()`, dynamic import, or bundler runtime execution for static evaluation.
 
-V1 is project local only. It still excludes package exports from `node_modules`, outside root imports, virtual modules, CommonJS, namespace reexports such as `export * as ns from './styles'`, calls/functions/mixins as CSS-rule values, object/array spreads, computed dynamic keys, optional chaining, template expressions, runtime dynamic values, SWC native integration, and webpack integration.
+First-iteration exclusions are explicit: remote/http modules, CommonJS and `require()`, runtime wasm init/function exports such as `.wasm?init`, arbitrary virtual modules without provider-supplied source, dynamic import graphs, non-literal loader output, namespace reexports such as `export * as ns from './styles'`, calls/functions/mixins as CSS-rule values, object/array spreads, computed dynamic keys, optional chaining, template expressions, runtime dynamic values, SWC native integration, and webpack integration remain unsupported. Static wasm support is limited to provider-supplied raw/url string forms that arrive as literals; runtime wasm initialization is not evaluated.
 
 Existing dynamic class-value identifiers keep class-value behavior when they cannot be proven static. Proven CSS-rule candidates with unsupported internals fail with `Cannot statically evaluate css prop value` diagnostics.
 
@@ -499,14 +520,16 @@ const badIdentifierValue = { color };
 const badSpread = { ...base, color: 'red' };
 const styles = { button: { color: 'red' } } as const;
 const variant = 'button';
+const dynamicModule = import('./styles');
 
 <div css={badIdentifierValue} />
 <div css={badSpread} />
 <div css={styles[variant]} />
 <div css={styles?.button} />
+<div css={dynamicModule} />
 ```
 
-These examples fail because V1 does not evaluate identifier object values, object spreads, dynamic member paths, or optional member paths inside static CSS-rule candidates.
+These examples fail because static evaluation does not evaluate identifier object values, object spreads, dynamic member paths, optional member paths, or dynamic import graphs inside static CSS-rule candidates.
 
 Ambiguous star barrels fail instead of picking a value:
 

--- a/site/src/content/styled.mdx
+++ b/site/src/content/styled.mdx
@@ -406,7 +406,7 @@ function MyComponent() {
 }
 ```
 
-V1 static evaluation supports direct object/array values, mutation-free same-file `const` object/array values, direct project-local ESM named imports, aliased named imports, default imports/exports, and static member paths such as `styles.button`:
+V1 static evaluation supports direct object/array values, mutation-free same-file `const` object/array values, project local ESM named imports, aliased named imports, default imports/exports, selected namespace members such as `styles.button`, whole namespace objects such as `css={styles}`, direct named reexports, and `export *` barrels:
 
 ```tsx
 const button = { color: 'blue' } as const;
@@ -429,16 +429,67 @@ export default panel;
 
 // App.tsx
 import panel, { card } from './styles';
+import * as styles from './styles';
 
 <div css={card} />
 <div css={panel} />
+<div css={styles.card} />
+```
+
+Whole namespace objects are supported when every exported value is a static literal CSS property object or fragment:
+
+```tsx
+// styles.ts
+export const button = { color: 'red' } as const;
+export const card = { padding: 16 } as const;
+
+// App.tsx
+import * as styles from './styles';
+
+<div css={styles} />
+```
+
+Project local reexport chains are static too. Direct named reexports and star barrels can expose values for named imports and namespace members:
+
+```tsx
+// primitives.ts
+export const button = { color: 'red' } as const;
+export const card = { padding: 16 } as const;
+
+// styles.ts
+export { button as primaryButton } from './primitives';
+export * from './primitives';
+
+// App.tsx
+import { primaryButton } from './styles';
+import * as styles from './styles';
+
+<div css={primaryButton} />
+<div css={styles.button} />
+```
+
+`export *` follows ESM semantics and does not forward `default`. Use an explicit default reexport when a barrel should expose a default value:
+
+```tsx
+// root.ts
+export default { minHeight: '100vh' } as const;
+
+// styles.ts
+export { default } from './root';
+export { default as root } from './root';
+
+// App.tsx
+import rootDefault, { root } from './styles';
+
+<div css={rootDefault} />
+<div css={root} />
 ```
 
 The practical literal grammar is small: string, number, boolean, `null`, unary numeric values, no-expression template literals such as `` `grid` ``, and nested object/array literals.
 
-Bundlers provide source resolution and loading only. Vite and esbuild give Mincho project-local source text and dependency edges, then Mincho parses that source and statically evaluates the supported AST subset. No module execution is used. Mincho never executes user modules to obtain `css` prop values, and it does not use Node, VM, `eval`, `require()`, dynamic import, or bundler runtime execution for static evaluation.
+Bundlers provide source resolution and loading only. Vite and esbuild give Mincho project local source text and dependency edges through the source provider, then Mincho parses that source, reads AST export manifests, and statically evaluates only the supported literal subset. No module execution is used. Mincho never executes user modules to obtain `css` prop values, and it does not use Node, VM, `eval`, `require()`, dynamic import, or bundler runtime execution for static evaluation.
 
-V1 is project-local only. It excludes namespace imports, reexports or barrels, package exports from `node_modules`, virtual modules, CommonJS, calls/functions/mixins as CSS-rule values, object/array spreads, computed dynamic keys, optional chaining, template expressions, runtime dynamic values, SWC-native integration, and webpack integration.
+V1 is project local only. It still excludes package exports from `node_modules`, outside root imports, virtual modules, CommonJS, namespace reexports such as `export * as ns from './styles'`, calls/functions/mixins as CSS-rule values, object/array spreads, computed dynamic keys, optional chaining, template expressions, runtime dynamic values, SWC native integration, and webpack integration.
 
 Existing dynamic class-value identifiers keep class-value behavior when they cannot be proven static. Proven CSS-rule candidates with unsupported internals fail with `Cannot statically evaluate css prop value` diagnostics.
 
@@ -456,3 +507,35 @@ const variant = 'button';
 ```
 
 These examples fail because V1 does not evaluate identifier object values, object spreads, dynamic member paths, or optional member paths inside static CSS-rule candidates.
+
+Ambiguous star barrels fail instead of picking a value:
+
+```tsx
+// red.ts
+export const button = { color: 'red' } as const;
+
+// blue.ts
+export const button = { color: 'blue' } as const;
+
+// styles.ts
+export * from './red';
+export * from './blue';
+
+// App.tsx
+import { button } from './styles';
+
+<div css={button} />
+```
+
+Whole namespace mode also fails when an exported namespace value is not static. The invalid export is not skipped:
+
+```tsx
+// styles.ts
+export const button = { color: 'red' } as const;
+export const dynamic = getStyle();
+
+// App.tsx
+import * as styles from './styles';
+
+<div css={styles} />
+```

--- a/site/turbo.json
+++ b/site/turbo.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "mdx-components.tsx",
+        "next.config.mjs",
+        "package.json",
+        "src/**/*.mdx",
+        "src/**/*.ts",
+        "src/**/*.tsx",
+        "tsconfig.json"
+      ],
+      "outputs": [".next/**", "!.next/cache/**", "!.next/dev/**", "out/**"]
+    }
+  }
+}


### PR DESCRIPTION
## Description
- extend static css evaluation to traverse namespace and barrel import graphs, including provider package sources
- share the new imported-module resolution, cache, boundary, and metadata flow across Babel, integration, Vite, and esbuild
- align supporting docs, snapshots, and workspace config updates with the expanded import-graph resolution behavior

## Related Issue
- #349

## Additional context
- base branch: `main`
- this continues the css prop static evaluation series after the merged foundation PR

## Checklist
- review the imported module traversal rules, graph boundaries, and diagnostics
- review how dependency metadata flows through integration, Vite, and esbuild for rebuild behavior
- review the supporting docs, snapshots, and config alignment for the new import resolution coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded static CSS evaluation to support provider-backed ESM sources, namespaces, `export *` re-exports, packages, virtual modules, and static-data payloads.
  * Added richer resolution/diagnostic metadata and improved dependency/watch tracking to improve correctness across builds.
  * Improved runtime messaging when the JSX `css` prop transform is missed.
* **Bug Fixes**
  * Improved handling of unsupported and ambiguous cases with more precise diagnostics, plus more reliable cache/invalidation behavior.
* **Documentation**
  * Updated `css` prop static-evaluation docs to match the expanded capabilities and failure modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->