### PR TITLE
Feat: CSS Prop - Support static CJS evaluation

### DIFF
--- a/packages/babel/src/staticCssEval/cjsBindings.ts
+++ b/packages/babel/src/staticCssEval/cjsBindings.ts
@@ -1,0 +1,233 @@
+import { types as t } from "@babel/core";
+import type { NodePath } from "@babel/core";
+
+type StaticCssEvalBabelScope = NodePath<t.Node>["scope"];
+
+export type ImportedStaticCssEvalCjsBinding = {
+  readonly kind: "cjs-module" | "cjs-member" | "cjs-destructured";
+  readonly localName: string;
+  readonly importPath: string;
+  readonly propertyPath: readonly string[];
+};
+
+export type StaticCssEvalCjsRequireSource = {
+  readonly importPath: string;
+  readonly propertyPath: readonly string[];
+};
+
+export function collectStaticCssEvalCjsRequireBindings(
+  programPath: NodePath<t.Program>
+): Map<string, ImportedStaticCssEvalCjsBinding> {
+  const cjsImports = new Map<string, ImportedStaticCssEvalCjsBinding>();
+
+  for (const statementPath of programPath.get("body")) {
+    collectStaticCssEvalCjsRequireStatementBindings(statementPath, cjsImports);
+  }
+
+  return cjsImports;
+}
+
+export function isStaticCssEvalRequireCallExpression(
+  expression: t.Expression,
+  scope: StaticCssEvalBabelScope
+): expression is t.CallExpression {
+  return (
+    t.isCallExpression(expression) &&
+    t.isIdentifier(expression.callee) &&
+    expression.callee.name === "require" &&
+    !hasRequireValueBinding(scope)
+  );
+}
+
+export function isStaticCssEvalLiteralRequireCallExpression(
+  expression: t.Expression,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  return getStaticCssEvalLiteralRequireImportPath(expression, scope) !== null;
+}
+
+function collectStaticCssEvalCjsRequireStatementBindings(
+  statementPath: NodePath<t.Statement>,
+  cjsImports: Map<string, ImportedStaticCssEvalCjsBinding>
+): void {
+  if (!statementPath.isVariableDeclaration({ kind: "const" })) {
+    return;
+  }
+
+  for (const declaration of statementPath.node.declarations) {
+    collectStaticCssEvalCjsRequireDeclarator(
+      declaration,
+      statementPath.scope,
+      cjsImports
+    );
+  }
+}
+
+function collectStaticCssEvalCjsRequireDeclarator(
+  declaration: t.VariableDeclarator,
+  scope: StaticCssEvalBabelScope,
+  cjsImports: Map<string, ImportedStaticCssEvalCjsBinding>
+): void {
+  if (t.isIdentifier(declaration.id)) {
+    const source = getStaticCssEvalCjsRequireSource(declaration.init, scope);
+
+    if (!source) {
+      return;
+    }
+
+    cjsImports.set(declaration.id.name, {
+      kind: source.propertyPath.length === 0 ? "cjs-module" : "cjs-member",
+      localName: declaration.id.name,
+      importPath: source.importPath,
+      propertyPath: source.propertyPath
+    });
+    return;
+  }
+
+  if (!t.isObjectPattern(declaration.id)) {
+    return;
+  }
+
+  const importPath = getStaticCssEvalLiteralRequireImportPath(
+    declaration.init,
+    scope
+  );
+
+  if (!importPath) {
+    return;
+  }
+
+  for (const property of declaration.id.properties) {
+    collectStaticCssEvalCjsDestructuredBinding(
+      property,
+      importPath,
+      cjsImports
+    );
+  }
+}
+
+function collectStaticCssEvalCjsDestructuredBinding(
+  property: t.ObjectPattern["properties"][number],
+  importPath: string,
+  cjsImports: Map<string, ImportedStaticCssEvalCjsBinding>
+): void {
+  if (!t.isObjectProperty(property) || property.computed) {
+    return;
+  }
+
+  const propertyName = getStaticCssEvalObjectPatternPropertyName(property.key);
+  const localName = t.isIdentifier(property.value) ? property.value.name : null;
+
+  if (!propertyName || !localName) {
+    return;
+  }
+
+  cjsImports.set(localName, {
+    kind: "cjs-destructured",
+    localName,
+    importPath,
+    propertyPath: [propertyName]
+  });
+}
+
+export function getStaticCssEvalCjsRequireSource(
+  expression: t.Expression | null | undefined,
+  scope: StaticCssEvalBabelScope
+): StaticCssEvalCjsRequireSource | null {
+  const importPath = getStaticCssEvalLiteralRequireImportPath(
+    expression,
+    scope
+  );
+
+  if (importPath) {
+    return { importPath, propertyPath: [] };
+  }
+
+  return expression
+    ? getStaticCssEvalLiteralRequireMemberSource(expression, scope)
+    : null;
+}
+
+function getStaticCssEvalLiteralRequireMemberSource(
+  expression: t.Expression,
+  scope: StaticCssEvalBabelScope
+): StaticCssEvalCjsRequireSource | null {
+  const propertyPath: string[] = [];
+  let currentExpression: t.Expression = expression;
+
+  while (t.isMemberExpression(currentExpression)) {
+    const propertyName = getStaticCssEvalMemberPropertyName(currentExpression);
+
+    if (!propertyName || !t.isExpression(currentExpression.object)) {
+      return null;
+    }
+
+    propertyPath.unshift(propertyName);
+    currentExpression = currentExpression.object;
+  }
+
+  const importPath = getStaticCssEvalLiteralRequireImportPath(
+    currentExpression,
+    scope
+  );
+
+  return importPath && propertyPath.length > 0
+    ? { importPath, propertyPath }
+    : null;
+}
+
+export function getStaticCssEvalLiteralRequireImportPath(
+  expression: t.Expression | null | undefined,
+  scope: StaticCssEvalBabelScope
+): string | null {
+  if (!expression || !isStaticCssEvalRequireCallExpression(expression, scope)) {
+    return null;
+  }
+
+  const [specifier] = expression.arguments;
+
+  return expression.arguments.length === 1 && t.isStringLiteral(specifier)
+    ? specifier.value
+    : null;
+}
+
+function getStaticCssEvalMemberPropertyName(
+  expression: t.MemberExpression
+): string | null {
+  return !expression.computed && t.isIdentifier(expression.property)
+    ? expression.property.name
+    : null;
+}
+
+function getStaticCssEvalObjectPatternPropertyName(
+  propertyKey: t.ObjectProperty["key"]
+): string | null {
+  if (t.isIdentifier(propertyKey)) {
+    return propertyKey.name;
+  }
+
+  return t.isStringLiteral(propertyKey) ? propertyKey.value : null;
+}
+
+function hasRequireValueBinding(scope: StaticCssEvalBabelScope): boolean {
+  const binding = scope.getBinding("require");
+
+  if (!binding) {
+    return false;
+  }
+
+  if (
+    (binding.path.isImportSpecifier() ||
+      binding.path.isImportDefaultSpecifier() ||
+      binding.path.isImportNamespaceSpecifier()) &&
+    binding.path.parentPath.isImportDeclaration()
+  ) {
+    return (
+      binding.path.parentPath.node.importKind !== "type" &&
+      (!binding.path.isImportSpecifier() ||
+        binding.path.node.importKind !== "type")
+    );
+  }
+
+  return true;
+}

--- a/packages/babel/src/staticCssEval/cjsContracts.ts
+++ b/packages/babel/src/staticCssEval/cjsContracts.ts
@@ -1,0 +1,147 @@
+import type { StaticCssEvalDiagnosticId } from "./types.js";
+
+export type StaticCssEvalCjsGrammarContractStatus =
+  | "accepted-static-grammar"
+  | "rejected-static-grammar";
+
+export interface StaticCssEvalCjsGrammarContractEntry {
+  readonly construct: string;
+  readonly grammar: string;
+  readonly behavior: string;
+  readonly status: StaticCssEvalCjsGrammarContractStatus;
+  readonly diagnosticId?: StaticCssEvalDiagnosticId;
+}
+
+export interface StaticCssEvalCjsHelperRecognizerContractEntry {
+  readonly helper: string;
+  readonly acceptedWhen: string;
+  readonly rejectedWhen: string;
+  readonly diagnosticId: StaticCssEvalDiagnosticId;
+}
+
+// Todo 2 contract only: accepted grammar names future AST-recognizable shapes.
+// Parser, binding collection, export maps, helper recognition, and resolver support
+// remain fail-closed until their later todos wire these contracts into behavior.
+export const STATIC_CSS_EVAL_CJS_GRAMMAR_CONTRACTS = [
+  {
+    construct: "Literal require namespace",
+    grammar: 'const styles = require("./styles")',
+    behavior: "Bind the effective CommonJS module value for member access",
+    status: "accepted-static-grammar"
+  },
+  {
+    construct: "Literal require member",
+    grammar: 'const button = require("./styles").button',
+    behavior:
+      'Resolve member "button" from the effective CommonJS module value',
+    status: "accepted-static-grammar"
+  },
+  {
+    construct: "Shallow require destructure",
+    grammar: 'const { button, card: cardStyle } = require("./styles")',
+    behavior:
+      "Resolve each local binding from the effective CommonJS module value",
+    status: "accepted-static-grammar"
+  },
+  {
+    construct: "Direct module value export",
+    grammar: "module.exports = value",
+    behavior: "Replace the effective CommonJS module value with a static value",
+    status: "accepted-static-grammar"
+  },
+  {
+    construct: "Named export property",
+    grammar: "exports.button = value; module.exports.button = value",
+    behavior:
+      "Assign or override a named property when alias semantics are safe",
+    status: "accepted-static-grammar"
+  },
+  {
+    construct: "Default export property",
+    grammar: "exports.default = value; module.exports.default = value",
+    behavior:
+      'Create the explicit "default" property without guessing ESM interop',
+    status: "accepted-static-grammar"
+  },
+  {
+    construct: "defineProperty value export",
+    grammar: 'Object.defineProperty(exports, "button", { value })',
+    behavior: "Use a static descriptor value as a named export",
+    status: "accepted-static-grammar"
+  },
+  {
+    construct: "defineProperty getter export",
+    grammar:
+      'Object.defineProperty(exports, "button", { get: function () { return value; } })',
+    behavior:
+      "Accept a getter only when it has one static identifier/member return",
+    status: "accepted-static-grammar"
+  },
+  {
+    construct: "Dynamic require",
+    grammar: "require(expression)",
+    behavior:
+      "Reject runtime specifier resolution; no Node resolver or execution",
+    status: "rejected-static-grammar",
+    diagnosticId: "STATIC_CSS_EVAL_CJS_DYNAMIC_REQUIRE_UNSUPPORTED"
+  },
+  {
+    construct: "Unsupported CJS export mutation",
+    grammar: "conditional exports.button = value; exports[dynamic] = value",
+    behavior:
+      "Reject export mutations that depend on runtime order or dynamic names",
+    status: "rejected-static-grammar",
+    diagnosticId: "STATIC_CSS_EVAL_CJS_EXPORT_UNSUPPORTED"
+  },
+  {
+    construct: "Unsupported helper",
+    grammar: "helperName(exports, source)",
+    behavior:
+      "Reject helper calls unless a local side-effect-free AST fingerprint matches",
+    status: "rejected-static-grammar",
+    diagnosticId: "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED"
+  },
+  {
+    construct: "Full bundle runtime",
+    grammar: "webpackBootstrap((modules) => runtimeRequire(id))",
+    behavior:
+      "Reject bundled module factories, chunk registries, and bootstrap requires",
+    status: "rejected-static-grammar",
+    diagnosticId: "STATIC_CSS_EVAL_CJS_BUNDLE_RUNTIME_UNSUPPORTED"
+  }
+] as const satisfies readonly StaticCssEvalCjsGrammarContractEntry[];
+
+export const STATIC_CSS_EVAL_CJS_HELPER_RECOGNIZER_CONTRACTS = [
+  {
+    helper: "TypeScript __createBinding",
+    acceptedWhen:
+      "A local helper definition matches the supported binding descriptor shape and the source came from a literal require",
+    rejectedWhen:
+      "The helper name appears without the local helper fingerprint or the source is not a literal require binding",
+    diagnosticId: "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED"
+  },
+  {
+    helper: "TypeScript __exportStar",
+    acceptedWhen:
+      "A local helper definition matches the supported export-star loop and the source argument is a literal require",
+    rejectedWhen:
+      "The helper name appears without the local helper fingerprint or the source argument is dynamic",
+    diagnosticId: "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED"
+  },
+  {
+    helper: "Babel/SWC defineProperty getter",
+    acceptedWhen:
+      "The descriptor target is exports, the export name is literal, and the getter returns exactly one static identifier/member",
+    rejectedWhen:
+      "The descriptor has a setter, spread, dynamic name, unknown key, or side-effectful getter body",
+    diagnosticId: "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED"
+  },
+  {
+    helper: "esbuild __export + __toCommonJS",
+    acceptedWhen:
+      "Both local helper definitions match the known export-object fingerprint and getters return static values",
+    rejectedWhen:
+      "Either helper is name-only, user-defined with a different body, or wrapped in bundle runtime machinery",
+    diagnosticId: "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED"
+  }
+] as const satisfies readonly StaticCssEvalCjsHelperRecognizerContractEntry[];

--- a/packages/babel/src/staticCssEval/cjsCreateBindingFingerprint.ts
+++ b/packages/babel/src/staticCssEval/cjsCreateBindingFingerprint.ts
@@ -1,0 +1,271 @@
+import { types as t } from "@babel/core";
+import {
+  getIdentifierParamName,
+  getSingleBodyStatement,
+  type StaticCssEvalBabelScope,
+  type TscHelperFunction
+} from "./cjsHelperLookup.js";
+
+export function isTscCreateBindingFunction(
+  helperFunction: TscHelperFunction,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  const objectName = getIdentifierParamName(helperFunction, 0);
+  const moduleName = getIdentifierParamName(helperFunction, 1);
+  const keyName = getIdentifierParamName(helperFunction, 2);
+  const aliasName = getIdentifierParamName(helperFunction, 3);
+
+  if (!objectName || !moduleName || !keyName || !aliasName) {
+    return false;
+  }
+
+  const statements = helperFunction.body.body;
+  const [first, second, third, fourth] = statements;
+  const descriptorName = second
+    ? getDescriptorDeclarationName(second, moduleName, keyName, scope)
+    : null;
+
+  return (
+    (statements.length === 4 &&
+      first !== undefined &&
+      third !== undefined &&
+      fourth !== undefined &&
+      descriptorName !== null &&
+      isDefaultAliasStatement(first, aliasName, keyName) &&
+      isDescriptorRefreshStatement(
+        third,
+        descriptorName,
+        moduleName,
+        keyName
+      ) &&
+      isDefinePropertyStatement(
+        fourth,
+        objectName,
+        aliasName,
+        descriptorName,
+        scope
+      )) ||
+    (statements.length === 2 &&
+      first !== undefined &&
+      second !== undefined &&
+      isDefaultAliasStatement(first, aliasName, keyName) &&
+      isBindingAssignmentStatement(
+        second,
+        objectName,
+        aliasName,
+        moduleName,
+        keyName
+      ))
+  );
+}
+
+function getDescriptorDeclarationName(
+  statement: t.Statement,
+  moduleName: string,
+  keyName: string,
+  scope: StaticCssEvalBabelScope
+): string | null {
+  if (
+    !t.isVariableDeclaration(statement) ||
+    statement.declarations.length !== 1
+  ) {
+    return null;
+  }
+
+  const [declaration] = statement.declarations;
+
+  return declaration &&
+    t.isIdentifier(declaration.id) &&
+    declaration.init &&
+    isObjectGetOwnPropertyDescriptorCall(
+      declaration.init,
+      moduleName,
+      keyName,
+      scope
+    )
+    ? declaration.id.name
+    : null;
+}
+
+function isDefaultAliasStatement(
+  statement: t.Statement,
+  aliasName: string,
+  keyName: string
+): boolean {
+  return (
+    t.isIfStatement(statement) &&
+    !statement.alternate &&
+    t.isBinaryExpression(statement.test, { operator: "===" }) &&
+    isIdentifierAndUndefinedComparison(statement.test, aliasName) &&
+    isAliasAssignmentStatement(statement.consequent, aliasName, keyName)
+  );
+}
+
+function isIdentifierAndUndefinedComparison(
+  expression: t.BinaryExpression,
+  identifierName: string
+): boolean {
+  return (
+    (t.isIdentifier(expression.left, { name: identifierName }) &&
+      t.isIdentifier(expression.right, { name: "undefined" })) ||
+    (t.isIdentifier(expression.right, { name: identifierName }) &&
+      t.isIdentifier(expression.left, { name: "undefined" }))
+  );
+}
+
+function isAliasAssignmentStatement(
+  statement: t.Statement,
+  aliasName: string,
+  keyName: string
+): boolean {
+  return (
+    t.isExpressionStatement(statement) &&
+    t.isAssignmentExpression(statement.expression, { operator: "=" }) &&
+    t.isIdentifier(statement.expression.left, { name: aliasName }) &&
+    t.isIdentifier(statement.expression.right, { name: keyName })
+  );
+}
+
+function isDescriptorRefreshStatement(
+  statement: t.Statement,
+  descriptorName: string,
+  moduleName: string,
+  keyName: string
+): boolean {
+  const bodyStatement = t.isIfStatement(statement)
+    ? getSingleBodyStatement(statement.consequent)
+    : null;
+
+  return (
+    t.isIfStatement(statement) &&
+    !statement.alternate &&
+    bodyStatement !== null &&
+    isDescriptorAssignmentStatement(
+      bodyStatement,
+      descriptorName,
+      moduleName,
+      keyName
+    )
+  );
+}
+
+function isDescriptorAssignmentStatement(
+  statement: t.Statement,
+  descriptorName: string,
+  moduleName: string,
+  keyName: string
+): boolean {
+  return (
+    t.isExpressionStatement(statement) &&
+    t.isAssignmentExpression(statement.expression, { operator: "=" }) &&
+    t.isIdentifier(statement.expression.left, { name: descriptorName }) &&
+    t.isObjectExpression(statement.expression.right) &&
+    objectExpressionHasGetter(statement.expression.right, moduleName, keyName)
+  );
+}
+
+function isDefinePropertyStatement(
+  statement: t.Statement,
+  objectName: string,
+  aliasName: string,
+  descriptorName: string,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  return (
+    t.isExpressionStatement(statement) &&
+    t.isCallExpression(statement.expression) &&
+    isObjectMethodCall(statement.expression, "defineProperty", scope) &&
+    t.isIdentifier(statement.expression.arguments[0], { name: objectName }) &&
+    t.isIdentifier(statement.expression.arguments[1], { name: aliasName }) &&
+    t.isIdentifier(statement.expression.arguments[2], { name: descriptorName })
+  );
+}
+
+function isBindingAssignmentStatement(
+  statement: t.Statement,
+  objectName: string,
+  aliasName: string,
+  moduleName: string,
+  keyName: string
+): boolean {
+  return (
+    t.isExpressionStatement(statement) &&
+    t.isAssignmentExpression(statement.expression, { operator: "=" }) &&
+    isComputedMember(statement.expression.left, objectName, aliasName) &&
+    isComputedMember(statement.expression.right, moduleName, keyName)
+  );
+}
+
+function isObjectGetOwnPropertyDescriptorCall(
+  expression: t.Expression,
+  moduleName: string,
+  keyName: string,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  return (
+    t.isCallExpression(expression) &&
+    isObjectMethodCall(expression, "getOwnPropertyDescriptor", scope) &&
+    t.isIdentifier(expression.arguments[0], { name: moduleName }) &&
+    t.isIdentifier(expression.arguments[1], { name: keyName })
+  );
+}
+
+function isObjectMethodCall(
+  expression: t.CallExpression,
+  methodName: string,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  return (
+    t.isMemberExpression(expression.callee) &&
+    !expression.callee.computed &&
+    t.isIdentifier(expression.callee.object, { name: "Object" }) &&
+    !scope.getBinding("Object") &&
+    t.isIdentifier(expression.callee.property, { name: methodName })
+  );
+}
+
+function objectExpressionHasGetter(
+  expression: t.ObjectExpression,
+  moduleName: string,
+  keyName: string
+): boolean {
+  return expression.properties.some(
+    (property) =>
+      t.isObjectProperty(property) &&
+      !property.computed &&
+      t.isIdentifier(property.key, { name: "get" }) &&
+      t.isFunctionExpression(property.value) &&
+      getterReturnsComputedMember(property.value, moduleName, keyName)
+  );
+}
+
+function getterReturnsComputedMember(
+  helperFunction: TscHelperFunction,
+  moduleName: string,
+  keyName: string
+): boolean {
+  const [statement] = helperFunction.body.body;
+
+  return (
+    helperFunction.params.length === 0 &&
+    helperFunction.body.body.length === 1 &&
+    statement !== undefined &&
+    t.isReturnStatement(statement) &&
+    isComputedMember(statement.argument, moduleName, keyName)
+  );
+}
+
+function isComputedMember(
+  expression: t.Node | null | undefined,
+  objectName: string,
+  propertyName: string
+): boolean {
+  return (
+    expression !== null &&
+    expression !== undefined &&
+    t.isMemberExpression(expression) &&
+    expression.computed &&
+    t.isIdentifier(expression.object, { name: objectName }) &&
+    t.isIdentifier(expression.property, { name: propertyName })
+  );
+}

--- a/packages/babel/src/staticCssEval/cjsEsbuildCopyPropsDescriptorFingerprint.ts
+++ b/packages/babel/src/staticCssEval/cjsEsbuildCopyPropsDescriptorFingerprint.ts
@@ -1,0 +1,187 @@
+import { types as t } from "@babel/core";
+import type { StaticCssEvalBabelScope } from "./cjsHelperLookup.js";
+import { getSingleBodyStatement } from "./cjsHelperLookup.js";
+import {
+  getObjectKeyName,
+  isObjectDefinePropertyReference
+} from "./cjsEsbuildHelperLookup.js";
+import { isObjectGetOwnPropertyDescriptorReference } from "./cjsEsbuildObjectHelperReferences.js";
+
+export function isCopyPropsDefinePropertyStatement(options: {
+  readonly statement: t.Statement;
+  readonly targetName: string;
+  readonly sourceName: string;
+  readonly keyName: string;
+  readonly descriptorName: string;
+  readonly scope: StaticCssEvalBabelScope;
+}): boolean {
+  const bodyStatement = getSingleBodyStatement(options.statement);
+
+  if (!bodyStatement || !t.isExpressionStatement(bodyStatement)) {
+    return false;
+  }
+
+  const expression = bodyStatement.expression;
+  const descriptor = t.isCallExpression(expression)
+    ? expression.arguments[2]
+    : null;
+
+  return (
+    t.isCallExpression(expression) &&
+    expression.arguments.length === 3 &&
+    isObjectDefinePropertyReference(expression.callee, options.scope) &&
+    t.isIdentifier(expression.arguments[0], { name: options.targetName }) &&
+    t.isIdentifier(expression.arguments[1], { name: options.keyName }) &&
+    t.isObjectExpression(descriptor) &&
+    descriptorHasGetter({
+      descriptor,
+      sourceName: options.sourceName,
+      keyName: options.keyName,
+      descriptorName: options.descriptorName,
+      scope: options.scope
+    })
+  );
+}
+
+function descriptorHasGetter(options: {
+  readonly descriptor: t.ObjectExpression;
+  readonly sourceName: string;
+  readonly keyName: string;
+  readonly descriptorName: string;
+  readonly scope: StaticCssEvalBabelScope;
+}): boolean {
+  const [getter, enumerable] = options.descriptor.properties;
+
+  return (
+    options.descriptor.properties.length === 2 &&
+    isExpectedGetterProperty(getter, options.sourceName, options.keyName) &&
+    isExpectedEnumerableProperty({
+      property: enumerable,
+      sourceName: options.sourceName,
+      keyName: options.keyName,
+      descriptorName: options.descriptorName,
+      scope: options.scope
+    })
+  );
+}
+
+function isExpectedGetterProperty(
+  property: t.ObjectExpression["properties"][number] | undefined,
+  sourceName: string,
+  keyName: string
+): boolean {
+  return (
+    t.isObjectProperty(property) &&
+    !property.computed &&
+    getObjectKeyName(property.key) === "get" &&
+    t.isExpression(property.value) &&
+    isZeroArgGetterForMember(property.value, sourceName, keyName)
+  );
+}
+
+function isExpectedEnumerableProperty(options: {
+  readonly property: t.ObjectExpression["properties"][number] | undefined;
+  readonly sourceName: string;
+  readonly keyName: string;
+  readonly descriptorName: string;
+  readonly scope: StaticCssEvalBabelScope;
+}): boolean {
+  return (
+    t.isObjectProperty(options.property) &&
+    !options.property.computed &&
+    getObjectKeyName(options.property.key) === "enumerable" &&
+    t.isExpression(options.property.value) &&
+    isExpectedEnumerableExpression({
+      expression: options.property.value,
+      sourceName: options.sourceName,
+      keyName: options.keyName,
+      descriptorName: options.descriptorName,
+      scope: options.scope
+    })
+  );
+}
+
+function isExpectedEnumerableExpression(options: {
+  readonly expression: t.Expression;
+  readonly sourceName: string;
+  readonly keyName: string;
+  readonly descriptorName: string;
+  readonly scope: StaticCssEvalBabelScope;
+}): boolean {
+  return (
+    t.isLogicalExpression(options.expression, { operator: "||" }) &&
+    t.isUnaryExpression(options.expression.left, { operator: "!" }) &&
+    isDescriptorAssignment({
+      expression: options.expression.left.argument,
+      sourceName: options.sourceName,
+      keyName: options.keyName,
+      descriptorName: options.descriptorName,
+      scope: options.scope
+    }) &&
+    t.isMemberExpression(options.expression.right) &&
+    !options.expression.right.computed &&
+    t.isIdentifier(options.expression.right.object, {
+      name: options.descriptorName
+    }) &&
+    t.isIdentifier(options.expression.right.property, { name: "enumerable" })
+  );
+}
+
+function isDescriptorAssignment(options: {
+  readonly expression: t.Node;
+  readonly sourceName: string;
+  readonly keyName: string;
+  readonly descriptorName: string;
+  readonly scope: StaticCssEvalBabelScope;
+}): boolean {
+  return (
+    t.isAssignmentExpression(options.expression, { operator: "=" }) &&
+    t.isIdentifier(options.expression.left, { name: options.descriptorName }) &&
+    isOwnPropertyDescriptorCall({
+      expression: options.expression.right,
+      sourceName: options.sourceName,
+      keyName: options.keyName,
+      scope: options.scope
+    })
+  );
+}
+
+function isOwnPropertyDescriptorCall(options: {
+  readonly expression: t.Expression;
+  readonly sourceName: string;
+  readonly keyName: string;
+  readonly scope: StaticCssEvalBabelScope;
+}): boolean {
+  return (
+    t.isCallExpression(options.expression) &&
+    options.expression.arguments.length === 2 &&
+    isObjectGetOwnPropertyDescriptorReference(
+      options.expression.callee,
+      options.scope
+    ) &&
+    t.isIdentifier(options.expression.arguments[0], {
+      name: options.sourceName
+    }) &&
+    t.isIdentifier(options.expression.arguments[1], { name: options.keyName })
+  );
+}
+
+function isZeroArgGetterForMember(
+  expression: t.Expression,
+  sourceName: string,
+  keyName: string
+): boolean {
+  if (
+    !t.isArrowFunctionExpression(expression) ||
+    expression.params.length !== 0
+  ) {
+    return false;
+  }
+
+  return (
+    t.isMemberExpression(expression.body) &&
+    expression.body.computed &&
+    t.isIdentifier(expression.body.object, { name: sourceName }) &&
+    t.isIdentifier(expression.body.property, { name: keyName })
+  );
+}

--- a/packages/babel/src/staticCssEval/cjsEsbuildCopyPropsGuards.ts
+++ b/packages/babel/src/staticCssEval/cjsEsbuildCopyPropsGuards.ts
@@ -1,0 +1,98 @@
+import { types as t } from "@babel/core";
+import type { StaticCssEvalBabelScope } from "./cjsHelperLookup.js";
+import {
+  isObjectGetOwnPropertyNamesReference,
+  isObjectHasOwnPropertyReference
+} from "./cjsEsbuildObjectHelperReferences.js";
+
+export function isExpectedSourceTypeGuard(
+  expression: t.Expression,
+  sourceName: string
+): boolean {
+  return (
+    t.isLogicalExpression(expression, { operator: "||" }) &&
+    t.isLogicalExpression(expression.left, { operator: "&&" }) &&
+    t.isIdentifier(expression.left.left, { name: sourceName }) &&
+    isTypeofCheck(expression.left.right, sourceName, "object") &&
+    isTypeofCheck(expression.right, sourceName, "function")
+  );
+}
+
+export function isOwnPropertyNamesCall(options: {
+  readonly expression: t.Expression;
+  readonly sourceName: string;
+  readonly scope: StaticCssEvalBabelScope;
+}): boolean {
+  return (
+    t.isCallExpression(options.expression) &&
+    options.expression.arguments.length === 1 &&
+    isObjectGetOwnPropertyNamesReference(
+      options.expression.callee,
+      options.scope
+    ) &&
+    t.isIdentifier(options.expression.arguments[0], {
+      name: options.sourceName
+    })
+  );
+}
+
+export function isExpectedCopyGuard(options: {
+  readonly expression: t.Expression;
+  readonly targetName: string;
+  readonly keyName: string;
+  readonly exceptName: string;
+  readonly scope: StaticCssEvalBabelScope;
+}): boolean {
+  return (
+    t.isLogicalExpression(options.expression, { operator: "&&" }) &&
+    isNegatedHasOwnPropCall({
+      expression: options.expression.left,
+      targetName: options.targetName,
+      keyName: options.keyName,
+      scope: options.scope
+    }) &&
+    t.isBinaryExpression(options.expression.right, { operator: "!==" }) &&
+    t.isIdentifier(options.expression.right.left, { name: options.keyName }) &&
+    t.isIdentifier(options.expression.right.right, { name: options.exceptName })
+  );
+}
+
+function isNegatedHasOwnPropCall(options: {
+  readonly expression: t.Expression;
+  readonly targetName: string;
+  readonly keyName: string;
+  readonly scope: StaticCssEvalBabelScope;
+}): boolean {
+  const callExpression = t.isUnaryExpression(options.expression, {
+    operator: "!"
+  })
+    ? options.expression.argument
+    : null;
+
+  return (
+    t.isCallExpression(callExpression) &&
+    callExpression.arguments.length === 2 &&
+    t.isMemberExpression(callExpression.callee) &&
+    !callExpression.callee.computed &&
+    t.isIdentifier(callExpression.callee.property, { name: "call" }) &&
+    isObjectHasOwnPropertyReference(
+      callExpression.callee.object,
+      options.scope
+    ) &&
+    t.isIdentifier(callExpression.arguments[0], { name: options.targetName }) &&
+    t.isIdentifier(callExpression.arguments[1], { name: options.keyName })
+  );
+}
+
+function isTypeofCheck(
+  expression: t.Expression,
+  sourceName: string,
+  typeName: "function" | "object"
+): boolean {
+  return (
+    t.isBinaryExpression(expression, { operator: "===" }) &&
+    t.isUnaryExpression(expression.left, { operator: "typeof" }) &&
+    t.isIdentifier(expression.left.argument, { name: sourceName }) &&
+    t.isStringLiteral(expression.right, { value: typeName })
+  );
+}

--- a/packages/babel/src/staticCssEval/cjsEsbuildExportHelperFingerprint.ts
+++ b/packages/babel/src/staticCssEval/cjsEsbuildExportHelperFingerprint.ts
@@ -1,0 +1,112 @@
+import { types as t } from "@babel/core";
+import type { StaticCssEvalBabelScope } from "./cjsHelperLookup.js";
+import { getSingleBodyStatement } from "./cjsHelperLookup.js";
+import {
+  getBoundEsbuildHelperFunctions,
+  getForInKeyName,
+  getIdentifierParamName,
+  getObjectKeyName,
+  getOnlyBodyStatement,
+  isObjectDefinePropertyReference,
+  type EsbuildHelperFunction
+} from "./cjsEsbuildHelperLookup.js";
+
+export function isSupportedEsbuildExportHelper(
+  helperName: string,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  const helperFunctions = getBoundEsbuildHelperFunctions(helperName, scope);
+  return (
+    helperFunctions.length > 0 &&
+    helperFunctions.every((helperFunction) =>
+      isExportFunction(helperFunction, scope)
+    )
+  );
+}
+
+function isExportFunction(
+  helperFunction: EsbuildHelperFunction,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  const targetName = getIdentifierParamName(helperFunction, 0);
+  const allName = getIdentifierParamName(helperFunction, 1);
+  const statement = getOnlyBodyStatement(helperFunction);
+
+  if (!targetName || !allName || !statement || !t.isForInStatement(statement)) {
+    return false;
+  }
+
+  const keyName = getForInKeyName(statement.left);
+
+  return (
+    keyName !== null &&
+    t.isIdentifier(statement.right, { name: allName }) &&
+    isExportDefinePropertyStatement({
+      statement: statement.body,
+      targetName,
+      allName,
+      keyName,
+      scope
+    })
+  );
+}
+
+function isExportDefinePropertyStatement(options: {
+  readonly statement: t.Statement;
+  readonly targetName: string;
+  readonly allName: string;
+  readonly keyName: string;
+  readonly scope: StaticCssEvalBabelScope;
+}): boolean {
+  const bodyStatement = getSingleBodyStatement(options.statement);
+
+  if (!bodyStatement || !t.isExpressionStatement(bodyStatement)) {
+    return false;
+  }
+
+  const expression = bodyStatement.expression;
+  const descriptor = t.isCallExpression(expression)
+    ? expression.arguments[2]
+    : null;
+
+  return (
+    t.isCallExpression(expression) &&
+    isObjectDefinePropertyReference(expression.callee, options.scope) &&
+    t.isIdentifier(expression.arguments[0], { name: options.targetName }) &&
+    t.isIdentifier(expression.arguments[1], { name: options.keyName }) &&
+    t.isObjectExpression(descriptor) &&
+    descriptorHasExportGetter(descriptor, options.allName, options.keyName)
+  );
+}
+
+function descriptorHasExportGetter(
+  descriptor: t.ObjectExpression,
+  allName: string,
+  keyName: string
+): boolean {
+  let hasExportGetter = false;
+
+  for (const property of descriptor.properties) {
+    if (!t.isObjectProperty(property) || property.computed) {
+      return false;
+    }
+
+    if (getObjectKeyName(property.key) !== "get") {
+      continue;
+    }
+
+    if (
+      hasExportGetter ||
+      !t.isMemberExpression(property.value) ||
+      !property.value.computed ||
+      !t.isIdentifier(property.value.object, { name: allName }) ||
+      !t.isIdentifier(property.value.property, { name: keyName })
+    ) {
+      return false;
+    }
+
+    hasExportGetter = true;
+  }
+
+  return hasExportGetter;
+}

--- a/packages/babel/src/staticCssEval/cjsEsbuildHelperLookup.ts
+++ b/packages/babel/src/staticCssEval/cjsEsbuildHelperLookup.ts
@@ -1,0 +1,151 @@
+import { types as t } from "@babel/core";
+import type { StaticCssEvalBabelScope } from "./cjsHelperLookup.js";
+
+export type EsbuildHelperFunction =
+  | t.ArrowFunctionExpression
+  | t.FunctionDeclaration
+  | t.FunctionExpression;
+
+type EsbuildHelperExpression = t.ArrowFunctionExpression | t.FunctionExpression;
+
+export function getBoundEsbuildHelperFunctions(
+  helperName: string,
+  scope: StaticCssEvalBabelScope
+): EsbuildHelperFunction[] {
+  const binding = scope.getBinding(helperName);
+
+  if (!binding) {
+    return [];
+  }
+
+  if (
+    binding.path.isFunctionDeclaration() &&
+    binding.path.node.id?.name === helperName
+  ) {
+    return [binding.path.node];
+  }
+
+  if (
+    binding.path.isVariableDeclarator() &&
+    t.isIdentifier(binding.path.node.id, { name: helperName }) &&
+    isEsbuildHelperFunction(binding.path.node.init)
+  ) {
+    return [binding.path.node.init];
+  }
+
+  return [];
+}
+
+export function getIdentifierParamName(
+  helperFunction: EsbuildHelperFunction,
+  index: number
+): string | null {
+  const param = helperFunction.params[index];
+  return param && t.isIdentifier(param) ? param.name : null;
+}
+
+export function getOnlyBodyStatement(
+  helperFunction: EsbuildHelperFunction
+): t.Statement | null {
+  if (!t.isBlockStatement(helperFunction.body)) {
+    return null;
+  }
+
+  const [statement] = helperFunction.body.body;
+  return helperFunction.body.body.length === 1 && statement ? statement : null;
+}
+
+export function getReturnExpression(
+  helperFunction: EsbuildHelperFunction
+): t.Expression | null {
+  if (
+    t.isArrowFunctionExpression(helperFunction) &&
+    t.isExpression(helperFunction.body)
+  ) {
+    return helperFunction.body;
+  }
+
+  const statement = getOnlyBodyStatement(helperFunction);
+  return statement &&
+    t.isReturnStatement(statement) &&
+    t.isExpression(statement.argument)
+    ? statement.argument
+    : null;
+}
+
+export function getForInKeyName(
+  left: t.ForInStatement["left"] | t.ForOfStatement["left"]
+): string | null {
+  if (t.isIdentifier(left)) {
+    return left.name;
+  }
+
+  if (!t.isVariableDeclaration(left) || left.declarations.length !== 1) {
+    return null;
+  }
+
+  const [declaration] = left.declarations;
+  return declaration && t.isIdentifier(declaration.id)
+    ? declaration.id.name
+    : null;
+}
+
+export function getObjectKeyName(key: t.ObjectProperty["key"]): string | null {
+  if (t.isIdentifier(key)) {
+    return key.name;
+  }
+
+  return t.isStringLiteral(key) ? key.value : null;
+}
+
+export function isObjectDefinePropertyReference(
+  expression: t.Expression | t.V8IntrinsicIdentifier,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  if (isObjectMethodReference(expression, "defineProperty", scope)) {
+    return true;
+  }
+
+  if (!t.isIdentifier(expression)) {
+    return false;
+  }
+
+  const binding = scope.getBinding(expression.name);
+  return (
+    binding?.path.isVariableDeclarator() === true &&
+    isObjectMethodReference(binding.path.node.init, "defineProperty", scope)
+  );
+}
+
+export function isReturnIdentifierStatement(
+  statement: t.Statement,
+  identifierName: string
+): boolean {
+  return (
+    t.isReturnStatement(statement) &&
+    t.isIdentifier(statement.argument, { name: identifierName })
+  );
+}
+
+function isObjectMethodReference(
+  expression: t.Node | null | undefined,
+  methodName: string,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  return (
+    t.isMemberExpression(expression) &&
+    !expression.computed &&
+    t.isIdentifier(expression.object, { name: "Object" }) &&
+    !scope.getBinding("Object") &&
+    t.isIdentifier(expression.property, { name: methodName })
+  );
+}
+
+function isEsbuildHelperFunction(
+  expression: t.Expression | null | undefined
+): expression is EsbuildHelperExpression {
+  return (
+    t.isArrowFunctionExpression(expression) ||
+    t.isFunctionExpression(expression)
+  );
+}

--- a/packages/babel/src/staticCssEval/cjsEsbuildHelpers.ts
+++ b/packages/babel/src/staticCssEval/cjsEsbuildHelpers.ts
@@ -1,0 +1,301 @@
+import { types as t } from "@babel/core";
+import type { NodePath } from "@babel/core";
+import {
+  createBundleRuntimeUnsupportedOperation,
+  createExpressionSetOperation,
+  createHelperUnsupportedOperation
+} from "./cjsExportOperationEntries.js";
+import {
+  getCjsAssignmentTarget,
+  getCjsExportSurfaceExpression
+} from "./cjsExportTargets.js";
+import { getObjectKeyName } from "./cjsEsbuildHelperLookup.js";
+import { isSupportedEsbuildExportHelper } from "./cjsEsbuildExportHelperFingerprint.js";
+import { isSupportedEsbuildToCommonJsHelper } from "./cjsEsbuildToCommonJsHelperFingerprint.js";
+import type {
+  StaticCssEvalCjsExportMapOperation,
+  StaticCssEvalCjsExportState
+} from "./cjsExports.js";
+import type { StaticCssEvalExportName } from "./types.js";
+
+type StaticCssEvalBabelScope = NodePath<t.Node>["scope"];
+
+const commonJsBundleRuntimeHelpers = new Set([
+  "__commonJS",
+  "__require",
+  "__esm",
+  "__webpack_modules__",
+  "__webpack_require__",
+  "__turbopack_context__",
+  "__turbopack_require__",
+  "$parcel$require",
+  "parcelRequire",
+  "webpackJsonp"
+]);
+
+export function collectEsbuildBundleRuntimeOperations(options: {
+  readonly state: StaticCssEvalCjsExportState;
+  readonly statementPath: NodePath<t.Statement>;
+}): StaticCssEvalCjsExportMapOperation[] {
+  const runtimeName = getEsbuildBundleRuntimeName(options.statementPath.node);
+
+  return runtimeName
+    ? [
+        createBundleRuntimeUnsupportedOperation({
+          declaration: options.statementPath.node,
+          node: options.statementPath.node,
+          runtimeName,
+          state: options.state
+        })
+      ]
+    : [];
+}
+
+export function collectEsbuildHelperOperations(options: {
+  readonly expression: t.CallExpression;
+  readonly state: StaticCssEvalCjsExportState;
+  readonly statementPath: NodePath<t.Statement>;
+}): StaticCssEvalCjsExportMapOperation[] | null {
+  if (!t.isIdentifier(options.expression.callee, { name: "__export" })) {
+    return null;
+  }
+
+  const [target, getters] = options.expression.arguments;
+  const targetSurface = t.isExpression(target)
+    ? getEsbuildExportTargetSurface(target, options.statementPath)
+    : null;
+
+  if (
+    !isSupportedEsbuildExportHelper("__export", options.statementPath.scope) ||
+    !targetSurface ||
+    (targetSurface === "exports"
+      ? !options.state.exportsAliasSafe
+      : !options.state.moduleObjectLike) ||
+    !t.isObjectExpression(getters)
+  ) {
+    return [createEsbuildHelperUnsupportedOperation(options, null)];
+  }
+
+  return getters.properties.map((property) =>
+    createEsbuildExportOperation({ ...options, property })
+  );
+}
+
+function getEsbuildExportTargetSurface(
+  target: t.Expression,
+  statementPath: NodePath<t.Statement>
+) {
+  const { scope } = statementPath;
+  const targetSurface = getCjsExportSurfaceExpression(target, scope);
+
+  if (targetSurface || !t.isIdentifier(target)) {
+    return targetSurface;
+  }
+
+  const binding = scope.getBinding(target.name);
+
+  if (
+    !binding ||
+    !binding.constant ||
+    binding.kind !== "const" ||
+    !binding.path.isVariableDeclarator()
+  ) {
+    return null;
+  }
+
+  const declarationPath = binding.path.parentPath;
+  const programPath = statementPath.parentPath;
+
+  if (
+    !declarationPath?.isVariableDeclaration({ kind: "const" }) ||
+    !programPath?.isProgram() ||
+    declarationPath.parentPath?.node !== programPath.node
+  ) {
+    return null;
+  }
+
+  const statements = programPath.node.body;
+  const declarationIndex = statements.indexOf(declarationPath.node);
+  const statementIndex = statements.indexOf(statementPath.node);
+
+  if (declarationIndex < 0 || declarationIndex >= statementIndex) {
+    return null;
+  }
+
+  const { init } = binding.path.node;
+  const aliasSurface =
+    init && t.isExpression(init)
+      ? getCjsExportSurfaceExpression(init, binding.scope)
+      : null;
+
+  return aliasSurface === "module.exports" &&
+    statements
+      .slice(declarationIndex + 1, statementIndex)
+      .some(
+        (statement) =>
+          t.isExpressionStatement(statement) &&
+          t.isAssignmentExpression(statement.expression) &&
+          getCjsAssignmentTarget(statement.expression.left, scope).kind ===
+            "module-replacement"
+      )
+    ? null
+    : aliasSurface;
+}
+
+export function collectEsbuildModuleReplacementOperations(options: {
+  readonly declaration: t.Statement;
+  readonly expression: t.AssignmentExpression;
+  readonly scope: StaticCssEvalBabelScope;
+  readonly state: StaticCssEvalCjsExportState;
+}): StaticCssEvalCjsExportMapOperation[] | null {
+  const target = getCjsAssignmentTarget(options.expression.left, options.scope);
+
+  if (target.kind !== "module-replacement") {
+    return null;
+  }
+
+  const right = options.expression.right;
+
+  if (!t.isCallExpression(right) || !t.isIdentifier(right.callee)) {
+    return null;
+  }
+
+  if (commonJsBundleRuntimeHelpers.has(right.callee.name)) {
+    options.state.exportsAliasSafe = false;
+    options.state.moduleObjectLike = false;
+
+    return [
+      { kind: "clear-cjs-exports" },
+      createBundleRuntimeUnsupportedOperation({
+        declaration: options.declaration,
+        node: options.expression,
+        runtimeName: right.callee.name,
+        state: options.state
+      })
+    ];
+  }
+
+  if (right.callee.name !== "__toCommonJS") {
+    return null;
+  }
+
+  options.state.exportsAliasSafe = false;
+  options.state.moduleObjectLike = false;
+
+  return isSupportedEsbuildToCommonJsHelper(right.callee.name, options.scope)
+    ? [{ kind: "preserve-cjs-exports" }]
+    : [
+        { kind: "clear-cjs-exports" },
+        createHelperUnsupportedOperation({
+          declaration: options.declaration,
+          exportName: null,
+          helperName: right.callee.name,
+          node: options.expression,
+          state: options.state
+        })
+      ];
+}
+
+function createEsbuildExportOperation(options: {
+  readonly expression: t.CallExpression;
+  readonly property: t.ObjectExpression["properties"][number];
+  readonly state: StaticCssEvalCjsExportState;
+  readonly statementPath: NodePath<t.Statement>;
+}): StaticCssEvalCjsExportMapOperation {
+  const exportName = getEsbuildExportName(options.property);
+  const expression = getEsbuildGetterExpression(options.property);
+
+  return exportName && expression
+    ? createExpressionSetOperation(
+        exportName,
+        expression,
+        options.statementPath.node
+      )
+    : createEsbuildHelperUnsupportedOperation(options, exportName);
+}
+
+function getEsbuildExportName(
+  property: t.ObjectExpression["properties"][number]
+): StaticCssEvalExportName {
+  return t.isObjectProperty(property) && !property.computed
+    ? getObjectKeyName(property.key)
+    : null;
+}
+
+function getEsbuildGetterExpression(
+  property: t.ObjectExpression["properties"][number]
+): t.Expression | null {
+  if (
+    !t.isObjectProperty(property) ||
+    !t.isArrowFunctionExpression(property.value) ||
+    property.value.params.length !== 0 ||
+    !t.isExpression(property.value.body)
+  ) {
+    return null;
+  }
+
+  return t.isIdentifier(property.value.body) ||
+    t.isMemberExpression(property.value.body)
+    ? property.value.body
+    : null;
+}
+
+function createEsbuildHelperUnsupportedOperation(
+  options: {
+    readonly expression: t.CallExpression;
+    readonly state: StaticCssEvalCjsExportState;
+    readonly statementPath: NodePath<t.Statement>;
+  },
+  exportName: StaticCssEvalExportName
+): StaticCssEvalCjsExportMapOperation {
+  return createHelperUnsupportedOperation({
+    declaration: options.statementPath.node,
+    exportName,
+    helperName: "__export",
+    node: options.expression,
+    state: options.state
+  });
+}
+
+function getEsbuildBundleRuntimeName(statement: t.Statement): string | null {
+  if (t.isFunctionDeclaration(statement) && statement.id) {
+    return commonJsBundleRuntimeHelpers.has(statement.id.name)
+      ? statement.id.name
+      : null;
+  }
+
+  if (t.isVariableDeclaration(statement)) {
+    for (const declaration of statement.declarations) {
+      const idName = t.isIdentifier(declaration.id)
+        ? declaration.id.name
+        : null;
+      const calleeName = getCallCalleeName(declaration.init);
+
+      if (idName && commonJsBundleRuntimeHelpers.has(idName)) {
+        return idName;
+      }
+
+      if (calleeName && commonJsBundleRuntimeHelpers.has(calleeName)) {
+        return calleeName;
+      }
+    }
+  }
+
+  if (!t.isExpressionStatement(statement)) {
+    return null;
+  }
+
+  const calleeName = t.isAssignmentExpression(statement.expression)
+    ? getCallCalleeName(statement.expression.right)
+    : getCallCalleeName(statement.expression);
+
+  return calleeName && commonJsBundleRuntimeHelpers.has(calleeName)
+    ? calleeName
+    : null;
+}
+
+function getCallCalleeName(node: t.Node | null | undefined): string | null {
+  return t.isCallExpression(node) && t.isIdentifier(node.callee)
+    ? node.callee.name
+    : null;
+}

--- a/packages/babel/src/staticCssEval/cjsEsbuildObjectHelperReferences.ts
+++ b/packages/babel/src/staticCssEval/cjsEsbuildObjectHelperReferences.ts
@@ -1,0 +1,85 @@
+import { types as t } from "@babel/core";
+import type { StaticCssEvalBabelScope } from "./cjsHelperLookup.js";
+
+export function isObjectGetOwnPropertyNamesReference(
+  expression: t.Expression | t.V8IntrinsicIdentifier,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  return isObjectMethodReference(expression, "getOwnPropertyNames", scope);
+}
+
+export function isObjectGetOwnPropertyDescriptorReference(
+  expression: t.Expression | t.V8IntrinsicIdentifier,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  return isObjectMethodReference(expression, "getOwnPropertyDescriptor", scope);
+}
+
+export function isObjectHasOwnPropertyReference(
+  expression: t.Expression | t.Super,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  if (isObjectHasOwnPropertyMemberExpression(expression, scope)) {
+    return true;
+  }
+
+  if (!t.isIdentifier(expression)) {
+    return false;
+  }
+
+  const binding = scope.getBinding(expression.name);
+  return (
+    binding?.path.isVariableDeclarator() === true &&
+    isObjectHasOwnPropertyMemberExpression(binding.path.node.init, scope)
+  );
+}
+
+function isObjectMethodReference(
+  expression: t.Expression | t.V8IntrinsicIdentifier,
+  methodName: string,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  if (isObjectMethodMemberExpression(expression, methodName, scope)) {
+    return true;
+  }
+
+  if (!t.isIdentifier(expression)) {
+    return false;
+  }
+
+  const binding = scope.getBinding(expression.name);
+  return (
+    binding?.path.isVariableDeclarator() === true &&
+    isObjectMethodMemberExpression(binding.path.node.init, methodName, scope)
+  );
+}
+
+function isObjectMethodMemberExpression(
+  expression: t.Node | null | undefined,
+  methodName: string,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  return (
+    t.isMemberExpression(expression) &&
+    !expression.computed &&
+    t.isIdentifier(expression.object, { name: "Object" }) &&
+    !scope.getBinding("Object") &&
+    t.isIdentifier(expression.property, { name: methodName })
+  );
+}
+
+function isObjectHasOwnPropertyMemberExpression(
+  expression: t.Node | null | undefined,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  return (
+    t.isMemberExpression(expression) &&
+    !expression.computed &&
+    t.isMemberExpression(expression.object) &&
+    !expression.object.computed &&
+    t.isIdentifier(expression.object.object, { name: "Object" }) &&
+    !scope.getBinding("Object") &&
+    t.isIdentifier(expression.object.property, { name: "prototype" }) &&
+    t.isIdentifier(expression.property, { name: "hasOwnProperty" })
+  );
+}

--- a/packages/babel/src/staticCssEval/cjsEsbuildToCommonJsHelperFingerprint.ts
+++ b/packages/babel/src/staticCssEval/cjsEsbuildToCommonJsHelperFingerprint.ts
@@ -1,0 +1,242 @@
+import { types as t } from "@babel/core";
+import { isCopyPropsDefinePropertyStatement } from "./cjsEsbuildCopyPropsDescriptorFingerprint.js";
+import {
+  isExpectedCopyGuard,
+  isExpectedSourceTypeGuard,
+  isOwnPropertyNamesCall
+} from "./cjsEsbuildCopyPropsGuards.js";
+import type { StaticCssEvalBabelScope } from "./cjsHelperLookup.js";
+import { getSingleBodyStatement } from "./cjsHelperLookup.js";
+import {
+  getBoundEsbuildHelperFunctions,
+  getForInKeyName,
+  getIdentifierParamName,
+  getObjectKeyName,
+  getReturnExpression,
+  isObjectDefinePropertyReference,
+  isReturnIdentifierStatement,
+  type EsbuildHelperFunction
+} from "./cjsEsbuildHelperLookup.js";
+
+export function isSupportedEsbuildToCommonJsHelper(
+  helperName: string,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  const helperFunctions = getBoundEsbuildHelperFunctions(helperName, scope);
+  return (
+    helperFunctions.length > 0 &&
+    helperFunctions.every((helperFunction) =>
+      isToCommonJsFunction(helperFunction, scope)
+    )
+  );
+}
+
+function isToCommonJsFunction(
+  helperFunction: EsbuildHelperFunction,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  const moduleName = getIdentifierParamName(helperFunction, 0);
+  const expression = getReturnExpression(helperFunction);
+
+  return (
+    moduleName !== null &&
+    expression !== null &&
+    isCopyPropsWrapperExpression({ expression, moduleName, scope })
+  );
+}
+
+function isCopyPropsWrapperExpression(options: {
+  readonly expression: t.Expression;
+  readonly moduleName: string;
+  readonly scope: StaticCssEvalBabelScope;
+}): boolean {
+  if (!t.isCallExpression(options.expression)) {
+    return false;
+  }
+
+  const [target, source] = options.expression.arguments;
+  return (
+    t.isIdentifier(options.expression.callee) &&
+    isSupportedEsbuildCopyPropsHelper(
+      options.expression.callee.name,
+      options.scope
+    ) &&
+    t.isExpression(target) &&
+    isEsModuleMarkerExpression(target, options.scope) &&
+    t.isIdentifier(source, { name: options.moduleName })
+  );
+}
+
+function isSupportedEsbuildCopyPropsHelper(
+  helperName: string,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  const helperFunctions = getBoundEsbuildHelperFunctions(helperName, scope);
+  return (
+    helperFunctions.length > 0 &&
+    helperFunctions.every((helperFunction) =>
+      isCopyPropsFunction(helperFunction, scope)
+    )
+  );
+}
+
+function isCopyPropsFunction(
+  helperFunction: EsbuildHelperFunction,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  const parts = getCopyPropsFunctionParts(helperFunction);
+
+  return (
+    parts !== null &&
+    isCopyPropsGuardedLoop({
+      statement: parts.guardStatement,
+      targetName: parts.targetName,
+      sourceName: parts.sourceName,
+      exceptName: parts.exceptName,
+      descriptorName: parts.descriptorName,
+      scope
+    }) &&
+    isReturnIdentifierStatement(parts.returnStatement, parts.targetName)
+  );
+}
+
+type CopyPropsFunctionParts = {
+  readonly targetName: string;
+  readonly sourceName: string;
+  readonly exceptName: string;
+  readonly descriptorName: string;
+  readonly guardStatement: t.IfStatement;
+  readonly returnStatement: t.Statement;
+};
+
+function getCopyPropsFunctionParts(
+  helperFunction: EsbuildHelperFunction
+): CopyPropsFunctionParts | null {
+  const targetName = getIdentifierParamName(helperFunction, 0);
+  const sourceName = getIdentifierParamName(helperFunction, 1);
+  const exceptName = getIdentifierParamName(helperFunction, 2);
+  const descriptorName = getIdentifierParamName(helperFunction, 3);
+
+  if (
+    !targetName ||
+    !sourceName ||
+    !exceptName ||
+    !descriptorName ||
+    !t.isBlockStatement(helperFunction.body)
+  ) {
+    return null;
+  }
+
+  const [guardStatement, returnStatement] = helperFunction.body.body;
+
+  return helperFunction.body.body.length === 2 &&
+    t.isIfStatement(guardStatement) &&
+    returnStatement
+    ? {
+        targetName,
+        sourceName,
+        exceptName,
+        descriptorName,
+        guardStatement,
+        returnStatement
+      }
+    : null;
+}
+
+function isCopyPropsGuardedLoop(options: {
+  readonly statement: t.IfStatement;
+  readonly targetName: string;
+  readonly sourceName: string;
+  readonly exceptName: string;
+  readonly descriptorName: string;
+  readonly scope: StaticCssEvalBabelScope;
+}): boolean {
+  if (!isExpectedSourceTypeGuard(options.statement.test, options.sourceName)) {
+    return false;
+  }
+
+  const bodyStatement = getSingleBodyStatement(options.statement.consequent);
+
+  return (
+    t.isForOfStatement(bodyStatement) &&
+    isCopyPropsForOfStatement({
+      statement: bodyStatement,
+      targetName: options.targetName,
+      sourceName: options.sourceName,
+      exceptName: options.exceptName,
+      descriptorName: options.descriptorName,
+      scope: options.scope
+    })
+  );
+}
+
+function isCopyPropsForOfStatement(options: {
+  readonly statement: t.ForOfStatement;
+  readonly targetName: string;
+  readonly sourceName: string;
+  readonly exceptName: string;
+  readonly descriptorName: string;
+  readonly scope: StaticCssEvalBabelScope;
+}): boolean {
+  const keyName = getForInKeyName(options.statement.left);
+  const bodyStatement = getSingleBodyStatement(options.statement.body);
+
+  return (
+    keyName !== null &&
+    isOwnPropertyNamesCall({
+      expression: options.statement.right,
+      sourceName: options.sourceName,
+      scope: options.scope
+    }) &&
+    bodyStatement !== null &&
+    t.isIfStatement(bodyStatement) &&
+    isExpectedCopyGuard({
+      expression: bodyStatement.test,
+      targetName: options.targetName,
+      keyName,
+      exceptName: options.exceptName,
+      scope: options.scope
+    }) &&
+    isCopyPropsDefinePropertyStatement({
+      statement: bodyStatement.consequent,
+      targetName: options.targetName,
+      sourceName: options.sourceName,
+      keyName,
+      descriptorName: options.descriptorName,
+      scope: options.scope
+    })
+  );
+}
+
+function isEsModuleMarkerExpression(
+  expression: t.Expression,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  const [target, key, descriptor] = t.isCallExpression(expression)
+    ? expression.arguments
+    : [];
+
+  return (
+    t.isCallExpression(expression) &&
+    expression.arguments.length === 3 &&
+    isObjectDefinePropertyReference(expression.callee, scope) &&
+    t.isObjectExpression(target) &&
+    target.properties.length === 0 &&
+    t.isStringLiteral(key, { value: "__esModule" }) &&
+    t.isObjectExpression(descriptor) &&
+    hasTrueValueDescriptor(descriptor)
+  );
+}
+
+function hasTrueValueDescriptor(descriptor: t.ObjectExpression): boolean {
+  return (
+    descriptor.properties.length === 1 &&
+    descriptor.properties.some(
+      (property) =>
+        t.isObjectProperty(property) &&
+        !property.computed &&
+        getObjectKeyName(property.key) === "value" &&
+        t.isBooleanLiteral(property.value, { value: true })
+    )
+  );
+}

--- a/packages/babel/src/staticCssEval/cjsExportDescriptors.ts
+++ b/packages/babel/src/staticCssEval/cjsExportDescriptors.ts
@@ -1,0 +1,122 @@
+import { types as t } from "@babel/core";
+import { getStaticCssEvalMemberReference } from "./candidates.js";
+
+export type StaticCssEvalCjsDescriptorExpressionResult =
+  | { readonly kind: "supported"; readonly expression: t.Expression }
+  | { readonly kind: "unsupported"; readonly mutation: string };
+
+export function getDefinePropertyDescriptorExpression(
+  expression: t.CallExpression
+): StaticCssEvalCjsDescriptorExpressionResult {
+  const descriptor = expression.arguments[2];
+
+  if (!descriptor || !t.isObjectExpression(descriptor)) {
+    return {
+      kind: "unsupported",
+      mutation: "Object.defineProperty descriptor is dynamic"
+    };
+  }
+
+  let valueExpression: t.Expression | null = null;
+  let getterExpression: t.Expression | null = null;
+
+  for (const property of descriptor.properties) {
+    if (t.isSpreadElement(property)) {
+      return {
+        kind: "unsupported",
+        mutation: "Object.defineProperty descriptor spread"
+      };
+    }
+
+    if (!t.isObjectProperty(property) || property.computed) {
+      return {
+        kind: "unsupported",
+        mutation: "Object.defineProperty descriptor has unsupported key"
+      };
+    }
+
+    const keyName = getObjectKeyName(property.key);
+
+    if (keyName === "set") {
+      return {
+        kind: "unsupported",
+        mutation: "Object.defineProperty setter descriptor"
+      };
+    }
+
+    if (keyName === "value" && t.isExpression(property.value)) {
+      valueExpression = property.value;
+      continue;
+    }
+
+    if (keyName === "get") {
+      if (
+        !t.isFunctionExpression(property.value) ||
+        property.value.async ||
+        property.value.generator
+      ) {
+        return {
+          kind: "unsupported",
+          mutation: "Object.defineProperty getter is dynamic"
+        };
+      }
+
+      getterExpression = getStaticGetterReturnExpression(property.value);
+
+      if (!getterExpression) {
+        return {
+          kind: "unsupported",
+          mutation:
+            "Object.defineProperty getter must return one identifier or member expression"
+        };
+      }
+    }
+  }
+
+  if (valueExpression && getterExpression) {
+    return {
+      kind: "unsupported",
+      mutation: "Object.defineProperty descriptor mixes value and getter"
+    };
+  }
+
+  if (valueExpression) {
+    return { kind: "supported", expression: valueExpression };
+  }
+
+  return getterExpression
+    ? { kind: "supported", expression: getterExpression }
+    : {
+        kind: "unsupported",
+        mutation: "Object.defineProperty descriptor has no static value"
+      };
+}
+
+export function getObjectKeyName(key: t.ObjectProperty["key"]): string | null {
+  if (t.isIdentifier(key)) {
+    return key.name;
+  }
+
+  return t.isStringLiteral(key) ? key.value : null;
+}
+
+function getStaticGetterReturnExpression(
+  expression: t.FunctionExpression
+): t.Expression | null {
+  const [statement] = expression.body.body;
+
+  if (
+    expression.params.length !== 0 ||
+    expression.body.body.length !== 1 ||
+    !statement ||
+    !t.isReturnStatement(statement) ||
+    !statement.argument ||
+    !t.isExpression(statement.argument)
+  ) {
+    return null;
+  }
+
+  const reference = getStaticCssEvalMemberReference(statement.argument);
+
+  return reference?.kind === "supported" ? statement.argument : null;
+}

--- a/packages/babel/src/staticCssEval/cjsExportModuleReplacement.ts
+++ b/packages/babel/src/staticCssEval/cjsExportModuleReplacement.ts
@@ -1,0 +1,98 @@
+import { types as t } from "@babel/core";
+import { getObjectKeyName } from "./cjsExportDescriptors.js";
+import {
+  createExpressionSetOperation,
+  createUnsupportedOperation
+} from "./cjsExportOperationEntries.js";
+import type {
+  StaticCssEvalCjsExportMapOperation,
+  StaticCssEvalCjsExportState
+} from "./cjsExports.js";
+
+export function collectModuleReplacementOperations(options: {
+  readonly expression: t.AssignmentExpression;
+  readonly declaration: t.Statement;
+  readonly state: StaticCssEvalCjsExportState;
+}): StaticCssEvalCjsExportMapOperation[] {
+  options.state.exportsAliasSafe = false;
+  const operations: StaticCssEvalCjsExportMapOperation[] = [
+    { kind: "clear-cjs-exports" }
+  ];
+
+  if (t.isArrayExpression(options.expression.right)) {
+    options.state.moduleObjectLike = false;
+    return [
+      ...operations,
+      createExpressionSetOperation(
+        null,
+        options.expression.right,
+        options.declaration
+      )
+    ];
+  }
+
+  if (!t.isObjectExpression(options.expression.right)) {
+    options.state.moduleObjectLike = false;
+    return [
+      ...operations,
+      createExpressionSetOperation(
+        null,
+        options.expression.right,
+        options.declaration
+      )
+    ];
+  }
+
+  operations.push(
+    createExpressionSetOperation(
+      null,
+      options.expression.right,
+      options.declaration
+    )
+  );
+
+  for (const property of options.expression.right.properties) {
+    if (!t.isObjectProperty(property) || property.computed) {
+      options.state.moduleObjectLike = false;
+      return [
+        ...operations,
+        createUnsupportedOperation({
+          declaration: options.declaration,
+          exportName: null,
+          mutation:
+            "module.exports object replacement contains unsupported property",
+          node: property,
+          state: options.state
+        })
+      ];
+    }
+
+    const exportName = getObjectKeyName(property.key);
+
+    if (!exportName || !t.isExpression(property.value)) {
+      options.state.moduleObjectLike = false;
+      return [
+        ...operations,
+        createUnsupportedOperation({
+          declaration: options.declaration,
+          exportName: exportName ?? null,
+          mutation:
+            "module.exports object replacement contains unsupported value",
+          node: property,
+          state: options.state
+        })
+      ];
+    }
+
+    operations.push(
+      createExpressionSetOperation(
+        exportName,
+        property.value,
+        options.declaration
+      )
+    );
+  }
+
+  options.state.moduleObjectLike = true;
+  return operations;
+}

--- a/packages/babel/src/staticCssEval/cjsExportOperationEntries.ts
+++ b/packages/babel/src/staticCssEval/cjsExportOperationEntries.ts
@@ -1,0 +1,113 @@
+import { types as t } from "@babel/core";
+import {
+  createStaticCssEvalCjsBundleRuntimeUnsupportedDiagnostic,
+  createStaticCssEvalCjsExportUnsupportedDiagnostic,
+  createStaticCssEvalCjsHelperUnsupportedDiagnostic
+} from "./diagnostics.js";
+import type {
+  StaticCssEvalCjsExportMapOperation,
+  StaticCssEvalCjsExportState
+} from "./cjsExports.js";
+import type { ExportMapEntry } from "./moduleCache.js";
+import type {
+  StaticCssEvalExportName,
+  StaticCssEvalSourceLocation
+} from "./types.js";
+
+export function createExpressionSetOperation(
+  exportName: StaticCssEvalExportName,
+  expression: t.Expression,
+  declaration: t.Statement
+): StaticCssEvalCjsExportMapOperation {
+  return createSetOperation({
+    kind: "expression",
+    exportName,
+    expression,
+    declaration
+  });
+}
+
+export function createUnsupportedOperation(options: {
+  readonly declaration: t.Statement;
+  readonly exportName: StaticCssEvalExportName;
+  readonly mutation: string;
+  readonly node: t.Node;
+  readonly state: StaticCssEvalCjsExportState;
+}): StaticCssEvalCjsExportMapOperation {
+  return createSetOperation({
+    kind: "unsupported",
+    exportName: options.exportName,
+    unsupportedKind: "cjs-export",
+    declaration: options.declaration,
+    diagnostic: createStaticCssEvalCjsExportUnsupportedDiagnostic(
+      {
+        owner: createSourceLocation(options.state.file, options.node),
+        exportName: options.exportName
+      },
+      options.mutation
+    ),
+    cjsExportMutation: options.mutation
+  });
+}
+
+export function createHelperUnsupportedOperation(options: {
+  readonly declaration: t.Statement;
+  readonly exportName: StaticCssEvalExportName;
+  readonly helperName: string;
+  readonly node: t.Node;
+  readonly state: StaticCssEvalCjsExportState;
+}): StaticCssEvalCjsExportMapOperation {
+  return createSetOperation({
+    kind: "unsupported",
+    exportName: options.exportName,
+    unsupportedKind: "cjs-helper",
+    declaration: options.declaration,
+    diagnostic: createStaticCssEvalCjsHelperUnsupportedDiagnostic(
+      {
+        owner: createSourceLocation(options.state.file, options.node),
+        exportName: options.exportName
+      },
+      options.helperName
+    ),
+    cjsHelperName: options.helperName
+  });
+}
+
+export function createBundleRuntimeUnsupportedOperation(options: {
+  readonly declaration: t.Statement;
+  readonly node: t.Node;
+  readonly runtimeName: string;
+  readonly state: StaticCssEvalCjsExportState;
+}): StaticCssEvalCjsExportMapOperation {
+  return createSetOperation({
+    kind: "unsupported",
+    exportName: null,
+    unsupportedKind: "cjs-bundle-runtime",
+    declaration: options.declaration,
+    diagnostic: createStaticCssEvalCjsBundleRuntimeUnsupportedDiagnostic(
+      {
+        owner: createSourceLocation(options.state.file, options.node),
+        exportName: null
+      },
+      options.runtimeName
+    ),
+    cjsBundleRuntimeName: options.runtimeName
+  });
+}
+
+function createSetOperation(
+  entry: ExportMapEntry
+): StaticCssEvalCjsExportMapOperation {
+  return { kind: "set", entry };
+}
+
+function createSourceLocation(
+  file: string,
+  node: t.Node
+): StaticCssEvalSourceLocation {
+  return {
+    file,
+    ...(typeof node.start === "number" ? { start: node.start } : {}),
+    ...(typeof node.end === "number" ? { end: node.end } : {})
+  };
+}

--- a/packages/babel/src/staticCssEval/cjsExportOperations.ts
+++ b/packages/babel/src/staticCssEval/cjsExportOperations.ts
@@ -1,0 +1,211 @@
+import { types as t } from "@babel/core";
+import type { NodePath } from "@babel/core";
+import { getDefinePropertyDescriptorExpression } from "./cjsExportDescriptors.js";
+import { collectModuleReplacementOperations } from "./cjsExportModuleReplacement.js";
+import { collectTopLevelCjsHelperAssignmentOperations } from "./cjsHelpers.js";
+import {
+  createExpressionSetOperation,
+  createUnsupportedOperation
+} from "./cjsExportOperationEntries.js";
+import {
+  formatAssignmentTarget,
+  getCjsAssignmentTarget,
+  getDefinePropertyExportName,
+  getDefinePropertySurface,
+  getTargetExportName,
+  isObjectDefinePropertyCall,
+  type StaticCssEvalCjsExportSurface
+} from "./cjsExportTargets.js";
+import type {
+  StaticCssEvalCjsExportMapOperation,
+  StaticCssEvalCjsExportState
+} from "./cjsExports.js";
+
+type StaticCssEvalBabelScope = NodePath<t.Node>["scope"];
+
+export function collectAssignmentExpressionOperations(options: {
+  readonly expression: t.AssignmentExpression;
+  readonly declaration: t.Statement;
+  readonly scope: StaticCssEvalBabelScope;
+  readonly state: StaticCssEvalCjsExportState;
+  readonly topLevel: boolean;
+}): StaticCssEvalCjsExportMapOperation[] {
+  const target = getCjsAssignmentTarget(options.expression.left, options.scope);
+
+  if (target.kind === "not-cjs") {
+    return [];
+  }
+
+  if (!options.topLevel) {
+    if (target.kind === "module-replacement") {
+      options.state.exportsAliasSafe = false;
+      options.state.moduleObjectLike = false;
+    }
+
+    return [
+      createUnsupportedOperation({
+        declaration: options.declaration,
+        exportName: getTargetExportName(target),
+        mutation: `non-top-level ${formatAssignmentTarget(target)} assignment`,
+        node: options.expression,
+        state: options.state
+      })
+    ];
+  }
+
+  if (target.kind === "unsupported" || options.expression.operator !== "=") {
+    const mutation =
+      target.kind === "unsupported"
+        ? target.mutation
+        : `${formatAssignmentTarget(target)} ${options.expression.operator} assignment`;
+
+    return [
+      createUnsupportedOperation({
+        declaration: options.declaration,
+        exportName: getTargetExportName(target),
+        mutation,
+        node: options.expression,
+        state: options.state
+      })
+    ];
+  }
+
+  if (target.kind === "module-replacement") {
+    const helperOperations = collectTopLevelCjsHelperAssignmentOperations({
+      declaration: options.declaration,
+      expression: options.expression,
+      scope: options.scope,
+      state: options.state
+    });
+
+    if (helperOperations !== null) {
+      return helperOperations;
+    }
+
+    return collectModuleReplacementOperations(options);
+  }
+
+  if (!isSurfaceAssignmentSafe(target.surface, options.state)) {
+    return [
+      createUnsupportedOperation({
+        declaration: options.declaration,
+        exportName: target.exportName,
+        mutation: `${target.surface}.${target.exportName} assignment after module.exports replacement`,
+        node: options.expression.left,
+        state: options.state
+      })
+    ];
+  }
+
+  if (t.isAssignmentExpression(options.expression.right)) {
+    return [
+      { kind: "clear-cjs-exports" },
+      createUnsupportedOperation({
+        declaration: options.declaration,
+        exportName: null,
+        mutation: "chained CommonJS export assignment",
+        node: options.expression,
+        state: options.state
+      })
+    ];
+  }
+
+  return [
+    createExpressionSetOperation(
+      target.exportName,
+      options.expression.right,
+      options.declaration
+    )
+  ];
+}
+
+export function collectDefinePropertyOperations(options: {
+  readonly expression: t.CallExpression;
+  readonly declaration: t.Statement;
+  readonly scope: StaticCssEvalBabelScope;
+  readonly state: StaticCssEvalCjsExportState;
+  readonly topLevel: boolean;
+}): StaticCssEvalCjsExportMapOperation[] {
+  if (!isObjectDefinePropertyCall(options.expression, options.scope)) {
+    return [];
+  }
+
+  const surface = getDefinePropertySurface(options.expression, options.scope);
+
+  if (!surface) {
+    return [];
+  }
+
+  const exportName = getDefinePropertyExportName(options.expression);
+
+  if (!options.topLevel || !exportName) {
+    return [
+      createUnsupportedOperation({
+        declaration: options.declaration,
+        exportName: exportName ?? null,
+        mutation: options.topLevel
+          ? "Object.defineProperty computed export name"
+          : "non-top-level Object.defineProperty export descriptor",
+        node: options.expression,
+        state: options.state
+      })
+    ];
+  }
+
+  if (!isSurfaceAssignmentSafe(surface, options.state)) {
+    return createAliasUnsafeDefinePropertyOperation({
+      ...options,
+      exportName,
+      surface
+    });
+  }
+
+  const descriptorResult = getDefinePropertyDescriptorExpression(
+    options.expression
+  );
+
+  return descriptorResult.kind === "supported"
+    ? [
+        createExpressionSetOperation(
+          exportName,
+          descriptorResult.expression,
+          options.declaration
+        )
+      ]
+    : [
+        createUnsupportedOperation({
+          declaration: options.declaration,
+          exportName,
+          mutation: descriptorResult.mutation,
+          node: options.expression,
+          state: options.state
+        })
+      ];
+}
+
+function createAliasUnsafeDefinePropertyOperation(options: {
+  readonly expression: t.CallExpression;
+  readonly declaration: t.Statement;
+  readonly exportName: string;
+  readonly state: StaticCssEvalCjsExportState;
+  readonly surface: StaticCssEvalCjsExportSurface;
+}): StaticCssEvalCjsExportMapOperation[] {
+  return [
+    createUnsupportedOperation({
+      declaration: options.declaration,
+      exportName: options.exportName,
+      mutation: `Object.defineProperty ${options.surface}.${options.exportName} after module.exports replacement`,
+      node: options.expression,
+      state: options.state
+    })
+  ];
+}
+
+function isSurfaceAssignmentSafe(
+  surface: StaticCssEvalCjsExportSurface,
+  state: StaticCssEvalCjsExportState
+): boolean {
+  return surface === "exports"
+    ? state.exportsAliasSafe
+    : state.moduleObjectLike;
+}

--- a/packages/babel/src/staticCssEval/cjsExportStarFingerprint.ts
+++ b/packages/babel/src/staticCssEval/cjsExportStarFingerprint.ts
@@ -1,0 +1,222 @@
+import { types as t } from "@babel/core";
+import { getBoundHelperFunctions } from "./cjsHelperLookup.js";
+import {
+  getIdentifierParamName,
+  getSingleBodyStatement,
+  type StaticCssEvalBabelScope,
+  type TscHelperFunction
+} from "./cjsHelperLookup.js";
+import { isTscCreateBindingFunction } from "./cjsCreateBindingFingerprint.js";
+
+export function isTscExportStarFunction(
+  helperFunction: TscHelperFunction,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  const moduleName = getIdentifierParamName(helperFunction, 0);
+  const exportsName = getIdentifierParamName(helperFunction, 1);
+  const [statement] = helperFunction.body.body;
+
+  if (!moduleName || !exportsName || helperFunction.body.body.length !== 1) {
+    return false;
+  }
+
+  if (!statement || !t.isForInStatement(statement)) {
+    return false;
+  }
+
+  const keyName = getForInKeyName(statement.left);
+  const guard = getSingleIfStatement(statement.body);
+
+  return (
+    keyName !== null &&
+    t.isIdentifier(statement.right, { name: moduleName }) &&
+    guard !== null &&
+    expressionContainsDefaultExclusion(guard.test, keyName) &&
+    expressionContainsHasOwnPropertyGuard(
+      guard.test,
+      exportsName,
+      keyName,
+      scope
+    ) &&
+    isExportStarCreateBindingStatement(
+      guard.consequent,
+      exportsName,
+      moduleName,
+      keyName,
+      scope
+    )
+  );
+}
+
+function getForInKeyName(left: t.ForInStatement["left"]): string | null {
+  if (t.isIdentifier(left)) {
+    return left.name;
+  }
+
+  if (!t.isVariableDeclaration(left) || left.declarations.length !== 1) {
+    return null;
+  }
+
+  const [declaration] = left.declarations;
+  return declaration && t.isIdentifier(declaration.id)
+    ? declaration.id.name
+    : null;
+}
+
+function getSingleIfStatement(statement: t.Statement): t.IfStatement | null {
+  const bodyStatement = getSingleBodyStatement(statement);
+  return bodyStatement &&
+    t.isIfStatement(bodyStatement) &&
+    bodyStatement.alternate === null
+    ? bodyStatement
+    : null;
+}
+
+function isExportStarCreateBindingStatement(
+  statement: t.Statement,
+  exportsName: string,
+  moduleName: string,
+  keyName: string,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  const bodyStatement = getSingleBodyStatement(statement);
+
+  return (
+    bodyStatement !== null &&
+    t.isExpressionStatement(bodyStatement) &&
+    t.isCallExpression(bodyStatement.expression) &&
+    t.isIdentifier(bodyStatement.expression.callee) &&
+    isBoundCreateBindingHelper(bodyStatement.expression.callee.name, scope) &&
+    t.isIdentifier(bodyStatement.expression.arguments[0], {
+      name: exportsName
+    }) &&
+    t.isIdentifier(bodyStatement.expression.arguments[1], {
+      name: moduleName
+    }) &&
+    t.isIdentifier(bodyStatement.expression.arguments[2], { name: keyName })
+  );
+}
+
+function isBoundCreateBindingHelper(
+  helperName: string,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  const helperFunctions = getBoundHelperFunctions(helperName, scope);
+  return (
+    helperFunctions.length > 0 &&
+    helperFunctions.every((helperFunction) =>
+      isTscCreateBindingFunction(helperFunction, scope)
+    )
+  );
+}
+
+function expressionContainsDefaultExclusion(
+  expression: t.Expression,
+  keyName: string
+): boolean {
+  return expressionContains(
+    expression,
+    (candidate) =>
+      t.isBinaryExpression(candidate, { operator: "!==" }) &&
+      ((t.isIdentifier(candidate.left, { name: keyName }) &&
+        t.isStringLiteral(candidate.right, { value: "default" })) ||
+        (t.isIdentifier(candidate.right, { name: keyName }) &&
+          t.isStringLiteral(candidate.left, { value: "default" })))
+  );
+}
+
+function expressionContainsHasOwnPropertyGuard(
+  expression: t.Expression,
+  exportsName: string,
+  keyName: string,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  return expressionContains(
+    expression,
+    (candidate) =>
+      t.isCallExpression(candidate) &&
+      isHasOwnPropertyCallCallee(candidate.callee, scope) &&
+      t.isIdentifier(candidate.arguments[0], { name: exportsName }) &&
+      t.isIdentifier(candidate.arguments[1], { name: keyName })
+  );
+}
+
+function isHasOwnPropertyCallCallee(
+  callee: t.Expression | t.V8IntrinsicIdentifier,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  if (
+    !t.isMemberExpression(callee) ||
+    callee.computed ||
+    !t.isIdentifier(callee.property, { name: "call" }) ||
+    !t.isMemberExpression(callee.object) ||
+    callee.object.computed ||
+    !t.isIdentifier(callee.object.property, { name: "hasOwnProperty" }) ||
+    !t.isMemberExpression(callee.object.object) ||
+    callee.object.object.computed
+  ) {
+    return false;
+  }
+
+  return (
+    t.isIdentifier(callee.object.object.object, { name: "Object" }) &&
+    !scope.getBinding("Object") &&
+    t.isIdentifier(callee.object.object.property, { name: "prototype" })
+  );
+}
+
+function expressionContains(
+  expression: t.Expression,
+  predicate: (candidate: t.Expression) => boolean
+): boolean {
+  if (predicate(expression)) {
+    return true;
+  }
+
+  if (t.isLogicalExpression(expression) || t.isBinaryExpression(expression)) {
+    return (
+      (t.isExpression(expression.left) &&
+        expressionContains(expression.left, predicate)) ||
+      expressionContains(expression.right, predicate)
+    );
+  }
+
+  if (t.isUnaryExpression(expression)) {
+    return expressionContains(expression.argument, predicate);
+  }
+
+  if (t.isConditionalExpression(expression)) {
+    return (
+      expressionContains(expression.test, predicate) ||
+      expressionContains(expression.consequent, predicate) ||
+      expressionContains(expression.alternate, predicate)
+    );
+  }
+
+  if (t.isMemberExpression(expression)) {
+    return (
+      (t.isExpression(expression.object) &&
+        expressionContains(expression.object, predicate)) ||
+      (t.isExpression(expression.property) &&
+        expressionContains(expression.property, predicate))
+    );
+  }
+
+  if (t.isCallExpression(expression)) {
+    if (
+      t.isExpression(expression.callee) &&
+      expressionContains(expression.callee, predicate)
+    ) {
+      return true;
+    }
+
+    return expression.arguments.some(
+      (argument) =>
+        t.isExpression(argument) && expressionContains(argument, predicate)
+    );
+  }
+
+  return t.isParenthesizedExpression(expression)
+    ? expressionContains(expression.expression, predicate)
+    : false;
+}

--- a/packages/babel/src/staticCssEval/cjsExportTargets.ts
+++ b/packages/babel/src/staticCssEval/cjsExportTargets.ts
@@ -1,0 +1,178 @@
+import { types as t } from "@babel/core";
+import type { NodePath } from "@babel/core";
+import type { StaticCssEvalExportName } from "./types.js";
+
+type StaticCssEvalBabelScope = NodePath<t.Node>["scope"];
+
+export type StaticCssEvalCjsExportSurface = "exports" | "module.exports";
+
+export type StaticCssEvalCjsAssignmentTarget =
+  | { readonly kind: "not-cjs" }
+  | { readonly kind: "module-replacement" }
+  | {
+      readonly kind: "property";
+      readonly exportName: string;
+      readonly surface: StaticCssEvalCjsExportSurface;
+    }
+  | {
+      readonly kind: "unsupported";
+      readonly exportName: StaticCssEvalExportName;
+      readonly mutation: string;
+    };
+
+export function getCjsAssignmentTarget(
+  left: t.LVal | t.OptionalMemberExpression,
+  scope: StaticCssEvalBabelScope
+): StaticCssEvalCjsAssignmentTarget {
+  const directTarget = getDirectCjsAssignmentTarget(left, scope);
+
+  if (directTarget.kind !== "not-cjs" || !t.isMemberExpression(left)) {
+    return directTarget;
+  }
+
+  if (!t.isMemberExpression(left.object)) {
+    return directTarget;
+  }
+
+  const outerTarget = getDirectCjsAssignmentTarget(left.object, scope);
+
+  if (outerTarget.kind === "unsupported") {
+    return outerTarget;
+  }
+
+  return outerTarget.kind === "property"
+    ? {
+        kind: "unsupported",
+        exportName: outerTarget.exportName,
+        mutation: `nested ${outerTarget.surface}.${outerTarget.exportName} property assignment`
+      }
+    : directTarget;
+}
+
+function getDirectCjsAssignmentTarget(
+  left: t.LVal | t.OptionalMemberExpression,
+  scope: StaticCssEvalBabelScope
+): StaticCssEvalCjsAssignmentTarget {
+  if (!t.isMemberExpression(left)) {
+    return { kind: "not-cjs" };
+  }
+
+  if (isModuleExportsExpression(left, scope)) {
+    return { kind: "module-replacement" };
+  }
+
+  if (t.isIdentifier(left.object) && isExportsIdentifier(left.object, scope)) {
+    return getPropertyAssignmentTarget("exports", left);
+  }
+
+  return t.isExpression(left.object) &&
+    isModuleExportsExpression(left.object, scope)
+    ? getPropertyAssignmentTarget("module.exports", left)
+    : { kind: "not-cjs" };
+}
+
+export function isObjectDefinePropertyCall(
+  expression: t.CallExpression,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  return (
+    t.isMemberExpression(expression.callee) &&
+    !expression.callee.computed &&
+    t.isIdentifier(expression.callee.object, { name: "Object" }) &&
+    !scope.getBinding("Object") &&
+    t.isIdentifier(expression.callee.property, { name: "defineProperty" })
+  );
+}
+
+export function getDefinePropertySurface(
+  expression: t.CallExpression,
+  scope: StaticCssEvalBabelScope
+): StaticCssEvalCjsExportSurface | null {
+  const [target] = expression.arguments;
+
+  if (!target || !t.isExpression(target)) {
+    return null;
+  }
+
+  return getCjsExportSurfaceExpression(target, scope);
+}
+
+export function getCjsExportSurfaceExpression(
+  expression: t.Expression,
+  scope: StaticCssEvalBabelScope
+): StaticCssEvalCjsExportSurface | null {
+  if (t.isIdentifier(expression) && isExportsIdentifier(expression, scope)) {
+    return "exports";
+  }
+
+  return isModuleExportsExpression(expression, scope) ? "module.exports" : null;
+}
+
+export function getDefinePropertyExportName(
+  expression: t.CallExpression
+): string | null {
+  const [, exportName] = expression.arguments;
+
+  return exportName && t.isStringLiteral(exportName) ? exportName.value : null;
+}
+
+export function getTargetExportName(
+  target: Exclude<StaticCssEvalCjsAssignmentTarget, { kind: "not-cjs" }>
+): StaticCssEvalExportName {
+  return target.kind === "module-replacement" ? null : target.exportName;
+}
+
+export function formatAssignmentTarget(
+  target: Exclude<StaticCssEvalCjsAssignmentTarget, { kind: "not-cjs" }>
+): string {
+  if (target.kind === "module-replacement") {
+    return "module.exports";
+  }
+
+  return target.kind === "property"
+    ? `${target.surface}.${target.exportName}`
+    : "computed commonjs export";
+}
+
+function getPropertyAssignmentTarget(
+  surface: StaticCssEvalCjsExportSurface,
+  expression: t.MemberExpression
+): StaticCssEvalCjsAssignmentTarget {
+  const exportName = getNonComputedMemberPropertyName(expression);
+
+  return exportName
+    ? { kind: "property", exportName, surface }
+    : {
+        kind: "unsupported",
+        exportName: null,
+        mutation: `computed ${surface} export assignment`
+      };
+}
+
+function isExportsIdentifier(
+  expression: t.Identifier,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  return expression.name === "exports" && !scope.getBinding("exports");
+}
+
+function isModuleExportsExpression(
+  expression: t.Expression,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  return (
+    t.isMemberExpression(expression) &&
+    !expression.computed &&
+    t.isIdentifier(expression.object, { name: "module" }) &&
+    !scope.getBinding("module") &&
+    t.isIdentifier(expression.property, { name: "exports" })
+  );
+}
+
+function getNonComputedMemberPropertyName(
+  expression: t.MemberExpression
+): string | null {
+  return !expression.computed && t.isIdentifier(expression.property)
+    ? expression.property.name
+    : null;
+}

--- a/packages/babel/src/staticCssEval/cjsExports.ts
+++ b/packages/babel/src/staticCssEval/cjsExports.ts
@@ -1,0 +1,131 @@
+import { types as t } from "@babel/core";
+import type { NodePath } from "@babel/core";
+import { collectStaticCssEvalCjsRequireBindings } from "./cjsBindings.js";
+import {
+  collectAssignmentExpressionOperations,
+  collectDefinePropertyOperations
+} from "./cjsExportOperations.js";
+import { collectTopLevelCjsHelperOperations } from "./cjsHelpers.js";
+import type { ExportMapEntry } from "./moduleCache.js";
+import type { ExportGraphStarReexportEntry } from "./moduleCache.js";
+
+export type StaticCssEvalCjsExportMapOperation =
+  | { readonly kind: "clear-cjs-exports" }
+  | { readonly kind: "preserve-cjs-exports" }
+  | { readonly kind: "set"; readonly entry: ExportMapEntry }
+  | {
+      readonly kind: "star-reexport";
+      readonly entry: ExportGraphStarReexportEntry;
+    };
+
+interface StaticCssEvalCjsExportCollectorOptions {
+  readonly file: string;
+  readonly programPath: NodePath<t.Program>;
+}
+
+export type StaticCssEvalCjsExportState = {
+  readonly file: string;
+  exportsAliasSafe: boolean;
+  moduleObjectLike: boolean;
+};
+
+export function collectStaticCssEvalCjsExportMapOperations(
+  options: StaticCssEvalCjsExportCollectorOptions
+): StaticCssEvalCjsExportMapOperation[] {
+  const state: StaticCssEvalCjsExportState = {
+    file: options.file,
+    exportsAliasSafe: true,
+    moduleObjectLike: true
+  };
+  const operations: StaticCssEvalCjsExportMapOperation[] = [];
+  const cjsImports = collectStaticCssEvalCjsRequireBindings(
+    options.programPath
+  );
+
+  for (const statementPath of options.programPath.get("body")) {
+    const directOperations = collectTopLevelCjsExportOperations(
+      statementPath,
+      state
+    );
+    const helperOperations =
+      directOperations.length === 0
+        ? collectTopLevelCjsHelperOperations({
+            cjsImports,
+            state,
+            statementPath
+          })
+        : [];
+
+    operations.push(
+      ...(directOperations.length > 0
+        ? directOperations
+        : helperOperations.length > 0
+          ? helperOperations
+          : collectNestedCjsExportUnsupportedOperations(statementPath, state))
+    );
+  }
+
+  return operations;
+}
+
+function collectTopLevelCjsExportOperations(
+  statementPath: NodePath<t.Statement>,
+  state: StaticCssEvalCjsExportState
+): StaticCssEvalCjsExportMapOperation[] {
+  if (!statementPath.isExpressionStatement()) {
+    return [];
+  }
+
+  const { expression } = statementPath.node;
+  const baseOptions = {
+    declaration: statementPath.node,
+    scope: statementPath.scope,
+    state,
+    topLevel: true
+  };
+
+  if (t.isAssignmentExpression(expression)) {
+    return collectAssignmentExpressionOperations({
+      ...baseOptions,
+      expression
+    });
+  }
+
+  return t.isCallExpression(expression)
+    ? collectDefinePropertyOperations({ ...baseOptions, expression })
+    : [];
+}
+
+function collectNestedCjsExportUnsupportedOperations(
+  statementPath: NodePath<t.Statement>,
+  state: StaticCssEvalCjsExportState
+): StaticCssEvalCjsExportMapOperation[] {
+  const operations: StaticCssEvalCjsExportMapOperation[] = [];
+
+  statementPath.traverse({
+    AssignmentExpression(path) {
+      operations.push(
+        ...collectAssignmentExpressionOperations({
+          expression: path.node,
+          declaration: statementPath.node,
+          scope: path.scope,
+          state,
+          topLevel: false
+        })
+      );
+    },
+    CallExpression(path) {
+      operations.push(
+        ...collectDefinePropertyOperations({
+          expression: path.node,
+          declaration: statementPath.node,
+          scope: path.scope,
+          state,
+          topLevel: false
+        })
+      );
+    }
+  });
+
+  return operations;
+}

--- a/packages/babel/src/staticCssEval/cjsHelperFingerprints.ts
+++ b/packages/babel/src/staticCssEval/cjsHelperFingerprints.ts
@@ -1,0 +1,32 @@
+import type { StaticCssEvalBabelScope } from "./cjsHelperLookup.js";
+import { getBoundHelperFunctions } from "./cjsHelperLookup.js";
+import { isTscCreateBindingFunction } from "./cjsCreateBindingFingerprint.js";
+import { isTscExportStarFunction } from "./cjsExportStarFingerprint.js";
+
+export function isSupportedTscCreateBindingHelper(
+  helperName: string,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  const helperFunctions = getBoundHelperFunctions(helperName, scope);
+
+  return (
+    helperFunctions.length > 0 &&
+    helperFunctions.every((helperFunction) =>
+      isTscCreateBindingFunction(helperFunction, scope)
+    )
+  );
+}
+
+export function isSupportedTscExportStarHelper(
+  helperName: string,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  const helperFunctions = getBoundHelperFunctions(helperName, scope);
+
+  return (
+    helperFunctions.length > 0 &&
+    helperFunctions.every((helperFunction) =>
+      isTscExportStarFunction(helperFunction, scope)
+    )
+  );
+}

--- a/packages/babel/src/staticCssEval/cjsHelperLookup.ts
+++ b/packages/babel/src/staticCssEval/cjsHelperLookup.ts
@@ -1,0 +1,91 @@
+import { types as t } from "@babel/core";
+import type { NodePath } from "@babel/core";
+
+export type StaticCssEvalBabelScope = NodePath<t.Node>["scope"];
+export type TscHelperFunction = t.FunctionDeclaration | t.FunctionExpression;
+
+export function getBoundHelperFunctions(
+  helperName: string,
+  scope: StaticCssEvalBabelScope
+): TscHelperFunction[] {
+  const binding = scope.getBinding(helperName);
+
+  if (!binding) {
+    return [];
+  }
+
+  if (
+    binding.path.isFunctionDeclaration() &&
+    binding.path.node.id?.name === helperName
+  ) {
+    return [binding.path.node];
+  }
+
+  if (
+    !binding.path.isVariableDeclarator() ||
+    !t.isIdentifier(binding.path.node.id, { name: helperName }) ||
+    !binding.path.node.init ||
+    !t.isExpression(binding.path.node.init)
+  ) {
+    return [];
+  }
+
+  const helperFunctions: TscHelperFunction[] = [];
+  collectFunctionExpressions(binding.path.node.init, helperFunctions);
+  return helperFunctions;
+}
+
+export function getIdentifierParamName(
+  helperFunction: TscHelperFunction,
+  index: number
+): string | null {
+  const param = helperFunction.params[index];
+  return param && t.isIdentifier(param) ? param.name : null;
+}
+
+export function getSingleBodyStatement(
+  statement: t.Statement
+): t.Statement | null {
+  if (t.isBlockStatement(statement)) {
+    const [bodyStatement] = statement.body;
+    return statement.body.length === 1 && bodyStatement ? bodyStatement : null;
+  }
+
+  return statement;
+}
+
+function collectFunctionExpressions(
+  expression: t.Expression,
+  helperFunctions: TscHelperFunction[]
+): void {
+  if (t.isFunctionExpression(expression)) {
+    helperFunctions.push(expression);
+    return;
+  }
+
+  if (t.isLogicalExpression(expression) || t.isBinaryExpression(expression)) {
+    if (t.isExpression(expression.left)) {
+      collectFunctionExpressions(expression.left, helperFunctions);
+    }
+    collectFunctionExpressions(expression.right, helperFunctions);
+    return;
+  }
+
+  if (t.isConditionalExpression(expression)) {
+    collectFunctionExpressions(expression.test, helperFunctions);
+    collectFunctionExpressions(expression.consequent, helperFunctions);
+    collectFunctionExpressions(expression.alternate, helperFunctions);
+    return;
+  }
+
+  if (t.isParenthesizedExpression(expression)) {
+    collectFunctionExpressions(expression.expression, helperFunctions);
+    return;
+  }
+
+  if (t.isSequenceExpression(expression)) {
+    for (const item of expression.expressions) {
+      collectFunctionExpressions(item, helperFunctions);
+    }
+  }
+}

--- a/packages/babel/src/staticCssEval/cjsHelpers.ts
+++ b/packages/babel/src/staticCssEval/cjsHelpers.ts
@@ -1,0 +1,191 @@
+import { types as t } from "@babel/core";
+import type { NodePath } from "@babel/core";
+import { getStaticCssEvalLiteralRequireImportPath } from "./cjsBindings.js";
+import {
+  collectEsbuildBundleRuntimeOperations,
+  collectEsbuildHelperOperations,
+  collectEsbuildModuleReplacementOperations
+} from "./cjsEsbuildHelpers.js";
+import {
+  isSupportedTscCreateBindingHelper,
+  isSupportedTscExportStarHelper
+} from "./cjsHelperFingerprints.js";
+import { createHelperUnsupportedOperation } from "./cjsExportOperationEntries.js";
+import { getCjsExportSurfaceExpression } from "./cjsExportTargets.js";
+import type { ImportedStaticCssEvalCjsBinding } from "./cjsBindings.js";
+import type {
+  StaticCssEvalCjsExportMapOperation,
+  StaticCssEvalCjsExportState
+} from "./cjsExports.js";
+import type { ExportMapReexportEntry } from "./moduleCache.js";
+
+export function collectTopLevelCjsHelperOperations(options: {
+  readonly cjsImports: ReadonlyMap<string, ImportedStaticCssEvalCjsBinding>;
+  readonly state: StaticCssEvalCjsExportState;
+  readonly statementPath: NodePath<t.Statement>;
+}): StaticCssEvalCjsExportMapOperation[] {
+  const bundleRuntimeOperations = collectEsbuildBundleRuntimeOperations({
+    state: options.state,
+    statementPath: options.statementPath
+  });
+
+  if (bundleRuntimeOperations.length > 0) {
+    return bundleRuntimeOperations;
+  }
+
+  if (!options.statementPath.isExpressionStatement()) {
+    return [];
+  }
+
+  const { expression } = options.statementPath.node;
+
+  if (!t.isCallExpression(expression) || !t.isIdentifier(expression.callee)) {
+    return [];
+  }
+
+  const esbuildOperations = collectEsbuildHelperOperations({
+    expression,
+    state: options.state,
+    statementPath: options.statementPath
+  });
+
+  if (esbuildOperations !== null) {
+    return esbuildOperations;
+  }
+
+  if (expression.callee.name === "__createBinding") {
+    return [collectCreateBindingOperation({ ...options, expression })];
+  }
+
+  return expression.callee.name === "__exportStar"
+    ? [collectExportStarOperation({ ...options, expression })]
+    : [];
+}
+
+export function collectTopLevelCjsHelperAssignmentOperations(options: {
+  readonly declaration: t.Statement;
+  readonly expression: t.AssignmentExpression;
+  readonly scope: NodePath<t.Node>["scope"];
+  readonly state: StaticCssEvalCjsExportState;
+}): StaticCssEvalCjsExportMapOperation[] | null {
+  return collectEsbuildModuleReplacementOperations(options);
+}
+
+function collectCreateBindingOperation(options: {
+  readonly cjsImports: ReadonlyMap<string, ImportedStaticCssEvalCjsBinding>;
+  readonly expression: t.CallExpression;
+  readonly state: StaticCssEvalCjsExportState;
+  readonly statementPath: NodePath<t.Statement>;
+}): StaticCssEvalCjsExportMapOperation {
+  const helperName = "__createBinding";
+  const [target, source, importedName, exportedName] =
+    options.expression.arguments;
+  const targetSurface = t.isExpression(target)
+    ? getCjsExportSurfaceExpression(target, options.statementPath.scope)
+    : null;
+  const sourceBinding = t.isIdentifier(source)
+    ? options.cjsImports.get(source.name)
+    : undefined;
+
+  if (
+    !isSupportedTscCreateBindingHelper(
+      helperName,
+      options.statementPath.scope
+    ) ||
+    !targetSurface ||
+    !isSurfaceAssignmentSafe(targetSurface, options.state) ||
+    !sourceBinding ||
+    sourceBinding.kind !== "cjs-module" ||
+    !t.isStringLiteral(importedName) ||
+    (exportedName !== undefined && !t.isStringLiteral(exportedName))
+  ) {
+    return createHelperUnsupportedOperation({
+      declaration: options.statementPath.node,
+      exportName: t.isStringLiteral(exportedName)
+        ? exportedName.value
+        : t.isStringLiteral(importedName)
+          ? importedName.value
+          : null,
+      helperName,
+      node: options.expression,
+      state: options.state
+    });
+  }
+
+  return {
+    kind: "set",
+    entry: createReexportEntry({
+      declaration: options.statementPath.node,
+      exportName: exportedName?.value ?? importedName.value,
+      importedName: importedName.value,
+      source: sourceBinding.importPath
+    })
+  };
+}
+
+function collectExportStarOperation(options: {
+  readonly expression: t.CallExpression;
+  readonly state: StaticCssEvalCjsExportState;
+  readonly statementPath: NodePath<t.Statement>;
+}): StaticCssEvalCjsExportMapOperation {
+  const helperName = "__exportStar";
+  const [source, target] = options.expression.arguments;
+  const targetSurface = t.isExpression(target)
+    ? getCjsExportSurfaceExpression(target, options.statementPath.scope)
+    : null;
+  const importPath = t.isExpression(source)
+    ? getStaticCssEvalLiteralRequireImportPath(
+        source,
+        options.statementPath.scope
+      )
+    : null;
+
+  if (
+    !isSupportedTscExportStarHelper(helperName, options.statementPath.scope) ||
+    !targetSurface ||
+    !isSurfaceAssignmentSafe(targetSurface, options.state) ||
+    !importPath
+  ) {
+    return createHelperUnsupportedOperation({
+      declaration: options.statementPath.node,
+      exportName: null,
+      helperName,
+      node: options.expression,
+      state: options.state
+    });
+  }
+
+  return {
+    kind: "star-reexport",
+    entry: {
+      kind: "star-reexport",
+      exportName: "*",
+      source: importPath,
+      declaration: options.statementPath.node
+    }
+  };
+}
+
+function createReexportEntry(options: {
+  readonly declaration: t.Statement;
+  readonly exportName: string;
+  readonly importedName: string;
+  readonly source: string;
+}): ExportMapReexportEntry {
+  return {
+    kind: "reexport",
+    exportName: options.exportName,
+    importedName: options.importedName,
+    source: options.source,
+    declaration: options.declaration
+  };
+}
+
+function isSurfaceAssignmentSafe(
+  surface: "exports" | "module.exports",
+  state: StaticCssEvalCjsExportState
+): boolean {
+  return surface === "exports"
+    ? state.exportsAliasSafe
+    : state.moduleObjectLike;
+}

--- a/packages/babel/src/staticCssEval/cjsRequireAnalysis.ts
+++ b/packages/babel/src/staticCssEval/cjsRequireAnalysis.ts
@@ -1,0 +1,189 @@
+import { types as t } from "@babel/core";
+import type { NodePath } from "@babel/core";
+import { isStaticCssEvalRequireCallExpression } from "./cjsBindings.js";
+
+type StaticCssEvalBabelScope = NodePath<t.Node>["scope"];
+
+export function containsStaticCssEvalRequireCallExpression(
+  expression: t.Expression,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  const unwrappedExpression = unwrapTransparentExpression(expression);
+
+  if (isStaticCssEvalRequireCallExpression(unwrappedExpression, scope)) {
+    return true;
+  }
+
+  if (
+    t.isFunctionExpression(unwrappedExpression) ||
+    t.isArrowFunctionExpression(unwrappedExpression) ||
+    t.isClassExpression(unwrappedExpression)
+  ) {
+    return false;
+  }
+
+  if (t.isTemplateLiteral(unwrappedExpression)) {
+    return unwrappedExpression.expressions.some((item) =>
+      containsExpressionNode(item, scope)
+    );
+  }
+
+  if (t.isTaggedTemplateExpression(unwrappedExpression)) {
+    return (
+      containsExpressionNode(unwrappedExpression.tag, scope) ||
+      containsExpressionNode(unwrappedExpression.quasi, scope)
+    );
+  }
+
+  if (
+    t.isCallExpression(unwrappedExpression) ||
+    t.isOptionalCallExpression(unwrappedExpression)
+  ) {
+    return (
+      containsExpressionNode(unwrappedExpression.callee, scope) ||
+      unwrappedExpression.arguments.some((argument) =>
+        containsExpressionNode(argument, scope)
+      )
+    );
+  }
+
+  if (t.isNewExpression(unwrappedExpression)) {
+    return (
+      containsExpressionNode(unwrappedExpression.callee, scope) ||
+      unwrappedExpression.arguments.some((argument) =>
+        containsExpressionNode(argument, scope)
+      )
+    );
+  }
+
+  if (t.isAwaitExpression(unwrappedExpression)) {
+    return containsExpressionNode(unwrappedExpression.argument, scope);
+  }
+
+  if (t.isAssignmentExpression(unwrappedExpression)) {
+    return (
+      containsExpressionNode(unwrappedExpression.left, scope) ||
+      containsExpressionNode(unwrappedExpression.right, scope)
+    );
+  }
+
+  if (t.isTSInstantiationExpression(unwrappedExpression)) {
+    return containsExpressionNode(unwrappedExpression.expression, scope);
+  }
+
+  if (
+    t.isMemberExpression(unwrappedExpression) ||
+    t.isOptionalMemberExpression(unwrappedExpression)
+  ) {
+    return (
+      containsExpressionNode(unwrappedExpression.object, scope) ||
+      (unwrappedExpression.computed &&
+        containsExpressionNode(unwrappedExpression.property, scope))
+    );
+  }
+
+  if (t.isConditionalExpression(unwrappedExpression)) {
+    return (
+      containsStaticCssEvalRequireCallExpression(
+        unwrappedExpression.test,
+        scope
+      ) ||
+      containsStaticCssEvalRequireCallExpression(
+        unwrappedExpression.consequent,
+        scope
+      ) ||
+      containsStaticCssEvalRequireCallExpression(
+        unwrappedExpression.alternate,
+        scope
+      )
+    );
+  }
+
+  if (
+    t.isLogicalExpression(unwrappedExpression) ||
+    t.isBinaryExpression(unwrappedExpression)
+  ) {
+    return (
+      containsExpressionNode(unwrappedExpression.left, scope) ||
+      containsStaticCssEvalRequireCallExpression(
+        unwrappedExpression.right,
+        scope
+      )
+    );
+  }
+
+  if (t.isSequenceExpression(unwrappedExpression)) {
+    return unwrappedExpression.expressions.some((item) =>
+      containsStaticCssEvalRequireCallExpression(item, scope)
+    );
+  }
+
+  if (t.isArrayExpression(unwrappedExpression)) {
+    return unwrappedExpression.elements.some((element) =>
+      containsExpressionNode(element, scope)
+    );
+  }
+
+  if (t.isObjectExpression(unwrappedExpression)) {
+    return unwrappedExpression.properties.some((property) =>
+      containsObjectPropertyRequireCall(property, scope)
+    );
+  }
+
+  if (t.isUnaryExpression(unwrappedExpression)) {
+    return containsStaticCssEvalRequireCallExpression(
+      unwrappedExpression.argument,
+      scope
+    );
+  }
+
+  return false;
+}
+
+function containsObjectPropertyRequireCall(
+  property: t.ObjectExpression["properties"][number],
+  scope: StaticCssEvalBabelScope
+): boolean {
+  if (t.isSpreadElement(property)) {
+    return containsExpressionNode(property.argument, scope);
+  }
+
+  if (!t.isObjectProperty(property)) {
+    return false;
+  }
+
+  return (
+    (property.computed && containsExpressionNode(property.key, scope)) ||
+    containsExpressionNode(property.value, scope)
+  );
+}
+
+function containsExpressionNode(
+  node: t.Node | null | undefined,
+  scope: StaticCssEvalBabelScope
+): boolean {
+  if (t.isSpreadElement(node)) {
+    return containsExpressionNode(node.argument, scope);
+  }
+
+  return t.isExpression(node)
+    ? containsStaticCssEvalRequireCallExpression(node, scope)
+    : false;
+}
+
+function unwrapTransparentExpression(expression: t.Expression): t.Expression {
+  let currentExpression = expression;
+
+  while (
+    t.isParenthesizedExpression(currentExpression) ||
+    t.isTSAsExpression(currentExpression) ||
+    t.isTSSatisfiesExpression(currentExpression) ||
+    t.isTSNonNullExpression(currentExpression) ||
+    t.isTSTypeAssertion(currentExpression) ||
+    t.isTypeCastExpression(currentExpression)
+  ) {
+    currentExpression = currentExpression.expression;
+  }
+
+  return currentExpression;
+}

--- a/packages/babel/src/staticCssEval/cjsResolver.ts
+++ b/packages/babel/src/staticCssEval/cjsResolver.ts
@@ -1,0 +1,74 @@
+import type {
+  ImportedStaticCssEvalCjsBinding,
+  StaticCssEvalCjsRequireSource
+} from "./cjsBindings.js";
+import type {
+  BindingProvenance,
+  ResolutionDependencyKind,
+  StaticCssEvalExportName
+} from "./types.js";
+
+type StaticCssEvalCjsProvenanceKind = Extract<
+  BindingProvenance["kind"],
+  "imported" | "reexported"
+>;
+
+export type StaticCssEvalCjsResolutionRequestParts = {
+  readonly specifier: string;
+  readonly exportName: StaticCssEvalExportName;
+  readonly memberPath: string[];
+  readonly dependencyKind: ResolutionDependencyKind;
+  readonly provenanceKind: StaticCssEvalCjsProvenanceKind;
+  readonly reexportName?: string;
+};
+
+export function createStaticCssEvalCjsImportRequestParts(options: {
+  readonly binding: ImportedStaticCssEvalCjsBinding;
+  readonly queryMemberPath: readonly string[];
+}): StaticCssEvalCjsResolutionRequestParts {
+  return createStaticCssEvalCjsRequestParts({
+    source: options.binding,
+    queryMemberPath: options.queryMemberPath,
+    dependencyKind: "imported",
+    provenanceKind: "imported"
+  });
+}
+
+export function createStaticCssEvalCjsReexportRequestParts(options: {
+  readonly source: StaticCssEvalCjsRequireSource;
+  readonly queryMemberPath: readonly string[];
+  readonly reexportName: string;
+}): StaticCssEvalCjsResolutionRequestParts {
+  return createStaticCssEvalCjsRequestParts({
+    source: options.source,
+    queryMemberPath: options.queryMemberPath,
+    dependencyKind: "reexported",
+    provenanceKind: "reexported",
+    reexportName: options.reexportName
+  });
+}
+
+function createStaticCssEvalCjsRequestParts(options: {
+  readonly source: StaticCssEvalCjsRequireSource;
+  readonly queryMemberPath: readonly string[];
+  readonly dependencyKind: ResolutionDependencyKind;
+  readonly provenanceKind: StaticCssEvalCjsProvenanceKind;
+  readonly reexportName?: string;
+}): StaticCssEvalCjsResolutionRequestParts {
+  const propertyPath = [
+    ...options.source.propertyPath,
+    ...options.queryMemberPath
+  ];
+  const [exportName, ...memberPath] = propertyPath;
+
+  return {
+    specifier: options.source.importPath,
+    exportName: exportName ?? null,
+    memberPath,
+    dependencyKind: options.dependencyKind,
+    provenanceKind: options.provenanceKind,
+    ...(options.reexportName !== undefined
+      ? { reexportName: options.reexportName }
+      : {})
+  };
+}

--- a/packages/babel/src/staticCssEval/diagnostics.ts
+++ b/packages/babel/src/staticCssEval/diagnostics.ts
@@ -241,6 +241,77 @@ export function createStaticCssEvalCjsUnsupportedDiagnostic(
   });
 }
 
+export function createStaticCssEvalCjsDynamicRequireUnsupportedDiagnostic(
+  context: StaticCssEvalDiagnosticContext
+): StaticCssEvalDiagnostic {
+  return createStaticCssEvalDiagnostic({
+    id: "STATIC_CSS_EVAL_CJS_DYNAMIC_REQUIRE_UNSUPPORTED",
+    code: "unsupported-source",
+    reason: "commonjs-require",
+    detail: "commonjs dynamic require is unsupported",
+    owner: context.owner,
+    dependency: context.dependency,
+    importPath: context.importPath,
+    exportName: context.exportName,
+    memberPath: context.memberPath,
+    importChain: context.importChain
+  });
+}
+
+export function createStaticCssEvalCjsExportUnsupportedDiagnostic(
+  context: StaticCssEvalDiagnosticContext,
+  exportMutation: string
+): StaticCssEvalDiagnostic {
+  return createStaticCssEvalDiagnostic({
+    id: "STATIC_CSS_EVAL_CJS_EXPORT_UNSUPPORTED",
+    code: "unsupported-source",
+    reason: "unsupported-source-shape",
+    detail: `commonjs export mutation is unsupported: ${exportMutation}`,
+    owner: context.owner,
+    dependency: context.dependency,
+    importPath: context.importPath,
+    exportName: context.exportName,
+    memberPath: context.memberPath,
+    importChain: context.importChain
+  });
+}
+
+export function createStaticCssEvalCjsHelperUnsupportedDiagnostic(
+  context: StaticCssEvalDiagnosticContext,
+  helperName: string
+): StaticCssEvalDiagnostic {
+  return createStaticCssEvalDiagnostic({
+    id: "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED",
+    code: "unsupported-source",
+    reason: "unsupported-source-shape",
+    detail: `commonjs helper is unsupported: ${helperName}`,
+    owner: context.owner,
+    dependency: context.dependency,
+    importPath: context.importPath,
+    exportName: context.exportName,
+    memberPath: context.memberPath,
+    importChain: context.importChain
+  });
+}
+
+export function createStaticCssEvalCjsBundleRuntimeUnsupportedDiagnostic(
+  context: StaticCssEvalDiagnosticContext,
+  runtimeName: string
+): StaticCssEvalDiagnostic {
+  return createStaticCssEvalDiagnostic({
+    id: "STATIC_CSS_EVAL_CJS_BUNDLE_RUNTIME_UNSUPPORTED",
+    code: "unsupported-source",
+    reason: "runtime-dynamic-value",
+    detail: `commonjs bundle runtime is unsupported: ${runtimeName}`,
+    owner: context.owner,
+    dependency: context.dependency,
+    importPath: context.importPath,
+    exportName: context.exportName,
+    memberPath: context.memberPath,
+    importChain: context.importChain
+  });
+}
+
 export function createStaticCssEvalExportStarUnsupportedDiagnostic(
   context: StaticCssEvalDiagnosticContext,
   importPath: string
@@ -674,6 +745,59 @@ if (import.meta.vitest) {
         message:
           "Cannot statically evaluate css prop value: commonjs require is unsupported",
         reason: "commonjs-require",
+        owner
+      });
+
+      expect(
+        createStaticCssEvalCjsDynamicRequireUnsupportedDiagnostic({ owner })
+      ).toEqual({
+        id: "STATIC_CSS_EVAL_CJS_DYNAMIC_REQUIRE_UNSUPPORTED",
+        code: "unsupported-source",
+        message:
+          "Cannot statically evaluate css prop value: commonjs dynamic require is unsupported",
+        reason: "commonjs-require",
+        owner
+      });
+
+      expect(
+        createStaticCssEvalCjsExportUnsupportedDiagnostic(
+          { owner },
+          "conditional module.exports assignment"
+        )
+      ).toEqual({
+        id: "STATIC_CSS_EVAL_CJS_EXPORT_UNSUPPORTED",
+        code: "unsupported-source",
+        message:
+          "Cannot statically evaluate css prop value: commonjs export mutation is unsupported: conditional module.exports assignment",
+        reason: "unsupported-source-shape",
+        owner
+      });
+
+      expect(
+        createStaticCssEvalCjsHelperUnsupportedDiagnostic(
+          { owner },
+          "__exportStar"
+        )
+      ).toEqual({
+        id: "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED",
+        code: "unsupported-source",
+        message:
+          "Cannot statically evaluate css prop value: commonjs helper is unsupported: __exportStar",
+        reason: "unsupported-source-shape",
+        owner
+      });
+
+      expect(
+        createStaticCssEvalCjsBundleRuntimeUnsupportedDiagnostic(
+          { owner },
+          "webpack bootstrap"
+        )
+      ).toEqual({
+        id: "STATIC_CSS_EVAL_CJS_BUNDLE_RUNTIME_UNSUPPORTED",
+        code: "unsupported-source",
+        message:
+          "Cannot statically evaluate css prop value: commonjs bundle runtime is unsupported: webpack bootstrap",
+        reason: "runtime-dynamic-value",
         owner
       });
 

--- a/packages/babel/src/staticCssEval/importedModules.ts
+++ b/packages/babel/src/staticCssEval/importedModules.ts
@@ -15,12 +15,31 @@ import {
   createStaticCssEvalProviderSourceMetadata,
   enforceStaticCssEvalProviderSourcePolicy
 } from "./boundary.js";
+import {
+  collectStaticCssEvalCjsRequireBindings,
+  getStaticCssEvalCjsRequireSource,
+  isStaticCssEvalLiteralRequireCallExpression
+} from "./cjsBindings.js";
+import type {
+  ImportedStaticCssEvalCjsBinding,
+  StaticCssEvalCjsRequireSource
+} from "./cjsBindings.js";
+import { containsStaticCssEvalRequireCallExpression } from "./cjsRequireAnalysis.js";
+import {
+  createStaticCssEvalCjsImportRequestParts,
+  createStaticCssEvalCjsReexportRequestParts
+} from "./cjsResolver.js";
+import type { StaticCssEvalCjsResolutionRequestParts } from "./cjsResolver.js";
 import type {
   StaticCssEvalProviderSourceMetadata,
   StaticCssEvalProviderSourcePolicyDescriptor
 } from "./boundary.js";
 import {
   createStaticCssEvalAmbiguousExportStarDiagnostic,
+  createStaticCssEvalCjsBundleRuntimeUnsupportedDiagnostic,
+  createStaticCssEvalCjsDynamicRequireUnsupportedDiagnostic,
+  createStaticCssEvalCjsExportUnsupportedDiagnostic,
+  createStaticCssEvalCjsHelperUnsupportedDiagnostic,
   createStaticCssEvalCjsUnsupportedDiagnostic,
   createStaticCssEvalComputedMemberUnsupportedDiagnostic,
   createStaticCssEvalDiagnostic,
@@ -71,6 +90,7 @@ import type {
   ResolutionDependencyKind,
   StaticCssEvalCacheKey,
   StaticCssEvalDiagnostic,
+  StaticCssEvalDiagnosticId,
   StaticCssEvalExportName,
   StaticCssEvalProvider,
   StaticCssEvalQuery,
@@ -99,6 +119,8 @@ export type ImportedStaticCssEvalImportBinding =
       localName: string;
       importPath: string;
     };
+
+export type { ImportedStaticCssEvalCjsBinding };
 
 export type ImportedStaticCssEvalExportBinding = ExportMapEntry;
 
@@ -194,6 +216,7 @@ export interface ImportedStaticCssEvalImportResolution extends StaticCssEvalProv
 export interface ImportedStaticCssEvalModuleRecord extends StaticCssEvalModuleRecord {
   source: string;
   imports: ReadonlyMap<string, ImportedStaticCssEvalImportBinding>;
+  cjsImports: ReadonlyMap<string, ImportedStaticCssEvalCjsBinding>;
   exports: ReadonlyMap<
     StaticCssEvalExportName,
     ImportedStaticCssEvalExportBinding
@@ -223,9 +246,6 @@ const importResolutionKeySeparator = "\0";
 export function createImportedStaticCssEvalProvider(
   options: CreateImportedStaticCssEvalProviderOptions
 ): StaticCssEvalProvider {
-  // Imported css props are resolved from parsed ESM AST/export maps only.
-  // Keep module execution, `export *`, packages, CJS, spread, computed paths,
-  // and broad namespace handling unsupported instead of adding fallbacks here.
   const resolver = new ImportedStaticCssEvalResolver(options);
 
   return {
@@ -253,6 +273,9 @@ function createImportedStaticCssEvalModuleRecordWithCache(
   );
 
   const imports = new Map<string, ImportedStaticCssEvalImportBinding>();
+  const cjsImports = collectStaticCssEvalCjsRequireBindings(
+    parsedModule.programPath
+  );
 
   for (const statement of parsedModule.program.body) {
     collectModuleImportBindings(statement, imports);
@@ -271,6 +294,7 @@ function createImportedStaticCssEvalModuleRecordWithCache(
     dependencies: [],
     source: loadedModule.source,
     imports,
+    cjsImports,
     exports: parsedModule.exportMap,
     exportAllReexportSources: parsedModule.unsupportedExportStars.flatMap(
       (entry) => (entry.source ? [entry.source] : [])
@@ -443,9 +467,17 @@ class ImportedStaticCssEvalResolver {
       return { kind: "not-candidate" };
     }
 
+    const owner = createQueryOwnerLocation(query);
+    const state = createResolutionState(owner);
     const importBinding = ownerRecord.imports.get(query.bindingName);
+    const cjsBinding = ownerRecord.cjsImports.get(query.bindingName);
+    const requestResult = importBinding
+      ? createResolutionRequest(query, importBinding)
+      : cjsBinding
+        ? createCjsResolutionRequest(query, cjsBinding)
+        : null;
 
-    if (!importBinding) {
+    if (!requestResult) {
       const cjsDiagnostic = this.#createCjsUnsupportedDiagnostic(
         ownerRecord,
         query
@@ -455,14 +487,10 @@ class ImportedStaticCssEvalResolver {
         ? createImportedStaticCssEvalErrorResult({
             query,
             diagnostic: cjsDiagnostic,
-            state: createResolutionState(createQueryOwnerLocation(query))
+            state
           })
         : { kind: "not-candidate" };
     }
-
-    const owner = createQueryOwnerLocation(query);
-    const state = createResolutionState(owner);
-    const requestResult = createResolutionRequest(query, importBinding);
 
     if (requestResult.kind === "error") {
       return createImportedStaticCssEvalErrorResult({
@@ -724,6 +752,17 @@ class ImportedStaticCssEvalResolver {
     const exportEntry = record.exports.get(request.exportName);
 
     if (!exportEntry) {
+      const cjsModuleUnsupportedEntry = getCjsModuleUnsupportedEntry(record);
+
+      if (cjsModuleUnsupportedEntry) {
+        return this.#resolveExportMapEntry(
+          record,
+          cjsModuleUnsupportedEntry,
+          request,
+          state
+        );
+      }
+
       return this.#resolveExportStarEntries(record, request, state);
     }
 
@@ -736,8 +775,12 @@ class ImportedStaticCssEvalResolver {
     request: ImportedStaticCssEvalResolutionRequest,
     state: ImportedStaticCssEvalResolutionState
   ): ImportedStaticCssEvalResolutionResult {
+    const cjsReexportSource =
+      exportEntry.kind === "reexport" || exportEntry.kind === "unsupported"
+        ? null
+        : getStaticExportEntryCjsRequireSource(record, exportEntry);
     const effectiveRequest =
-      exportEntry.kind === "reexport"
+      exportEntry.kind === "reexport" || cjsReexportSource
         ? {
             ...request,
             dependencyKind: "reexported" as const,
@@ -784,6 +827,17 @@ class ImportedStaticCssEvalResolver {
       return this.#resolveReexportEntry(
         record,
         exportEntry,
+        effectiveRequest,
+        state,
+        provenance
+      );
+    }
+
+    if (cjsReexportSource) {
+      return this.#resolveCjsReexportEntry(
+        record,
+        exportEntry,
+        cjsReexportSource,
         effectiveRequest,
         state,
         provenance
@@ -1386,6 +1440,45 @@ class ImportedStaticCssEvalResolver {
       : this.#resolveModuleExport(importResult.record, reexportRequest, state);
   }
 
+  #resolveCjsReexportEntry(
+    record: ImportedStaticCssEvalModuleRecord,
+    exportEntry: Exclude<ExportMapEntry, { kind: "reexport" | "unsupported" }>,
+    source: StaticCssEvalCjsRequireSource,
+    request: ImportedStaticCssEvalResolutionRequest,
+    state: ImportedStaticCssEvalResolutionState,
+    provenance: BindingProvenance
+  ): ImportedStaticCssEvalResolutionResult {
+    const reexportParts = createStaticCssEvalCjsReexportRequestParts({
+      source,
+      queryMemberPath: request.memberPath,
+      reexportName: formatExportName(exportEntry.exportName)
+    });
+    const reexportRequest = createResolutionRequestFromCjsParts(
+      record.id,
+      reexportParts
+    );
+    const importResult = this.#resolveProviderImport(
+      reexportRequest,
+      state.owner,
+      state
+    );
+
+    return importResult.kind === "error"
+      ? {
+          kind: "error",
+          diagnostic: importResult.diagnostic,
+          provenance,
+          cacheKey: createImportedStaticCssEvalCacheKey(
+            state.owner.file,
+            record.parsedModule,
+            request.exportName,
+            request.memberPath,
+            record
+          )
+        }
+      : this.#resolveModuleExport(importResult.record, reexportRequest, state);
+  }
+
   #createMissingExportResult(
     record: ImportedStaticCssEvalModuleRecord,
     request: ImportedStaticCssEvalResolutionRequest,
@@ -1463,17 +1556,35 @@ class ImportedStaticCssEvalResolver {
       ? getStaticCssEvalConstBindingInitExpression(binding)
       : null;
 
+    const unwrappedInit = init
+      ? unwrapTransparentCssRuleExpression(init)
+      : null;
+
     if (
-      !init ||
-      !isRequireCallExpression(unwrapTransparentCssRuleExpression(init))
+      !unwrappedInit ||
+      !containsStaticCssEvalRequireCallExpression(
+        unwrappedInit,
+        ownerRecord.programPath.scope
+      )
     ) {
       return null;
     }
 
-    return createStaticCssEvalCjsUnsupportedDiagnostic({
+    const context = {
       owner: createQueryOwnerLocation(query),
-      memberPath: query.memberPath
-    });
+      ...(query.memberPath ? { memberPath: query.memberPath } : {})
+    };
+
+    if (
+      !isStaticCssEvalLiteralRequireCallExpression(
+        unwrappedInit,
+        ownerRecord.programPath.scope
+      )
+    ) {
+      return createStaticCssEvalCjsDynamicRequireUnsupportedDiagnostic(context);
+    }
+
+    return createStaticCssEvalCjsUnsupportedDiagnostic(context);
   }
 
   #resolveImport(
@@ -1685,6 +1796,103 @@ function createResolutionRequest(
   };
 }
 
+function createCjsResolutionRequest(
+  query: StaticCssEvalQuery,
+  binding: ImportedStaticCssEvalCjsBinding
+): { kind: "resolved"; request: ImportedStaticCssEvalResolutionRequest } {
+  const requestParts = createStaticCssEvalCjsImportRequestParts({
+    binding,
+    queryMemberPath: [...(query.memberPath ?? [])]
+  });
+
+  return {
+    kind: "resolved",
+    request: createResolutionRequestFromCjsParts(query.importerId, requestParts)
+  };
+}
+
+function createResolutionRequestFromCjsParts(
+  importer: string,
+  parts: StaticCssEvalCjsResolutionRequestParts
+): ImportedStaticCssEvalResolutionRequest {
+  return {
+    importer,
+    specifier: parts.specifier,
+    exportName: parts.exportName,
+    memberPath: parts.memberPath,
+    dependencyKind: parts.dependencyKind,
+    provenanceKind: parts.provenanceKind,
+    ...(parts.reexportName !== undefined
+      ? { reexportName: parts.reexportName }
+      : {})
+  };
+}
+
+function getStaticExportEntryCjsRequireSource(
+  record: ImportedStaticCssEvalModuleRecord,
+  exportEntry: Exclude<ExportMapEntry, { kind: "reexport" | "unsupported" }>
+): StaticCssEvalCjsRequireSource | null {
+  return exportEntry.kind === "expression"
+    ? getStaticExpressionCjsRequireSource(record, exportEntry.expression)
+    : getLocalBindingCjsRequireSource(record, exportEntry.localName, []);
+}
+
+function getStaticExpressionCjsRequireSource(
+  record: ImportedStaticCssEvalModuleRecord,
+  expression: t.Expression
+): StaticCssEvalCjsRequireSource | null {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+  const directSource = getStaticCssEvalCjsRequireSource(
+    unwrappedExpression,
+    record.programPath.scope
+  );
+
+  if (directSource) {
+    return directSource;
+  }
+
+  const reference = getStaticCssEvalMemberReference(unwrappedExpression);
+
+  return reference?.kind === "supported"
+    ? getLocalBindingCjsRequireSource(
+        record,
+        reference.bindingName,
+        reference.memberPath
+      )
+    : null;
+}
+
+function getLocalBindingCjsRequireSource(
+  record: ImportedStaticCssEvalModuleRecord,
+  localName: string,
+  memberPath: readonly string[]
+): StaticCssEvalCjsRequireSource | null {
+  const binding = record.programPath.scope.getBinding(localName);
+  const expression = binding
+    ? getStaticCssEvalConstBindingInitExpression(binding)
+    : null;
+  const source = getStaticCssEvalCjsRequireSource(
+    expression ? unwrapTransparentCssRuleExpression(expression) : null,
+    record.programPath.scope
+  );
+
+  return source
+    ? appendStaticCssEvalCjsRequireSource(source, memberPath)
+    : null;
+}
+
+function appendStaticCssEvalCjsRequireSource(
+  source: StaticCssEvalCjsRequireSource,
+  memberPath: readonly string[]
+): StaticCssEvalCjsRequireSource {
+  return memberPath.length === 0
+    ? source
+    : {
+        importPath: source.importPath,
+        propertyPath: [...source.propertyPath, ...memberPath]
+      };
+}
+
 function resolveStaticExportMapEntry(
   record: ImportedStaticCssEvalModuleRecord,
   exportEntry: Exclude<ExportMapEntry, { kind: "reexport" | "unsupported" }>,
@@ -1770,13 +1978,27 @@ function getStaticExportEntryExpression(
     const expression = unwrapTransparentCssRuleExpression(
       exportEntry.expression
     );
+    const reference = getStaticCssEvalMemberReference(expression);
 
-    if (t.isIdentifier(expression)) {
+    if (reference?.kind === "supported") {
       return getLocalBindingExpressionResult(
         record,
-        expression.name,
-        exportEntry.exportName
+        reference.bindingName,
+        exportEntry.exportName,
+        reference.memberPath
       );
+    }
+
+    if (reference?.kind === "unsupported") {
+      return {
+        kind: "error",
+        diagnostic: createStaticCssEvalComputedMemberUnsupportedDiagnostic({
+          owner: { file: record.id },
+          dependency: { file: record.id },
+          exportName: exportEntry.exportName,
+          memberPath: reference.memberPath
+        })
+      };
     }
 
     return { kind: "resolved", expression, localName: null };
@@ -1792,7 +2014,8 @@ function getStaticExportEntryExpression(
 function getLocalBindingExpressionResult(
   record: ImportedStaticCssEvalModuleRecord,
   localName: string,
-  exportName: StaticCssEvalExportName
+  exportName: StaticCssEvalExportName,
+  memberPath: readonly string[] = []
 ):
   | { kind: "resolved"; expression: t.Expression; localName: string }
   | { kind: "error"; diagnostic: StaticCssEvalDiagnostic } {
@@ -1802,9 +2025,30 @@ function getLocalBindingExpressionResult(
     : null;
 
   if (expression) {
+    const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+    const memberExpression = resolveStaticObjectMemberPath(
+      unwrappedExpression,
+      memberPath
+    );
+
+    if (!memberExpression) {
+      return {
+        kind: "error",
+        diagnostic: createStaticCssEvalDynamicExpressionUnsupportedDiagnostic(
+          {
+            owner: { file: record.id },
+            dependency: { file: record.id },
+            exportName,
+            memberPath
+          },
+          unwrappedExpression.type
+        )
+      };
+    }
+
     return {
       kind: "resolved",
-      expression: unwrapTransparentCssRuleExpression(expression),
+      expression: memberExpression,
       localName
     };
   }
@@ -1873,10 +2117,44 @@ function createUnsupportedExportEntryDiagnostic(
     );
   }
 
+  if (exportEntry.unsupportedKind === "cjs-export") {
+    return createStaticCssEvalCjsExportUnsupportedDiagnostic(
+      context,
+      exportEntry.cjsExportMutation ?? exportEntry.declaration.type
+    );
+  }
+
+  if (exportEntry.unsupportedKind === "cjs-helper") {
+    return createStaticCssEvalCjsHelperUnsupportedDiagnostic(
+      context,
+      exportEntry.cjsHelperName ?? exportEntry.declaration.type
+    );
+  }
+
+  if (exportEntry.unsupportedKind === "cjs-bundle-runtime") {
+    return createStaticCssEvalCjsBundleRuntimeUnsupportedDiagnostic(
+      context,
+      exportEntry.cjsBundleRuntimeName ?? exportEntry.declaration.type
+    );
+  }
+
   return createStaticCssEvalDynamicExpressionUnsupportedDiagnostic(
     context,
     exportEntry.declaration.type
   );
+}
+
+function getCjsModuleUnsupportedEntry(
+  record: ImportedStaticCssEvalModuleRecord
+): Extract<ExportMapEntry, { kind: "unsupported" }> | null {
+  const entry = record.exports.get(null);
+
+  return entry?.kind === "unsupported" &&
+    (entry.unsupportedKind === "cjs-bundle-runtime" ||
+      entry.unsupportedKind === "cjs-helper" ||
+      entry.unsupportedKind === "cjs-export")
+    ? entry
+    : null;
 }
 
 function createBindingProvenance(
@@ -2225,14 +2503,6 @@ function formatStaticCssEvalQueryExpression(query: StaticCssEvalQuery): string {
     : "";
 
   return `${bindingName}${memberPath}`;
-}
-
-function isRequireCallExpression(expression: t.Expression): boolean {
-  return (
-    t.isCallExpression(expression) &&
-    t.isIdentifier(expression.callee) &&
-    expression.callee.name === "require"
-  );
 }
 
 function hasImportedStaticCssBindingMutation(
@@ -2921,6 +3191,55 @@ if (import.meta.vitest) {
     });
   }
 
+  type CjsUnsupportedFixture = {
+    readonly stylesSource: string;
+    readonly ownerSource: string;
+    readonly bindingName: string;
+    readonly expectedDiagnosticId: StaticCssEvalDiagnosticId;
+    readonly memberPath?: readonly string[];
+  };
+
+  function expectCjsUnsupportedFixture(fixture: CjsUnsupportedFixture): void {
+    expect(
+      resolveFixture(
+        createProvider(fixture.stylesSource, fixture.ownerSource),
+        fixture.bindingName,
+        [...(fixture.memberPath ?? [])]
+      )
+    ).toMatchObject({
+      kind: "error",
+      diagnostic: { id: fixture.expectedDiagnosticId }
+    });
+  }
+
+  function createEsbuildHelperSource(copyPropsSource: string): string {
+    return `
+      var __defProp = Object.defineProperty;
+      var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+      var __getOwnPropNames = Object.getOwnPropertyNames;
+      var __hasOwnProp = Object.prototype.hasOwnProperty;
+      var __export = (target, all) => {
+        for (var name in all)
+          __defProp(target, name, { get: all[name], enumerable: true });
+      };
+      ${copyPropsSource}
+      var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+    `;
+  }
+
+  function createEsbuildCopyPropsHelperSource(): string {
+    return `
+      var __copyProps = (to, from, except, desc) => {
+        if (from && typeof from === "object" || typeof from === "function") {
+          for (let key of __getOwnPropNames(from))
+            if (!__hasOwnProp.call(to, key) && key !== except)
+              __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+        }
+        return to;
+      };
+    `;
+  }
+
   describe("imported static css eval module records", () => {
     it("matches parser plugins to the loaded module extension", () => {
       expect(() =>
@@ -2958,6 +3277,85 @@ if (import.meta.vitest) {
       expect(red.sourceHash).toMatch(/^inline:[a-z0-9]+$/);
       expect(red.sourceHash).toBe(red.parsedModule.sourceHash);
       expect(red.sourceHash).not.toBe(sky.sourceHash);
+    });
+
+    it("collects literal CommonJS require bindings into module records", () => {
+      const record = createImportedStaticCssEvalModuleRecord({
+        id: ownerId,
+        source: `
+          import type { ThemeTokens } from "./styles";
+
+          const styles = require("./styles");
+          const memberButton = require("./styles").button;
+          const memberDefault = require("./styles").default;
+          const { button, card: cardStyle } = require("./styles");
+        `
+      });
+
+      expect(record.imports.has("ThemeTokens")).toBe(false);
+      expect([...record.cjsImports.entries()]).toEqual([
+        [
+          "styles",
+          {
+            kind: "cjs-module",
+            localName: "styles",
+            importPath: "./styles",
+            propertyPath: []
+          }
+        ],
+        [
+          "memberButton",
+          {
+            kind: "cjs-member",
+            localName: "memberButton",
+            importPath: "./styles",
+            propertyPath: ["button"]
+          }
+        ],
+        [
+          "memberDefault",
+          {
+            kind: "cjs-member",
+            localName: "memberDefault",
+            importPath: "./styles",
+            propertyPath: ["default"]
+          }
+        ],
+        [
+          "button",
+          {
+            kind: "cjs-destructured",
+            localName: "button",
+            importPath: "./styles",
+            propertyPath: ["button"]
+          }
+        ],
+        [
+          "cardStyle",
+          {
+            kind: "cjs-destructured",
+            localName: "cardStyle",
+            importPath: "./styles",
+            propertyPath: ["card"]
+          }
+        ]
+      ]);
+    });
+
+    it("ignores literal CommonJS require when require is locally bound", () => {
+      const record = createImportedStaticCssEvalModuleRecord({
+        id: ownerId,
+        source: `const require = makeRequire(); const styles = require("./styles");`
+      });
+      const provider = createProvider(
+        `export const button = { color: "red" } as const;`,
+        `const require = makeRequire(); const styles = require("./styles"); <div css={styles.button} />;`
+      );
+
+      expect(record.cjsImports.has("styles")).toBe(false);
+      expect(resolveFixture(provider, "styles", ["button"])).toEqual({
+        kind: "not-candidate"
+      });
     });
 
     it("resolves named, aliased, default object, default const, and same-module export aliases", () => {
@@ -4180,7 +4578,260 @@ if (import.meta.vitest) {
       });
     });
 
-    it("rejects missing exports, unresolved imports, cjs, and cycles with exact diagnostics", () => {
+    it("resolves static CommonJS require bindings and require-backed CJS exports", () => {
+      const cjsImportProvider = createProvider(
+        `
+          export const button = { color: "red" } as const;
+          export const card = { color: "blue" } as const;
+          export default { color: "green" } as const;
+        `,
+        `
+          const styles = require("./styles");
+          const directButton = require("./styles").button;
+          const { card: cardStyle } = require("./styles");
+        `
+      );
+
+      expect(
+        resolveFixture(cjsImportProvider, "styles", ["button"])
+      ).toMatchObject({
+        kind: "resolved",
+        value: { color: "red" },
+        provenance: {
+          kind: "imported",
+          file: stylesId,
+          exportName: "button"
+        },
+        dependencies: [
+          {
+            file: stylesId,
+            kind: "imported",
+            importer: ownerId,
+            specifier: "./styles",
+            exportName: "button",
+            memberPath: [],
+            inspected: true,
+            contributed: true
+          }
+        ]
+      });
+      expect(resolveFixture(cjsImportProvider, "directButton")).toMatchObject({
+        kind: "resolved",
+        value: { color: "red" }
+      });
+      expect(resolveFixture(cjsImportProvider, "cardStyle")).toMatchObject({
+        kind: "resolved",
+        value: { color: "blue" }
+      });
+
+      expect(
+        resolveFixture(
+          createProvider(
+            `module.exports = { button: { color: "red" }, card: { color: "blue" } };`,
+            `const styles = require("./styles"); <div css={styles} />;`
+          ),
+          "styles"
+        )
+      ).toMatchObject({
+        kind: "resolved",
+        value: {
+          button: { color: "red" },
+          card: { color: "blue" }
+        },
+        provenance: {
+          kind: "imported",
+          file: stylesId,
+          exportName: null
+        }
+      });
+
+      const cjsReexportProvider = createProvider(
+        `
+          export const button = { color: "red" } as const;
+          export const card = { color: "blue" } as const;
+        `,
+        `import { button, card } from "./barrel"; <><div css={button} /><div css={card} /></>;`,
+        `
+          const styles = require("./styles");
+          exports.button = styles.button;
+          exports.card = require("./styles").card;
+        `
+      );
+
+      expect(resolveFixture(cjsReexportProvider, "button")).toMatchObject({
+        kind: "resolved",
+        value: { color: "red" },
+        provenance: {
+          kind: "reexported",
+          file: stylesId,
+          exportName: "button",
+          reexportName: "button"
+        },
+        dependencies: [
+          {
+            file: barrelId,
+            kind: "reexported",
+            inspected: true,
+            contributed: true
+          },
+          {
+            file: stylesId,
+            kind: "reexported",
+            inspected: true,
+            contributed: true
+          }
+        ],
+        resolutionChain: [
+          { importer: ownerId, source: barrelId, exportName: "button" },
+          { importer: barrelId, source: stylesId, exportName: "button" }
+        ]
+      });
+      expect(resolveFixture(cjsReexportProvider, "card")).toMatchObject({
+        kind: "resolved",
+        value: { color: "blue" },
+        provenance: {
+          kind: "reexported",
+          file: stylesId,
+          exportName: "card",
+          reexportName: "card"
+        }
+      });
+    });
+
+    it("resolves esbuild static CommonJS helper named default and require-backed exports", () => {
+      const esbuildStylesSource = `
+        ${createEsbuildHelperSource(createEsbuildCopyPropsHelperSource())}
+        const button = { color: "red" };
+        const root = { color: "green" };
+        __export(exports, {
+          button: () => button,
+          default: () => root
+        });
+        module.exports = __toCommonJS(exports);
+      `;
+      const esbuildProvider = createProvider(
+        esbuildStylesSource,
+        `const styles = require("./styles"); <><div css={styles.button} /><div css={styles.default} /></>;`
+      );
+      const buttonResult = expectResolvedResult(
+        resolveFixture(esbuildProvider, "styles", ["button"])
+      );
+      const defaultResult = expectResolvedResult(
+        resolveFixture(esbuildProvider, "styles", ["default"])
+      );
+
+      expect(buttonResult.value).toEqual({ color: "red" });
+      expect(defaultResult.value).toEqual({ color: "green" });
+
+      const reexportProvider = createProvider(
+        `export const button = { color: "blue" } as const;`,
+        `import { button } from "./barrel"; <div css={button} />;`,
+        `
+          ${createEsbuildHelperSource(createEsbuildCopyPropsHelperSource())}
+          const styles = require("./styles");
+          __export(exports, { button: () => styles.button });
+          module.exports = __toCommonJS(exports);
+        `
+      );
+
+      expect(resolveFixture(reexportProvider, "button")).toMatchObject({
+        kind: "resolved",
+        value: { color: "blue" },
+        provenance: {
+          kind: "reexported",
+          file: stylesId,
+          exportName: "button",
+          reexportName: "button"
+        },
+        resolutionChain: [
+          { importer: ownerId, source: barrelId, exportName: "button" },
+          { importer: barrelId, source: stylesId, exportName: "button" }
+        ]
+      });
+    });
+
+    it("rejects esbuild copyProps helper definitions missing required guard pieces", () => {
+      const cases: readonly string[] = [
+        `
+          var __copyProps = (to, from, except, desc) => {
+            if (from) {
+              for (let key of __getOwnPropNames(from))
+                if (!__hasOwnProp.call(to, key) && key !== except)
+                  __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+            }
+            return to;
+          };
+        `,
+        `
+          var __copyProps = (to, from, except, desc) => {
+            if (from && typeof from === "object" || typeof from === "function") {
+              for (let key of Object.keys(from))
+                if (!__hasOwnProp.call(to, key) && key !== except)
+                  __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+            }
+            return to;
+          };
+        `,
+        `
+          var __copyProps = (to, from, except, desc) => {
+            if (from && typeof from === "object" || typeof from === "function") {
+              for (let key of __getOwnPropNames(from))
+                if (key !== except)
+                  __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+            }
+            return to;
+          };
+        `,
+        `
+          var __copyProps = (to, from, except, desc) => {
+            if (from && typeof from === "object" || typeof from === "function") {
+              for (let key of __getOwnPropNames(from))
+                if (!__hasOwnProp.call(to, key))
+                  __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+            }
+            return to;
+          };
+        `,
+        `
+          var __copyProps = (to, from, except, desc) => {
+            if (from && typeof from === "object" || typeof from === "function") {
+              for (let key of __getOwnPropNames(from))
+                if (!__hasOwnProp.call(to, key) && key !== except)
+                  __defProp(to, key, { get: () => from[key], enumerable: true });
+            }
+            return to;
+          };
+        `,
+        `
+          var __copyProps = (to, from, except, desc) => {
+            if (from && typeof from === "object" || typeof from === "function") {
+              for (let key of __getOwnPropNames(from))
+                if (!__hasOwnProp.call(to, key) && key !== except)
+                  __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) });
+            }
+            return to;
+          };
+        `
+      ];
+
+      for (const copyPropsSource of cases) {
+        expectCjsUnsupportedFixture({
+          stylesSource: `
+            ${createEsbuildHelperSource(copyPropsSource)}
+            var entry_exports = {};
+            const button = { color: "red" };
+            __export(entry_exports, { button: () => button });
+            module.exports = __toCommonJS(entry_exports);
+          `,
+          ownerSource: `const styles = require("./styles"); <div css={styles.button} />;`,
+          bindingName: "styles",
+          memberPath: ["button"],
+          expectedDiagnosticId: "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED"
+        });
+      }
+    });
+
+    it("rejects missing exports, unresolved imports, dynamic cjs, and cycles with exact diagnostics", () => {
       expect(
         resolveFixture(
           createProvider(
@@ -4233,17 +4884,18 @@ if (import.meta.vitest) {
         resolveFixture(
           createProvider(
             `export const button = { color: "red" } as const;`,
-            `const button = require("./styles"); <div css={button} />;`
+            `const styles = require(name); <div css={styles.button} />;`
           ),
-          "button"
+          "styles",
+          ["button"]
         )
       ).toMatchObject({
         kind: "error",
         diagnostic: {
-          id: "STATIC_CSS_EVAL_CJS_UNSUPPORTED",
+          id: "STATIC_CSS_EVAL_CJS_DYNAMIC_REQUIRE_UNSUPPORTED",
           reason: "commonjs-require",
           message:
-            "Cannot statically evaluate css prop value: commonjs require is unsupported"
+            "Cannot statically evaluate css prop value: commonjs dynamic require is unsupported"
         }
       });
 
@@ -4280,6 +4932,284 @@ if (import.meta.vitest) {
           id: "STATIC_CSS_EVAL_IMPORT_CYCLE"
         }
       });
+    });
+
+    it("rejects unsupported CommonJS require forms with narrow dynamic diagnostics", () => {
+      const cases: readonly CjsUnsupportedFixture[] = [
+        {
+          stylesSource: `export const button = { color: "red" } as const;`,
+          ownerSource: `const styles = require(name); <div css={styles.button} />;`,
+          bindingName: "styles",
+          memberPath: ["button"],
+          expectedDiagnosticId:
+            "STATIC_CSS_EVAL_CJS_DYNAMIC_REQUIRE_UNSUPPORTED"
+        },
+        {
+          stylesSource: `export const button = { color: "red" } as const;`,
+          ownerSource:
+            "const styles = require(`./${name}`); <div css={styles.button} />;",
+          bindingName: "styles",
+          memberPath: ["button"],
+          expectedDiagnosticId:
+            "STATIC_CSS_EVAL_CJS_DYNAMIC_REQUIRE_UNSUPPORTED"
+        },
+        {
+          stylesSource: `export const button = { color: "red" } as const;`,
+          ownerSource: `const styles = enabled ? require("./styles") : require("./fallback"); <div css={styles.button} />;`,
+          bindingName: "styles",
+          memberPath: ["button"],
+          expectedDiagnosticId:
+            "STATIC_CSS_EVAL_CJS_DYNAMIC_REQUIRE_UNSUPPORTED"
+        },
+        {
+          stylesSource: `export const button = { color: "red" } as const;`,
+          ownerSource:
+            "const styles = `prefix-${require(name)}`; <div css={styles.button} />;",
+          bindingName: "styles",
+          memberPath: ["button"],
+          expectedDiagnosticId:
+            "STATIC_CSS_EVAL_CJS_DYNAMIC_REQUIRE_UNSUPPORTED"
+        },
+        {
+          stylesSource: `export const button = { color: "red" } as const;`,
+          ownerSource:
+            "const styles = require(name)`styles`; <div css={styles.button} />;",
+          bindingName: "styles",
+          memberPath: ["button"],
+          expectedDiagnosticId:
+            "STATIC_CSS_EVAL_CJS_DYNAMIC_REQUIRE_UNSUPPORTED"
+        },
+        {
+          stylesSource: `export const button = { color: "red" } as const;`,
+          ownerSource:
+            "const styles = tag`styles-${require(name)}`; <div css={styles.button} />;",
+          bindingName: "styles",
+          memberPath: ["button"],
+          expectedDiagnosticId:
+            "STATIC_CSS_EVAL_CJS_DYNAMIC_REQUIRE_UNSUPPORTED"
+        },
+        {
+          stylesSource: `export const button = { color: "red" } as const;`,
+          ownerSource:
+            "const styles = new (require(name))(); <div css={styles.button} />;",
+          bindingName: "styles",
+          memberPath: ["button"],
+          expectedDiagnosticId:
+            "STATIC_CSS_EVAL_CJS_DYNAMIC_REQUIRE_UNSUPPORTED"
+        },
+        {
+          stylesSource: `export const button = { color: "red" } as const;`,
+          ownerSource:
+            "const styles = new Styles(require(name)); <div css={styles.button} />;",
+          bindingName: "styles",
+          memberPath: ["button"],
+          expectedDiagnosticId:
+            "STATIC_CSS_EVAL_CJS_DYNAMIC_REQUIRE_UNSUPPORTED"
+        },
+        {
+          stylesSource: `export const button = { color: "red" } as const;`,
+          ownerSource:
+            "const styles = await require(name); <div css={styles.button} />;",
+          bindingName: "styles",
+          memberPath: ["button"],
+          expectedDiagnosticId:
+            "STATIC_CSS_EVAL_CJS_DYNAMIC_REQUIRE_UNSUPPORTED"
+        },
+        {
+          stylesSource: `export const button = { color: "red" } as const;`,
+          ownerSource:
+            "const styles = (target = require(name)); <div css={styles.button} />;",
+          bindingName: "styles",
+          memberPath: ["button"],
+          expectedDiagnosticId:
+            "STATIC_CSS_EVAL_CJS_DYNAMIC_REQUIRE_UNSUPPORTED"
+        },
+        {
+          stylesSource: `export const button = { color: "red" } as const;`,
+          ownerSource:
+            "const styles = (target[require(name)] = fallback); <div css={styles.button} />;",
+          bindingName: "styles",
+          memberPath: ["button"],
+          expectedDiagnosticId:
+            "STATIC_CSS_EVAL_CJS_DYNAMIC_REQUIRE_UNSUPPORTED"
+        },
+        {
+          stylesSource: `export const button = { color: "red" } as const;`,
+          ownerSource:
+            "const styles = (require(name))<unknown>; <div css={styles.button} />;",
+          bindingName: "styles",
+          memberPath: ["button"],
+          expectedDiagnosticId:
+            "STATIC_CSS_EVAL_CJS_DYNAMIC_REQUIRE_UNSUPPORTED"
+        }
+      ];
+
+      for (const fixture of cases) {
+        expectCjsUnsupportedFixture(fixture);
+      }
+    });
+
+    it("fails closed when CommonJS globals are lexically shadowed", () => {
+      const shadowedRequireProvider = createProvider(
+        `export const button = { color: "red" } as const;`,
+        `const require = makeRequire(); const styles = require("./styles"); <div css={styles.button} />;`
+      );
+
+      expect(
+        resolveFixture(shadowedRequireProvider, "styles", ["button"])
+      ).toEqual({
+        kind: "not-candidate"
+      });
+      expectCjsUnsupportedFixture({
+        stylesSource: `const exports = {}; exports.button = { color: "red" };`,
+        ownerSource: `const styles = require("./styles"); <div css={styles.button} />;`,
+        bindingName: "styles",
+        memberPath: ["button"],
+        expectedDiagnosticId: "STATIC_CSS_EVAL_UNRESOLVED_EXPORT"
+      });
+      expectCjsUnsupportedFixture({
+        stylesSource: `const module = {}; module.exports = { button: { color: "red" } };`,
+        ownerSource: `const styles = require("./styles"); <div css={styles.button} />;`,
+        bindingName: "styles",
+        memberPath: ["button"],
+        expectedDiagnosticId: "STATIC_CSS_EVAL_UNRESOLVED_EXPORT"
+      });
+
+      const parameterShadowedExportsSource = `
+        function write(exports) {
+          exports.button = { color: "red" };
+        }
+        write({});
+      `;
+      const parameterShadowedExportsRecord =
+        createImportedStaticCssEvalModuleRecord({
+          id: stylesId,
+          source: parameterShadowedExportsSource
+        });
+
+      expect(parameterShadowedExportsRecord.exports.has("button")).toBe(false);
+      expectCjsUnsupportedFixture({
+        stylesSource: parameterShadowedExportsSource,
+        ownerSource: `const styles = require("./styles"); <div css={styles.button} />;`,
+        bindingName: "styles",
+        memberPath: ["button"],
+        expectedDiagnosticId: "STATIC_CSS_EVAL_UNRESOLVED_EXPORT"
+      });
+    });
+
+    it("rejects unsupported CommonJS export mutations before className compilation", () => {
+      const cases: readonly CjsUnsupportedFixture[] = [
+        {
+          stylesSource: `
+            const button = { color: "red" };
+            if (enabled) exports.button = button;
+          `,
+          ownerSource: `const styles = require("./styles"); <div css={styles.button} />;`,
+          bindingName: "styles",
+          memberPath: ["button"],
+          expectedDiagnosticId: "STATIC_CSS_EVAL_CJS_EXPORT_UNSUPPORTED"
+        },
+        {
+          stylesSource: `
+            const button = { color: "red" };
+            for (const name of ["button"]) exports.button = button;
+          `,
+          ownerSource: `const styles = require("./styles"); <div css={styles.button} />;`,
+          bindingName: "styles",
+          memberPath: ["button"],
+          expectedDiagnosticId: "STATIC_CSS_EVAL_CJS_EXPORT_UNSUPPORTED"
+        },
+        {
+          stylesSource: `
+            const root = {};
+            module.exports = root;
+            exports.button = { color: "red" };
+          `,
+          ownerSource: `const styles = require("./styles"); <div css={styles.button} />;`,
+          bindingName: "styles",
+          memberPath: ["button"],
+          expectedDiagnosticId: "STATIC_CSS_EVAL_CJS_EXPORT_UNSUPPORTED"
+        }
+      ];
+
+      for (const fixture of cases) {
+        expectCjsUnsupportedFixture(fixture);
+      }
+    });
+
+    it("rejects unsupported CommonJS helper definitions before className compilation", () => {
+      const cases: readonly CjsUnsupportedFixture[] = [
+        {
+          stylesSource: `
+            function __createBinding() { sideEffect(); }
+            const theme = require("./theme");
+            __createBinding(exports, theme, "button");
+          `,
+          ownerSource: `const styles = require("./styles"); <div css={styles.button} />;`,
+          bindingName: "styles",
+          memberPath: ["button"],
+          expectedDiagnosticId: "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED"
+        },
+        {
+          stylesSource: `
+            const button = { color: "red" };
+            var __export = function () { sideEffect(); };
+            __export(exports, { button: function () { return button; } });
+          `,
+          ownerSource: `const styles = require("./styles"); <div css={styles.button} />;`,
+          bindingName: "styles",
+          memberPath: ["button"],
+          expectedDiagnosticId: "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED"
+        }
+      ];
+
+      for (const fixture of cases) {
+        expectCjsUnsupportedFixture(fixture);
+      }
+    });
+
+    it("rejects Webpack Turbopack and Parcel CommonJS bundle runtime snippets", () => {
+      const cases: readonly CjsUnsupportedFixture[] = [
+        {
+          stylesSource: `
+            var __webpack_modules__ = {
+              "./style": function (module) {
+                module.exports = { button: { color: "red" } };
+              }
+            };
+            function __webpack_require__(id) { return __webpack_modules__[id]({ exports: {} }); }
+            module.exports = __webpack_require__("./style");
+          `,
+          ownerSource: `const styles = require("./styles"); <div css={styles.button} />;`,
+          bindingName: "styles",
+          memberPath: ["button"],
+          expectedDiagnosticId: "STATIC_CSS_EVAL_CJS_BUNDLE_RUNTIME_UNSUPPORTED"
+        },
+        {
+          stylesSource: `
+            function __turbopack_require__(id) { return id; }
+            module.exports = __turbopack_require__("[project]/style");
+          `,
+          ownerSource: `const styles = require("./styles"); <div css={styles.button} />;`,
+          bindingName: "styles",
+          memberPath: ["button"],
+          expectedDiagnosticId: "STATIC_CSS_EVAL_CJS_BUNDLE_RUNTIME_UNSUPPORTED"
+        },
+        {
+          stylesSource: `
+            var parcelRequire = function (id) { return id; };
+            module.exports = parcelRequire("style");
+          `,
+          ownerSource: `const styles = require("./styles"); <div css={styles.button} />;`,
+          bindingName: "styles",
+          memberPath: ["button"],
+          expectedDiagnosticId: "STATIC_CSS_EVAL_CJS_BUNDLE_RUNTIME_UNSUPPORTED"
+        }
+      ];
+
+      for (const fixture of cases) {
+        expectCjsUnsupportedFixture(fixture);
+      }
     });
 
     it("rejects computed namespace members and ignores type-only imports", () => {

--- a/packages/babel/src/staticCssEval/moduleCache.ts
+++ b/packages/babel/src/staticCssEval/moduleCache.ts
@@ -1,6 +1,9 @@
-import { transformSync, types as t } from "@babel/core";
-import type { NodePath, PluginObj } from "@babel/core";
+import { types as t } from "@babel/core";
+import type { NodePath } from "@babel/core";
+import { collectStaticCssEvalCjsExportMapOperations } from "./cjsExports.js";
+import type { StaticCssEvalCjsExportMapOperation } from "./cjsExports.js";
 import { createStaticCssEvalDiagnostic } from "./diagnostics.js";
+import { parseStaticCssModuleProgram } from "./moduleParser.js";
 import type {
   StaticCssEvalDiagnostic,
   StaticCssEvalExportName,
@@ -12,7 +15,6 @@ import type {
 export const STATIC_CSS_MODULE_CACHE_PARSER_VERSION = "babel-core-parser:v2";
 export const STATIC_CSS_MODULE_CACHE_SUPPORT_VERSION =
   "static-css-module-export-graph:v2";
-
 export interface StaticCssModuleSource {
   resolvedFile: string;
   source: string;
@@ -63,7 +65,7 @@ export interface ExportMapExpressionEntry {
   kind: "expression";
   exportName: StaticCssEvalExportName;
   expression: t.Expression;
-  declaration: t.ExportDefaultDeclaration;
+  declaration: t.ExportDefaultDeclaration | t.Statement;
 }
 
 export interface ExportMapLocalEntry {
@@ -79,19 +81,25 @@ export interface ExportMapReexportEntry {
   exportName: StaticCssEvalExportName;
   importedName: string;
   source: string;
-  declaration: t.ExportNamedDeclaration;
+  declaration: t.ExportNamedDeclaration | t.Statement;
 }
 
 export interface ExportMapUnsupportedEntry {
   kind: "unsupported";
   exportName: StaticCssEvalExportName;
-  unsupportedKind: "default-declaration" | "export-namespace" | "export-star";
-  declaration:
-    | t.ExportAllDeclaration
-    | t.ExportDefaultDeclaration
-    | t.ExportNamedDeclaration;
+  unsupportedKind:
+    | "cjs-bundle-runtime"
+    | "cjs-helper"
+    | "cjs-export"
+    | "default-declaration"
+    | "export-namespace"
+    | "export-star";
+  declaration: StaticCssModuleExportDeclaration | t.Statement;
   diagnostic: StaticCssEvalDiagnostic;
   source?: string;
+  cjsExportMutation?: string;
+  cjsHelperName?: string;
+  cjsBundleRuntimeName?: string;
 }
 
 export type ExportGraphEntry = ExportMapEntry | ExportGraphStarReexportEntry;
@@ -100,7 +108,7 @@ export interface ExportGraphStarReexportEntry {
   readonly kind: "star-reexport";
   readonly exportName: "*";
   readonly source: string;
-  readonly declaration: t.ExportAllDeclaration;
+  readonly declaration: t.ExportAllDeclaration | t.Statement;
 }
 
 export interface StaticCssModuleExportStarSource {
@@ -139,6 +147,7 @@ interface StaticCssModuleExportGraphBuildState {
   exportGraph: ExportGraphEntry[];
   exportStarReexports: ExportGraphStarReexportEntry[];
   unsupportedExportStars: ExportGraphStarReexportEntry[];
+  cjsExportNames: Set<StaticCssEvalExportName>;
 }
 
 export interface StaticCssModuleCache {
@@ -240,36 +249,11 @@ function parseStaticCssModule(
   source: StaticCssModuleSource,
   cacheKey: ExportMapCacheKey
 ): ParsedStaticCssModule {
-  const parserOptions = cacheKey.parserOptions;
-  const programPathRef: { current?: NodePath<t.Program> } = {};
-  const captureProgramPathPlugin: PluginObj = {
-    visitor: {
-      Program(path: NodePath<t.Program>) {
-        programPathRef.current = path;
-        path.stop();
-      }
-    }
-  };
-  const result = transformSync(source.source, {
-    filename: source.resolvedFile,
-    ast: true,
-    code: false,
-    sourceType: "module",
-    configFile: false,
-    babelrc: false,
-    parserOpts: {
-      plugins: [
-        ...(parserOptions.jsx ? (["jsx"] as const) : []),
-        ...(parserOptions.typescript ? (["typescript"] as const) : [])
-      ]
-    },
-    plugins: [captureProgramPathPlugin]
+  const { ast, programPath } = parseStaticCssModuleProgram({
+    resolvedFile: source.resolvedFile,
+    source: source.source,
+    parserOptions: cacheKey.parserOptions
   });
-  const programPath = programPathRef.current;
-
-  if (!programPath || !result?.ast) {
-    throw new Error(`Failed to parse static css module ${source.resolvedFile}`);
-  }
 
   const importDeclarations: t.ImportDeclaration[] = [];
   const exportDeclarations: StaticCssModuleExportDeclaration[] = [];
@@ -290,7 +274,11 @@ function parseStaticCssModule(
     exportGraph,
     exportStarReexports,
     unsupportedExportStars
-  } = buildStaticCssModuleExportMap(source.resolvedFile, exportDeclarations);
+  } = buildStaticCssModuleExportMap(
+    source.resolvedFile,
+    exportDeclarations,
+    programPath
+  );
 
   return {
     file: source.resolvedFile,
@@ -299,7 +287,7 @@ function parseStaticCssModule(
     sourceHash: source.sourceHash,
     sourceVersionHash: createSourceVersionHash(source),
     cacheKey,
-    ast: result.ast,
+    ast,
     program: programPath.node,
     programPath,
     importDeclarations,
@@ -327,7 +315,7 @@ function getStaticCssModuleParserOptions(
       ...(jsx ? (["jsx"] as const) : []),
       ...(typescript ? (["typescript"] as const) : [])
     ],
-    sourceType: "module",
+    sourceType: "unambiguous",
     jsx,
     typescript
   };
@@ -335,7 +323,8 @@ function getStaticCssModuleParserOptions(
 
 function buildStaticCssModuleExportMap(
   file: string,
-  exportDeclarations: readonly StaticCssModuleExportDeclaration[]
+  exportDeclarations: readonly StaticCssModuleExportDeclaration[],
+  programPath: NodePath<t.Program>
 ): {
   exportMap: ReadonlyMap<StaticCssEvalExportName, ExportMapEntry>;
   exportGraph: readonly ExportGraphEntry[];
@@ -347,11 +336,21 @@ function buildStaticCssModuleExportMap(
     exportMap: new Map<StaticCssEvalExportName, ExportMapEntry>(),
     exportGraph: [],
     exportStarReexports: [],
-    unsupportedExportStars: []
+    unsupportedExportStars: [],
+    cjsExportNames: new Set<StaticCssEvalExportName>()
   };
 
   for (const declaration of exportDeclarations) {
     collectStaticCssModuleExportEntries(declaration, state);
+  }
+
+  if (programPath.node.sourceType === "script") {
+    for (const operation of collectStaticCssEvalCjsExportMapOperations({
+      file,
+      programPath
+    })) {
+      applyStaticCssEvalCjsExportMapOperation(operation, state);
+    }
   }
 
   return {
@@ -561,6 +560,43 @@ function addExportMapEntry(
   state.exportGraph.push(entry);
 }
 
+function applyStaticCssEvalCjsExportMapOperation(
+  operation: StaticCssEvalCjsExportMapOperation,
+  state: StaticCssModuleExportGraphBuildState
+): void {
+  switch (operation.kind) {
+    case "clear-cjs-exports":
+      for (const exportName of state.cjsExportNames) {
+        state.exportMap.delete(exportName);
+      }
+      state.exportStarReexports = state.exportStarReexports.filter(
+        (entry) => !state.cjsExportNames.has(entry.exportName)
+      );
+      state.unsupportedExportStars = state.unsupportedExportStars.filter(
+        (entry) => !state.cjsExportNames.has(entry.exportName)
+      );
+      state.exportGraph = state.exportGraph.filter(
+        (entry) =>
+          entry.kind !== "star-reexport" ||
+          !state.cjsExportNames.has(entry.exportName)
+      );
+      state.cjsExportNames.clear();
+      return;
+    case "preserve-cjs-exports":
+      return;
+    case "set":
+      state.cjsExportNames.add(operation.entry.exportName);
+      addExportMapEntry(state, operation.entry);
+      return;
+    case "star-reexport":
+      state.cjsExportNames.add(operation.entry.exportName);
+      addExportStarReexportEntry(state, operation.entry);
+      return;
+    default:
+      return assertNever(operation);
+  }
+}
+
 function addExportStarReexportEntry(
   state: StaticCssModuleExportGraphBuildState,
   entry: ExportGraphStarReexportEntry
@@ -763,6 +799,111 @@ if (import.meta.vitest) {
     };
   }
 
+  function expectExpressionEntry(
+    entry: ExportMapEntry | null
+  ): Extract<ExportMapEntry, { kind: "expression" }> {
+    expect(entry?.kind).toBe("expression");
+
+    if (!entry || entry.kind !== "expression") {
+      throw new TypeError("expected expression export map entry");
+    }
+
+    return entry;
+  }
+
+  function expectUnsupportedEntry(
+    entry: ExportMapEntry | null
+  ): Extract<ExportMapEntry, { kind: "unsupported" }> {
+    expect(entry?.kind).toBe("unsupported");
+
+    if (!entry || entry.kind !== "unsupported") {
+      throw new TypeError("expected unsupported export map entry");
+    }
+
+    return entry;
+  }
+
+  function getObjectExpressionStringProperty(
+    expression: t.Expression,
+    propertyName: string
+  ): string | null {
+    if (!t.isObjectExpression(expression)) {
+      return null;
+    }
+
+    for (const property of expression.properties) {
+      if (!t.isObjectProperty(property) || property.computed) {
+        continue;
+      }
+
+      const keyName = t.isIdentifier(property.key)
+        ? property.key.name
+        : t.isStringLiteral(property.key)
+          ? property.key.value
+          : null;
+
+      if (keyName !== propertyName || !t.isStringLiteral(property.value)) {
+        continue;
+      }
+
+      return property.value.value;
+    }
+
+    return null;
+  }
+
+  function createTscCreateBindingHelperSource(): string {
+    return `
+      var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        var desc = Object.getOwnPropertyDescriptor(m, k);
+        if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+          desc = { enumerable: true, get: function() { return m[k]; } };
+        }
+        Object.defineProperty(o, k2, desc);
+      }) : (function(o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        o[k2] = m[k];
+      }));
+    `;
+  }
+
+  function createTscExportStarHelperSource(): string {
+    return `
+      var __exportStar = (this && this.__exportStar) || function(m, exports) {
+        for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+      };
+    `;
+  }
+
+  function createEsbuildHelperSource(copyPropsSource: string): string {
+    return `
+      var __defProp = Object.defineProperty;
+      var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+      var __getOwnPropNames = Object.getOwnPropertyNames;
+      var __hasOwnProp = Object.prototype.hasOwnProperty;
+      var __export = (target, all) => {
+        for (var name in all)
+          __defProp(target, name, { get: all[name], enumerable: true });
+      };
+      ${copyPropsSource}
+      var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+    `;
+  }
+
+  function createEsbuildCopyPropsHelperSource(): string {
+    return `
+      var __copyProps = (to, from, except, desc) => {
+        if (from && typeof from === "object" || typeof from === "function") {
+          for (let key of __getOwnPropNames(from))
+            if (!__hasOwnProp.call(to, key) && key !== except)
+              __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+        }
+        return to;
+      };
+    `;
+  }
+
   describe("static css module parse/export-map cache", () => {
     it("parses the same resolved file and source identity once per cache instance", () => {
       const cache = createStaticCssModuleCache();
@@ -837,6 +978,1102 @@ if (import.meta.vitest) {
       expect(parsedModule.programPath.node).toBe(parsedModule.program);
       expect(parsedModule.importDeclarations).toHaveLength(1);
       expect(parsedModule.exportDeclarations).toHaveLength(1);
+    });
+
+    it("parses CommonJS source with CJS-capable parser cache identity", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(`
+        const x = require("./x");
+        module.exports = x;
+      `);
+
+      const parsedModule = cache.getParsedModule(source);
+
+      expect(parsedModule.program.sourceType).toBe("script");
+      expect(parsedModule.cacheKey).toMatchObject({
+        parserVersion: "babel-core-parser:v2",
+        supportVersion: STATIC_CSS_MODULE_CACHE_SUPPORT_VERSION,
+        parserOptions: {
+          plugins: ["typescript"],
+          sourceType: "unambiguous",
+          jsx: false,
+          typescript: true
+        }
+      });
+      expect(parsedModule.importDeclarations).toHaveLength(0);
+      expect(parsedModule.exportDeclarations).toHaveLength(0);
+      expect(parsedModule.exportMap.size).toBe(1);
+      expect(
+        expectExpressionEntry(cache.getExportMapEntry(source, null)).expression
+      ).toMatchObject({
+        type: "Identifier",
+        name: "x"
+      });
+    });
+
+    it("collects literal CommonJS module-value exports into the export map", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(`module.exports = "theme";`);
+
+      expect(
+        expectExpressionEntry(cache.getExportMapEntry(source, null)).expression
+      ).toMatchObject({
+        type: "StringLiteral",
+        value: "theme"
+      });
+    });
+
+    it("collects literal require-call CommonJS module-value exports into the export map", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(`module.exports = require("./theme");`);
+
+      expect(
+        expectExpressionEntry(cache.getExportMapEntry(source, null)).expression
+      ).toMatchObject({
+        type: "CallExpression",
+        callee: {
+          type: "Identifier",
+          name: "require"
+        },
+        arguments: [{ type: "StringLiteral", value: "./theme" }]
+      });
+    });
+
+    it("collects direct CommonJS object and property exports into the export map", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(`
+        const card = { color: "blue" };
+        module.exports = {
+          button: { color: "red" },
+          card
+        };
+      `);
+      const buttonEntry = expectExpressionEntry(
+        cache.getExportMapEntry(source, "button")
+      );
+      const cardEntry = expectExpressionEntry(
+        cache.getExportMapEntry(source, "card")
+      );
+
+      expect(
+        getObjectExpressionStringProperty(buttonEntry.expression, "color")
+      ).toBe("red");
+      expect(cardEntry.expression).toMatchObject({
+        type: "Identifier",
+        name: "card"
+      });
+    });
+
+    it("lets last static top-level CommonJS property assignment win", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(`
+        exports.button = { color: "red" };
+        module.exports.card = { color: "blue" };
+        exports.default = { color: "green" };
+        exports.button = { color: "orange" };
+      `);
+      const buttonEntry = expectExpressionEntry(
+        cache.getExportMapEntry(source, "button")
+      );
+      const cardEntry = expectExpressionEntry(
+        cache.getExportMapEntry(source, "card")
+      );
+      const defaultEntry = expectExpressionEntry(
+        cache.getExportMapEntry(source, "default")
+      );
+
+      expect(
+        getObjectExpressionStringProperty(buttonEntry.expression, "color")
+      ).toBe("orange");
+      expect(
+        getObjectExpressionStringProperty(cardEntry.expression, "color")
+      ).toBe("blue");
+      expect(
+        getObjectExpressionStringProperty(defaultEntry.expression, "color")
+      ).toBe("green");
+    });
+
+    it("collects CommonJS defineProperty value and getter exports", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(`
+        const button = { color: "red" };
+        const source = { card: { color: "blue" } };
+        Object.defineProperty(exports, "button", {
+          value: button,
+          enumerable: true
+        });
+        Object.defineProperty(module.exports, "card", {
+          enumerable: true,
+          get: function () {
+            return source.card;
+          }
+        });
+      `);
+      const buttonEntry = expectExpressionEntry(
+        cache.getExportMapEntry(source, "button")
+      );
+      const cardEntry = expectExpressionEntry(
+        cache.getExportMapEntry(source, "card")
+      );
+
+      expect(buttonEntry.expression).toMatchObject({
+        type: "Identifier",
+        name: "button"
+      });
+      expect(cardEntry.expression).toMatchObject({
+        type: "MemberExpression"
+      });
+    });
+
+    it("collects static TypeScript helper createBinding and exportStar reexports", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(`
+        ${createTscCreateBindingHelperSource()}
+        ${createTscExportStarHelperSource()}
+        const styles = require("./styles");
+        __createBinding(exports, styles, "button");
+        __createBinding(exports, styles, "card", "renamedCard");
+        __exportStar(require("./theme"), exports);
+        __exportStar(require("./tokens"), exports);
+      `);
+
+      const parsedModule = cache.getParsedModule(source);
+      const buttonEntry = cache.getExportMapEntry(source, "button");
+      const renamedCardEntry = cache.getExportMapEntry(source, "renamedCard");
+
+      expect(buttonEntry).toMatchObject({
+        kind: "reexport",
+        exportName: "button",
+        importedName: "button",
+        source: "./styles"
+      });
+      expect(renamedCardEntry).toMatchObject({
+        kind: "reexport",
+        exportName: "renamedCard",
+        importedName: "card",
+        source: "./styles"
+      });
+      expect(parsedModule.exportStarReexports).toEqual([
+        expect.objectContaining({
+          kind: "star-reexport",
+          exportName: "*",
+          source: "./theme"
+        }),
+        expect.objectContaining({
+          kind: "star-reexport",
+          exportName: "*",
+          source: "./tokens"
+        })
+      ]);
+
+      const [themeStar, tokensStar] = parsedModule.exportStarReexports;
+
+      if (!themeStar || !tokensStar) {
+        throw new TypeError("expected helper export-star graph entries");
+      }
+
+      const exportNameTable = createStaticCssModuleExportNameTable(
+        parsedModule.exportMap,
+        [
+          {
+            entry: themeStar,
+            exportNames: ["button", "default", "themeOnly"]
+          },
+          { entry: tokensStar, exportNames: ["themeOnly", "token"] }
+        ]
+      );
+
+      expect(exportNameTable.get("button")).toMatchObject({
+        kind: "explicit",
+        exportName: "button",
+        entry: expect.objectContaining({ kind: "reexport" })
+      });
+      expect(exportNameTable.get("default")).toBeUndefined();
+      expect(exportNameTable.get("themeOnly")).toMatchObject({
+        kind: "ambiguous-star",
+        exportName: "themeOnly",
+        sources: ["./theme", "./tokens"]
+      });
+      expect(exportNameTable.get("token")).toMatchObject({
+        kind: "star",
+        exportName: "token",
+        source: "./tokens"
+      });
+    });
+
+    it("clears CJS star re-export metadata on module.exports replacement", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(`
+        ${createTscCreateBindingHelperSource()}
+        ${createTscExportStarHelperSource()}
+        __exportStar(require("./theme"), exports);
+        module.exports = { button: { color: "red" } };
+      `);
+
+      const parsedModule = cache.getParsedModule(source);
+      const buttonEntry = expectExpressionEntry(
+        cache.getExportMapEntry(source, "button")
+      );
+
+      expect(buttonEntry.expression).toMatchObject({
+        type: "ObjectExpression"
+      });
+      expect(
+        getObjectExpressionStringProperty(buttonEntry.expression, "color")
+      ).toBe("red");
+      expect(parsedModule.exportStarReexports).toHaveLength(0);
+      expect(parsedModule.unsupportedExportStars).toHaveLength(0);
+      expect(
+        parsedModule.exportGraph.some((entry) => entry.kind === "star-reexport")
+      ).toBe(false);
+    });
+
+    it("rejects TypeScript helper impostors and non-literal helper sources", () => {
+      const cache = createStaticCssModuleCache();
+      const alteredCreateBindingSource = createSource(`
+        function __createBinding() { sideEffect(); }
+        const styles = require("./styles");
+        __createBinding(exports, styles, "button");
+      `);
+      const dynamicBindingSource = createSource(
+        `
+          ${createTscCreateBindingHelperSource()}
+          const styles = loadStyles();
+          __createBinding(exports, styles, "card");
+        `,
+        "hash:styles-dynamic-helper-source"
+      );
+      const alteredExportStarSource = createSource(
+        `
+          ${createTscCreateBindingHelperSource()}
+          function __exportStar() { sideEffect(); }
+          __exportStar(require("./styles"), exports);
+        `,
+        "hash:styles-altered-export-star"
+      );
+
+      const alteredCreateBindingEntry = expectUnsupportedEntry(
+        cache.getExportMapEntry(alteredCreateBindingSource, "button")
+      );
+      const dynamicBindingEntry = expectUnsupportedEntry(
+        cache.getExportMapEntry(dynamicBindingSource, "card")
+      );
+      const alteredExportStarModule = cache.getParsedModule(
+        alteredExportStarSource
+      );
+
+      expect(alteredCreateBindingEntry).toMatchObject({
+        unsupportedKind: "cjs-helper",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED",
+          exportName: "button"
+        }
+      });
+      expect(dynamicBindingEntry).toMatchObject({
+        unsupportedKind: "cjs-helper",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED",
+          exportName: "card"
+        }
+      });
+      expect(alteredExportStarModule.exportStarReexports).toHaveLength(0);
+      expect(alteredExportStarModule.exportGraph).toEqual([
+        expect.objectContaining({
+          kind: "unsupported",
+          exportName: null,
+          unsupportedKind: "cjs-helper",
+          diagnostic: expect.objectContaining({
+            id: "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED"
+          })
+        })
+      ]);
+    });
+
+    it("rejects TypeScript exportStar helpers with alternate branches", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(`
+        ${createTscCreateBindingHelperSource()}
+        ${createTscExportStarHelperSource().replace(
+          "__createBinding(exports, m, p);",
+          "__createBinding(exports, m, p); else sideEffect();"
+        )}
+        __exportStar(require("./theme"), exports);
+      `);
+      const parsedModule = cache.getParsedModule(source);
+
+      expect(parsedModule.exportStarReexports).toHaveLength(0);
+      expect(parsedModule.exportGraph).toEqual([
+        expect.objectContaining({
+          kind: "unsupported",
+          exportName: null,
+          unsupportedKind: "cjs-helper",
+          diagnostic: expect.objectContaining({
+            id: "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED"
+          })
+        })
+      ]);
+    });
+
+    it("rejects TypeScript helper fingerprints when Object is shadowed", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(`
+        const Object = {};
+        ${createTscCreateBindingHelperSource()}
+        ${createTscExportStarHelperSource()}
+        const styles = require("./styles");
+        __createBinding(exports, styles, "button");
+        __exportStar(require("./theme"), exports);
+      `);
+      const bindingEntry = expectUnsupportedEntry(
+        cache.getExportMapEntry(source, "button")
+      );
+      const parsedModule = cache.getParsedModule(source);
+
+      expect(bindingEntry).toMatchObject({
+        unsupportedKind: "cjs-helper",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED",
+          exportName: "button"
+        }
+      });
+      expect(parsedModule.exportStarReexports).toHaveLength(0);
+      expect(parsedModule.exportGraph).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: "unsupported",
+            exportName: null,
+            unsupportedKind: "cjs-helper",
+            diagnostic: expect.objectContaining({
+              id: "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED"
+            })
+          })
+        ])
+      );
+    });
+
+    it("collects esbuild static CommonJS export-object helpers into the export map", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(`
+        ${createEsbuildHelperSource(createEsbuildCopyPropsHelperSource())}
+        const button = { color: "red" };
+        const root = { color: "green" };
+        const styles = require("./styles");
+        __export(exports, {
+          button: () => button,
+          default: () => root,
+          themed: () => styles.button
+        });
+        module.exports = __toCommonJS(exports);
+      `);
+
+      const buttonEntry = expectExpressionEntry(
+        cache.getExportMapEntry(source, "button")
+      );
+      const defaultEntry = expectExpressionEntry(
+        cache.getExportMapEntry(source, "default")
+      );
+      const themedEntry = expectExpressionEntry(
+        cache.getExportMapEntry(source, "themed")
+      );
+
+      expect(buttonEntry.expression).toMatchObject({
+        type: "Identifier",
+        name: "button"
+      });
+      expect(defaultEntry.expression).toMatchObject({
+        type: "Identifier",
+        name: "root"
+      });
+      expect(themedEntry.expression).toMatchObject({
+        type: "MemberExpression"
+      });
+    });
+
+    it("collects esbuild export helpers targeting direct CommonJS aliases", () => {
+      const cache = createStaticCssModuleCache();
+      const sources = [
+        createSource(
+          `
+            ${createEsbuildHelperSource(createEsbuildCopyPropsHelperSource())}
+            const entry_exports = exports;
+            const button = { color: "red" };
+            __export(entry_exports, { button: () => button });
+          `,
+          "hash:esbuild-exports-alias"
+        ),
+        createSource(
+          `
+            ${createEsbuildHelperSource(createEsbuildCopyPropsHelperSource())}
+            const entry_module_exports = module.exports;
+            const button = { color: "red" };
+            __export(entry_module_exports, { button: () => button });
+          `,
+          "hash:esbuild-module-exports-alias"
+        )
+      ];
+
+      for (const source of sources) {
+        const buttonEntry = expectExpressionEntry(
+          cache.getExportMapEntry(source, "button")
+        );
+
+        expect(buttonEntry.expression).toMatchObject({
+          type: "Identifier",
+          name: "button"
+        });
+      }
+    });
+
+    it("rejects direct CommonJS aliases after nested module.exports replacement", () => {
+      const cache = createStaticCssModuleCache();
+      const sources = [
+        createSource(
+          `
+            ${createEsbuildHelperSource(createEsbuildCopyPropsHelperSource())}
+            const entry_exports = exports;
+            if (enabled) {
+              module.exports = {};
+            }
+            const button = { color: "red" };
+            __export(entry_exports, { button: () => button });
+          `,
+          "hash:esbuild-exports-alias-nested-replacement"
+        ),
+        createSource(
+          `
+            ${createEsbuildHelperSource(createEsbuildCopyPropsHelperSource())}
+            const entry_module_exports = module.exports;
+            if (enabled) {
+              module.exports = {};
+            }
+            const button = { color: "red" };
+            __export(entry_module_exports, { button: () => button });
+          `,
+          "hash:esbuild-module-exports-alias-nested-replacement"
+        )
+      ];
+
+      for (const source of sources) {
+        expect(cache.getExportMapEntry(source, "button")).toBeNull();
+        const unsupportedEntry = expectUnsupportedEntry(
+          cache.getExportMapEntry(source, null)
+        );
+
+        expect(unsupportedEntry).toMatchObject({
+          unsupportedKind: "cjs-helper",
+          diagnostic: {
+            id: "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED",
+            exportName: null
+          }
+        });
+      }
+    });
+
+    it("rejects esbuild export helpers with computed getter descriptor keys", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(`
+        ${createEsbuildHelperSource(
+          createEsbuildCopyPropsHelperSource()
+        ).replace(
+          "{ get: all[name], enumerable: true }",
+          '{ ["get"]: all[name], enumerable: true }'
+        )}
+        const button = { color: "red" };
+        __export(exports, { button: () => button });
+      `);
+      const unsupportedEntry = expectUnsupportedEntry(
+        cache.getExportMapEntry(source, null)
+      );
+
+      expect(unsupportedEntry).toMatchObject({
+        unsupportedKind: "cjs-helper",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED",
+          exportName: null
+        }
+      });
+      expect(cache.getExportMapEntry(source, "button")).toBeNull();
+    });
+
+    it("rejects esbuild export helpers with getter descriptor overrides", () => {
+      const cache = createStaticCssModuleCache();
+      const cases = [
+        {
+          descriptor:
+            '{ get: all[name], ["get"]: () => all[name], enumerable: true }',
+          sourceHash: "hash:esbuild-export-getter-computed-override"
+        },
+        {
+          descriptor:
+            "{ get: all[name], get: () => all[name], enumerable: true }",
+          sourceHash: "hash:esbuild-export-getter-duplicate-override"
+        }
+      ];
+
+      for (const { descriptor, sourceHash } of cases) {
+        const source = createSource(
+          `
+            ${createEsbuildHelperSource(
+              createEsbuildCopyPropsHelperSource()
+            ).replace("{ get: all[name], enumerable: true }", descriptor)}
+            const button = { color: "red" };
+            __export(exports, { button: () => button });
+          `,
+          sourceHash
+        );
+        expect(cache.getExportMapEntry(source, "button")).toBeNull();
+        const unsupportedEntry = expectUnsupportedEntry(
+          cache.getExportMapEntry(source, null)
+        );
+
+        expect(unsupportedEntry).toMatchObject({
+          unsupportedKind: "cjs-helper",
+          diagnostic: {
+            id: "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED",
+            exportName: null
+          }
+        });
+      }
+    });
+
+    it("rejects esbuild export helpers with unsafe targets", () => {
+      const cache = createStaticCssModuleCache();
+      const sources = [
+        createSource(
+          `
+            ${createEsbuildHelperSource(createEsbuildCopyPropsHelperSource())}
+            const target = {};
+            const button = { color: "red" };
+            __export(target, { button: () => button });
+          `,
+          "hash:esbuild-arbitrary-target"
+        ),
+        createSource(
+          `
+            ${createEsbuildHelperSource(createEsbuildCopyPropsHelperSource())}
+            const button = { color: "red" };
+            __export(unresolved, { button: () => button });
+          `,
+          "hash:esbuild-unresolved-target"
+        ),
+        createSource(
+          `
+            ${createEsbuildHelperSource(createEsbuildCopyPropsHelperSource())}
+            let entry_exports = exports;
+            entry_exports = {};
+            const button = { color: "red" };
+            __export(entry_exports, { button: () => button });
+          `,
+          "hash:esbuild-reassigned-alias"
+        ),
+        createSource(
+          `
+            ${createEsbuildHelperSource(createEsbuildCopyPropsHelperSource())}
+            const exports = {};
+            const entry_exports = exports;
+            const button = { color: "red" };
+            __export(entry_exports, { button: () => button });
+          `,
+          "hash:esbuild-shadowed-exports-alias"
+        ),
+        createSource(
+          `
+            ${createEsbuildHelperSource(createEsbuildCopyPropsHelperSource())}
+            const module = { exports: {} };
+            const entry_module_exports = module.exports;
+            const button = { color: "red" };
+            __export(entry_module_exports, { button: () => button });
+          `,
+          "hash:esbuild-shadowed-module-alias"
+        ),
+        createSource(
+          `
+            ${createEsbuildHelperSource(createEsbuildCopyPropsHelperSource())}
+            const button = { color: "red" };
+            __export(entry_exports, { button: () => button });
+            const entry_exports = exports;
+          `,
+          "hash:esbuild-use-before-alias-declaration"
+        ),
+        createSource(
+          `
+            ${createEsbuildHelperSource(createEsbuildCopyPropsHelperSource())}
+            const root_alias = exports;
+            const entry_exports = root_alias;
+            const button = { color: "red" };
+            __export(entry_exports, { button: () => button });
+          `,
+          "hash:esbuild-recursive-alias"
+        ),
+        createSource(
+          `
+            ${createEsbuildHelperSource(createEsbuildCopyPropsHelperSource())}
+            const entry_module_exports = module.exports;
+            module.exports = {};
+            const button = { color: "red" };
+            __export(entry_module_exports, { button: () => button });
+          `,
+          "hash:esbuild-module-exports-alias-replacement"
+        ),
+        createSource(
+          `
+            ${createEsbuildHelperSource(createEsbuildCopyPropsHelperSource())}
+            const button = { color: "red" };
+            module.exports = {};
+            __export(exports, { button: () => button });
+          `,
+          "hash:esbuild-unsafe-exports-alias"
+        ),
+        createSource(
+          `
+            ${createEsbuildHelperSource(createEsbuildCopyPropsHelperSource())}
+            const root = { color: "green" };
+            const button = { color: "red" };
+            module.exports = root;
+            __export(module.exports, { button: () => button });
+          `,
+          "hash:esbuild-unsafe-module-object"
+        )
+      ];
+
+      for (const source of sources) {
+        const unsupportedEntry = expectUnsupportedEntry(
+          cache.getExportMapEntry(source, null)
+        );
+
+        expect(unsupportedEntry).toMatchObject({
+          unsupportedKind: "cjs-helper",
+          diagnostic: {
+            id: "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED",
+            exportName: null
+          }
+        });
+        expect(cache.getExportMapEntry(source, "button")).toBeNull();
+      }
+    });
+
+    it("rejects esbuild copyProps helper definitions missing required guard pieces", () => {
+      const cache = createStaticCssModuleCache();
+      const cases: readonly string[] = [
+        `
+          var __copyProps = (to, from, except, desc) => {
+            if (from) {
+              for (let key of __getOwnPropNames(from))
+                if (!__hasOwnProp.call(to, key) && key !== except)
+                  __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+            }
+            return to;
+          };
+        `,
+        `
+          var __copyProps = (to, from, except, desc) => {
+            if (from && typeof from === "object" || typeof from === "function") {
+              for (let key of Object.keys(from))
+                if (!__hasOwnProp.call(to, key) && key !== except)
+                  __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+            }
+            return to;
+          };
+        `,
+        `
+          var __copyProps = (to, from, except, desc) => {
+            if (from && typeof from === "object" || typeof from === "function") {
+              for (let key of __getOwnPropNames(from))
+                if (key !== except)
+                  __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+            }
+            return to;
+          };
+        `,
+        `
+          var __copyProps = (to, from, except, desc) => {
+            if (from && typeof from === "object" || typeof from === "function") {
+              for (let key of __getOwnPropNames(from))
+                if (!__hasOwnProp.call(to, key))
+                  __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+            }
+            return to;
+          };
+        `,
+        `
+          var __copyProps = (to, from, except, desc) => {
+            if (from && typeof from === "object" || typeof from === "function") {
+              for (let key of __getOwnPropNames(from))
+                if (!__hasOwnProp.call(to, key) && key !== except)
+                  __defProp(to, key, { get: () => from[key], enumerable: true });
+            }
+            return to;
+          };
+        `,
+        `
+          var __copyProps = (to, from, except, desc) => {
+            if (from && typeof from === "object" || typeof from === "function") {
+              for (let key of __getOwnPropNames(from))
+                if (!__hasOwnProp.call(to, key) && key !== except)
+                  __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) });
+            }
+            return to;
+          };
+        `
+      ];
+
+      for (const copyPropsSource of cases) {
+        const source = createSource(
+          `
+            ${createEsbuildHelperSource(copyPropsSource)}
+            var entry_exports = {};
+            const button = { color: "red" };
+            __export(entry_exports, { button: () => button });
+            module.exports = __toCommonJS(entry_exports);
+          `,
+          `hash:esbuild-copy-props-negative-${cases.indexOf(copyPropsSource)}`
+        );
+        const unsupportedEntry = expectUnsupportedEntry(
+          cache.getExportMapEntry(source, null)
+        );
+
+        expect(unsupportedEntry).toMatchObject({
+          unsupportedKind: "cjs-helper",
+          diagnostic: {
+            id: "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED",
+            exportName: null
+          }
+        });
+        expect(cache.getExportMapEntry(source, "button")).toBeNull();
+      }
+    });
+
+    it("rejects alias-unsafe CommonJS export mutations after module.exports replacement", () => {
+      const cache = createStaticCssModuleCache();
+      const unsafeSource = createSource(`
+        const root = { color: "root" };
+        module.exports = root;
+        exports.button = { color: "red" };
+      `);
+      const safeSource = createSource(
+        `
+          module.exports = {};
+          module.exports.button = { color: "red" };
+        `,
+        "hash:styles-safe-module-exports-extension"
+      );
+      const unsafeEntry = expectUnsupportedEntry(
+        cache.getExportMapEntry(unsafeSource, "button")
+      );
+      const safeEntry = expectExpressionEntry(
+        cache.getExportMapEntry(safeSource, "button")
+      );
+
+      expect(unsafeEntry).toMatchObject({
+        unsupportedKind: "cjs-export",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_CJS_EXPORT_UNSUPPORTED"
+        }
+      });
+      expect(
+        getObjectExpressionStringProperty(safeEntry.expression, "color")
+      ).toBe("red");
+    });
+
+    it("replaces static CommonJS property exports after nested mutations", () => {
+      const cache = createStaticCssModuleCache();
+      const cases = [
+        {
+          source: createSource(
+            `
+              exports.theme = { button: { color: "red" } };
+              exports.theme.button = { color: "blue" };
+            `,
+            "hash:nested-exports-property-mutation"
+          ),
+          exportName: "theme",
+          mutation: "nested exports.theme property assignment"
+        },
+        {
+          source: createSource(
+            `
+              module.exports.a = { b: { color: "red" } };
+              module.exports.a.b = { color: "blue" };
+            `,
+            "hash:nested-module-exports-property-mutation"
+          ),
+          exportName: "a",
+          mutation: "nested module.exports.a property assignment"
+        }
+      ];
+
+      for (const { source, exportName, mutation } of cases) {
+        const unsupportedEntry = expectUnsupportedEntry(
+          cache.getExportMapEntry(source, exportName)
+        );
+
+        expect(unsupportedEntry).toMatchObject({
+          unsupportedKind: "cjs-export",
+          cjsExportMutation: mutation,
+          diagnostic: {
+            id: "STATIC_CSS_EVAL_CJS_EXPORT_UNSUPPORTED",
+            exportName
+          }
+        });
+      }
+    });
+
+    it("records unsupported entries for nested computed CommonJS property bases", () => {
+      const cache = createStaticCssModuleCache();
+      const cases = [
+        {
+          source: createSource(
+            `
+              const name = "theme";
+              exports[name].button = { color: "blue" };
+            `,
+            "hash:nested-computed-exports-property-base"
+          ),
+          mutation: "computed exports export assignment"
+        },
+        {
+          source: createSource(
+            `
+              const name = "a";
+              module.exports[name].button = { color: "blue" };
+            `,
+            "hash:nested-computed-module-exports-property-base"
+          ),
+          mutation: "computed module.exports export assignment"
+        }
+      ];
+
+      for (const { source, mutation } of cases) {
+        const unsupportedEntry = expectUnsupportedEntry(
+          cache.getExportMapEntry(source, null)
+        );
+
+        expect(unsupportedEntry).toMatchObject({
+          unsupportedKind: "cjs-export",
+          cjsExportMutation: mutation,
+          diagnostic: {
+            id: "STATIC_CSS_EVAL_CJS_EXPORT_UNSUPPORTED",
+            exportName: null
+          }
+        });
+      }
+    });
+
+    it("leaves depth-three CommonJS member mutations out of export tracking", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(
+        `
+          exports.theme = { button: { color: "red" } };
+          exports.theme.button.color = "blue";
+        `,
+        "hash:depth-three-exports-property-mutation"
+      );
+
+      expectExpressionEntry(cache.getExportMapEntry(source, "theme"));
+    });
+
+    it("records deterministic unsupported entries for unsafe CommonJS export descriptors", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(`
+        const name = "button";
+        const button = { color: "red" };
+        exports[name] = button;
+        Object.defineProperty(exports, "spread", {
+          ...descriptor,
+          value: button
+        });
+        Object.defineProperty(exports, "setter", {
+          set: function (value) {},
+          value: button
+        });
+        Object.defineProperty(exports, "getter", {
+          get: function () {
+            track();
+            return button;
+          }
+        });
+        if (enabled) {
+          exports.nested = button;
+        }
+      `);
+      const parsedModule = cache.getParsedModule(source);
+
+      const computedEntry = expectUnsupportedEntry(
+        cache.getExportMapEntry(source, null)
+      );
+
+      expect(computedEntry).toMatchObject({
+        unsupportedKind: "cjs-export",
+        diagnostic: {
+          id: "STATIC_CSS_EVAL_CJS_EXPORT_UNSUPPORTED"
+        }
+      });
+      for (const exportName of ["spread", "setter", "getter", "nested"]) {
+        const unsupportedEntry = expectUnsupportedEntry(
+          cache.getExportMapEntry(source, exportName)
+        );
+
+        expect(unsupportedEntry).toMatchObject({
+          unsupportedKind: "cjs-export",
+          diagnostic: {
+            id: "STATIC_CSS_EVAL_CJS_EXPORT_UNSUPPORTED",
+            exportName
+          }
+        });
+      }
+      expect(parsedModule.exportGraph).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: "unsupported",
+            exportName: null,
+            unsupportedKind: "cjs-export"
+          }),
+          expect.objectContaining({
+            kind: "unsupported",
+            exportName: "nested",
+            unsupportedKind: "cjs-export"
+          })
+        ])
+      );
+    });
+
+    it("rejects async and generator CommonJS defineProperty getters", () => {
+      const cache = createStaticCssModuleCache();
+      const cases = [
+        {
+          source: createSource(
+            `
+              const button = { color: "red" };
+              Object.defineProperty(exports, "asyncButton", {
+                get: async function () {
+                  return button;
+                }
+              });
+            `,
+            "hash:async-define-property-getter"
+          ),
+          exportName: "asyncButton"
+        },
+        {
+          source: createSource(
+            `
+              const button = { color: "red" };
+              Object.defineProperty(exports, "generatorButton", {
+                get: function* () {
+                  return button;
+                }
+              });
+            `,
+            "hash:generator-define-property-getter"
+          ),
+          exportName: "generatorButton"
+        }
+      ];
+
+      for (const { source, exportName } of cases) {
+        const unsupportedEntry = expectUnsupportedEntry(
+          cache.getExportMapEntry(source, exportName)
+        );
+
+        expect(unsupportedEntry).toMatchObject({
+          unsupportedKind: "cjs-export",
+          cjsExportMutation: "Object.defineProperty getter is dynamic",
+          diagnostic: {
+            id: "STATIC_CSS_EVAL_CJS_EXPORT_UNSUPPORTED",
+            exportName
+          }
+        });
+      }
+    });
+
+    it("clears CommonJS export entries for chained assignments", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(`
+        const a = { color: "red" };
+        const b = { color: "blue" };
+        const value = { color: "green" };
+        exports.a = a;
+        exports.b = b;
+        exports.a = exports.b = value;
+      `);
+      const parsedModule = cache.getParsedModule(source);
+      const unsupportedEntries = parsedModule.exportGraph.filter(
+        (entry) => entry.kind === "unsupported" && entry.exportName === null
+      );
+
+      expect(cache.getExportMapEntry(source, "a")).toBeNull();
+      expect(cache.getExportMapEntry(source, "b")).toBeNull();
+      expect(unsupportedEntries).toEqual([
+        expect.objectContaining({
+          unsupportedKind: "cjs-export",
+          diagnostic: expect.objectContaining({
+            id: "STATIC_CSS_EVAL_CJS_EXPORT_UNSUPPORTED",
+            exportName: null
+          })
+        })
+      ]);
+    });
+
+    it("preserves ESM import and export cache behavior with CJS-capable parsing", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(
+        `
+          import { color } from "./tokens";
+          export const button = { color };
+        `,
+        "hash:esm-v1"
+      );
+
+      const parsedModule = cache.getParsedModule(source);
+      const cachedModule = cache.getParsedModule(source);
+
+      expect(cachedModule).toBe(parsedModule);
+      expect(parsedModule.program.sourceType).toBe("module");
+      expect(parsedModule.cacheKey.parserOptions.sourceType).toBe(
+        "unambiguous"
+      );
+      expect(parsedModule.importDeclarations).toHaveLength(1);
+      expect(parsedModule.exportDeclarations).toHaveLength(1);
+      expect(cache.getExportMapEntry(source, "button")).toMatchObject({
+        kind: "local",
+        exportName: "button",
+        localName: "button",
+        declarationKind: "const"
+      });
+
+      const instrumentation = getStaticCssModuleCacheInstrumentation(cache);
+      expect(instrumentation.misses).toBe(1);
+      expect(instrumentation.hits).toBe(2);
+      expect(instrumentation.parseCountByFile.get(stylesId)).toBe(1);
+    });
+
+    it("keeps ESM export map entries for module sources with CJS-like mutation", () => {
+      const cache = createStaticCssModuleCache();
+      const source = createSource(
+        `
+          import { color } from "./tokens";
+          export const button = { color };
+          exports.button = { color: "blue" };
+        `,
+        "hash:esm-module-cjs-mutation"
+      );
+
+      const parsedModule = cache.getParsedModule(source);
+
+      expect(parsedModule.program.sourceType).toBe("module");
+      expect(cache.getExportMapEntry(source, "button")).toMatchObject({
+        kind: "local",
+        exportName: "button",
+        localName: "button",
+        declarationKind: "const"
+      });
+      expect(
+        parsedModule.exportGraph.filter(
+          (entry) =>
+            entry.kind === "unsupported" &&
+            entry.unsupportedKind === "cjs-export"
+        )
+      ).toHaveLength(0);
     });
 
     it("recognizes supported export map entry categories", () => {

--- a/packages/babel/src/staticCssEval/moduleParser.ts
+++ b/packages/babel/src/staticCssEval/moduleParser.ts
@@ -1,0 +1,52 @@
+import { transformSync, types as t } from "@babel/core";
+import type { NodePath, PluginObj } from "@babel/core";
+import type { StaticCssEvalParserOptionsKey } from "./types.js";
+
+export interface StaticCssModuleParserInput {
+  readonly resolvedFile: string;
+  readonly source: string;
+  readonly parserOptions: StaticCssEvalParserOptionsKey;
+}
+
+export interface StaticCssModuleParserResult {
+  readonly ast: t.File;
+  readonly programPath: NodePath<t.Program>;
+}
+
+export function parseStaticCssModuleProgram(
+  input: StaticCssModuleParserInput
+): StaticCssModuleParserResult {
+  const programPathRef: { current?: NodePath<t.Program> } = {};
+  const captureProgramPathPlugin: PluginObj = {
+    visitor: {
+      Program(path: NodePath<t.Program>) {
+        programPathRef.current = path;
+        path.stop();
+      }
+    }
+  };
+  const result = transformSync(input.source, {
+    filename: input.resolvedFile,
+    ast: true,
+    code: false,
+    sourceType: input.parserOptions.sourceType,
+    configFile: false,
+    babelrc: false,
+    parserOpts: {
+      plugins: [
+        ...(input.parserOptions.jsx ? (["jsx"] as const) : []),
+        ...(input.parserOptions.typescript ? (["typescript"] as const) : [])
+      ]
+    },
+    plugins: [captureProgramPathPlugin]
+  });
+  const programPath = programPathRef.current;
+
+  if (!programPath || !result?.ast) {
+    throw new TypeError(
+      `Failed to parse static css module ${input.resolvedFile}`
+    );
+  }
+
+  return { ast: result.ast, programPath };
+}

--- a/packages/babel/src/staticCssEval/types.ts
+++ b/packages/babel/src/staticCssEval/types.ts
@@ -215,6 +215,10 @@ export type StaticCssEvalDiagnosticId =
   | "STATIC_CSS_EVAL_NAMESPACE_UNSUPPORTED"
   | "STATIC_CSS_EVAL_NAMESPACE_REEXPORT_UNSUPPORTED"
   | "STATIC_CSS_EVAL_NAMESPACE_PARTIAL_UNSUPPORTED"
+  | "STATIC_CSS_EVAL_CJS_DYNAMIC_REQUIRE_UNSUPPORTED"
+  | "STATIC_CSS_EVAL_CJS_EXPORT_UNSUPPORTED"
+  | "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED"
+  | "STATIC_CSS_EVAL_CJS_BUNDLE_RUNTIME_UNSUPPORTED"
   | "STATIC_CSS_EVAL_CJS_UNSUPPORTED"
   | "STATIC_CSS_EVAL_IMPORT_CYCLE"
   | "STATIC_CSS_EVAL_UNRESOLVED_IMPORT"
@@ -235,6 +239,10 @@ export const STATIC_CSS_EVAL_DIAGNOSTIC_IDS = [
   "STATIC_CSS_EVAL_NAMESPACE_UNSUPPORTED",
   "STATIC_CSS_EVAL_NAMESPACE_REEXPORT_UNSUPPORTED",
   "STATIC_CSS_EVAL_NAMESPACE_PARTIAL_UNSUPPORTED",
+  "STATIC_CSS_EVAL_CJS_DYNAMIC_REQUIRE_UNSUPPORTED",
+  "STATIC_CSS_EVAL_CJS_EXPORT_UNSUPPORTED",
+  "STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED",
+  "STATIC_CSS_EVAL_CJS_BUNDLE_RUNTIME_UNSUPPORTED",
   "STATIC_CSS_EVAL_CJS_UNSUPPORTED",
   "STATIC_CSS_EVAL_IMPORT_CYCLE",
   "STATIC_CSS_EVAL_UNRESOLVED_IMPORT",
@@ -540,8 +548,9 @@ export const STATIC_CSS_EVAL_SUPPORT_MATRIX = [
   },
   {
     construct: "CommonJS / `require()`",
-    behavior: "Unsupported",
-    status: "unsupported"
+    behavior:
+      "Supported for AST-only static forms: literal `require()` bindings, direct static CJS exports, and recognized compiler helper output; dynamic `require()` and runtime/bundler CommonJS execution remain unsupported",
+    status: "supported"
   },
   {
     construct:
@@ -665,6 +674,10 @@ if (import.meta.vitest) {
     STATIC_CSS_EVAL_NAMESPACE_UNSUPPORTED: true,
     STATIC_CSS_EVAL_NAMESPACE_REEXPORT_UNSUPPORTED: true,
     STATIC_CSS_EVAL_NAMESPACE_PARTIAL_UNSUPPORTED: true,
+    STATIC_CSS_EVAL_CJS_DYNAMIC_REQUIRE_UNSUPPORTED: true,
+    STATIC_CSS_EVAL_CJS_EXPORT_UNSUPPORTED: true,
+    STATIC_CSS_EVAL_CJS_HELPER_UNSUPPORTED: true,
+    STATIC_CSS_EVAL_CJS_BUNDLE_RUNTIME_UNSUPPORTED: true,
     STATIC_CSS_EVAL_CJS_UNSUPPORTED: true,
     STATIC_CSS_EVAL_IMPORT_CYCLE: true,
     STATIC_CSS_EVAL_UNRESOLVED_IMPORT: true,
@@ -915,7 +928,10 @@ if (import.meta.vitest) {
       );
       expect(
         supportMatrixByConstruct.get("CommonJS / `require()`")
-      ).toMatchObject({ status: "unsupported" });
+      ).toMatchObject({
+        status: "supported",
+        behavior: expect.stringContaining("dynamic `require()`")
+      });
       expect(
         supportMatrixConstructs.some(
           (construct) => construct === "Export star (`export *`)"
@@ -1023,7 +1039,7 @@ if (import.meta.vitest) {
       expect(staticCssEvalDiagnosticIds).toEqual(
         STATIC_CSS_EVAL_DIAGNOSTIC_IDS
       );
-      expect(staticCssEvalDiagnosticIds).toHaveLength(18);
+      expect(staticCssEvalDiagnosticIds).toHaveLength(22);
     });
   });
 }

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -2724,6 +2724,43 @@ if (import.meta.vitest) {
       }
     });
 
+    it("registers CommonJS require dependency metadata from Babel integration", async () => {
+      const fixture = await createImportedCssPropEsbuildFixture(
+        "jsx-css-prop-cjs-require-watch-",
+        {
+          entrySource: `
+            const styles = require("./styles");
+
+            function App() {
+              return <div css={styles.button} />;
+            }
+          `,
+          styleSource: `exports.button = { color: "red" };`
+        }
+      );
+
+      try {
+        await spyOnSourceBabelTransform();
+
+        const stylesRealpath = normalizeStaticCssEvalFileId(
+          await fs.promises.realpath(fixture.stylesPath)
+        );
+        const harness = createBuildHarness({
+          absWorkingDir: fixture.root,
+          plugin: minchoEsbuildPlugin({ jsxCssProp: true })
+        });
+        const scriptLoadResult = (await harness.loadScript({
+          path: fixture.entryPath
+        })) as ScriptLoadResult;
+
+        expect(new Set(scriptLoadResult.watchFiles)).toEqual(
+          new Set([stylesRealpath])
+        );
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
     it("refreshes export-star namespace member watch files when leaf and barrel targets change", async () => {
       const realEsbuild = await import("esbuild");
       const fixture = await createImportedCssPropEsbuildFixture(

--- a/packages/integration/src/babel.ts
+++ b/packages/integration/src/babel.ts
@@ -1143,6 +1143,130 @@ if (import.meta.vitest) {
       );
     });
 
+    it("resolves CommonJS require css prop metadata through the async source-provider prepass", async () => {
+      const componentSource = `
+        const styles = require("./styles");
+
+        function App() {
+          return <div css={styles.button} />;
+        }
+      `;
+      const stylesSource = `exports.button = { color: "red" };`;
+      const { filePaths } = await createBabelFixtureFiles(
+        {
+          "component.tsx": componentSource,
+          "styles.cjs": stylesSource
+        },
+        "css-prop-cjs-require-metadata"
+      );
+      const componentId = filePaths["component.tsx"];
+      const stylesId = filePaths["styles.cjs"];
+      const provider = createFileBackedStaticCssEvalSourceProvider({
+        resolutions: {
+          [`${componentId}\0./styles`]: stylesId
+        }
+      });
+
+      const { code, result, staticCssEval } = await babelTransform(
+        componentId,
+        {
+          jsxCssProp: true,
+          staticCssEvalSourceProvider: provider
+        }
+      );
+      const [, sidecarSource] = result;
+
+      expect(sidecarSource).toContain('color: "red"');
+      expect(code).not.toContain("_cx(styles.button)");
+      expect(staticCssEval?.dependencyFiles).toEqual([stylesId]);
+      expect(staticCssEval?.ownerToDependencies.get(componentId)).toEqual([
+        stylesId
+      ]);
+      expect(staticCssEval?.dependencyToOwners.get(stylesId)).toEqual([
+        componentId
+      ]);
+      expect(staticCssEval?.resolvedDependencies).toEqual([
+        expect.objectContaining({
+          importerId: componentId,
+          specifier: "./styles",
+          resolvedFile: stylesId,
+          canonicalModuleId: `test:${stylesId}`,
+          normalizedPathKey: stylesId,
+          resolverKind: "test",
+          loaded: true,
+          sourceIdentity: createTestSourceIdentity(stylesSource)
+        })
+      ]);
+      expect(staticCssEval?.dependencies).toEqual([
+        expect.objectContaining({
+          file: stylesId,
+          kind: "imported",
+          importer: componentId,
+          specifier: "./styles",
+          exportName: "button",
+          memberPath: [],
+          inspected: true,
+          contributed: true
+        })
+      ]);
+      expect(staticCssEval?.cacheKeys[0]).toMatchObject({
+        importerFile: componentId,
+        resolvedFile: stylesId,
+        resolvedId: stylesId,
+        exportName: "button",
+        memberPath: [],
+        sourceHash: createTestSourceIdentity(stylesSource).sourceHash
+      });
+      expect(staticCssEval?.diagnostics).toEqual([]);
+      expect(staticCssEval?.resolvedModuleIds).toContain(stylesId);
+    });
+
+    it("dedupes CommonJS unsupported diagnostics observed during transform", async () => {
+      const componentSource = `
+        const source = "./styles";
+        const styles = require(source);
+
+        function App() {
+          return <>
+            <div css={styles.button} />
+            <span css={styles.button} />
+          </>;
+        }
+      `;
+      const componentId = await createBabelFixture(
+        componentSource,
+        "css-prop-cjs-diagnostic-dedupe"
+      );
+      const provider = createFileBackedStaticCssEvalSourceProvider({
+        resolutions: {}
+      });
+      let thrownError: unknown;
+
+      try {
+        await babelTransform(componentId, {
+          jsxCssProp: true,
+          staticCssEvalSourceProvider: provider
+        });
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBeInstanceOf(BabelTransformError);
+
+      if (!(thrownError instanceof BabelTransformError)) {
+        throw new Error("Expected BabelTransformError for dynamic CJS require");
+      }
+
+      expect(
+        thrownError.staticCssEval?.diagnostics.filter(
+          (diagnostic) =>
+            diagnostic.id === "STATIC_CSS_EVAL_CJS_DYNAMIC_REQUIRE_UNSUPPORTED"
+        )
+      ).toHaveLength(1);
+      expect(thrownError.staticCssEval?.dependencyFiles).toEqual([]);
+      expect(thrownError.staticCssEval?.resolvedDependencies).toEqual([]);
+    });
+
     it("does not reuse an unresolved export result after imported source content changes", async () => {
       const fs = await import("node:fs/promises");
       const componentSource = `

--- a/packages/integration/src/staticCssEvalPrepass.ts
+++ b/packages/integration/src/staticCssEvalPrepass.ts
@@ -65,6 +65,13 @@ type StaticCssEvalPrepassImportBinding =
   >
     ? ImportBinding
     : never;
+type StaticCssEvalPrepassCjsImportBinding =
+  ImportedStaticCssEvalModuleRecord["cjsImports"] extends ReadonlyMap<
+    string,
+    infer CjsImportBinding
+  >
+    ? CjsImportBinding
+    : never;
 type StaticCssEvalPrepassExportName = string | null;
 type StaticCssEvalPrepassExportEntry =
   ImportedStaticCssEvalModuleRecord["exports"] extends ReadonlyMap<
@@ -78,6 +85,11 @@ interface StaticCssEvalPrepassExportRequest {
   exportName: StaticCssEvalPrepassExportName;
   memberPath: readonly string[];
   wholeNamespace: boolean;
+}
+
+interface StaticCssEvalPrepassDependencyRequest {
+  importPath: string;
+  exportRequest: StaticCssEvalPrepassExportRequest | null;
 }
 
 interface StaticCssEvalPrepassExportWalk {
@@ -178,17 +190,19 @@ export async function createStaticCssEvalPrepass(
   };
 
   for (const candidate of candidates) {
-    const importBinding = candidate.bindingName
-      ? ownerRecord.imports.get(candidate.bindingName)
-      : undefined;
+    const dependencyRequest = createStaticCssEvalPrepassDependencyRequest(
+      ownerRecord,
+      candidate.bindingName,
+      candidate.memberPath ?? []
+    );
 
-    if (!importBinding) {
+    if (!dependencyRequest) {
       continue;
     }
 
     const moduleRecord = await loadStaticCssEvalPrepassDependency(
       ownerId,
-      importBinding.importPath,
+      dependencyRequest.importPath,
       prepassContext
     );
 
@@ -196,15 +210,10 @@ export async function createStaticCssEvalPrepass(
       continue;
     }
 
-    const request = createStaticCssEvalPrepassExportRequest(
-      importBinding,
-      candidate.memberPath ?? []
-    );
-
-    if (request) {
+    if (dependencyRequest.exportRequest) {
       await loadStaticCssEvalPrepassGraphDependencies(
         moduleRecord,
-        request,
+        dependencyRequest.exportRequest,
         prepassContext
       );
     }
@@ -377,6 +386,40 @@ async function loadStaticCssEvalPrepassDependency(
   return moduleRecord;
 }
 
+function createStaticCssEvalPrepassDependencyRequest(
+  ownerRecord: ImportedStaticCssEvalModuleRecord,
+  bindingName: string | null | undefined,
+  memberPath: readonly string[]
+): StaticCssEvalPrepassDependencyRequest | null {
+  if (!bindingName) {
+    return null;
+  }
+
+  const importBinding = ownerRecord.imports.get(bindingName);
+
+  if (importBinding) {
+    return {
+      importPath: importBinding.importPath,
+      exportRequest: createStaticCssEvalPrepassExportRequest(
+        importBinding,
+        memberPath
+      )
+    };
+  }
+
+  const cjsBinding = ownerRecord.cjsImports.get(bindingName);
+
+  return cjsBinding
+    ? {
+        importPath: cjsBinding.importPath,
+        exportRequest: createStaticCssEvalPrepassCjsExportRequest(
+          cjsBinding,
+          memberPath
+        )
+      }
+    : null;
+}
+
 function createStaticCssEvalPrepassExportRequest(
   importBinding: StaticCssEvalPrepassImportBinding,
   memberPath: readonly string[]
@@ -409,6 +452,30 @@ function createStaticCssEvalPrepassExportRequest(
     default:
       return assertNever(importBinding);
   }
+}
+
+function createStaticCssEvalPrepassCjsExportRequest(
+  cjsBinding: StaticCssEvalPrepassCjsImportBinding,
+  memberPath: readonly string[]
+): StaticCssEvalPrepassExportRequest {
+  const [exportName, ...remainingMemberPath] = [
+    ...cjsBinding.propertyPath,
+    ...memberPath
+  ];
+
+  if (exportName === undefined) {
+    return {
+      exportName: null,
+      memberPath: [],
+      wholeNamespace: true
+    };
+  }
+
+  return {
+    exportName,
+    memberPath: remainingMemberPath,
+    wholeNamespace: false
+  };
 }
 
 async function loadStaticCssEvalPrepassGraphDependencies(
@@ -1702,6 +1769,251 @@ if (import.meta.vitest) {
         })
       ]);
       expect(result.resolvedModuleCache.has(stylesId)).toBe(true);
+    });
+
+    it("preloads direct CommonJS require dependencies from css prop candidates", async () => {
+      const ownerId = "/project/src/App.tsx";
+      const stylesId = "/project/src/styles.cjs";
+      const stylesWatchFile = "/project/src/styles.cjs";
+      const ownerSource = `
+        const styles = require("./styles");
+
+        function App() {
+          return <div css={styles.button} />;
+        }
+      `;
+      const stylesSource = `exports.button = { color: "red" };`;
+      const calls: {
+        resolved: Array<{ importerId: string; importPath: string }>;
+        loaded: string[];
+      } = { resolved: [], loaded: [] };
+      const provider: StaticCssEvalSourceProvider = {
+        resolve(importerId, importPath) {
+          calls.resolved.push({ importerId, importPath });
+
+          return importPath === "./styles"
+            ? {
+                resolvedFile: stylesId,
+                canonicalModuleId: stylesId,
+                normalizedPathKey: stylesId,
+                watchFiles: [stylesWatchFile],
+                resolverKind: "test"
+              }
+            : null;
+        },
+        load(id) {
+          calls.loaded.push(id);
+
+          if (id === ownerId) {
+            return { source: ownerSource };
+          }
+
+          return id === stylesId
+            ? {
+                source: stylesSource,
+                watchFiles: [stylesWatchFile],
+                resolverKind: "test"
+              }
+            : null;
+        }
+      };
+
+      const { result } = await createStaticCssEvalPrepass(ownerId, provider);
+
+      expect(calls.resolved).toEqual([
+        { importerId: ownerId, importPath: "./styles" }
+      ]);
+      expect(calls.loaded).toEqual([ownerId, stylesId]);
+      expect(result.dependencyFiles).toEqual([stylesId]);
+      expect(result.ownerToDependencies.get(ownerId)).toEqual([stylesId]);
+      expect(result.dependencyToOwners.get(stylesId)).toEqual([ownerId]);
+      expect(result.resolvedModuleCache.has(stylesId)).toBe(true);
+      expect(result.resolvedDependencies).toEqual([
+        expect.objectContaining({
+          importerId: ownerId,
+          specifier: "./styles",
+          resolvedFile: stylesId,
+          resolverKind: "test",
+          loaded: true,
+          watchFiles: [stylesWatchFile]
+        })
+      ]);
+    });
+
+    it("preloads CommonJS helper export-star dependencies from bare require candidates", async () => {
+      const ownerId = "/project/src/App.tsx";
+      const barrelId = "/project/src/barrel.cjs";
+      const stylesId = "/project/src/styles.cjs";
+      const sources: Record<string, string> = {
+        [ownerId]: `
+          const styles = require("./barrel");
+
+          function App() {
+            return <div css={styles} />;
+          }
+        `,
+        [barrelId]: `
+          var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+            if (k2 === undefined) k2 = k;
+            var desc = Object.getOwnPropertyDescriptor(m, k);
+            if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+              desc = { enumerable: true, get: function() { return m[k]; } };
+            }
+            Object.defineProperty(o, k2, desc);
+          }) : (function(o, m, k, k2) {
+            if (k2 === undefined) k2 = k;
+            o[k2] = m[k];
+          }));
+          var __exportStar = (this && this.__exportStar) || function(m, exports) {
+            for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+          };
+          __exportStar(require("./styles"), exports);
+        `,
+        [stylesId]: `exports.button = { color: "red" };`
+      };
+      const calls: {
+        resolved: Array<{ importerId: string; importPath: string }>;
+        loaded: string[];
+      } = { resolved: [], loaded: [] };
+      const provider: StaticCssEvalSourceProvider = {
+        resolve(importerId, importPath) {
+          calls.resolved.push({ importerId, importPath });
+
+          if (importerId === ownerId && importPath === "./barrel") {
+            return { id: barrelId };
+          }
+
+          return importerId === barrelId && importPath === "./styles"
+            ? { id: stylesId }
+            : null;
+        },
+        load(id) {
+          calls.loaded.push(id);
+
+          const source = sources[id];
+
+          return source === undefined ? null : { source };
+        }
+      };
+
+      const { result } = await createStaticCssEvalPrepass(ownerId, provider);
+
+      expect(calls.resolved).toEqual([
+        { importerId: ownerId, importPath: "./barrel" },
+        { importerId: barrelId, importPath: "./styles" }
+      ]);
+      expect(calls.loaded).toEqual([ownerId, barrelId, stylesId]);
+      expect(result.dependencyFiles).toEqual([barrelId, stylesId]);
+      expect(result.resolvedModuleCache.has(barrelId)).toBe(true);
+      expect(result.resolvedModuleCache.has(stylesId)).toBe(true);
+    });
+
+    it("preloads CommonJS helper export-star dependencies from require candidates", async () => {
+      const ownerId = "/project/src/App.tsx";
+      const barrelId = "/project/src/barrel.cjs";
+      const stylesId = "/project/src/styles.cjs";
+      const ownerSource = `
+        const styles = require("./barrel");
+
+        function App() {
+          return <div css={styles.button} />;
+        }
+      `;
+      const barrelSource = `
+        var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+          if (k2 === undefined) k2 = k;
+          var desc = Object.getOwnPropertyDescriptor(m, k);
+          if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+            desc = { enumerable: true, get: function() { return m[k]; } };
+          }
+          Object.defineProperty(o, k2, desc);
+        }) : (function(o, m, k, k2) {
+          if (k2 === undefined) k2 = k;
+          o[k2] = m[k];
+        }));
+        var __exportStar = (this && this.__exportStar) || function(m, exports) {
+          for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+        };
+        __exportStar(require("./styles"), exports);
+      `;
+      const stylesSource = `exports.button = { color: "red" };`;
+      const calls: {
+        resolved: Array<{ importerId: string; importPath: string }>;
+        loaded: string[];
+      } = { resolved: [], loaded: [] };
+      const provider: StaticCssEvalSourceProvider = {
+        resolve(importerId, importPath) {
+          calls.resolved.push({ importerId, importPath });
+
+          if (importerId === ownerId && importPath === "./barrel") {
+            return {
+              resolvedFile: barrelId,
+              canonicalModuleId: barrelId,
+              normalizedPathKey: barrelId,
+              watchFiles: [barrelId],
+              resolverKind: "test"
+            };
+          }
+
+          return importerId === barrelId && importPath === "./styles"
+            ? {
+                resolvedFile: stylesId,
+                canonicalModuleId: stylesId,
+                normalizedPathKey: stylesId,
+                watchFiles: [stylesId],
+                resolverKind: "test"
+              }
+            : null;
+        },
+        load(id) {
+          calls.loaded.push(id);
+
+          if (id === ownerId) {
+            return { source: ownerSource };
+          }
+
+          if (id === barrelId) {
+            return { source: barrelSource, watchFiles: [barrelId] };
+          }
+
+          return id === stylesId
+            ? { source: stylesSource, watchFiles: [stylesId] }
+            : null;
+        }
+      };
+
+      const { result } = await createStaticCssEvalPrepass(ownerId, provider);
+
+      expect(calls.resolved).toEqual([
+        { importerId: ownerId, importPath: "./barrel" },
+        { importerId: barrelId, importPath: "./styles" }
+      ]);
+      expect(calls.loaded).toEqual([ownerId, barrelId, stylesId]);
+      expect(result.dependencyFiles).toEqual([barrelId, stylesId]);
+      expect(result.ownerToDependencies.get(ownerId)).toEqual([
+        barrelId,
+        stylesId
+      ]);
+      expect(result.dependencyToOwners.get(barrelId)).toEqual([ownerId]);
+      expect(result.dependencyToOwners.get(stylesId)).toEqual([ownerId]);
+      expect(result.resolvedModuleCache.has(barrelId)).toBe(true);
+      expect(result.resolvedModuleCache.has(stylesId)).toBe(true);
+      expect(result.resolvedDependencies).toEqual([
+        expect.objectContaining({
+          importerId: ownerId,
+          specifier: "./barrel",
+          resolvedFile: barrelId,
+          loaded: true,
+          watchFiles: [barrelId]
+        }),
+        expect.objectContaining({
+          importerId: barrelId,
+          specifier: "./styles",
+          resolvedFile: stylesId,
+          loaded: true,
+          watchFiles: [stylesId]
+        })
+      ]);
     });
 
     it("records external-no-source provider metadata without filesystem fallback", async () => {

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -123,9 +123,11 @@ import panel, { card, layout } from "./styles";
 <div css={layout.stack} />
 ```
 
-Bundlers provide source resolution and loading only. Vite and esbuild give Mincho project-local source text plus dependency edges. Mincho parses that source and statically evaluates the supported AST subset. No module execution is used. Mincho never executes user modules to obtain `css` prop values, and it does not use Node, VM, `eval`, `require()`, dynamic import, or bundler runtime execution for static evaluation.
+Static CommonJS sources can also participate when the integration supplies deterministic source text. Supported shapes are narrow: literal `require("./styles")` namespace, member, and shallow destructure bindings; direct `module.exports` or `exports.name` export maps; static compiler output from tsc/Babel/SWC/Rollup/Vite; and recognized esbuild helper fingerprints. Mincho parses those files as AST only. It does not call Node `require()`, run package runtime resolution, or emulate Webpack/Turbopack/Parcel runtime bundles.
 
-V1 is project-local only. Resolved files must be real files inside the project root, outside `node_modules`, not virtual modules, and not package exports outside the root. V1 does not support namespace imports, reexports or barrels, package exports from `node_modules`, virtual modules, CommonJS, calls/functions/mixins as CSS-rule values, object/array spreads, computed dynamic keys, optional chaining, template expressions, runtime dynamic values, SWC-native integration, or webpack integration.
+Bundlers provide source resolution and loading only. Vite and esbuild give Mincho project-local source text plus dependency edges. Mincho parses that source and statically evaluates the supported AST subset. No module execution is used. Mincho never executes user modules to obtain `css` prop values, and it does not call Node `require()`, use VM or `eval`, evaluate dynamic imports, or run bundler runtime code for static evaluation.
+
+Provider-backed namespace imports, explicit/star reexports and barrels, package/node_modules/outside-root ESM sources, static-data literal payloads, and virtual modules are supported when deterministic parseable source or literal ESM payload plus source identity/dependency metadata are supplied. Namespace reexports (export * as ns), provider/external modules without loadable source, remote/http and runtime/dynamic cases remain unsupported. Mincho doesn't support dynamic CommonJS, package runtime resolution, calls/functions/mixins as CSS-rule values, object/array spreads, computed dynamic keys, optional chaining, template expressions, runtime dynamic values, SWC-native integration, or full Webpack/Turbopack/Parcel bundle runtime emulation.
 
 Failure policy:
 

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -3441,6 +3441,69 @@ if (import.meta.vitest) {
       }
     });
 
+    it("invalidates CommonJS require css prop dependencies from integration metadata", async () => {
+      const fixture = await createImportedCssPropViteFixture(
+        "jsx-css-prop-cjs-require-watch-",
+        {
+          entrySource: `
+            const styles = require("./styles");
+
+            function App() {
+              return <div css={styles.button} />;
+            }
+
+            export { App };
+          `,
+          styleSource: `exports.button = { color: "red" };`
+        }
+      );
+
+      try {
+        await spyOnSourceBabelTransform();
+        const harness = await createViteHarness({
+          configOverrides: {
+            command: "serve",
+            mode: "development",
+            root: fixture.root
+          },
+          pluginOptions: {
+            jsxCssProp: true
+          }
+        });
+        const stylesRealpath = normalizePath(
+          await fs.promises.realpath(fixture.stylesPath)
+        );
+        const redArtifact = await transformImportedCssPropToVirtualCss(
+          harness,
+          fixture.entryPath,
+          fixture.entrySource
+        );
+
+        expect(redArtifact.virtualCss).toContain("color: red;");
+        expect(new Set(harness.watchFiles)).toEqual(new Set([stylesRealpath]));
+
+        await fs.promises.writeFile(
+          fixture.stylesPath,
+          `exports.button = { color: "blue" };`
+        );
+        await harness.transform(
+          fixture.stylesPath,
+          await fs.promises.readFile(fixture.stylesPath, "utf8")
+        );
+        expect(await harness.load(redArtifact.resolvedVirtualId)).toBeNull();
+
+        const blueArtifact = await transformImportedCssPropToVirtualCss(
+          harness,
+          fixture.entryPath,
+          fixture.entrySource
+        );
+        expect(blueArtifact.virtualCss).toContain("color: blue;");
+        expect(new Set(harness.watchFiles)).toEqual(new Set([stylesRealpath]));
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
     it("registers whole namespace export-star watch metadata from Babel integration", async () => {
       const fixture = await createImportedCssPropViteFixture(
         "jsx-css-prop-whole-namespace-export-star-watch-",

--- a/site/src/content/styled.mdx
+++ b/site/src/content/styled.mdx
@@ -489,6 +489,26 @@ import virtualStyles from 'virtual:mincho-styles';
 <div css={virtualStyles.button} />
 ```
 
+CommonJS sources are supported when the provider supplies deterministic source text. Mincho parses the CommonJS AST, then follows only static shapes: literal `require("./styles")` bindings, shallow destructuring, direct `module.exports` or `exports.name` export maps, static `Object.defineProperty` value/getter descriptors, tsc/Babel/SWC/Rollup/Vite static output, and recognized esbuild helper fingerprints. The helper body must match a known side-effect-free shape; helper names alone are not trusted.
+
+```tsx
+// styles.cjs
+const button = { color: 'red' };
+const card = { padding: 16 };
+
+module.exports = { button, card };
+
+// App.tsx
+const styles = require('./styles.cjs');
+const { card: cardStyle } = require('./styles.cjs');
+
+<div css={styles.button} />
+<div css={cardStyle} />
+<div css={styles} />
+```
+
+Unsupported CommonJS stays fail-closed. Dynamic `require(expr)`, template or conditional require paths, package runtime resolution, helper-name-only matches, Node `require()` execution, VM or child-process loading, and full Webpack/Turbopack/Parcel bundle runtime emulation are not supported.
+
 `export *` follows ESM semantics and does not forward `default`. Use an explicit default reexport when a barrel should expose a default value:
 
 ```tsx
@@ -508,9 +528,9 @@ import rootDefault, { root } from './styles';
 
 The practical literal grammar is small: string, number, boolean, `null`, unary numeric values, no-expression template literals such as `` `grid` ``, and nested object/array literals.
 
-Bundlers provide source resolution and loading only. Vite and esbuild give Mincho provider-backed project/package/data/virtual source text, literal payloads, identity metadata, and dependency edges through the source provider. Mincho then parses source, reads AST export manifests, and statically evaluates only the supported literal subset. No module execution is used. Mincho never executes user modules to obtain `css` prop values, and it does not use Node, VM, `eval`, `require()`, dynamic import, or bundler runtime execution for static evaluation.
+Bundlers provide source resolution and loading only. Vite and esbuild give Mincho provider-backed project/package/data/virtual source text, literal payloads, identity metadata, and dependency edges through the source provider. Mincho then parses source, reads AST export manifests, and statically evaluates only the supported literal subset. No module execution is used. Mincho never executes user modules to obtain `css` prop values, and it does not call Node `require()`, use VM or `eval`, evaluate dynamic imports, or run bundler runtime code for static evaluation.
 
-First-iteration exclusions are explicit: remote/http modules, CommonJS and `require()`, runtime wasm init/function exports such as `.wasm?init`, arbitrary virtual modules without provider-supplied source, dynamic import graphs, non-literal loader output, namespace reexports such as `export * as ns from './styles'`, calls/functions/mixins as CSS-rule values, object/array spreads, computed dynamic keys, optional chaining, template expressions, runtime dynamic values, SWC native integration, and webpack integration remain unsupported. Static wasm support is limited to provider-supplied raw/url string forms that arrive as literals; runtime wasm initialization is not evaluated.
+Explicit exclusions remain: remote/http modules, dynamic `require(expr)`, template or conditional require paths, full Webpack/Turbopack/Parcel bundle runtime graph parsing, runtime wasm init/function exports such as `.wasm?init`, arbitrary virtual modules without provider-supplied source, dynamic import graphs, non-literal loader output, namespace reexports such as `export * as ns from './styles'`, calls/functions/mixins as CSS-rule values, object/array spreads, computed dynamic keys, optional chaining, template expressions, runtime dynamic values, and SWC native integration remain unsupported. Static wasm support is limited to provider-supplied raw/url string forms that arrive as literals; runtime wasm initialization is not evaluated.
 
 Existing dynamic class-value identifiers keep class-value behavior when they cannot be proven static. Proven CSS-rule candidates with unsupported internals fail with `Cannot statically evaluate css prop value` diagnostics.
 

--- a/turbo.json
+++ b/turbo.json
@@ -16,7 +16,10 @@
       ],
       "outputs": [
         ".cache/typescript/*",
-        "dist/**"
+        "dist/**",
+        "**/package.json",
+        "!package.json",
+        "!src/**/package.json"
       ]
     },
     "lint": {


### PR DESCRIPTION
## Description
Add static CSS evaluation support for CommonJS module patterns used by the CSS prop pipeline.

This change teaches the Babel static evaluator to recognize CommonJS export and helper shapes generated by TypeScript and esbuild, then wires that analysis through the integration, Vite, and esbuild layers so CSS dependencies keep being discovered correctly. It also documents the new static CJS support in the public docs.

## Related Issue
- #353

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added static CSS evaluation support for supported CommonJS `require()` patterns in CSS prop dependencies.
  * Supports literal imports, member access, destructuring, exports, reexports, descriptors, and recognized compiler-generated helpers.
  * Added dependency tracking, caching, file watching, invalidation, and CSS regeneration across integrations.
  * Unsupported dynamic, computed, runtime-dependent, and bundler-runtime patterns now provide specific diagnostics.

* **Documentation**
  * Updated CSS prop documentation with supported CommonJS patterns, limitations, and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
This PR focuses on static evaluation and dependency tracking for CJS modules rather than adding new runtime behavior.

## Checklist
- Review the CommonJS helper detection and export resolution flow in packages/babel/src/staticCssEval/
- Review dependency propagation changes in integration, Vite, and esbuild
- Review the doc updates for the supported static CJS cases
