### PR TITLE
Feat: CSS Prop - Resolve static operands and spreads

### DIFF
--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -937,6 +937,416 @@ if (import.meta.vitest) {
       expect(sameFileConst.result[1]).toContain("zIndex: +2");
     });
 
+    it("normalizes direct inline object and array spreads before jsx css prop classification", () => {
+      const inlineObject = babelTransform(
+        `
+        function App() {
+          return <div css={{ display: "flex", color: "blue" }} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+      const spreadObject = babelTransform(
+        `
+        const base = { display: "flex", color: "red" } as const;
+
+        function App() {
+          return <div css={{ ...base, color: "blue" }} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+      const spreadArray = babelTransform(
+        `
+        const stack = [{ display: "flex" }] as const;
+
+        function App() {
+          return <div css={[...stack, { gap: 8 }]} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+      const output = `${spreadObject.code}\n${spreadObject.result.join("\n")}\n${spreadArray.code}\n${spreadArray.result.join("\n")}`;
+
+      expect(spreadObject.result[1]).toBe(inlineObject.result[1]);
+      expect(spreadObject.code).not.toContain(" css=");
+      expect(spreadObject.code).not.toContain("...base");
+      expect(spreadObject.code).not.toContain("_cx(base)");
+      expect(spreadArray.code).not.toContain(" css=");
+      expect(spreadArray.code).not.toContain("...stack");
+      expect(spreadArray.code).not.toContain("_cx(stack)");
+      expect(spreadArray.code).not.toContain("unsupported-array-spread");
+      expect(spreadArray.result[1]).toContain("_css([{");
+      expect(spreadArray.result[1]).toContain('display: "flex"');
+      expect(spreadArray.result[1]).toContain("gap: 8");
+      expect(output).not.toContain("...base");
+      expect(output).not.toContain("...stack");
+    });
+
+    it("normalizes direct inline provider imported operands with metadata", () => {
+      const ownerFile = "/project/src/App.tsx";
+      const stylesFile = "/project/src/styles.ts";
+      const source = `
+        import { base, stack, tokens } from "./styles";
+        const isActive = true;
+
+        function App() {
+          return <>
+            <div css={{ ...base, color: tokens.color, active: isActive }} />
+            <div css={[...stack, { gap: 8 }]} />
+          </>;
+        }
+      `;
+      const { result, code, metadata } = babelTransform(
+        source,
+        {
+          jsxCssProp: true,
+          staticCssEvalProvider: createImportedStaticCssEvalProvider({
+            modules: [
+              { id: ownerFile, source },
+              {
+                id: stylesFile,
+                source: `
+                  export const base = { display: "flex", color: "red" } as const;
+                  export const stack = [{ alignItems: "center" }] as const;
+                  export const tokens = { color: "blue" } as const;
+                `
+              }
+            ],
+            importResolutions: [
+              {
+                importerId: ownerFile,
+                importPath: "./styles",
+                resolvedId: stylesFile
+              }
+            ]
+          })
+        },
+        { filename: ownerFile }
+      );
+      const staticCssEvalMetadata = metadata.minchoStaticCssEval;
+      const output = `${code}\n${result.join("\n")}`;
+
+      expect(code).not.toContain(" css=");
+      expect(code).not.toContain("...base");
+      expect(code).not.toContain("...stack");
+      expect(code).not.toContain("_cx(base)");
+      expect(code).not.toContain("_cx(stack)");
+      expect(result[1]).toContain("_css({");
+      expect(result[1]).toContain("_css([{");
+      expect(result[1]).toContain('display: "flex"');
+      expect(result[1]).toContain('color: "blue"');
+      expect(result[1]).toContain("active: isActive");
+      expect(result[1]).toContain('alignItems: "center"');
+      expect(result[1]).toContain("gap: 8");
+      expect(output).not.toContain("...base");
+      expect(output).not.toContain("...stack");
+      expect(staticCssEvalMetadata?.dependencies).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            file: stylesFile,
+            exportName: "base",
+            inspected: true,
+            contributed: true
+          }),
+          expect.objectContaining({
+            file: stylesFile,
+            exportName: "tokens",
+            memberPath: ["color"],
+            inspected: true,
+            contributed: true
+          }),
+          expect.objectContaining({
+            file: stylesFile,
+            exportName: "stack",
+            inspected: true,
+            contributed: true
+          })
+        ])
+      );
+      expect(staticCssEvalMetadata?.cacheKeys).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            resolvedId: stylesFile,
+            staticEvalSupportVersion: "static-css-module-export-graph:v3"
+          })
+        ])
+      );
+      expect(staticCssEvalMetadata?.resolvedModuleIds).toContain(stylesFile);
+    });
+
+    it("preserves inline fallback booleans without overriding spread precedence", () => {
+      const ownerFile = "/project/src/App.tsx";
+      const stylesFile = "/project/src/styles.ts";
+      const source = `
+        import { base, flags } from "./styles";
+        const isActive = true;
+
+        function App() {
+          return <>
+            <div css={{ ...base, active: isActive }} />
+            <div css={{ active: isActive, ...base }} />
+            <div css={{ nested: { active: isActive, ...base } }} />
+            <div css={[...flags, isActive]} />
+          </>;
+        }
+      `;
+      const { result, code } = babelTransform(
+        source,
+        {
+          jsxCssProp: true,
+          staticCssEvalProvider: createImportedStaticCssEvalProvider({
+            modules: [
+              { id: ownerFile, source },
+              {
+                id: stylesFile,
+                source: `
+                  export const base = { display: "flex", active: false } as const;
+                  export const flags = [false, false, { color: "red" }] as const;
+                `
+              }
+            ],
+            importResolutions: [
+              {
+                importerId: ownerFile,
+                importPath: "./styles",
+                resolvedId: stylesFile
+              }
+            ]
+          })
+        },
+        { filename: ownerFile }
+      );
+
+      expect(result[1]).toContain("active: isActive");
+      expect(result[1]).toContain("active: false");
+      expect(result[1]).toMatch(
+        /nested: \{\s+active: false,\s+display: "flex"\s+\}/
+      );
+      expect(code).toMatch(
+        /className=\{_cx\(false, false, _\$mincho\$\$App\d+, isActive\)\}/
+      );
+    });
+
+    it("does not count shallow alias hops as object recursion depth", () => {
+      const ownerFile = "/project/src/App.tsx";
+      const stylesFile = "/project/src/styles.ts";
+      const aliases = Array.from(
+        { length: 50 },
+        (_, index) => `const a${index + 1} = a${index};`
+      ).join("\n");
+      const source = `
+        import { base } from "./styles";
+        const a0 = { color: "red" };
+        ${aliases}
+
+        function App() {
+          return <div css={{ ...base, nested: a50 }} />;
+        }
+      `;
+      const { result } = babelTransform(
+        source,
+        {
+          jsxCssProp: true,
+          staticCssEvalProvider: createImportedStaticCssEvalProvider({
+            modules: [
+              { id: ownerFile, source },
+              {
+                id: stylesFile,
+                source: `export const base = { display: "flex" } as const;`
+              }
+            ],
+            importResolutions: [
+              {
+                importerId: ownerFile,
+                importPath: "./styles",
+                resolvedId: stylesFile
+              }
+            ]
+          })
+        },
+        { filename: ownerFile }
+      );
+
+      expect(result[1]).toContain('color: "red"');
+    });
+
+    it("rejects over-depth direct inline provider operands", () => {
+      const ownerFile = "/project/src/App.tsx";
+      const stylesFile = "/project/src/styles.ts";
+      const nestedRule = Array.from({ length: 51 }).reduce<string>(
+        (value) => `{ nested: ${value} }`,
+        '"leaf"'
+      );
+      const source = `
+        import { base } from "./styles";
+
+        function App() {
+          return <div css={{ ...base, nested: ${nestedRule} }} />;
+        }
+      `;
+
+      expect(() =>
+        babelTransform(
+          source,
+          {
+            jsxCssProp: true,
+            staticCssEvalProvider: createImportedStaticCssEvalProvider({
+              modules: [
+                { id: ownerFile, source },
+                {
+                  id: stylesFile,
+                  source: `export const base = { display: "flex" } as const;`
+                }
+              ],
+              importResolutions: [
+                {
+                  importerId: ownerFile,
+                  importPath: "./styles",
+                  resolvedId: stylesFile
+                }
+              ]
+            })
+          },
+          { filename: ownerFile }
+        )
+      ).toThrow("max object/array recursion depth exceeded");
+    });
+
+    it("rejects over-node-count direct inline provider operands", () => {
+      const ownerFile = "/project/src/App.tsx";
+      const stylesFile = "/project/src/styles.ts";
+      const classValues = Array.from({ length: 10_000 }, () => "true").join(
+        ", "
+      );
+      const source = `
+        import { stack } from "./styles";
+
+        function App() {
+          return <div css={[...stack, ${classValues}]} />;
+        }
+      `;
+
+      expect(() =>
+        babelTransform(
+          source,
+          {
+            jsxCssProp: true,
+            staticCssEvalProvider: createImportedStaticCssEvalProvider({
+              modules: [
+                { id: ownerFile, source },
+                {
+                  id: stylesFile,
+                  source: `export const stack = ["base"] as const;`
+                }
+              ],
+              importResolutions: [
+                {
+                  importerId: ownerFile,
+                  importPath: "./styles",
+                  resolvedId: stylesFile
+                }
+              ]
+            })
+          },
+          { filename: ownerFile }
+        )
+      ).toThrow("max static literal node count exceeded");
+    });
+
+    it("records package data and virtual provider metadata for direct inline operands", () => {
+      const ownerFile = "/project/src/App.tsx";
+      const packageBarrelFile = "pkg:@scope/styles";
+      const packageDataFile = "data:@scope/styles/tokens";
+      const virtualFile = "virtual:mincho-styles";
+      const source = `
+        import { base } from "@scope/styles";
+        import virtualTokens from "virtual:mincho-styles";
+
+        function App() {
+          return <div css={{ ...base, accent: virtualTokens.accent }} />;
+        }
+      `;
+      const { result, code, metadata } = babelTransform(
+        source,
+        {
+          jsxCssProp: true,
+          staticCssEvalProvider: createImportedStaticCssEvalProvider({
+            modules: [
+              { id: ownerFile, source },
+              {
+                id: packageBarrelFile,
+                source: `export { base } from "@scope/styles/tokens";`,
+                sourceKind: "package-source",
+                sourceOrigin: "package"
+              },
+              {
+                id: packageDataFile,
+                source: `export const base = { color: "green" } as const;`,
+                sourceKind: "static-data",
+                sourceOrigin: "data"
+              },
+              {
+                id: virtualFile,
+                source: `export default { accent: "purple" } as const;`,
+                sourceKind: "provider-virtual",
+                sourceOrigin: "provider"
+              }
+            ],
+            importResolutions: [
+              {
+                importerId: ownerFile,
+                importPath: "@scope/styles",
+                resolvedId: packageBarrelFile,
+                sourceKind: "package-source",
+                sourceOrigin: "package"
+              },
+              {
+                importerId: packageBarrelFile,
+                importPath: "@scope/styles/tokens",
+                resolvedId: packageDataFile,
+                sourceKind: "static-data",
+                sourceOrigin: "data"
+              },
+              {
+                importerId: ownerFile,
+                importPath: "virtual:mincho-styles",
+                resolvedId: virtualFile,
+                sourceKind: "provider-virtual",
+                sourceOrigin: "provider"
+              }
+            ]
+          })
+        },
+        { filename: ownerFile }
+      );
+      const staticCssEvalMetadata = metadata.minchoStaticCssEval;
+
+      expect(code).not.toContain(" css=");
+      expect(code).not.toContain("...base");
+      expect(result[1]).toContain('color: "green"');
+      expect(result[1]).toContain('accent: "purple"');
+      expect(staticCssEvalMetadata?.dependencies).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            file: packageDataFile,
+            sourceKind: "static-data",
+            sourceOrigin: "data",
+            contributed: true
+          }),
+          expect.objectContaining({
+            file: virtualFile,
+            sourceKind: "provider-virtual",
+            sourceOrigin: "provider",
+            contributed: true
+          })
+        ])
+      );
+      expect(staticCssEvalMetadata?.resolvedModuleIds).toEqual(
+        expect.arrayContaining([packageDataFile, virtualFile])
+      );
+    });
+
     it("resolves same-file const object member path grammar", () => {
       const fixtures = [
         {
@@ -992,29 +1402,9 @@ if (import.meta.vitest) {
     it("rejects unsupported same-file static css literal grammar deterministically", () => {
       const fixtures = [
         {
-          setup: `const color = "red"; const style = { color };`,
-          expression: "style",
-          reason: "identifier-object-value"
-        },
-        {
-          setup: `const theme = { color: "red" }; const style = { color: theme.color };`,
-          expression: "style",
-          reason: "member-expression-object-value"
-        },
-        {
           setup: `const color = "red"; const style = { color: \`var(\${color})\` };`,
           expression: "style",
           reason: "template-expression"
-        },
-        {
-          setup: `const base = { color: "blue" }; const style = { ...base, color: "red" };`,
-          expression: "style",
-          reason: "object spread"
-        },
-        {
-          setup: `const base = [{ color: "blue" }]; const style = [{ color: "red" }, ...base];`,
-          expression: "style",
-          reason: "array spread"
         },
         {
           setup: `const styles = { button: { color: "red" } };`,
@@ -1125,8 +1515,11 @@ if (import.meta.vitest) {
     it("preserves unresolved top-level css prop references as class values", () => {
       const { result, code } = babelTransform(
         `
+        const className = "panel";
+
         function App() {
           return <>
+            <div css={className} />
             <div css={unknownClassName} />
             <div css={externalStyles.button} />
           </>;
@@ -1139,9 +1532,61 @@ if (import.meta.vitest) {
       );
 
       expect(code).not.toContain(" css=");
+      expect(code).toContain("className={_cx(className)}");
       expect(code).toContain("className={_cx(unknownClassName)}");
       expect(code).toContain("className={_cx(externalStyles.button)}");
+      expect(code).not.toContain("_css(className)");
       expect(result[1]).not.toContain("_css(");
+    });
+
+    it("rejects direct inline css rule calls and functions through static eval diagnostics", () => {
+      const callFailure = captureJsxCssPropFailure(
+        `
+        function getColor() {
+          return "red";
+        }
+
+        function App() {
+          return <div css={{ color: getColor() }} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+      const functionFailure = captureJsxCssPropFailure(
+        `
+        function App() {
+          return <div css={{ color: () => "red" }} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(callFailure.error.message).toContain(
+        "dynamic expression is unsupported: CallExpression"
+      );
+      expect(functionFailure.error.message).toContain(
+        "dynamic expression is unsupported: ArrowFunctionExpression"
+      );
+      expect(
+        callFailure.metadata.minchoStaticCssEval?.diagnostics.map(
+          ({ id }) => id
+        )
+      ).toContain("STATIC_CSS_EVAL_DYNAMIC_EXPRESSION_UNSUPPORTED");
+      expect(
+        functionFailure.metadata.minchoStaticCssEval?.diagnostics.map(
+          ({ id }) => id
+        )
+      ).toContain("STATIC_CSS_EVAL_DYNAMIC_EXPRESSION_UNSUPPORTED");
+      expect(
+        callFailure.metadata.minchoStaticCssEval?.diagnostics.map(
+          ({ reason }) => reason
+        )
+      ).toContain("runtime-dynamic-value");
+      expect(
+        functionFailure.metadata.minchoStaticCssEval?.diagnostics.map(
+          ({ reason }) => reason
+        )
+      ).toContain("runtime-dynamic-value");
     });
 
     it("evaluates direct dynamic class-value css prop calls once", () => {
@@ -1172,22 +1617,23 @@ if (import.meta.vitest) {
       expect("css" in observed.props).toBe(false);
     });
 
-    it("rejects same-file static css rule member-expression object values", () => {
-      expect(() =>
-        babelTransform(
-          `
-          const theme = { color: "red" };
-          const style = { color: theme.color };
+    it("normalizes same-file static css rule member-expression object values", () => {
+      const { result, code } = babelTransform(
+        `
+        const theme = { color: "red" };
+        const style = { color: theme.color };
 
-          function App() {
-            return <div css={style} />;
-          }
-        `,
-          { jsxCssProp: true }
-        )
-      ).toThrow(
-        'Cannot statically evaluate css prop value: same-file binding "style" contains unsupported member-expression-object-value: MemberExpression'
+        function App() {
+          return <div css={style} />;
+        }
+      `,
+        { jsxCssProp: true }
       );
+
+      expect(code).not.toContain(" css=");
+      expect(code).toContain("className={_$mincho$$App2}");
+      expect(code).not.toContain("_cx(style)");
+      expect(result[1]).toContain('color: "red"');
     });
 
     it("keeps conditional const object css prop values in class-value mode", () => {

--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -47,7 +47,11 @@ export {
   createStaticCssEvalCacheKeyMetadataKey as internalCreateStaticCssEvalCacheKeyMetadataKey,
   createStaticCssEvalDiagnosticMetadataKey as internalCreateStaticCssEvalDiagnosticMetadataKey
 } from "./jsxCssProp.js";
-export { collectJsxCssPropStaticCssEvalCandidates as internalCollectJsxCssPropStaticCssEvalCandidates } from "./staticCssEval/candidates.js";
+export {
+  collectJsxCssPropStaticCssEvalCandidates as internalCollectJsxCssPropStaticCssEvalCandidates,
+  getStaticCssEvalMemberReference as internalGetStaticCssEvalMemberReference,
+  unwrapTransparentCssRuleExpression as internalUnwrapTransparentCssRuleExpression
+} from "./staticCssEval/candidates.js";
 export {
   createImportedStaticCssEvalModuleRecord as internalCreateImportedStaticCssEvalModuleRecord,
   createImportedStaticCssEvalProvider as internalCreateImportedStaticCssEvalProvider

--- a/packages/babel/src/jsxCssProp.ts
+++ b/packages/babel/src/jsxCssProp.ts
@@ -1,19 +1,38 @@
 import { types as t } from "@babel/core";
 import type { NodePath } from "@babel/core";
 import {
+  getStaticObjectPropertyName,
+  preserveDirectBooleanReferenceValue
+} from "./staticCssEval/ast.js";
+import {
   createStaticCssEvalCandidate,
+  getStaticCssEvalMemberReference,
   unwrapTransparentCssRuleExpression
 } from "./staticCssEval/candidates.js";
 import {
+  createStaticCssLiteralExpression,
   findUnsupportedImportedStaticCssEvalReferenceDiagnostic,
   resolveImportedStaticCssEvalExpression
 } from "./staticCssEval/importedModules.js";
+import {
+  createStaticCssEvalComputedMemberUnsupportedDiagnostic,
+  createStaticCssEvalDynamicExpressionUnsupportedDiagnostic,
+  createStaticCssEvalObjectSpreadUnsupportedDiagnostic
+} from "./staticCssEval/diagnostics.js";
+import {
+  enforceStaticCssEvalLiteralNodeCount,
+  enforceStaticCssEvalObjectArrayRecursionDepth
+} from "./staticCssEval/limits.js";
 import type {
   ResolutionDependency,
   StaticCssEvalCacheKey,
-  StaticCssEvalDiagnostic
+  StaticCssEvalDiagnostic,
+  StaticCssEvalProvider
 } from "./staticCssEval/types.js";
-import { resolveSameFileStaticCssEvalExpression } from "./staticCssEval/sameFile.js";
+import {
+  getStaticCssEvalConstBindingInitExpression,
+  resolveSameFileStaticCssEvalExpression
+} from "./staticCssEval/sameFile.js";
 import type {
   MinchoStaticCssEvalMetadata,
   PluginState,
@@ -71,6 +90,76 @@ type StaticCssEvalMetadataSource = {
   diagnostic?: StaticCssEvalDiagnostic;
   cacheKey?: StaticCssEvalCacheKey;
 };
+
+type InlineStaticCssRuleLiteralResult =
+  | { kind: "not-candidate" }
+  | {
+      kind: "resolved";
+      expression: t.ObjectExpression | t.ArrayExpression;
+      metadata: StaticCssEvalMetadataSource[];
+    }
+  | {
+      kind: "error";
+      diagnostic: StaticCssEvalDiagnostic;
+      metadata: StaticCssEvalMetadataSource[];
+    };
+
+type InlineStaticCssExpressionResult =
+  | {
+      kind: "resolved";
+      expression: t.Expression;
+      metadata: StaticCssEvalMetadataSource[];
+    }
+  | {
+      kind: "error";
+      diagnostic: StaticCssEvalDiagnostic;
+      metadata: StaticCssEvalMetadataSource[];
+    };
+
+type InlineStaticCssObjectExpressionResult =
+  | {
+      kind: "resolved";
+      expression: t.ObjectExpression;
+      metadata: StaticCssEvalMetadataSource[];
+    }
+  | {
+      kind: "error";
+      diagnostic: StaticCssEvalDiagnostic;
+      metadata: StaticCssEvalMetadataSource[];
+    };
+
+type InlineStaticCssArrayExpressionResult =
+  | {
+      kind: "resolved";
+      expression: t.ArrayExpression;
+      metadata: StaticCssEvalMetadataSource[];
+    }
+  | {
+      kind: "error";
+      diagnostic: StaticCssEvalDiagnostic;
+      metadata: StaticCssEvalMetadataSource[];
+    };
+
+interface InlineStaticCssEvaluationOptions {
+  expression: t.Expression;
+  ownerFile: string;
+  programPath: NodePath<t.Program>;
+  scope: NodePath<t.JSXOpeningElement>["scope"];
+  provider?: StaticCssEvalProvider;
+  metadata: StaticCssEvalMetadataSource[];
+  localStack?: readonly InlineStaticCssLocalStackFrame[];
+  state: InlineStaticCssEvaluationState;
+  depth: number;
+}
+
+interface InlineStaticCssEvaluationState {
+  count: number;
+}
+
+interface InlineStaticCssLocalStackFrame {
+  readonly bindingName: string;
+  readonly memberPath: readonly string[];
+}
 
 export function preprocessJsxCssProp(
   path: NodePath<t.Program>,
@@ -289,21 +378,79 @@ function getResolvedCssExpression(
 ): t.Expression {
   const cssExpression = getCssExpression(path, attribute);
   const ownerFile = getStaticCssEvalOwnerFile(state);
-  const staticCssEvalResult = resolveSameFileStaticCssEvalExpression({
-    expression: cssExpression,
-    ownerFile,
-    programPath,
-    scope: path.scope
-  });
-  registerStaticCssEvalResultMetadata(state, staticCssEvalResult);
+  const staticCssEvalResult = shouldResolveSameFileCssExpression(cssExpression)
+    ? resolveSameFileStaticCssEvalExpression({
+        expression: cssExpression,
+        ownerFile,
+        programPath,
+        scope: path.scope
+      })
+    : { kind: "not-candidate" as const };
 
   if (staticCssEvalResult.kind === "error") {
+    const inlineStaticCssEvalResult = resolveDirectInlineStaticCssRuleLiteral({
+      expression: cssExpression,
+      ownerFile,
+      programPath,
+      scope: path.scope,
+      provider: state.opts.staticCssEvalProvider,
+      metadata: [],
+      state: { count: 0 },
+      depth: 1
+    });
+
+    if (inlineStaticCssEvalResult.kind === "resolved") {
+      for (const metadata of inlineStaticCssEvalResult.metadata) {
+        registerStaticCssEvalResultMetadata(state, metadata);
+      }
+
+      return preserveDirectBooleanReferenceValues(
+        cssExpression,
+        inlineStaticCssEvalResult.expression
+      );
+    }
+
+    if (inlineStaticCssEvalResult.kind === "error") {
+      if (
+        shouldPreserveUnsupportedArraySpreadClassification(
+          cssExpression,
+          inlineStaticCssEvalResult.diagnostic
+        )
+      ) {
+        return cssExpression;
+      }
+
+      for (const metadata of inlineStaticCssEvalResult.metadata) {
+        registerStaticCssEvalResultMetadata(state, metadata);
+      }
+
+      throw path.buildCodeFrameError(
+        inlineStaticCssEvalResult.diagnostic.message
+      );
+    }
+
+    if (
+      shouldPreserveUnsupportedArraySpreadClassification(
+        cssExpression,
+        staticCssEvalResult.diagnostic
+      )
+    ) {
+      return cssExpression;
+    }
+
+    registerStaticCssEvalResultMetadata(state, staticCssEvalResult);
     throw path.buildCodeFrameError(staticCssEvalResult.diagnostic.message);
   }
 
   if (staticCssEvalResult.kind === "resolved") {
-    return staticCssEvalResult.expression;
+    registerStaticCssEvalResultMetadata(state, staticCssEvalResult);
+    return preserveDirectBooleanReferenceValues(
+      cssExpression,
+      normalizeResolvedCssRuleExpression(staticCssEvalResult.expression)
+    );
   }
+
+  registerStaticCssEvalResultMetadata(state, staticCssEvalResult);
 
   registerImportedStaticCssEvalProviderResultMetadata({
     expression: cssExpression,
@@ -355,6 +502,781 @@ function getResolvedCssExpression(
 
 function getStaticCssEvalOwnerFile(state: PluginState): string {
   return state.file.opts.filename ?? "<unknown>";
+}
+
+function shouldResolveSameFileCssExpression(expression: t.Expression): boolean {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+
+  return !(
+    t.isArrayExpression(unwrappedExpression) &&
+    !hasArraySpreadElement(unwrappedExpression) &&
+    isArrayClassValueExpression(unwrappedExpression)
+  );
+}
+
+function resolveDirectInlineStaticCssRuleLiteral(
+  options: InlineStaticCssEvaluationOptions
+): InlineStaticCssRuleLiteralResult {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(
+    options.expression
+  );
+
+  if (
+    !t.isObjectExpression(unwrappedExpression) &&
+    !t.isArrayExpression(unwrappedExpression)
+  ) {
+    return { kind: "not-candidate" };
+  }
+
+  const result = evaluateInlineStaticCssExpression({
+    ...options,
+    expression: unwrappedExpression
+  });
+
+  if (result.kind === "error") {
+    return result;
+  }
+
+  const { expression } = result;
+
+  return t.isObjectExpression(expression) || t.isArrayExpression(expression)
+    ? { ...result, expression }
+    : { kind: "not-candidate" };
+}
+
+function evaluateInlineStaticCssExpression(
+  options: InlineStaticCssEvaluationOptions
+): InlineStaticCssExpressionResult {
+  options.state.count += 1;
+  const countResult = enforceStaticCssEvalLiteralNodeCount({
+    ...createInlineStaticCssDiagnosticContext(options),
+    literalNodeCount: options.state.count
+  });
+
+  if (!countResult.ok) {
+    return {
+      kind: "error",
+      diagnostic: countResult.diagnostic,
+      metadata: options.metadata
+    };
+  }
+
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(
+    options.expression
+  );
+
+  if (
+    t.isObjectExpression(unwrappedExpression) ||
+    t.isArrayExpression(unwrappedExpression)
+  ) {
+    const depthResult = enforceStaticCssEvalObjectArrayRecursionDepth({
+      ...createInlineStaticCssDiagnosticContext(options),
+      recursionDepth: options.depth
+    });
+
+    if (!depthResult.ok) {
+      return {
+        kind: "error",
+        diagnostic: depthResult.diagnostic,
+        metadata: options.metadata
+      };
+    }
+  }
+
+  if (t.isObjectExpression(unwrappedExpression)) {
+    return evaluateInlineStaticCssObjectExpression({
+      ...options,
+      expression: unwrappedExpression
+    });
+  }
+
+  if (t.isArrayExpression(unwrappedExpression)) {
+    return evaluateInlineStaticCssArrayExpression({
+      ...options,
+      expression: unwrappedExpression
+    });
+  }
+
+  if (isInlineStaticCssPrimitiveLiteral(unwrappedExpression)) {
+    return {
+      kind: "resolved",
+      expression: normalizeInlineStaticCssPrimitiveLiteral(unwrappedExpression),
+      metadata: options.metadata
+    };
+  }
+
+  const providerReferenceResult = resolveProviderStaticCssExpression(options);
+
+  if (providerReferenceResult.kind !== "not-candidate") {
+    return providerReferenceResult;
+  }
+
+  const sameFileReferenceResult =
+    resolveInlineSameFileStaticCssExpression(options);
+
+  if (sameFileReferenceResult.kind !== "not-candidate") {
+    return sameFileReferenceResult;
+  }
+
+  return resolveSameFileNestedStaticCssExpression(options);
+}
+
+function evaluateInlineStaticCssObjectExpression(
+  options: InlineStaticCssEvaluationOptions & {
+    expression: t.ObjectExpression;
+  }
+): InlineStaticCssObjectExpressionResult {
+  const properties: t.ObjectExpression["properties"] = [];
+  let metadata = options.metadata;
+
+  for (const property of options.expression.properties) {
+    if (t.isSpreadElement(property)) {
+      const spreadResult = evaluateInlineStaticCssExpression({
+        ...options,
+        expression: property.argument,
+        metadata,
+        depth: options.depth + 1
+      });
+
+      if (spreadResult.kind === "error") {
+        return spreadResult;
+      }
+
+      metadata = spreadResult.metadata;
+
+      if (!t.isObjectExpression(spreadResult.expression)) {
+        return {
+          kind: "error",
+          diagnostic: createStaticCssEvalObjectSpreadUnsupportedDiagnostic(
+            createInlineStaticCssDiagnosticContext(options),
+            "<inline>",
+            "object"
+          ),
+          metadata
+        };
+      }
+
+      properties.push(
+        ...spreadResult.expression.properties.map((spreadProperty) =>
+          t.cloneNode(spreadProperty)
+        )
+      );
+      continue;
+    }
+
+    if (!t.isObjectProperty(property)) {
+      return {
+        kind: "error",
+        diagnostic: createStaticCssEvalDynamicExpressionUnsupportedDiagnostic(
+          createInlineStaticCssDiagnosticContext(options),
+          property.type
+        ),
+        metadata
+      };
+    }
+
+    if (property.computed) {
+      return {
+        kind: "error",
+        diagnostic: createStaticCssEvalComputedMemberUnsupportedDiagnostic(
+          createInlineStaticCssDiagnosticContext(options)
+        ),
+        metadata
+      };
+    }
+
+    if (!t.isExpression(property.value)) {
+      return {
+        kind: "error",
+        diagnostic: createStaticCssEvalDynamicExpressionUnsupportedDiagnostic(
+          createInlineStaticCssDiagnosticContext(options),
+          property.value.type
+        ),
+        metadata
+      };
+    }
+
+    const valueResult = evaluateInlineStaticCssExpression({
+      ...options,
+      expression: property.value,
+      metadata,
+      depth: options.depth + 1
+    });
+
+    if (valueResult.kind === "error") {
+      return valueResult;
+    }
+
+    metadata = valueResult.metadata;
+
+    const nextProperty = t.cloneNode(property);
+    nextProperty.value = preserveDirectBooleanReferenceValue(
+      property.value,
+      valueResult.expression
+    );
+    nextProperty.shorthand = false;
+    properties.push(nextProperty);
+  }
+
+  return {
+    kind: "resolved",
+    expression: normalizeResolvedObjectExpression(
+      t.objectExpression(properties)
+    ),
+    metadata
+  };
+}
+
+function evaluateInlineStaticCssArrayExpression(
+  options: InlineStaticCssEvaluationOptions & {
+    expression: t.ArrayExpression;
+  }
+): InlineStaticCssArrayExpressionResult {
+  const elements: t.ArrayExpression["elements"] = [];
+  let metadata = options.metadata;
+
+  for (const element of options.expression.elements) {
+    if (!element) {
+      return {
+        kind: "error",
+        diagnostic: createStaticCssEvalDynamicExpressionUnsupportedDiagnostic(
+          createInlineStaticCssDiagnosticContext(options),
+          "ArrayHole"
+        ),
+        metadata
+      };
+    }
+
+    if (t.isSpreadElement(element)) {
+      const spreadResult = evaluateInlineStaticCssExpression({
+        ...options,
+        expression: element.argument,
+        metadata,
+        depth: options.depth + 1
+      });
+
+      if (spreadResult.kind === "error") {
+        return spreadResult;
+      }
+
+      metadata = spreadResult.metadata;
+
+      if (!t.isArrayExpression(spreadResult.expression)) {
+        return {
+          kind: "error",
+          diagnostic: createStaticCssEvalObjectSpreadUnsupportedDiagnostic(
+            createInlineStaticCssDiagnosticContext(options),
+            "<inline>",
+            "array"
+          ),
+          metadata
+        };
+      }
+
+      for (const spreadElement of spreadResult.expression.elements) {
+        if (!spreadElement || t.isSpreadElement(spreadElement)) {
+          return {
+            kind: "error",
+            diagnostic: createStaticCssEvalObjectSpreadUnsupportedDiagnostic(
+              createInlineStaticCssDiagnosticContext(options),
+              "<inline>",
+              "array"
+            ),
+            metadata
+          };
+        }
+
+        elements.push(t.cloneNode(spreadElement));
+      }
+      continue;
+    }
+
+    const elementResult = evaluateInlineStaticCssExpression({
+      ...options,
+      expression: element,
+      metadata,
+      depth: options.depth + 1
+    });
+
+    if (elementResult.kind === "error") {
+      return elementResult;
+    }
+
+    metadata = elementResult.metadata;
+    elements.push(
+      preserveDirectBooleanReferenceValue(element, elementResult.expression)
+    );
+  }
+
+  return {
+    kind: "resolved",
+    expression: normalizeResolvedArrayExpression(t.arrayExpression(elements)),
+    metadata
+  };
+}
+
+function resolveProviderStaticCssExpression(
+  options: InlineStaticCssEvaluationOptions
+): InlineStaticCssExpressionResult | { kind: "not-candidate" } {
+  if (!options.provider) {
+    return { kind: "not-candidate" };
+  }
+
+  const candidate = createStaticCssEvalCandidate(
+    options.expression,
+    options.ownerFile
+  );
+
+  if (!candidate) {
+    return { kind: "not-candidate" };
+  }
+
+  const result = options.provider.getResolvedCssValue(candidate);
+
+  if (result.kind === "not-candidate") {
+    return { kind: "not-candidate" };
+  }
+
+  const metadata = [...options.metadata, result];
+
+  if (result.kind === "error") {
+    return { kind: "error", diagnostic: result.diagnostic, metadata };
+  }
+
+  return {
+    kind: "resolved",
+    expression: createStaticCssLiteralExpression(result.value),
+    metadata
+  };
+}
+
+function resolveInlineSameFileStaticCssExpression(
+  options: InlineStaticCssEvaluationOptions
+): InlineStaticCssExpressionResult | { kind: "not-candidate" } {
+  const reference = getStaticCssEvalMemberReference(options.expression);
+
+  if (reference?.kind !== "supported" || reference.memberPath.length > 0) {
+    return { kind: "not-candidate" };
+  }
+
+  const binding = options.scope.getBinding(reference.bindingName);
+
+  if (!binding) {
+    return { kind: "not-candidate" };
+  }
+
+  const currentFrame: InlineStaticCssLocalStackFrame = {
+    bindingName: reference.bindingName,
+    memberPath: []
+  };
+  const currentKey = createInlineStaticCssLocalStackKey(currentFrame);
+  const localStack = options.localStack ?? [];
+
+  if (
+    localStack.some(
+      (frame) => createInlineStaticCssLocalStackKey(frame) === currentKey
+    )
+  ) {
+    return { kind: "not-candidate" };
+  }
+
+  const initExpression = getStaticCssEvalConstBindingInitExpression(binding);
+
+  if (!initExpression) {
+    return { kind: "not-candidate" };
+  }
+
+  return evaluateInlineStaticCssExpression({
+    ...options,
+    expression: initExpression,
+    scope: binding.scope,
+    localStack: [...localStack, currentFrame],
+    depth: options.depth
+  });
+}
+
+function createInlineStaticCssLocalStackKey(
+  frame: InlineStaticCssLocalStackFrame
+): string {
+  return `${frame.bindingName}\0${frame.memberPath.join(".")}`;
+}
+
+function resolveSameFileNestedStaticCssExpression(
+  options: InlineStaticCssEvaluationOptions
+): InlineStaticCssExpressionResult {
+  const sameFileResult = resolveSameFileStaticCssEvalExpression({
+    expression: createNestedStaticCssEvalWrapper(options.expression),
+    ownerFile: options.ownerFile,
+    programPath: options.programPath,
+    scope: options.scope
+  });
+  const metadata = [...options.metadata, sameFileResult];
+
+  if (sameFileResult.kind === "error") {
+    return {
+      kind: "error",
+      diagnostic: sameFileResult.diagnostic,
+      metadata
+    };
+  }
+
+  if (sameFileResult.kind === "resolved") {
+    const expression = getNestedStaticCssEvalWrapperValue(
+      sameFileResult.expression
+    );
+
+    if (expression) {
+      return {
+        kind: "resolved",
+        expression: normalizeResolvedCssExpression(expression),
+        metadata
+      };
+    }
+  }
+
+  return {
+    kind: "error",
+    diagnostic: createStaticCssEvalDynamicExpressionUnsupportedDiagnostic(
+      createInlineStaticCssDiagnosticContext(options),
+      unwrapTransparentCssRuleExpression(options.expression).type
+    ),
+    metadata
+  };
+}
+
+function createNestedStaticCssEvalWrapper(
+  expression: t.Expression
+): t.ObjectExpression {
+  const wrapper = t.objectExpression([
+    t.objectProperty(t.identifier("value"), t.cloneNode(expression))
+  ]);
+  wrapper.start = expression.start;
+  wrapper.end = expression.end;
+  wrapper.loc = expression.loc;
+  return wrapper;
+}
+
+function getNestedStaticCssEvalWrapperValue(
+  expression: t.ObjectExpression | t.ArrayExpression
+): t.Expression | null {
+  if (!t.isObjectExpression(expression)) {
+    return null;
+  }
+
+  const [property] = expression.properties;
+
+  if (!t.isObjectProperty(property) || !t.isExpression(property.value)) {
+    return null;
+  }
+
+  return property.value;
+}
+
+function createInlineStaticCssDiagnosticContext(options: {
+  expression: t.Expression;
+  ownerFile: string;
+}): {
+  owner: { file: string; start?: number; end?: number };
+} {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(
+    options.expression
+  );
+
+  return {
+    owner: {
+      file: options.ownerFile,
+      ...(typeof unwrappedExpression.start === "number"
+        ? { start: unwrappedExpression.start }
+        : {}),
+      ...(typeof unwrappedExpression.end === "number"
+        ? { end: unwrappedExpression.end }
+        : {})
+    }
+  };
+}
+
+function shouldPreserveUnsupportedArraySpreadClassification(
+  expression: t.Expression,
+  diagnostic: StaticCssEvalDiagnostic
+): boolean {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+
+  return (
+    t.isArrayExpression(unwrappedExpression) &&
+    hasArraySpreadElement(unwrappedExpression) &&
+    (diagnostic.reason === "identifier-object-value" ||
+      diagnostic.reason === "member-expression-object-value")
+  );
+}
+
+function preserveDirectBooleanReferenceValues(
+  originalExpression: t.Expression,
+  resolvedExpression: t.ObjectExpression | t.ArrayExpression
+): t.ObjectExpression | t.ArrayExpression {
+  const unwrappedOriginal =
+    unwrapTransparentCssRuleExpression(originalExpression);
+
+  if (
+    t.isObjectExpression(unwrappedOriginal) &&
+    t.isObjectExpression(resolvedExpression)
+  ) {
+    if (
+      unwrappedOriginal.properties.some((property) =>
+        t.isSpreadElement(property)
+      )
+    ) {
+      return resolvedExpression;
+    }
+
+    return preserveObjectBooleanReferenceValues(
+      unwrappedOriginal,
+      resolvedExpression
+    );
+  }
+
+  if (
+    t.isArrayExpression(unwrappedOriginal) &&
+    t.isArrayExpression(resolvedExpression)
+  ) {
+    if (
+      unwrappedOriginal.elements.some((element) => t.isSpreadElement(element))
+    ) {
+      return resolvedExpression;
+    }
+
+    return preserveArrayBooleanReferenceValues(
+      unwrappedOriginal,
+      resolvedExpression
+    );
+  }
+
+  return resolvedExpression;
+}
+
+function preserveObjectBooleanReferenceValues(
+  originalExpression: t.ObjectExpression,
+  resolvedExpression: t.ObjectExpression
+): t.ObjectExpression {
+  const originalProperties = getDirectObjectPropertiesByKey(originalExpression);
+  const properties = resolvedExpression.properties.map((property) => {
+    if (!t.isObjectProperty(property) || property.computed) {
+      return t.cloneNode(property);
+    }
+
+    const propertyName = getStaticObjectPropertyName(property.key);
+    const originalProperty = propertyName
+      ? originalProperties.get(propertyName)
+      : undefined;
+    const nextProperty = t.cloneNode(property);
+
+    if (
+      originalProperty &&
+      t.isExpression(originalProperty.value) &&
+      t.isExpression(property.value)
+    ) {
+      nextProperty.value = preserveBooleanReferenceValue(
+        originalProperty.value,
+        property.value
+      );
+    }
+
+    return nextProperty;
+  });
+
+  return t.objectExpression(properties);
+}
+
+function getDirectObjectPropertiesByKey(
+  expression: t.ObjectExpression
+): Map<string, t.ObjectProperty> {
+  const properties = new Map<string, t.ObjectProperty>();
+
+  for (const property of expression.properties) {
+    if (!t.isObjectProperty(property) || property.computed) {
+      continue;
+    }
+
+    const propertyName = getStaticObjectPropertyName(property.key);
+
+    if (propertyName) {
+      properties.set(propertyName, property);
+    }
+  }
+
+  return properties;
+}
+
+function preserveArrayBooleanReferenceValues(
+  originalExpression: t.ArrayExpression,
+  resolvedExpression: t.ArrayExpression
+): t.ArrayExpression {
+  const elements = resolvedExpression.elements.map((element, index) => {
+    const originalElement = originalExpression.elements[index];
+
+    if (!element || t.isSpreadElement(element)) {
+      return element ? t.cloneNode(element) : null;
+    }
+
+    if (!originalElement || t.isSpreadElement(originalElement)) {
+      return t.cloneNode(element);
+    }
+
+    return preserveBooleanReferenceValue(originalElement, element);
+  });
+
+  return t.arrayExpression(elements);
+}
+
+function preserveBooleanReferenceValue(
+  originalExpression: t.Expression,
+  resolvedExpression: t.Expression
+): t.Expression {
+  const unwrappedOriginal =
+    unwrapTransparentCssRuleExpression(originalExpression);
+
+  if (t.isBooleanLiteral(resolvedExpression)) {
+    return preserveDirectBooleanReferenceValue(
+      unwrappedOriginal,
+      resolvedExpression
+    );
+  }
+
+  if (
+    t.isObjectExpression(unwrappedOriginal) &&
+    t.isObjectExpression(resolvedExpression)
+  ) {
+    return preserveDirectBooleanReferenceValues(
+      unwrappedOriginal,
+      resolvedExpression
+    );
+  }
+
+  if (
+    t.isArrayExpression(unwrappedOriginal) &&
+    t.isArrayExpression(resolvedExpression)
+  ) {
+    return preserveDirectBooleanReferenceValues(
+      unwrappedOriginal,
+      resolvedExpression
+    );
+  }
+
+  return t.cloneNode(resolvedExpression);
+}
+
+function normalizeResolvedCssRuleExpression(
+  expression: t.ObjectExpression | t.ArrayExpression
+): t.ObjectExpression | t.ArrayExpression {
+  return t.isObjectExpression(expression)
+    ? normalizeResolvedObjectExpression(expression)
+    : normalizeResolvedArrayExpression(expression);
+}
+
+function normalizeResolvedCssExpression(
+  expression: t.Expression
+): t.Expression {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+
+  if (t.isObjectExpression(unwrappedExpression)) {
+    return normalizeResolvedObjectExpression(unwrappedExpression);
+  }
+
+  if (t.isArrayExpression(unwrappedExpression)) {
+    return normalizeResolvedArrayExpression(unwrappedExpression);
+  }
+
+  return normalizeInlineStaticCssPrimitiveLiteral(unwrappedExpression);
+}
+
+function normalizeResolvedObjectExpression(
+  expression: t.ObjectExpression
+): t.ObjectExpression {
+  const properties: t.ObjectExpression["properties"] = [];
+  const propertyIndexes = new Map<string, number>();
+
+  for (const property of expression.properties) {
+    if (!t.isObjectProperty(property) || property.computed) {
+      properties.push(t.cloneNode(property));
+      continue;
+    }
+
+    const nextProperty = t.cloneNode(property);
+
+    if (t.isExpression(nextProperty.value)) {
+      nextProperty.value = normalizeResolvedCssExpression(nextProperty.value);
+    }
+
+    const propertyName = getStaticObjectPropertyName(nextProperty.key);
+
+    if (!propertyName) {
+      properties.push(nextProperty);
+      continue;
+    }
+
+    const existingIndex = propertyIndexes.get(propertyName);
+
+    if (existingIndex === undefined) {
+      propertyIndexes.set(propertyName, properties.length);
+      properties.push(nextProperty);
+      continue;
+    }
+
+    properties[existingIndex] = nextProperty;
+  }
+
+  return t.objectExpression(properties);
+}
+
+function normalizeResolvedArrayExpression(
+  expression: t.ArrayExpression
+): t.ArrayExpression {
+  return t.arrayExpression(
+    expression.elements.map((element) => {
+      if (!element || t.isSpreadElement(element)) {
+        return element ? t.cloneNode(element) : null;
+      }
+
+      return normalizeResolvedCssExpression(element);
+    })
+  );
+}
+
+function isInlineStaticCssPrimitiveLiteral(expression: t.Expression): boolean {
+  return (
+    t.isStringLiteral(expression) ||
+    t.isNumericLiteral(expression) ||
+    t.isBooleanLiteral(expression) ||
+    t.isNullLiteral(expression) ||
+    isInlineUnaryNumericLiteral(expression) ||
+    isInlineNoExpressionTemplateLiteral(expression)
+  );
+}
+
+function isInlineUnaryNumericLiteral(
+  expression: t.Expression
+): expression is t.UnaryExpression & { argument: t.NumericLiteral } {
+  return (
+    t.isUnaryExpression(expression) &&
+    (expression.operator === "+" || expression.operator === "-") &&
+    t.isNumericLiteral(expression.argument)
+  );
+}
+
+function isInlineNoExpressionTemplateLiteral(
+  expression: t.Expression
+): expression is t.TemplateLiteral {
+  return t.isTemplateLiteral(expression) && expression.expressions.length === 0;
+}
+
+function normalizeInlineStaticCssPrimitiveLiteral(
+  expression: t.Expression
+): t.Expression {
+  if (isInlineNoExpressionTemplateLiteral(expression)) {
+    const [quasi] = expression.quasis;
+    return t.stringLiteral(quasi?.value.cooked ?? quasi?.value.raw ?? "");
+  }
+
+  return t.cloneNode(expression);
 }
 
 function registerImportedStaticCssEvalProviderResultMetadata(options: {

--- a/packages/babel/src/staticCssEval/ast.ts
+++ b/packages/babel/src/staticCssEval/ast.ts
@@ -1,5 +1,21 @@
 import { types as t } from "@babel/core";
+import { unwrapTransparentCssRuleExpression } from "./candidates.js";
 import type { StaticCssEvalUnsupportedReason } from "./types.js";
+
+export function preserveDirectBooleanReferenceValue(
+  originalExpression: t.Expression,
+  resolvedExpression: t.Expression
+): t.Expression {
+  const original = unwrapTransparentCssRuleExpression(originalExpression);
+
+  return t.isBooleanLiteral(resolvedExpression) &&
+    (t.isIdentifier(original) ||
+      (t.isMemberExpression(original) &&
+        !original.computed &&
+        t.isIdentifier(original.property)))
+    ? t.cloneNode(original)
+    : t.cloneNode(resolvedExpression);
+}
 
 export function getStaticObjectMemberValue(
   expression: t.ObjectExpression,

--- a/packages/babel/src/staticCssEval/diagnostics.ts
+++ b/packages/babel/src/staticCssEval/diagnostics.ts
@@ -162,7 +162,7 @@ export function createStaticCssEvalObjectSpreadUnsupportedDiagnostic(
     id: "STATIC_CSS_EVAL_OBJECT_SPREAD_UNSUPPORTED",
     code: "unsupported-syntax",
     reason: "object-or-array-spread",
-    detail: `same-file binding "${bindingName}" contains an ${collection} spread`,
+    detail: `static css-rule binding "${bindingName}" contains an unsupported ${collection} spread operand`,
     owner: context.owner,
     dependency: context.dependency,
     importPath: context.importPath,
@@ -700,7 +700,22 @@ if (import.meta.vitest) {
         id: "STATIC_CSS_EVAL_OBJECT_SPREAD_UNSUPPORTED",
         code: "unsupported-syntax",
         message:
-          'Cannot statically evaluate css prop value: same-file binding "style" contains an object spread',
+          'Cannot statically evaluate css prop value: static css-rule binding "style" contains an unsupported object spread operand',
+        reason: "object-or-array-spread",
+        owner
+      });
+
+      expect(
+        createStaticCssEvalObjectSpreadUnsupportedDiagnostic(
+          { owner },
+          "style",
+          "array"
+        )
+      ).toEqual({
+        id: "STATIC_CSS_EVAL_OBJECT_SPREAD_UNSUPPORTED",
+        code: "unsupported-syntax",
+        message:
+          'Cannot statically evaluate css prop value: static css-rule binding "style" contains an unsupported array spread operand',
         reason: "object-or-array-spread",
         owner
       });

--- a/packages/babel/src/staticCssEval/importedModules.ts
+++ b/packages/babel/src/staticCssEval/importedModules.ts
@@ -1,6 +1,7 @@
 import { types as t } from "@babel/core";
 import type { NodePath } from "@babel/core";
 import hash from "@emotion/hash";
+import type { Binding } from "@babel/traverse";
 import {
   getStaticObjectMemberValue,
   getStaticObjectPropertyName,
@@ -11,6 +12,7 @@ import {
   getStaticCssEvalMemberReference,
   unwrapTransparentCssRuleExpression
 } from "./candidates.js";
+import type { StaticMemberReference } from "./candidates.js";
 import {
   createStaticCssEvalProviderSourceMetadata,
   enforceStaticCssEvalProviderSourcePolicy
@@ -48,6 +50,7 @@ import {
   createStaticCssEvalMutableBindingDiagnostic,
   createStaticCssEvalMutatedBindingDiagnostic,
   createStaticCssEvalNamespaceReexportUnsupportedDiagnostic,
+  createStaticCssEvalObjectSpreadUnsupportedDiagnostic,
   createStaticCssEvalPartialNamespaceFailureDiagnostic,
   createStaticCssEvalProviderSourceUnsupportedDiagnostic,
   createStaticCssEvalUnresolvedExportDiagnostic,
@@ -198,6 +201,47 @@ interface ImportedStaticCssEvalResolutionState {
 interface StaticCssLiteralValidationState {
   count: number;
 }
+
+interface ImportedStaticCssEvalLocalReferenceFrame {
+  readonly recordId: string;
+  readonly bindingName: string;
+  readonly memberPath: readonly string[];
+}
+
+type ImportedStaticCssEvalLiteralResult =
+  | { kind: "resolved"; value: StaticCssLiteral }
+  | { kind: "error"; diagnostic: StaticCssEvalDiagnostic };
+
+type ImportedStaticCssEvalLiteralReferenceResult =
+  | ImportedStaticCssEvalLiteralResult
+  | { kind: "not-candidate" };
+
+type ImportedStaticCssEvalDeclarationKind =
+  | "const"
+  | "let"
+  | "var"
+  | "function"
+  | "class";
+
+interface ImportedStaticCssEvalLiteralEvaluationOptions {
+  readonly expression: t.Expression;
+  readonly context: ImportedStaticCssEvalContext;
+  readonly record: ImportedStaticCssEvalModuleRecord;
+  readonly request: ImportedStaticCssEvalResolutionRequest;
+  readonly resolutionState: ImportedStaticCssEvalResolutionState;
+  readonly literalState: StaticCssLiteralValidationState;
+  readonly localStack: readonly ImportedStaticCssEvalLocalReferenceFrame[];
+  readonly depth: number;
+  readonly resolveReference: ImportedStaticCssEvalLiteralReferenceResolver;
+}
+
+interface ImportedStaticCssEvalLiteralReferenceOptions extends ImportedStaticCssEvalLiteralEvaluationOptions {
+  readonly reference: StaticMemberReference;
+}
+
+type ImportedStaticCssEvalLiteralReferenceResolver = (
+  options: ImportedStaticCssEvalLiteralReferenceOptions
+) => ImportedStaticCssEvalLiteralResult;
 
 export interface ImportedStaticCssEvalLoadedModule extends StaticCssEvalProviderSourcePolicyDescriptor {
   id: string;
@@ -849,7 +893,8 @@ class ImportedStaticCssEvalResolver {
       exportEntry,
       effectiveRequest,
       state,
-      provenance
+      provenance,
+      (options) => this.#resolveStaticCssLiteralReference(options)
     );
   }
 
@@ -1541,6 +1586,98 @@ class ImportedStaticCssEvalResolver {
     });
   }
 
+  #resolveStaticCssLiteralReference(
+    options: ImportedStaticCssEvalLiteralReferenceOptions
+  ): ImportedStaticCssEvalLiteralResult {
+    const { reference } = options;
+
+    if (reference.kind === "unsupported") {
+      return createUnsupportedImportedReferenceResult(options);
+    }
+
+    const cjsBinding = options.record.cjsImports.get(reference.bindingName);
+
+    if (cjsBinding) {
+      return this.#resolveProviderBackedLiteralReference(
+        options,
+        createCjsResolutionRequest(
+          createReferenceQuery(options.record.id, reference),
+          cjsBinding
+        ).request
+      );
+    }
+
+    const dynamicRequireDiagnostic =
+      createDynamicRequireOperandDiagnostic(options);
+
+    if (dynamicRequireDiagnostic) {
+      return { kind: "error", diagnostic: dynamicRequireDiagnostic };
+    }
+
+    const localResult = resolveSameModuleStaticLiteralReference(options);
+
+    if (localResult.kind !== "not-candidate") {
+      return localResult;
+    }
+
+    const importBinding = options.record.imports.get(reference.bindingName);
+
+    if (!importBinding) {
+      return createUnsupportedImportedLiteralResult(
+        options,
+        options.expression
+      );
+    }
+
+    const requestResult = createResolutionRequest(
+      createReferenceQuery(options.record.id, reference),
+      importBinding
+    );
+
+    if (requestResult.kind === "error") {
+      return { kind: "error", diagnostic: requestResult.diagnostic };
+    }
+
+    return this.#resolveProviderBackedLiteralReference(
+      options,
+      requestResult.request
+    );
+  }
+
+  #resolveProviderBackedLiteralReference(
+    options: ImportedStaticCssEvalLiteralReferenceOptions,
+    request: ImportedStaticCssEvalResolutionRequest
+  ): ImportedStaticCssEvalLiteralResult {
+    const importResult = this.#resolveProviderImport(
+      request,
+      options.resolutionState.owner,
+      options.resolutionState
+    );
+
+    if (importResult.kind === "error") {
+      return { kind: "error", diagnostic: importResult.diagnostic };
+    }
+
+    const exportResult = this.#resolveModuleExport(
+      importResult.record,
+      request,
+      options.resolutionState
+    );
+
+    if (exportResult.kind === "error") {
+      return { kind: "error", diagnostic: exportResult.diagnostic };
+    }
+
+    if (exportResult.kind === "not-candidate") {
+      return createUnsupportedImportedLiteralResult(
+        options,
+        options.expression
+      );
+    }
+
+    return { kind: "resolved", value: exportResult.value };
+  }
+
   #createCjsUnsupportedDiagnostic(
     ownerRecord: ImportedStaticCssEvalModuleRecord,
     query: StaticCssEvalQuery
@@ -1898,7 +2035,8 @@ function resolveStaticExportMapEntry(
   exportEntry: Exclude<ExportMapEntry, { kind: "reexport" | "unsupported" }>,
   request: ImportedStaticCssEvalResolutionRequest,
   state: ImportedStaticCssEvalResolutionState,
-  provenance: BindingProvenance
+  provenance: BindingProvenance,
+  resolveReference: ImportedStaticCssEvalLiteralReferenceResolver
 ): ImportedStaticCssEvalResolutionResult {
   const expressionResult = getStaticExportEntryExpression(record, exportEntry);
   const cacheKey = createImportedStaticCssEvalCacheKey(
@@ -1932,22 +2070,23 @@ function resolveStaticExportMapEntry(
     };
   }
 
-  const memberExpression = resolveStaticObjectMemberPath(
+  const selectedExpression = selectStaticCssEvalExpressionForMemberPath(
     expressionResult.expression,
     request.memberPath
   );
 
-  if (!memberExpression) {
-    return { kind: "not-candidate" };
-  }
-
   const context = createImportedLiteralContext(record, request, state);
-  const literalResult = evaluateStaticCssLiteralExpression(
-    memberExpression,
+  const literalResult = evaluateStaticCssLiteralExpression({
+    expression: selectedExpression.expression,
     context,
-    { count: 0 },
-    1
-  );
+    record,
+    request,
+    resolutionState: state,
+    literalState: { count: 0 },
+    localStack: [],
+    depth: 1,
+    resolveReference
+  });
 
   if (literalResult.kind === "error") {
     return {
@@ -1958,9 +2097,18 @@ function resolveStaticExportMapEntry(
     };
   }
 
+  const value = selectStaticCssLiteralMemberPath(
+    literalResult.value,
+    selectedExpression.deferredMemberPath
+  );
+
+  if (value.kind === "not-candidate") {
+    return { kind: "not-candidate" };
+  }
+
   return {
     kind: "resolved",
-    value: literalResult.value,
+    value: value.value,
     provenance,
     cacheKey
   };
@@ -2546,51 +2694,415 @@ function resolveStaticObjectMemberPath(
     : null;
 }
 
-function evaluateStaticCssLiteralExpression(
+function selectStaticCssEvalExpressionForMemberPath(
   expression: t.Expression,
-  context: ImportedStaticCssEvalContext,
-  state: StaticCssLiteralValidationState,
-  depth: number
-):
-  | { kind: "resolved"; value: StaticCssLiteral }
-  | { kind: "error"; diagnostic: StaticCssEvalDiagnostic } {
-  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
-  state.count += 1;
+  memberPath: readonly string[]
+): {
+  readonly expression: t.Expression;
+  readonly deferredMemberPath: string[];
+} {
+  const selectedExpression = resolveStaticObjectMemberPath(
+    expression,
+    memberPath
+  );
 
-  const countResult = enforceImportedStaticCssEvalLiteralCount(context, state);
+  if (selectedExpression) {
+    return {
+      expression: selectedExpression,
+      deferredMemberPath: []
+    };
+  }
+
+  return {
+    expression: unwrapTransparentCssRuleExpression(expression),
+    deferredMemberPath: [...memberPath]
+  };
+}
+
+function selectStaticCssLiteralMemberPath(
+  value: StaticCssLiteral,
+  memberPath: readonly string[]
+): { kind: "resolved"; value: StaticCssLiteral } | { kind: "not-candidate" } {
+  let currentValue = value;
+
+  for (const memberName of memberPath) {
+    if (!isStaticCssLiteralObject(currentValue)) {
+      return { kind: "not-candidate" };
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(currentValue, memberName)) {
+      return { kind: "not-candidate" };
+    }
+
+    const nextValue = currentValue[memberName];
+
+    if (nextValue === undefined) {
+      return { kind: "not-candidate" };
+    }
+
+    currentValue = nextValue;
+  }
+
+  return { kind: "resolved", value: currentValue };
+}
+
+function resolveSameModuleStaticLiteralReference(
+  options: ImportedStaticCssEvalLiteralReferenceOptions
+): ImportedStaticCssEvalLiteralReferenceResult {
+  if (options.reference.kind === "unsupported") {
+    return createUnsupportedImportedReferenceResult(options);
+  }
+
+  const binding = options.record.programPath.scope.getBinding(
+    options.reference.bindingName
+  );
+
+  if (!binding) {
+    return { kind: "not-candidate" };
+  }
+
+  const declarationKind =
+    getImportedStaticCssEvalBindingDeclarationKind(binding);
+  const init = getImportedStaticCssEvalVariableBindingInitExpression(binding);
+
+  if (!declarationKind || !init) {
+    return { kind: "not-candidate" };
+  }
+
+  if (declarationKind === "let" || declarationKind === "var") {
+    return {
+      kind: "error",
+      diagnostic: createStaticCssEvalMutableBindingDiagnostic(
+        createImportedLiteralDiagnosticContext(options.context),
+        options.reference.bindingName
+      )
+    };
+  }
+
+  if (declarationKind !== "const") {
+    return { kind: "not-candidate" };
+  }
+
+  const currentFrame: ImportedStaticCssEvalLocalReferenceFrame = {
+    recordId: options.record.id,
+    bindingName: options.reference.bindingName,
+    memberPath: [...options.reference.memberPath]
+  };
+  const cycleStartIndex = findImportedLocalAliasCycleStartIndex(
+    options.localStack,
+    currentFrame
+  );
+
+  if (cycleStartIndex !== -1) {
+    return {
+      kind: "error",
+      diagnostic: createImportedLocalAliasCycleDiagnostic(options.context, [
+        ...options.localStack.slice(cycleStartIndex),
+        currentFrame
+      ])
+    };
+  }
+
+  if (hasStaticCssEvalBindingMutation(options.record.programPath, binding)) {
+    return {
+      kind: "error",
+      diagnostic: createStaticCssEvalMutatedBindingDiagnostic(
+        createImportedLiteralDiagnosticContext(options.context),
+        options.reference.bindingName
+      )
+    };
+  }
+
+  const selectedExpression = selectStaticCssEvalExpressionForMemberPath(
+    init,
+    options.reference.memberPath
+  );
+  const literalResult = evaluateStaticCssLiteralExpression({
+    ...options,
+    expression: selectedExpression.expression,
+    localStack: [...options.localStack, currentFrame],
+    resolveReference: options.resolveReference
+  });
+
+  if (literalResult.kind === "error") {
+    return literalResult;
+  }
+
+  const selectedValue = selectStaticCssLiteralMemberPath(
+    literalResult.value,
+    selectedExpression.deferredMemberPath
+  );
+
+  return selectedValue.kind === "resolved"
+    ? selectedValue
+    : createUnsupportedImportedLiteralResult(options, options.expression);
+}
+
+function findImportedLocalAliasCycleStartIndex(
+  stack: readonly ImportedStaticCssEvalLocalReferenceFrame[],
+  currentFrame: ImportedStaticCssEvalLocalReferenceFrame
+): number {
+  const currentKey = createImportedLocalAliasCycleKey(currentFrame);
+
+  return stack.findIndex(
+    (frame) => createImportedLocalAliasCycleKey(frame) === currentKey
+  );
+}
+
+function createImportedLocalAliasCycleKey(
+  frame: ImportedStaticCssEvalLocalReferenceFrame
+): string {
+  return JSON.stringify([frame.recordId, frame.bindingName, frame.memberPath]);
+}
+
+function createImportedLocalAliasCycleDiagnostic(
+  context: ImportedStaticCssEvalContext,
+  cycle: readonly ImportedStaticCssEvalLocalReferenceFrame[]
+): StaticCssEvalDiagnostic {
+  const importChain = cycle.map(formatImportedLocalAliasCycleFrame);
+
+  return createStaticCssEvalDiagnostic({
+    id: "STATIC_CSS_EVAL_LOCAL_ALIAS_CYCLE",
+    code: "cycle-detected",
+    reason: "runtime-dynamic-value",
+    detail: `cyclic imported static css alias detected: ${importChain.join(
+      " -> "
+    )}`,
+    ...createImportedLiteralDiagnosticContext(context),
+    importChain
+  });
+}
+
+function formatImportedLocalAliasCycleFrame(
+  frame: ImportedStaticCssEvalLocalReferenceFrame
+): string {
+  const memberPath = frame.memberPath.length
+    ? `.${frame.memberPath.join(".")}`
+    : "";
+
+  return `${frame.recordId}#${frame.bindingName}${memberPath}`;
+}
+
+function createUnsupportedImportedReferenceResult(
+  options: ImportedStaticCssEvalLiteralReferenceOptions
+): ImportedStaticCssEvalLiteralResult {
+  if (options.reference.kind !== "unsupported") {
+    return createUnsupportedImportedLiteralResult(options, options.expression);
+  }
+
+  if (options.reference.reason === "optional-member-path") {
+    return {
+      kind: "error",
+      diagnostic: createStaticCssEvalDynamicExpressionUnsupportedDiagnostic(
+        createImportedLiteralDiagnosticContext(options.context),
+        options.reference.detail
+      )
+    };
+  }
+
+  return {
+    kind: "error",
+    diagnostic: createStaticCssEvalComputedMemberUnsupportedDiagnostic(
+      createImportedLiteralDiagnosticContext(options.context)
+    )
+  };
+}
+
+function createDynamicRequireOperandDiagnostic(
+  options: ImportedStaticCssEvalLiteralReferenceOptions
+): StaticCssEvalDiagnostic | null {
+  const binding = options.record.programPath.scope.getBinding(
+    options.reference.bindingName
+  );
+  const init = binding
+    ? getImportedStaticCssEvalVariableBindingInitExpression(binding)
+    : null;
+  const unwrappedInit = init ? unwrapTransparentCssRuleExpression(init) : null;
+
+  if (
+    !unwrappedInit ||
+    !containsStaticCssEvalRequireCallExpression(
+      unwrappedInit,
+      options.record.programPath.scope
+    )
+  ) {
+    return null;
+  }
+
+  const context = createImportedLiteralDiagnosticContext(options.context);
+
+  return isStaticCssEvalLiteralRequireCallExpression(
+    unwrappedInit,
+    options.record.programPath.scope
+  )
+    ? createStaticCssEvalCjsUnsupportedDiagnostic(context)
+    : createStaticCssEvalCjsDynamicRequireUnsupportedDiagnostic(context);
+}
+
+function createUnsupportedImportedLiteralResult(
+  options: Pick<ImportedStaticCssEvalLiteralEvaluationOptions, "context">,
+  expression: t.Expression
+): ImportedStaticCssEvalLiteralResult {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+
+  return {
+    kind: "error",
+    diagnostic: createImportedStaticCssEvalDiagnostic({
+      ...options.context,
+      code: "unsupported-syntax",
+      reason: getUnsupportedLiteralReason(unwrappedExpression),
+      detail: createUnsupportedLiteralDetail(
+        options.context.exportName,
+        unwrappedExpression
+      )
+    })
+  };
+}
+
+function createImportedObjectSpreadError(
+  context: ImportedStaticCssEvalContext,
+  collection: "object" | "array"
+): ImportedStaticCssEvalLiteralResult {
+  return {
+    kind: "error",
+    diagnostic: createStaticCssEvalObjectSpreadUnsupportedDiagnostic(
+      createImportedLiteralDiagnosticContext(context),
+      formatExportName(context.exportName),
+      collection
+    )
+  };
+}
+
+function createImportedLiteralDiagnosticContext(
+  context: ImportedStaticCssEvalContext
+): {
+  readonly owner: StaticCssEvalSourceLocation;
+  readonly dependency: StaticCssEvalSourceLocation;
+  readonly importPath: string;
+  readonly exportName: StaticCssEvalExportName;
+  readonly memberPath: readonly string[];
+} {
+  return {
+    owner: context.owner,
+    dependency: context.dependency,
+    importPath: context.importPath,
+    exportName: context.exportName,
+    memberPath: context.memberPath
+  };
+}
+
+function createReferenceQuery(
+  importerId: string,
+  reference: Extract<StaticMemberReference, { kind: "supported" }>
+): StaticCssEvalQuery {
+  return {
+    importerId,
+    expressionStart: 0,
+    expressionEnd: reference.bindingName.length,
+    bindingName: reference.bindingName,
+    ...(reference.memberPath.length > 0
+      ? { memberPath: [...reference.memberPath] }
+      : {})
+  };
+}
+
+function getImportedStaticCssEvalBindingDeclarationKind(
+  binding: Binding
+): ImportedStaticCssEvalDeclarationKind | null {
+  const bindingPath = binding.path;
+
+  if (bindingPath.isVariableDeclarator()) {
+    if (!t.isIdentifier(bindingPath.node.id)) {
+      return null;
+    }
+
+    if (!bindingPath.parentPath.isVariableDeclaration()) {
+      return null;
+    }
+
+    const { kind } = bindingPath.parentPath.node;
+    return kind === "const" || kind === "let" || kind === "var" ? kind : null;
+  }
+
+  if (bindingPath.isFunctionDeclaration()) {
+    return "function";
+  }
+
+  if (bindingPath.isClassDeclaration()) {
+    return "class";
+  }
+
+  return null;
+}
+
+function getImportedStaticCssEvalVariableBindingInitExpression(
+  binding: Binding
+): t.Expression | null {
+  const bindingPath = binding.path;
+
+  if (
+    !bindingPath.isVariableDeclarator() ||
+    !t.isIdentifier(bindingPath.node.id)
+  ) {
+    return null;
+  }
+
+  const initPath = bindingPath.get("init");
+
+  if (!initPath.node || !initPath.isExpression()) {
+    return null;
+  }
+
+  return initPath.node;
+}
+
+function evaluateStaticCssLiteralExpression(
+  options: ImportedStaticCssEvalLiteralEvaluationOptions
+): ImportedStaticCssEvalLiteralResult {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(
+    options.expression
+  );
+  options.literalState.count += 1;
+
+  const countResult = enforceImportedStaticCssEvalLiteralCount(
+    options.context,
+    options.literalState
+  );
 
   if (countResult) {
     return { kind: "error", diagnostic: countResult };
   }
 
   if (t.isObjectExpression(unwrappedExpression)) {
-    const depthResult = enforceImportedStaticCssEvalDepth(context, depth);
+    const depthResult = enforceImportedStaticCssEvalDepth(
+      options.context,
+      options.depth
+    );
 
     if (depthResult) {
       return { kind: "error", diagnostic: depthResult };
     }
 
-    return evaluateStaticCssObjectExpression(
-      unwrappedExpression,
-      context,
-      state,
-      depth
-    );
+    return evaluateStaticCssObjectExpression({
+      ...options,
+      expression: unwrappedExpression
+    });
   }
 
   if (t.isArrayExpression(unwrappedExpression)) {
-    const depthResult = enforceImportedStaticCssEvalDepth(context, depth);
+    const depthResult = enforceImportedStaticCssEvalDepth(
+      options.context,
+      options.depth
+    );
 
     if (depthResult) {
       return { kind: "error", diagnostic: depthResult };
     }
 
-    return evaluateStaticCssArrayExpression(
-      unwrappedExpression,
-      context,
-      state,
-      depth
-    );
+    return evaluateStaticCssArrayExpression({
+      ...options,
+      expression: unwrappedExpression
+    });
   }
 
   if (t.isStringLiteral(unwrappedExpression)) {
@@ -2635,67 +3147,72 @@ function evaluateStaticCssLiteralExpression(
     };
   }
 
-  return {
-    kind: "error",
-    diagnostic: createImportedStaticCssEvalDiagnostic({
-      ...context,
-      code: "unsupported-syntax",
-      reason: getUnsupportedLiteralReason(unwrappedExpression),
-      detail: createUnsupportedLiteralDetail(
-        context.exportName,
-        unwrappedExpression
-      )
-    })
-  };
+  const reference = getStaticCssEvalMemberReference(unwrappedExpression);
+
+  if (reference) {
+    return options.resolveReference({
+      ...options,
+      expression: unwrappedExpression,
+      reference
+    });
+  }
+
+  return createUnsupportedImportedLiteralResult(options, unwrappedExpression);
 }
 
 function evaluateStaticCssObjectExpression(
-  expression: t.ObjectExpression,
-  context: ImportedStaticCssEvalContext,
-  state: StaticCssLiteralValidationState,
-  depth: number
-):
-  | { kind: "resolved"; value: StaticCssLiteral }
-  | { kind: "error"; diagnostic: StaticCssEvalDiagnostic } {
-  const value: Record<string, StaticCssLiteral> = {};
+  options: ImportedStaticCssEvalLiteralEvaluationOptions & {
+    readonly expression: t.ObjectExpression;
+  }
+): ImportedStaticCssEvalLiteralResult {
+  const value: Record<string, StaticCssLiteral> = Object.create(null);
 
-  for (const property of expression.properties) {
+  for (const property of options.expression.properties) {
     if (t.isSpreadElement(property)) {
-      return createStaticCssLiteralError(
-        context,
-        "object-or-array-spread",
-        `imported export "${formatExportName(
-          context.exportName
-        )}" contains an object spread`
-      );
+      const spreadResult = evaluateStaticCssLiteralExpression({
+        ...options,
+        expression: property.argument,
+        depth: options.depth + 1
+      });
+
+      if (spreadResult.kind === "error") {
+        return spreadResult;
+      }
+
+      if (!isStaticCssLiteralObject(spreadResult.value)) {
+        return createImportedObjectSpreadError(options.context, "object");
+      }
+
+      Object.assign(value, spreadResult.value);
+      continue;
     }
 
     if (!t.isObjectProperty(property)) {
       return createStaticCssLiteralError(
-        context,
+        options.context,
         "function-or-call",
         `imported export "${formatExportName(
-          context.exportName
+          options.context.exportName
         )}" contains an object method`
       );
     }
 
     if (property.computed) {
       return createStaticCssLiteralError(
-        context,
+        options.context,
         "computed-object-key",
         `imported export "${formatExportName(
-          context.exportName
+          options.context.exportName
         )}" contains a computed object key`
       );
     }
 
     if (!t.isExpression(property.value)) {
       return createStaticCssLiteralError(
-        context,
+        options.context,
         "unsupported-literal",
         `imported export "${formatExportName(
-          context.exportName
+          options.context.exportName
         )}" contains a non-expression object value`
       );
     }
@@ -2704,20 +3221,19 @@ function evaluateStaticCssObjectExpression(
 
     if (!propertyName) {
       return createStaticCssLiteralError(
-        context,
+        options.context,
         "unsupported-literal",
         `imported export "${formatExportName(
-          context.exportName
+          options.context.exportName
         )}" contains an unsupported object key`
       );
     }
 
-    const propertyResult = evaluateStaticCssLiteralExpression(
-      property.value,
-      context,
-      state,
-      depth + 1
-    );
+    const propertyResult = evaluateStaticCssLiteralExpression({
+      ...options,
+      expression: property.value,
+      depth: options.depth + 1
+    });
 
     if (propertyResult.kind === "error") {
       return propertyResult;
@@ -2730,42 +3246,47 @@ function evaluateStaticCssObjectExpression(
 }
 
 function evaluateStaticCssArrayExpression(
-  expression: t.ArrayExpression,
-  context: ImportedStaticCssEvalContext,
-  state: StaticCssLiteralValidationState,
-  depth: number
-):
-  | { kind: "resolved"; value: StaticCssLiteral }
-  | { kind: "error"; diagnostic: StaticCssEvalDiagnostic } {
+  options: ImportedStaticCssEvalLiteralEvaluationOptions & {
+    readonly expression: t.ArrayExpression;
+  }
+): ImportedStaticCssEvalLiteralResult {
   const value: StaticCssLiteral[] = [];
 
-  for (const element of expression.elements) {
+  for (const element of options.expression.elements) {
     if (!element) {
       return createStaticCssLiteralError(
-        context,
+        options.context,
         "unsupported-literal",
         `imported export "${formatExportName(
-          context.exportName
+          options.context.exportName
         )}" contains an array hole`
       );
     }
 
     if (t.isSpreadElement(element)) {
-      return createStaticCssLiteralError(
-        context,
-        "object-or-array-spread",
-        `imported export "${formatExportName(
-          context.exportName
-        )}" contains an array spread`
-      );
+      const spreadResult = evaluateStaticCssLiteralExpression({
+        ...options,
+        expression: element.argument,
+        depth: options.depth + 1
+      });
+
+      if (spreadResult.kind === "error") {
+        return spreadResult;
+      }
+
+      if (!Array.isArray(spreadResult.value)) {
+        return createImportedObjectSpreadError(options.context, "array");
+      }
+
+      value.push(...spreadResult.value);
+      continue;
     }
 
-    const elementResult = evaluateStaticCssLiteralExpression(
-      element,
-      context,
-      state,
-      depth + 1
-    );
+    const elementResult = evaluateStaticCssLiteralExpression({
+      ...options,
+      expression: element,
+      depth: options.depth + 1
+    });
 
     if (elementResult.kind === "error") {
       return elementResult;
@@ -3039,6 +3560,12 @@ function isStaticCssRuleLiteralValue(
   return value !== null && typeof value === "object";
 }
 
+function isStaticCssLiteralObject(
+  value: StaticCssLiteral
+): value is { [key: string]: StaticCssLiteral } {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
 function formatExportName(exportName: StaticCssEvalExportName): string {
   return exportName === null ? "<local>" : exportName;
 }
@@ -3070,6 +3597,7 @@ if (import.meta.vitest) {
   const packageRawId = "data:@scope/styles/tokens.css?raw";
   const packageWasmUrlId = "data:@scope/styles/icon.wasm?url";
   const providerVirtualId = "virtual:mincho-styles";
+  const tokensId = "/project/src/tokens.ts";
 
   function createProviderFromModules(options: {
     modules: readonly ImportedStaticCssEvalLoadedModule[];
@@ -3449,6 +3977,254 @@ if (import.meta.vitest) {
         kind: "resolved",
         value: { color: "red" }
       });
+    });
+
+    it("resolves imported static css eval spreads from same-module and imported operands", () => {
+      const provider = createProviderFromModules({
+        modules: [
+          {
+            id: ownerId,
+            source: `
+              import { button, rule } from "./styles";
+              <><div css={button} /><div css={rule} /></>;
+            `
+          },
+          {
+            id: stylesId,
+            source: `
+              import { base, stack } from "./tokens";
+              const localBase = { color: "red", padding: 4 } as const;
+              const localStack = [{ display: "grid" }] as const;
+              export const button = { ...localBase, ...base, color: "blue" } as const;
+              export const rule = [...localStack, ...stack, { gap: 8 }] as const;
+            `
+          },
+          {
+            id: tokensId,
+            source: `
+              export const base = { color: "green", margin: 2 } as const;
+              export const stack = [{ alignItems: "center" }] as const;
+            `
+          }
+        ],
+        importResolutions: [
+          { importerId: ownerId, importPath: "./styles", resolvedId: stylesId },
+          { importerId: stylesId, importPath: "./tokens", resolvedId: tokensId }
+        ]
+      });
+
+      const button = expectResolvedResult(resolveFixture(provider, "button"));
+      const rule = expectResolvedResult(resolveFixture(provider, "rule"));
+
+      expect(button.value).toEqual({
+        color: "blue",
+        margin: 2,
+        padding: 4
+      });
+      expect(rule.value).toEqual([
+        { display: "grid" },
+        { alignItems: "center" },
+        { gap: 8 }
+      ]);
+      expect(button.dependencies).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            file: stylesId,
+            inspected: true,
+            contributed: true
+          }),
+          expect.objectContaining({
+            file: tokensId,
+            inspected: true,
+            contributed: true,
+            exportName: "base"
+          })
+        ])
+      );
+      expect(rule.dependencies).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            file: tokensId,
+            inspected: true,
+            contributed: true,
+            exportName: "stack"
+          })
+        ])
+      );
+    });
+
+    it("resolves imported static css eval identifier and namespace member operands", () => {
+      const provider = createProviderFromModules({
+        modules: [
+          {
+            id: ownerId,
+            source: `import { button } from "./styles"; <div css={button} />;`
+          },
+          {
+            id: stylesId,
+            source: `
+              import * as tokens from "./tokens";
+              const localColor = "red";
+              export const button = {
+                color: localColor,
+                backgroundColor: tokens.colors.primary,
+                padding: tokens.space
+              } as const;
+            `
+          },
+          {
+            id: tokensId,
+            source: `
+              export const colors = { primary: "blue" } as const;
+              export const space = 6;
+            `
+          }
+        ],
+        importResolutions: [
+          { importerId: ownerId, importPath: "./styles", resolvedId: stylesId },
+          { importerId: stylesId, importPath: "./tokens", resolvedId: tokensId }
+        ]
+      });
+
+      const result = expectResolvedResult(resolveFixture(provider, "button"));
+
+      expect(result.value).toEqual({
+        backgroundColor: "blue",
+        color: "red",
+        padding: 6
+      });
+      expect(result.dependencies).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            file: tokensId,
+            kind: "namespace-member",
+            exportName: "colors",
+            memberPath: ["primary"],
+            inspected: true,
+            contributed: true
+          }),
+          expect.objectContaining({
+            file: tokensId,
+            kind: "namespace-member",
+            exportName: "space",
+            memberPath: [],
+            inspected: true,
+            contributed: true
+          })
+        ])
+      );
+    });
+
+    it("resolves package data virtual and CommonJS operands through the expanded literal grammar", () => {
+      const packageProvider = createProviderFromModules({
+        modules: [
+          {
+            id: ownerId,
+            source: `import { button } from "@scope/styles"; <div css={button} />;`
+          },
+          {
+            id: packageBarrelId,
+            source: `export { button } from "@scope/styles/leaf";`,
+            sourceKind: "package-source",
+            sourceOrigin: "package"
+          },
+          {
+            id: packageLeafId,
+            source: `
+              import { base } from "@scope/styles/tokens";
+              import virtualTokens from "virtual:mincho-styles";
+              export const button = { ...base, accent: virtualTokens.accent } as const;
+            `,
+            sourceKind: "package-source",
+            sourceOrigin: "package"
+          },
+          {
+            id: packageDataId,
+            source: `export const base = { color: "green" } as const;`,
+            sourceKind: "static-data",
+            sourceOrigin: "data"
+          },
+          {
+            id: providerVirtualId,
+            source: `export default { accent: "purple" } as const;`,
+            sourceKind: "provider-virtual",
+            sourceOrigin: "provider"
+          }
+        ],
+        importResolutions: [
+          {
+            importerId: ownerId,
+            importPath: "@scope/styles",
+            resolvedId: packageBarrelId,
+            sourceKind: "package-source",
+            sourceOrigin: "package"
+          },
+          {
+            importerId: packageBarrelId,
+            importPath: "@scope/styles/leaf",
+            resolvedId: packageLeafId,
+            sourceKind: "package-source",
+            sourceOrigin: "package"
+          },
+          {
+            importerId: packageLeafId,
+            importPath: "@scope/styles/tokens",
+            resolvedId: packageDataId,
+            sourceKind: "static-data",
+            sourceOrigin: "data"
+          },
+          {
+            importerId: packageLeafId,
+            importPath: "virtual:mincho-styles",
+            resolvedId: providerVirtualId,
+            sourceKind: "provider-virtual",
+            sourceOrigin: "provider"
+          }
+        ]
+      });
+      const cjsProvider = createProvider(
+        `
+          const tokens = require("./tokens");
+          exports.button = { ...tokens.base, color: tokens.color };
+        `,
+        `const styles = require("./styles"); <div css={styles.button} />;`,
+        `export { button } from "./styles";`,
+        [
+          {
+            id: tokensId,
+            source: `
+              export const base = { padding: 4 } as const;
+              export const color = "red";
+            `
+          }
+        ],
+        [{ importerId: stylesId, importPath: "./tokens", resolvedId: tokensId }]
+      );
+
+      const packageResult = expectResolvedResult(
+        resolveFixture(packageProvider, "button")
+      );
+      const cjsResult = expectResolvedResult(
+        resolveFixture(cjsProvider, "styles", ["button"])
+      );
+
+      expect(packageResult.value).toEqual({ color: "green", accent: "purple" });
+      expect(packageResult.dependencies).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ file: packageDataId, contributed: true }),
+          expect.objectContaining({
+            file: providerVirtualId,
+            contributed: true
+          })
+        ])
+      );
+      expect(cjsResult.value).toEqual({ padding: 4, color: "red" });
+      expect(cjsResult.dependencies).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ file: stylesId, contributed: true }),
+          expect.objectContaining({ file: tokensId, contributed: true })
+        ])
+      );
     });
 
     it("resolves direct named reexport chains with inspected dependency metadata", () => {
@@ -3965,6 +4741,29 @@ if (import.meta.vitest) {
       expect(Object.hasOwn(result.value, "constructor")).toBe(true);
     });
 
+    it("preserves special property names on imported object literals", () => {
+      const result = expectResolvedResult(
+        resolveFixture(
+          createProvider(
+            `export const styles = { __proto__: { color: "red" }, constructor: { color: "blue" } } as const;`,
+            `import { styles } from "./styles"; <div css={styles} />;`
+          ),
+          "styles"
+        )
+      );
+
+      if (
+        result.value === null ||
+        typeof result.value !== "object" ||
+        Array.isArray(result.value)
+      ) {
+        throw new TypeError("expected a static object literal");
+      }
+
+      expect(Object.hasOwn(result.value, "__proto__")).toBe(true);
+      expect(Object.keys(result.value)).toContain("__proto__");
+    });
+
     it("rejects unsupported provider source kinds with source metadata", () => {
       const unresolvedId = "unresolved:@scope/missing";
       const externalId = "external:@scope/external";
@@ -4258,6 +5057,182 @@ if (import.meta.vitest) {
       ).toBe("dynamic-import");
     });
 
+    it("rejects imported static css eval wrong-shape spread operands", () => {
+      expect(
+        resolveFixture(
+          createProvider(
+            `
+              import { baseArray } from "./tokens";
+              export const button = { ...baseArray } as const;
+            `,
+            `import { button } from "./styles"; <div css={button} />;`,
+            `export { button } from "./styles";`,
+            [
+              {
+                id: tokensId,
+                source: `export const baseArray = [{ color: "red" }] as const;`
+              }
+            ],
+            [
+              {
+                importerId: stylesId,
+                importPath: "./tokens",
+                resolvedId: tokensId
+              }
+            ]
+          ),
+          "button"
+        )
+      ).toMatchObject({
+        kind: "error",
+        diagnostic: { id: "STATIC_CSS_EVAL_OBJECT_SPREAD_UNSUPPORTED" }
+      });
+      expect(
+        resolveFixture(
+          createProvider(
+            `
+              import { baseObject } from "./tokens";
+              export const rule = [...baseObject] as const;
+            `,
+            `import { rule } from "./styles"; <div css={rule} />;`,
+            `export { rule } from "./styles";`,
+            [
+              {
+                id: tokensId,
+                source: `export const baseObject = { color: "blue" } as const;`
+              }
+            ],
+            [
+              {
+                importerId: stylesId,
+                importPath: "./tokens",
+                resolvedId: tokensId
+              }
+            ]
+          ),
+          "rule"
+        )
+      ).toMatchObject({
+        kind: "error",
+        diagnostic: { id: "STATIC_CSS_EVAL_OBJECT_SPREAD_UNSUPPORTED" }
+      });
+    });
+
+    it("rejects imported static css eval mutated computed optional unresolved and dynamic operands", () => {
+      expect(
+        resolveFixture(
+          createProvider(`
+            let base = { color: "red" };
+            export const button = { ...base } as const;
+          `),
+          "button"
+        )
+      ).toMatchObject({
+        kind: "error",
+        diagnostic: { id: "STATIC_CSS_EVAL_MUTABLE_BINDING" }
+      });
+      expect(
+        resolveFixture(
+          createProvider(`
+            const base = { color: "red" } as const;
+            base.color = "blue";
+            export const button = { ...base } as const;
+          `),
+          "button"
+        )
+      ).toMatchObject({
+        kind: "error",
+        diagnostic: { id: "STATIC_CSS_EVAL_MUTATED_BINDING" }
+      });
+      expect(
+        resolveFixture(
+          createProvider(
+            `
+              import * as tokens from "./tokens";
+              const tokenName = "primary";
+              export const button = { color: tokens[tokenName] } as const;
+            `,
+            `import { button } from "./styles"; <div css={button} />;`,
+            `export { button } from "./styles";`,
+            [{ id: tokensId, source: `export const primary = "red";` }],
+            [
+              {
+                importerId: stylesId,
+                importPath: "./tokens",
+                resolvedId: tokensId
+              }
+            ]
+          ),
+          "button"
+        )
+      ).toMatchObject({
+        kind: "error",
+        diagnostic: { id: "STATIC_CSS_EVAL_COMPUTED_MEMBER_UNSUPPORTED" }
+      });
+      expect(
+        resolveFixture(
+          createProvider(
+            `
+              import * as tokens from "./tokens";
+              export const button = { color: tokens?.primary } as const;
+            `,
+            `import { button } from "./styles"; <div css={button} />;`,
+            `export { button } from "./styles";`,
+            [{ id: tokensId, source: `export const primary = "red";` }],
+            [
+              {
+                importerId: stylesId,
+                importPath: "./tokens",
+                resolvedId: tokensId
+              }
+            ]
+          ),
+          "button"
+        )
+      ).toMatchObject({
+        kind: "error",
+        diagnostic: { id: "STATIC_CSS_EVAL_DYNAMIC_EXPRESSION_UNSUPPORTED" }
+      });
+      expect(
+        resolveFixture(
+          createProvider(`
+            import { base } from "pkg";
+            export const button = { ...base } as const;
+          `),
+          "button"
+        )
+      ).toMatchObject({
+        kind: "error",
+        diagnostic: { id: "STATIC_CSS_EVAL_UNRESOLVED_IMPORT" }
+      });
+      expect(
+        resolveFixture(
+          createProvider(`
+            const tokens = require(name);
+            export const button = { ...tokens.base } as const;
+          `),
+          "button"
+        )
+      ).toMatchObject({
+        kind: "error",
+        diagnostic: { id: "STATIC_CSS_EVAL_CJS_DYNAMIC_REQUIRE_UNSUPPORTED" }
+      });
+      expect(
+        resolveFixture(
+          createProvider(
+            `export const button = { color: getColor() } as const;`
+          ),
+          "button"
+        )
+      ).toMatchObject({
+        kind: "error",
+        diagnostic: {
+          code: "unsupported-syntax",
+          reason: "function-or-call"
+        }
+      });
+    });
+
     it("terminates export star reexport cycles with deterministic diagnostics", () => {
       const result = resolveFixture(
         createProviderFromModules({
@@ -4493,6 +5468,90 @@ if (import.meta.vitest) {
       expect(red.cacheKey.sourceVersion).toBe("styles-red");
       expect(blue.cacheKey.sourceVersion).toBe("styles-blue");
       expect(red.cacheKey).not.toEqual(blue.cacheKey);
+    });
+
+    it("changes imported operand cache identity and static support version for expanded literals", () => {
+      const { cache, missesByFile } = createCountingStaticCssModuleCache();
+      const createVersionedProvider = (
+        tokenSource: string,
+        tokenHash: string,
+        tokenVersion: string
+      ) =>
+        createProviderFromModules({
+          modules: [
+            {
+              id: ownerId,
+              source: `import { button } from "./styles"; <div css={button} />;`,
+              sourceHash: "hash:owner-v1",
+              version: "owner-v1"
+            },
+            {
+              id: stylesId,
+              source: `import { base } from "./tokens"; export const button = { ...base } as const;`,
+              sourceHash: "hash:styles-v1",
+              version: "styles-v1"
+            },
+            {
+              id: tokensId,
+              source: tokenSource,
+              sourceHash: tokenHash,
+              version: tokenVersion
+            }
+          ],
+          importResolutions: [
+            {
+              importerId: ownerId,
+              importPath: "./styles",
+              resolvedId: stylesId
+            },
+            {
+              importerId: stylesId,
+              importPath: "./tokens",
+              resolvedId: tokensId
+            }
+          ],
+          moduleCache: cache
+        });
+
+      const red = expectResolvedResult(
+        resolveFixture(
+          createVersionedProvider(
+            `export const base = { color: "red" } as const;`,
+            "hash:tokens-red",
+            "tokens-red"
+          ),
+          "button"
+        )
+      );
+      const blue = expectResolvedResult(
+        resolveFixture(
+          createVersionedProvider(
+            `export const base = { color: "blue" } as const;`,
+            "hash:tokens-blue",
+            "tokens-blue"
+          ),
+          "button"
+        )
+      );
+
+      expect(red.value).toEqual({ color: "red" });
+      expect(blue.value).toEqual({ color: "blue" });
+      expect(missesByFile.get(tokensId)).toBe(2);
+      expect(red.cacheKey.staticEvalSupportVersion).toBe(
+        "static-css-module-export-graph:v3"
+      );
+      expect(STATIC_CSS_MODULE_CACHE_SUPPORT_VERSION).toBe(
+        "static-css-module-export-graph:v3"
+      );
+      expect(
+        formatExportMapCacheKey(
+          createExportMapCacheKey({
+            resolvedFile: stylesId,
+            source: "",
+            sourceHash: "hash:styles-v1"
+          })
+        )
+      ).toContain('"supportVersion":"static-css-module-export-graph:v3"');
     });
 
     it("resolves limited namespace members from project-local literal chains", () => {

--- a/packages/babel/src/staticCssEval/moduleCache.ts
+++ b/packages/babel/src/staticCssEval/moduleCache.ts
@@ -14,7 +14,7 @@ import type {
 
 export const STATIC_CSS_MODULE_CACHE_PARSER_VERSION = "babel-core-parser:v2";
 export const STATIC_CSS_MODULE_CACHE_SUPPORT_VERSION =
-  "static-css-module-export-graph:v2";
+  "static-css-module-export-graph:v3";
 export interface StaticCssModuleSource {
   resolvedFile: string;
   source: string;

--- a/packages/babel/src/staticCssEval/sameFile.ts
+++ b/packages/babel/src/staticCssEval/sameFile.ts
@@ -5,7 +5,8 @@ import {
   getStaticMemberPropertyName,
   getStaticObjectMemberValue,
   getStaticObjectPropertyName,
-  getUnsupportedLiteralReason
+  getUnsupportedLiteralReason,
+  preserveDirectBooleanReferenceValue
 } from "./ast.js";
 import {
   getStaticCssEvalMemberReference,
@@ -86,6 +87,7 @@ type SameFileBindingResolutionResult =
   | {
       kind: "resolved";
       expression: t.Expression;
+      scope: Scope;
       metadata: SameFileStaticCssEvalMetadata;
     }
   | {
@@ -116,6 +118,30 @@ interface LiteralValidationState {
   count: number;
 }
 
+type SameFileStaticLiteralEvaluationResult =
+  | {
+      kind: "resolved";
+      expression: t.Expression;
+      metadata: SameFileStaticCssEvalMetadata;
+    }
+  | {
+      kind: "error";
+      diagnostic: StaticCssEvalDiagnostic;
+      metadata?: SameFileStaticCssEvalMetadata;
+    };
+
+interface SameFileStaticLiteralEvaluationOptions {
+  expression: t.Expression;
+  context: SameFileStaticCssEvalContext;
+  ownerFile: string;
+  programPath: NodePath<t.Program>;
+  scope: Scope;
+  stack: SameFileBindingStackFrame[];
+  state: LiteralValidationState;
+  depth: number;
+  metadata: SameFileStaticCssEvalMetadata;
+}
+
 const arrayMutationMethods = new Set([
   "copyWithin",
   "fill",
@@ -138,12 +164,57 @@ const objectMutationMethods = new Set([
 export function resolveSameFileStaticCssEvalExpression(
   options: ResolveSameFileStaticCssEvalOptions
 ): SameFileStaticCssEvalResult {
-  const reference = getStaticCssEvalMemberReference(options.expression);
-  const expressionRange = getExpressionRange(
-    unwrapTransparentCssRuleExpression(options.expression)
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(
+    options.expression
   );
+  const expressionRange = getExpressionRange(unwrappedExpression);
 
-  if (!reference || !expressionRange) {
+  if (!expressionRange) {
+    return { kind: "not-candidate" };
+  }
+
+  if (isStaticCssRuleLiteral(unwrappedExpression)) {
+    const context: SameFileStaticCssEvalContext = {
+      bindingName: "<inline>",
+      memberPath: [],
+      owner: {
+        file: options.ownerFile,
+        start: expressionRange.start,
+        end: expressionRange.end
+      }
+    };
+    const normalizedLiteral = evaluateSameFileStaticLiteralExpression({
+      expression: unwrappedExpression,
+      context,
+      ownerFile: options.ownerFile,
+      programPath: options.programPath,
+      scope: options.scope,
+      stack: [],
+      state: { count: 0 },
+      depth: 1,
+      metadata: createSameFileInlineMetadata(options.ownerFile)
+    });
+
+    if (normalizedLiteral.kind === "error") {
+      return createSameFileErrorResult(
+        normalizedLiteral.diagnostic,
+        normalizedLiteral.metadata
+      );
+    }
+
+    if (!isStaticCssRuleLiteral(normalizedLiteral.expression)) {
+      return { kind: "not-candidate" };
+    }
+
+    return createSameFileResolvedResult(
+      normalizedLiteral.expression,
+      normalizedLiteral.metadata
+    );
+  }
+
+  const reference = getStaticCssEvalMemberReference(unwrappedExpression);
+
+  if (!reference) {
     return { kind: "not-candidate" };
   }
 
@@ -232,29 +303,33 @@ export function resolveSameFileStaticCssEvalExpression(
     return { kind: "not-candidate" };
   }
 
-  const validationDiagnostic = validateStaticCssLiteralExpression(
-    resolvedExpression,
+  const normalizedLiteral = evaluateSameFileStaticLiteralExpression({
+    expression: resolvedExpression,
     context,
-    { count: 0 },
-    1
-  );
+    ownerFile: options.ownerFile,
+    programPath: options.programPath,
+    scope: bindingResolution.scope,
+    stack: [{ binding, bindingName: reference.bindingName, memberPath }],
+    state: { count: 0 },
+    depth: 1,
+    metadata: bindingResolution.metadata
+  });
 
-  if (validationDiagnostic) {
+  if (normalizedLiteral.kind === "error") {
     return createSameFileErrorResult(
-      validationDiagnostic,
-      bindingResolution.metadata
+      normalizedLiteral.diagnostic,
+      normalizedLiteral.metadata
     );
   }
 
-  return {
-    kind: "resolved",
-    status: "resolved",
-    expression: normalizeStaticCssLiteralExpression(resolvedExpression),
-    provenance: bindingResolution.metadata.provenance,
-    dependencies: bindingResolution.metadata.dependencies,
-    resolutionChain: bindingResolution.metadata.resolutionChain,
-    diagnostics: []
-  };
+  if (!isStaticCssRuleLiteral(normalizedLiteral.expression)) {
+    return { kind: "not-candidate" };
+  }
+
+  return createSameFileResolvedResult(
+    normalizedLiteral.expression,
+    normalizedLiteral.metadata
+  );
 }
 
 function resolveSameFileBindingExpression(
@@ -427,6 +502,7 @@ function resolveSameFileBindingExpression(
     return {
       kind: "resolved",
       expression: resolvedExpression,
+      scope: options.binding.scope,
       metadata
     };
   }
@@ -480,6 +556,7 @@ function prependSameFileMetadata(
   return {
     kind: "resolved",
     expression: result.expression,
+    scope: result.scope,
     metadata: mergeSameFileMetadata(metadata, result.metadata)
   };
 }
@@ -531,6 +608,35 @@ function createSameFileMetadata(
         provenance
       }
     ]
+  };
+}
+
+function createSameFileInlineMetadata(
+  ownerFile: string
+): SameFileStaticCssEvalMetadata {
+  return {
+    provenance: {
+      kind: "local",
+      file: ownerFile,
+      bindingName: "<inline>"
+    },
+    dependencies: [],
+    resolutionChain: []
+  };
+}
+
+function createSameFileResolvedResult(
+  expression: t.ObjectExpression | t.ArrayExpression,
+  metadata: SameFileStaticCssEvalMetadata
+): SameFileStaticCssEvalResult {
+  return {
+    kind: "resolved",
+    status: "resolved",
+    expression,
+    provenance: metadata.provenance,
+    dependencies: metadata.dependencies,
+    resolutionChain: metadata.resolutionChain,
+    diagnostics: []
   };
 }
 
@@ -1061,159 +1167,406 @@ function pathTouchesBinding(
   return false;
 }
 
-function validateStaticCssLiteralExpression(
-  expression: t.Expression,
-  context: SameFileStaticCssEvalContext,
-  state: LiteralValidationState,
-  depth: number
-): StaticCssEvalDiagnostic | null {
-  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
-  state.count += 1;
+function evaluateSameFileStaticLiteralExpression(
+  options: SameFileStaticLiteralEvaluationOptions
+): SameFileStaticLiteralEvaluationResult {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(
+    options.expression
+  );
+  options.state.count += 1;
 
   const countResult = enforceStaticCssEvalLiteralNodeCount({
-    owner: context.owner,
-    memberPath: context.memberPath,
-    literalNodeCount: state.count
+    owner: options.context.owner,
+    memberPath: options.context.memberPath,
+    literalNodeCount: options.state.count
   });
 
   if (!countResult.ok) {
-    return countResult.diagnostic;
+    return {
+      kind: "error",
+      diagnostic: countResult.diagnostic,
+      metadata: options.metadata
+    };
   }
 
   if (t.isObjectExpression(unwrappedExpression)) {
     const depthResult = enforceStaticCssEvalObjectArrayRecursionDepth({
-      owner: context.owner,
-      memberPath: context.memberPath,
-      recursionDepth: depth
+      owner: options.context.owner,
+      memberPath: options.context.memberPath,
+      recursionDepth: options.depth
     });
 
     if (!depthResult.ok) {
-      return depthResult.diagnostic;
+      return {
+        kind: "error",
+        diagnostic: depthResult.diagnostic,
+        metadata: options.metadata
+      };
     }
 
-    return validateStaticCssObjectExpression(
-      unwrappedExpression,
-      context,
-      state,
-      depth
-    );
+    return evaluateSameFileStaticObjectExpression({
+      ...options,
+      expression: unwrappedExpression
+    });
   }
 
   if (t.isArrayExpression(unwrappedExpression)) {
     const depthResult = enforceStaticCssEvalObjectArrayRecursionDepth({
-      owner: context.owner,
-      memberPath: context.memberPath,
-      recursionDepth: depth
+      owner: options.context.owner,
+      memberPath: options.context.memberPath,
+      recursionDepth: options.depth
     });
 
     if (!depthResult.ok) {
-      return depthResult.diagnostic;
+      return {
+        kind: "error",
+        diagnostic: depthResult.diagnostic,
+        metadata: options.metadata
+      };
     }
 
-    return validateStaticCssArrayExpression(
-      unwrappedExpression,
-      context,
-      state,
-      depth
-    );
+    return evaluateSameFileStaticArrayExpression({
+      ...options,
+      expression: unwrappedExpression
+    });
   }
 
   if (isSupportedStaticCssPrimitiveLiteral(unwrappedExpression)) {
-    return null;
+    return {
+      kind: "resolved",
+      expression:
+        normalizeSupportedStaticCssPrimitiveLiteral(unwrappedExpression),
+      metadata: options.metadata
+    };
   }
 
-  return createUnsupportedLiteralDiagnostic(context, unwrappedExpression);
+  const reference = getStaticCssEvalMemberReference(unwrappedExpression);
+
+  if (reference) {
+    return evaluateSameFileStaticLiteralReference(options, reference);
+  }
+
+  return {
+    kind: "error",
+    diagnostic: createUnsupportedLiteralDiagnostic(
+      options.context,
+      unwrappedExpression
+    ),
+    metadata: options.metadata
+  };
 }
 
-function validateStaticCssObjectExpression(
-  expression: t.ObjectExpression,
-  context: SameFileStaticCssEvalContext,
-  state: LiteralValidationState,
-  depth: number
-): StaticCssEvalDiagnostic | null {
-  for (const property of expression.properties) {
+function evaluateSameFileStaticObjectExpression(
+  options: SameFileStaticLiteralEvaluationOptions & {
+    expression: t.ObjectExpression;
+  }
+): SameFileStaticLiteralEvaluationResult {
+  const properties: t.ObjectExpression["properties"] = [];
+  let metadata = options.metadata;
+
+  for (const property of options.expression.properties) {
     if (t.isSpreadElement(property)) {
-      return createStaticCssEvalObjectSpreadUnsupportedDiagnostic(
-        createSameFileDiagnosticContext(context),
-        context.bindingName,
-        "object"
+      const spreadResult = evaluateSameFileStaticLiteralExpression({
+        ...options,
+        expression: property.argument,
+        metadata,
+        depth: options.depth + 1
+      });
+
+      if (spreadResult.kind === "error") {
+        return spreadResult;
+      }
+
+      metadata = spreadResult.metadata;
+
+      if (!t.isObjectExpression(spreadResult.expression)) {
+        return {
+          kind: "error",
+          diagnostic: createStaticCssEvalObjectSpreadUnsupportedDiagnostic(
+            createSameFileDiagnosticContext(options.context),
+            options.context.bindingName,
+            "object"
+          ),
+          metadata
+        };
+      }
+
+      properties.push(
+        ...spreadResult.expression.properties.map((spreadProperty) =>
+          t.cloneNode(spreadProperty)
+        )
       );
+      continue;
     }
 
     if (!t.isObjectProperty(property)) {
-      return createStaticCssEvalDynamicExpressionUnsupportedDiagnostic(
-        createSameFileDiagnosticContext(context),
-        property.type
-      );
+      return {
+        kind: "error",
+        diagnostic: createStaticCssEvalDynamicExpressionUnsupportedDiagnostic(
+          createSameFileDiagnosticContext(options.context),
+          property.type
+        ),
+        metadata
+      };
     }
 
     if (property.computed) {
-      return createStaticCssEvalComputedMemberUnsupportedDiagnostic(
-        createSameFileDiagnosticContext(context)
-      );
+      return {
+        kind: "error",
+        diagnostic: createStaticCssEvalComputedMemberUnsupportedDiagnostic(
+          createSameFileDiagnosticContext(options.context)
+        ),
+        metadata
+      };
     }
 
     if (!t.isExpression(property.value)) {
-      return createSameFileStaticCssEvalDiagnostic(
-        context,
-        "unsupported-syntax",
-        "unsupported-literal",
-        `same-file binding "${context.bindingName}" contains a non-expression object value`
-      );
+      return {
+        kind: "error",
+        diagnostic: createSameFileStaticCssEvalDiagnostic(
+          options.context,
+          "unsupported-syntax",
+          "unsupported-literal",
+          `same-file binding "${options.context.bindingName}" contains a non-expression object value`
+        ),
+        metadata
+      };
     }
 
-    const diagnostic = validateStaticCssLiteralExpression(
+    const valueResult = evaluateSameFileStaticLiteralExpression({
+      ...options,
+      expression: property.value,
+      metadata,
+      depth: options.depth + 1
+    });
+
+    if (valueResult.kind === "error") {
+      return valueResult;
+    }
+
+    metadata = valueResult.metadata;
+
+    const nextProperty = t.cloneNode(property);
+    nextProperty.value = preserveDirectBooleanReferenceValue(
       property.value,
-      context,
-      state,
-      depth + 1
+      valueResult.expression
     );
-
-    if (diagnostic) {
-      return diagnostic;
-    }
+    nextProperty.shorthand = false;
+    properties.push(nextProperty);
   }
 
-  return null;
+  const normalizedProperties: t.ObjectExpression["properties"] = [];
+  const propertyIndexes = new Map<string, number>();
+
+  for (const property of properties) {
+    if (!t.isObjectProperty(property) || property.computed) {
+      normalizedProperties.push(property);
+      continue;
+    }
+
+    const propertyName = getStaticObjectPropertyName(property.key);
+    const existingIndex =
+      propertyName === null ? undefined : propertyIndexes.get(propertyName);
+
+    if (existingIndex === undefined) {
+      if (propertyName !== null) {
+        propertyIndexes.set(propertyName, normalizedProperties.length);
+      }
+
+      normalizedProperties.push(property);
+      continue;
+    }
+
+    normalizedProperties[existingIndex] = property;
+  }
+
+  return {
+    kind: "resolved",
+    expression: t.objectExpression(normalizedProperties),
+    metadata
+  };
 }
 
-function validateStaticCssArrayExpression(
-  expression: t.ArrayExpression,
-  context: SameFileStaticCssEvalContext,
-  state: LiteralValidationState,
-  depth: number
-): StaticCssEvalDiagnostic | null {
-  for (const element of expression.elements) {
+function evaluateSameFileStaticArrayExpression(
+  options: SameFileStaticLiteralEvaluationOptions & {
+    expression: t.ArrayExpression;
+  }
+): SameFileStaticLiteralEvaluationResult {
+  const elements: t.ArrayExpression["elements"] = [];
+  let metadata = options.metadata;
+
+  for (const element of options.expression.elements) {
     if (!element) {
-      return createSameFileStaticCssEvalDiagnostic(
-        context,
-        "unsupported-syntax",
-        "unsupported-literal",
-        `same-file binding "${context.bindingName}" contains an array hole`
-      );
+      return {
+        kind: "error",
+        diagnostic: createSameFileArrayHoleDiagnostic(options.context),
+        metadata
+      };
     }
 
     if (t.isSpreadElement(element)) {
-      return createStaticCssEvalObjectSpreadUnsupportedDiagnostic(
-        createSameFileDiagnosticContext(context),
-        context.bindingName,
-        "array"
-      );
+      const spreadResult = evaluateSameFileStaticLiteralExpression({
+        ...options,
+        expression: element.argument,
+        metadata,
+        depth: options.depth + 1
+      });
+
+      if (spreadResult.kind === "error") {
+        return spreadResult;
+      }
+
+      metadata = spreadResult.metadata;
+
+      if (!t.isArrayExpression(spreadResult.expression)) {
+        return {
+          kind: "error",
+          diagnostic: createStaticCssEvalObjectSpreadUnsupportedDiagnostic(
+            createSameFileDiagnosticContext(options.context),
+            options.context.bindingName,
+            "array"
+          ),
+          metadata
+        };
+      }
+
+      for (const spreadElement of spreadResult.expression.elements) {
+        if (!spreadElement) {
+          return {
+            kind: "error",
+            diagnostic: createSameFileArrayHoleDiagnostic(options.context),
+            metadata
+          };
+        }
+
+        if (t.isSpreadElement(spreadElement)) {
+          return {
+            kind: "error",
+            diagnostic: createStaticCssEvalObjectSpreadUnsupportedDiagnostic(
+              createSameFileDiagnosticContext(options.context),
+              options.context.bindingName,
+              "array"
+            ),
+            metadata
+          };
+        }
+
+        elements.push(t.cloneNode(spreadElement));
+      }
+      continue;
     }
 
-    const diagnostic = validateStaticCssLiteralExpression(
-      element,
-      context,
-      state,
-      depth + 1
+    const elementResult = evaluateSameFileStaticLiteralExpression({
+      ...options,
+      expression: element,
+      metadata,
+      depth: options.depth + 1
+    });
+
+    if (elementResult.kind === "error") {
+      return elementResult;
+    }
+
+    metadata = elementResult.metadata;
+    elements.push(
+      preserveDirectBooleanReferenceValue(element, elementResult.expression)
     );
-
-    if (diagnostic) {
-      return diagnostic;
-    }
   }
 
-  return null;
+  return {
+    kind: "resolved",
+    expression: t.arrayExpression(elements),
+    metadata
+  };
+}
+
+function evaluateSameFileStaticLiteralReference(
+  options: SameFileStaticLiteralEvaluationOptions,
+  reference: StaticMemberReference
+): SameFileStaticLiteralEvaluationResult {
+  if (reference.kind === "unsupported") {
+    return {
+      kind: "error",
+      diagnostic: createUnsupportedMemberReferenceDiagnostic(
+        reference,
+        options.context
+      ),
+      metadata: options.metadata
+    };
+  }
+
+  const binding = options.scope.getBinding(reference.bindingName);
+
+  if (!binding) {
+    return {
+      kind: "error",
+      diagnostic: createUnsupportedLiteralDiagnostic(
+        options.context,
+        options.expression
+      ),
+      metadata: options.metadata
+    };
+  }
+
+  const bindingResolution = resolveSameFileBindingExpression({
+    binding,
+    bindingName: reference.bindingName,
+    memberPath: reference.memberPath,
+    ownerFile: options.ownerFile,
+    owner: options.context.owner,
+    programPath: options.programPath,
+    stack: options.stack
+  });
+
+  if (bindingResolution.kind === "error") {
+    return {
+      kind: "error",
+      diagnostic: bindingResolution.diagnostic,
+      metadata: bindingResolution.metadata
+        ? mergeSameFileMetadata(options.metadata, bindingResolution.metadata)
+        : options.metadata
+    };
+  }
+
+  if (bindingResolution.kind === "not-candidate") {
+    return {
+      kind: "error",
+      diagnostic: createUnsupportedLiteralDiagnostic(
+        options.context,
+        options.expression
+      ),
+      metadata: options.metadata
+    };
+  }
+
+  return evaluateSameFileStaticLiteralExpression({
+    ...options,
+    expression: bindingResolution.expression,
+    scope: bindingResolution.scope,
+    stack: [
+      ...options.stack,
+      {
+        binding,
+        bindingName: reference.bindingName,
+        memberPath: [...reference.memberPath]
+      }
+    ],
+    metadata: mergeSameFileMetadata(
+      options.metadata,
+      bindingResolution.metadata
+    )
+  });
+}
+
+function createSameFileArrayHoleDiagnostic(
+  context: SameFileStaticCssEvalContext
+): StaticCssEvalDiagnostic {
+  return createSameFileStaticCssEvalDiagnostic(
+    context,
+    "unsupported-syntax",
+    "unsupported-literal",
+    `same-file binding "${context.bindingName}" contains an array hole`
+  );
 }
 
 function isSupportedStaticCssPrimitiveLiteral(
@@ -1245,58 +1598,10 @@ function isNoExpressionTemplateLiteral(
   return t.isTemplateLiteral(expression) && expression.expressions.length === 0;
 }
 
-function normalizeStaticCssLiteralExpression(
-  expression: t.ObjectExpression | t.ArrayExpression
-): t.ObjectExpression | t.ArrayExpression {
-  const normalizedExpression = normalizeStaticCssLiteralValue(expression);
-
-  if (
-    !t.isObjectExpression(normalizedExpression) &&
-    !t.isArrayExpression(normalizedExpression)
-  ) {
-    throw new Error(
-      "Expected normalized static css literal to remain object/array"
-    );
-  }
-
-  return normalizedExpression;
-}
-
-function normalizeStaticCssLiteralValue(
+function normalizeSupportedStaticCssPrimitiveLiteral(
   expression: t.Expression
 ): t.Expression {
   const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
-
-  if (t.isObjectExpression(unwrappedExpression)) {
-    return t.objectExpression(
-      unwrappedExpression.properties.map((property) => {
-        const nextProperty = t.cloneNode(property);
-
-        if (
-          t.isObjectProperty(nextProperty) &&
-          t.isExpression(nextProperty.value)
-        ) {
-          nextProperty.value = normalizeStaticCssLiteralValue(
-            nextProperty.value
-          );
-        }
-
-        return nextProperty;
-      })
-    );
-  }
-
-  if (t.isArrayExpression(unwrappedExpression)) {
-    return t.arrayExpression(
-      unwrappedExpression.elements.map((element) => {
-        if (!element || t.isSpreadElement(element)) {
-          return element ? t.cloneNode(element) : null;
-        }
-
-        return normalizeStaticCssLiteralValue(element);
-      })
-    );
-  }
 
   if (isNoExpressionTemplateLiteral(unwrappedExpression)) {
     const [quasi] = unwrappedExpression.quasis;
@@ -1328,6 +1633,7 @@ function createUnsupportedLiteralDiagnostic(
     `same-file binding "${context.bindingName}" contains unsupported ${reason}: ${expression.type}`
   );
 }
+
 function createSameFileStaticCssEvalDiagnostic(
   context: SameFileStaticCssEvalContext,
   code: StaticCssEvalDiagnostic["code"],
@@ -1438,6 +1744,19 @@ if (import.meta.vitest) {
     return result;
   }
 
+  function expectSingleNotCandidate(
+    source: string
+  ): Extract<SameFileStaticCssEvalResult, { kind: "not-candidate" }> {
+    const [result] = resolveSameFileFixture(source);
+    expect(result?.kind).toBe("not-candidate");
+
+    if (!result || result.kind !== "not-candidate") {
+      throw new Error("Expected same-file fixture to remain a class value");
+    }
+
+    return result;
+  }
+
   function expectSingleDiagnosticId(
     source: string,
     diagnosticId: NonNullable<StaticCssEvalDiagnostic["id"]>
@@ -1466,11 +1785,31 @@ if (import.meta.vitest) {
     expression: t.ObjectExpression | t.ArrayExpression,
     propertyName: string
   ): string | null {
+    const value = getObjectPropertyExpression(expression, propertyName);
+
+    return value && t.isStringLiteral(value) ? value.value : null;
+  }
+
+  function getNumericObjectProperty(
+    expression: t.ObjectExpression | t.ArrayExpression,
+    propertyName: string
+  ): number | null {
+    const value = getObjectPropertyExpression(expression, propertyName);
+
+    return value && t.isNumericLiteral(value) ? value.value : null;
+  }
+
+  function getObjectPropertyExpression(
+    expression: t.ObjectExpression | t.ArrayExpression,
+    propertyName: string
+  ): t.Expression | null {
     if (!t.isObjectExpression(expression)) {
       return null;
     }
 
-    for (const property of expression.properties) {
+    for (let index = expression.properties.length - 1; index >= 0; index -= 1) {
+      const property = expression.properties[index];
+
       if (!t.isObjectProperty(property) || property.computed) {
         continue;
       }
@@ -1479,13 +1818,41 @@ if (import.meta.vitest) {
         continue;
       }
 
-      return t.isStringLiteral(property.value) ? property.value.value : null;
+      return t.isExpression(property.value) ? property.value : null;
     }
 
     return null;
   }
 
+  function expectNoSpreadElement(
+    expression: t.ObjectExpression | t.ArrayExpression
+  ): void {
+    if (t.isObjectExpression(expression)) {
+      expect(
+        expression.properties.some((property) => t.isSpreadElement(property))
+      ).toBe(false);
+      return;
+    }
+
+    expect(
+      expression.elements.some((element) =>
+        Boolean(element && t.isSpreadElement(element))
+      )
+    ).toBe(false);
+  }
+
   describe("same-file static css eval resolver", () => {
+    it("keeps top-level primitive identifiers as class values", () => {
+      const result = expectSingleNotCandidate(`
+        const className = "btn-primary";
+        function App() {
+          return <button css={className} />;
+        }
+      `);
+
+      expect(result.status).toBeUndefined();
+    });
+
     it("resolves local const objects with local provenance and dependencies", () => {
       const resolved = expectSingleResolved(`
         const button = { color: "red" };
@@ -1525,6 +1892,126 @@ if (import.meta.vitest) {
         ],
         diagnostics: []
       });
+    });
+
+    it("resolves local object spreads with last-key-wins semantics", () => {
+      const resolved = expectSingleResolved(`
+        const base = { color: "red", padding: 4 };
+        const button = { ...base, color: "blue" };
+        function App() {
+          return <button css={button} />;
+        }
+      `);
+
+      expectNoSpreadElement(resolved.expression);
+      expect(
+        t.isObjectExpression(resolved.expression)
+          ? resolved.expression.properties.filter(
+              (property) =>
+                t.isObjectProperty(property) &&
+                !property.computed &&
+                getStaticObjectPropertyName(property.key) === "color"
+            )
+          : []
+      ).toHaveLength(1);
+      expect(getStringObjectProperty(resolved.expression, "color")).toBe(
+        "blue"
+      );
+      expect(getNumericObjectProperty(resolved.expression, "padding")).toBe(4);
+    });
+
+    it("resolves direct object spreads through the same-file resolver API", () => {
+      const resolved = expectSingleResolved(`
+        const base = { color: "red", padding: 4 };
+        function App() {
+          return <button css={{ ...base, color: "blue" }} />;
+        }
+      `);
+
+      expectNoSpreadElement(resolved.expression);
+      expect(getStringObjectProperty(resolved.expression, "color")).toBe(
+        "blue"
+      );
+      expect(getNumericObjectProperty(resolved.expression, "padding")).toBe(4);
+    });
+
+    it("resolves local array spreads in order", () => {
+      const resolved = expectSingleResolved(`
+        const stack = [{ display: "grid" }];
+        const rule = [...stack, { gap: 8 }];
+        function App() {
+          return <button css={rule} />;
+        }
+      `);
+
+      expectNoSpreadElement(resolved.expression);
+      expect(t.isArrayExpression(resolved.expression)).toBe(true);
+
+      if (!t.isArrayExpression(resolved.expression)) {
+        throw new Error(
+          "Expected same-file array spread to resolve to an array"
+        );
+      }
+
+      expect(resolved.expression.elements).toHaveLength(2);
+      const [firstRule, secondRule] = resolved.expression.elements;
+      expect(
+        firstRule && t.isObjectExpression(firstRule)
+          ? getStringObjectProperty(firstRule, "display")
+          : null
+      ).toBe("grid");
+      expect(
+        secondRule && t.isObjectExpression(secondRule)
+          ? getNumericObjectProperty(secondRule, "gap")
+          : null
+      ).toBe(8);
+    });
+
+    it("resolves direct array spreads through the same-file resolver API", () => {
+      const resolved = expectSingleResolved(`
+        const stack = [{ display: "grid" }];
+        function App() {
+          return <button css={[...stack, { gap: 8 }]} />;
+        }
+      `);
+
+      expectNoSpreadElement(resolved.expression);
+      expect(t.isArrayExpression(resolved.expression)).toBe(true);
+
+      if (!t.isArrayExpression(resolved.expression)) {
+        throw new Error(
+          "Expected direct same-file array spread to resolve to an array"
+        );
+      }
+
+      expect(resolved.expression.elements).toHaveLength(2);
+      const [firstRule, secondRule] = resolved.expression.elements;
+      expect(
+        firstRule && t.isObjectExpression(firstRule)
+          ? getStringObjectProperty(firstRule, "display")
+          : null
+      ).toBe("grid");
+      expect(
+        secondRule && t.isObjectExpression(secondRule)
+          ? getNumericObjectProperty(secondRule, "gap")
+          : null
+      ).toBe(8);
+    });
+
+    it("resolves local identifier and member values inside object literals", () => {
+      const resolved = expectSingleResolved(`
+        const color = "red";
+        const tokens = { primary: "blue" };
+        const button = { color, backgroundColor: tokens.primary };
+        function App() {
+          return <button css={button} />;
+        }
+      `);
+
+      expect(getStringObjectProperty(resolved.expression, "color")).toBe("red");
+      expect(
+        getStringObjectProperty(resolved.expression, "backgroundColor")
+      ).toBe("blue");
     });
 
     it("resolves safe local aliases through transparent TypeScript wrappers", () => {
@@ -1609,16 +2096,6 @@ if (import.meta.vitest) {
       );
       expectSingleDiagnosticId(
         `
-          const base = { color: "red" };
-          const button = { ...base };
-          function App() {
-            return <button css={button} />;
-          }
-        `,
-        "STATIC_CSS_EVAL_OBJECT_SPREAD_UNSUPPORTED"
-      );
-      expectSingleDiagnosticId(
-        `
           const styles = { button: { color: "red" } };
           const variant = "button";
           function App() {
@@ -1639,6 +2116,95 @@ if (import.meta.vitest) {
       expectSingleDiagnosticId(
         `
           const button = { color: getColor() };
+          function App() {
+            return <button css={button} />;
+          }
+        `,
+        "STATIC_CSS_EVAL_DYNAMIC_EXPRESSION_UNSUPPORTED"
+      );
+    });
+
+    it("rejects unsafe spread operands deterministically", () => {
+      expectSingleDiagnosticId(
+        `
+          const base = [{ color: "red" }];
+          const button = { ...base };
+          function App() {
+            return <button css={button} />;
+          }
+        `,
+        "STATIC_CSS_EVAL_OBJECT_SPREAD_UNSUPPORTED"
+      );
+      expectSingleDiagnosticId(
+        `
+          const base = { color: "red" };
+          const rule = [...base];
+          function App() {
+            return <button css={rule} />;
+          }
+        `,
+        "STATIC_CSS_EVAL_OBJECT_SPREAD_UNSUPPORTED"
+      );
+      expectSingleDiagnosticId(
+        `
+          let base = { color: "red" };
+          const button = { ...base };
+          function App() {
+            return <button css={button} />;
+          }
+        `,
+        "STATIC_CSS_EVAL_MUTABLE_BINDING"
+      );
+      expectSingleDiagnosticId(
+        `
+          const base = { color: "red" };
+          base.color = "blue";
+          const button = { ...base };
+          function App() {
+            return <button css={button} />;
+          }
+        `,
+        "STATIC_CSS_EVAL_MUTATED_BINDING"
+      );
+    });
+
+    it("rejects computed and optional member values deterministically", () => {
+      expectSingleDiagnosticId(
+        `
+          const tokens = { primary: "red" };
+          const tokenName = "primary";
+          const button = { color: tokens[tokenName] };
+          function App() {
+            return <button css={button} />;
+          }
+        `,
+        "STATIC_CSS_EVAL_COMPUTED_MEMBER_UNSUPPORTED"
+      );
+      expectSingleDiagnosticId(
+        `
+          const tokens = { primary: "red" };
+          const button = { color: tokens?.primary };
+          function App() {
+            return <button css={button} />;
+          }
+        `,
+        "STATIC_CSS_EVAL_DYNAMIC_EXPRESSION_UNSUPPORTED"
+      );
+    });
+
+    it("rejects function values and calls deterministically", () => {
+      expectSingleDiagnosticId(
+        `
+          const button = { color: getColor() };
+          function App() {
+            return <button css={button} />;
+          }
+        `,
+        "STATIC_CSS_EVAL_DYNAMIC_EXPRESSION_UNSUPPORTED"
+      );
+      expectSingleDiagnosticId(
+        `
+          const button = { color: () => "red" };
           function App() {
             return <button css={button} />;
           }

--- a/packages/babel/src/staticCssEval/types.ts
+++ b/packages/babel/src/staticCssEval/types.ts
@@ -629,8 +629,21 @@ export const STATIC_CSS_EVAL_SUPPORT_MATRIX = [
     status: "unsupported"
   },
   {
-    construct: "Object spread / array spread",
-    behavior: "Unsupported",
+    construct: "Static object/array spreads in css-rule literals",
+    behavior:
+      "Supported when every spread operand statically resolves to a same-shape object or array literal",
+    status: "supported"
+  },
+  {
+    construct: "Static identifier/member values in css-rule literals",
+    behavior:
+      "Supported when identifiers and non-computed member paths resolve to static literals through same-file or provider-backed bindings",
+    status: "supported"
+  },
+  {
+    construct: "Dynamic or wrong-shape object/array spread operands",
+    behavior:
+      "Unsupported; unresolved, mutable, computed, function/call, dynamic, or wrong collection shape operands fail closed with diagnostics",
     status: "unsupported"
   },
   {
@@ -934,10 +947,42 @@ if (import.meta.vitest) {
       });
       expect(
         supportMatrixConstructs.some(
+          (construct) => construct === "Object spread / array spread"
+        )
+      ).toBe(false);
+      expect(
+        supportMatrixByConstruct.get(
+          "Static object/array spreads in css-rule literals"
+        )
+      ).toMatchObject({
+        status: "supported",
+        behavior: expect.stringContaining("same-shape")
+      });
+      expect(
+        supportMatrixByConstruct.get(
+          "Static identifier/member values in css-rule literals"
+        )
+      ).toMatchObject({ status: "supported" });
+      expect(
+        supportMatrixByConstruct.get(
+          "Dynamic or wrong-shape object/array spread operands"
+        )
+      ).toMatchObject({
+        status: "unsupported",
+        behavior: expect.stringContaining("fail closed")
+      });
+      expect(
+        supportMatrixByConstruct.get("Calls / mixins / functions")
+      ).toMatchObject({ status: "unsupported" });
+      expect(
+        supportMatrixByConstruct.get("Runtime dynamic values")
+      ).toMatchObject({ status: "unsupported" });
+      expect(
+        supportMatrixConstructs.some(
           (construct) => construct === "Export star (`export *`)"
         )
       ).toBe(false);
-      expect(STATIC_CSS_EVAL_SUPPORT_MATRIX).toHaveLength(39);
+      expect(STATIC_CSS_EVAL_SUPPORT_MATRIX).toHaveLength(41);
     });
 
     it("accepts synchronous provider and cache key contracts", () => {

--- a/packages/integration/src/babel.ts
+++ b/packages/integration/src/babel.ts
@@ -899,6 +899,342 @@ if (import.meta.vitest) {
       expect(staticCssEval?.resolvedModuleCache.has(unusedId)).toBe(false);
     });
 
+    it("prepass loads reachable spread and identifier operands without broad import sweep", async () => {
+      const path = await import("node:path");
+      const ownerSource = `
+        import { direct } from "./direct";
+        import { button } from "./styles";
+        import { tokens } from "./tokens";
+        import { unused } from "./unused";
+
+        const localButton = { ...direct, background: tokens.accent };
+        const unusedValue = unused;
+
+        function App() {
+          return <>
+            <div css={{ ...localButton, ...button.text }} />
+            <span>{unusedValue}</span>
+          </>;
+        }
+      `;
+      const fixturePath = await createBabelFixture(
+        ownerSource,
+        "css-prop-prepass-reachable-spread-identifier"
+      );
+      const fixtureRoot = path.dirname(fixturePath);
+      const directId = path.join(fixtureRoot, "direct.ts");
+      const stylesId = path.join(fixtureRoot, "styles.ts");
+      const tokensId = path.join(fixtureRoot, "tokens.ts");
+      const unusedId = path.join(fixtureRoot, "unused.ts");
+      const baseId = path.join(fixtureRoot, "base.ts");
+      const paletteId = path.join(fixtureRoot, "palette.ts");
+      const ignoredId = path.join(fixtureRoot, "ignored.ts");
+      const { provider, calls } = createFakeStaticCssEvalSourceProvider({
+        sources: {
+          [fixturePath]: ownerSource,
+          [directId]: `export const direct = { marginTop: 1 } as const;`,
+          [stylesId]: `
+            import { base } from "./base";
+            import { palette } from "./palette";
+            import { ignored } from "./ignored";
+
+            const unusedStyle = ignored;
+
+            export const button = {
+              text: { ...base, color: palette.primary },
+              ignored
+            } as const;
+          `,
+          [tokensId]: `export const tokens = { accent: "gold" } as const;`,
+          [unusedId]: `export const unused = { color: "blue" } as const;`,
+          [baseId]: `export const base = { padding: 4 } as const;`,
+          [paletteId]: `export const palette = { primary: "red" } as const;`,
+          [ignoredId]: `export const ignored = { color: "orange" } as const;`
+        },
+        resolutions: {
+          [`${fixturePath}\0./direct`]: directId,
+          [`${fixturePath}\0./styles`]: stylesId,
+          [`${fixturePath}\0./tokens`]: tokensId,
+          [`${fixturePath}\0./unused`]: unusedId,
+          [`${stylesId}\0./base`]: baseId,
+          [`${stylesId}\0./palette`]: paletteId,
+          [`${stylesId}\0./ignored`]: ignoredId
+        }
+      });
+
+      const { staticCssEval } = await babelTransform(fixturePath, {
+        jsxCssProp: true,
+        staticCssEvalSourceProvider: provider
+      });
+
+      expect(calls.resolved).toEqual([
+        { importerId: fixturePath, importPath: "./direct" },
+        { importerId: fixturePath, importPath: "./tokens" },
+        { importerId: fixturePath, importPath: "./styles" },
+        { importerId: stylesId, importPath: "./base" },
+        { importerId: stylesId, importPath: "./palette" }
+      ]);
+      expect(calls.loaded).toEqual([
+        fixturePath,
+        directId,
+        tokensId,
+        stylesId,
+        baseId,
+        paletteId
+      ]);
+      expect(staticCssEval?.dependencyFiles).toEqual([
+        directId,
+        tokensId,
+        stylesId,
+        baseId,
+        paletteId
+      ]);
+      expect(staticCssEval?.resolvedModuleCache.has(unusedId)).toBe(false);
+      expect(staticCssEval?.resolvedModuleCache.has(ignoredId)).toBe(false);
+    });
+
+    it("prepass loads package data virtual and CommonJS static operands", async () => {
+      const ownerSource = `
+        import { packageButton } from "@scope/styles";
+        import { dataButton } from "@scope/styles/tokens.json";
+        import { virtualButton } from "virtual:mincho/styles";
+
+        const cjsStyles = require("./styles.cjs");
+
+        function App() {
+          return <div css={{
+            ...packageButton,
+            color: dataButton.color,
+            background: virtualButton.background,
+            borderColor: cjsStyles.colors.border
+          }} />;
+        }
+      `;
+      const ownerId = await createBabelFixture(
+        ownerSource,
+        "css-prop-prepass-package-data-virtual-commonjs"
+      );
+      const packageId = "pkg:@scope/styles/index.ts";
+      const packageLoadId = `${packageId}?condition=import`;
+      const dataId = "pkg:@scope/styles/tokens.json?import";
+      const virtualId = "\0virtual:mincho/styles";
+      const cjsId = "/project/src/styles.cjs";
+      const calls: FakeStaticCssEvalSourceProviderCalls = {
+        resolved: [],
+        loaded: []
+      };
+      const resolutions = new Map<string, StaticCssEvalSourceResolution>([
+        [
+          `${ownerId}\0@scope/styles`,
+          {
+            resolvedFile: packageId,
+            canonicalModuleId: "pkg:@scope/styles",
+            normalizedPathKey: packageLoadId,
+            sourceKind: "package-source",
+            resolverKind: "test"
+          }
+        ],
+        [
+          `${ownerId}\0@scope/styles/tokens.json`,
+          {
+            resolvedFile: dataId,
+            canonicalModuleId: dataId,
+            normalizedPathKey: dataId,
+            sourceKind: "static-data",
+            resolverKind: "test"
+          }
+        ],
+        [
+          `${ownerId}\0virtual:mincho/styles`,
+          {
+            resolvedFile: virtualId,
+            canonicalModuleId: virtualId,
+            normalizedPathKey: virtualId,
+            sourceKind: "provider-virtual",
+            resolverKind: "test"
+          }
+        ],
+        [
+          `${ownerId}\0./styles.cjs`,
+          {
+            resolvedFile: cjsId,
+            canonicalModuleId: cjsId,
+            normalizedPathKey: cjsId,
+            resolverKind: "test"
+          }
+        ]
+      ]);
+      const loadedSources = new Map<string, StaticCssEvalLoadedSource>([
+        [ownerId, { source: ownerSource }],
+        [
+          packageLoadId,
+          {
+            sourceText: `export const packageButton = { padding: 8 } as const;`,
+            sourceKind: "package-source",
+            sourceIdentity: { sourceHash: "package-source-v1" },
+            resolverKind: "test"
+          }
+        ],
+        [
+          dataId,
+          {
+            sourceText: JSON.stringify({ dataButton: { color: "green" } }),
+            sourceKind: "static-data",
+            sourceIdentity: { sourceHash: "data-source-v1" },
+            resolverKind: "test"
+          }
+        ],
+        [
+          virtualId,
+          {
+            sourceText: `export const virtualButton = { background: "blue" } as const;`,
+            sourceKind: "provider-virtual",
+            sourceIdentity: { sourceHash: "virtual-source-v1" },
+            resolverKind: "test"
+          }
+        ],
+        [
+          cjsId,
+          {
+            sourceText: `exports.colors = { border: "black" };`,
+            resolverKind: "test"
+          }
+        ]
+      ]);
+      const provider: StaticCssEvalSourceProvider = {
+        resolve(importerId, importPath) {
+          calls.resolved.push({ importerId, importPath });
+          return resolutions.get(`${importerId}\0${importPath}`) ?? null;
+        },
+        load(id) {
+          calls.loaded.push(id);
+          return loadedSources.get(id) ?? null;
+        }
+      };
+
+      const { staticCssEval } = await babelTransform(ownerId, {
+        jsxCssProp: true,
+        staticCssEvalSourceProvider: provider
+      });
+
+      expect(calls.resolved).toEqual([
+        { importerId: ownerId, importPath: "@scope/styles" },
+        { importerId: ownerId, importPath: "@scope/styles/tokens.json" },
+        { importerId: ownerId, importPath: "virtual:mincho/styles" },
+        { importerId: ownerId, importPath: "./styles.cjs" }
+      ]);
+      expect(calls.loaded).toEqual([
+        ownerId,
+        packageLoadId,
+        dataId,
+        virtualId,
+        cjsId
+      ]);
+      expect(staticCssEval?.resolvedDependencies).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            resolvedFile: packageId,
+            sourceKind: "package-source",
+            sourceOrigin: "package",
+            loaded: true
+          }),
+          expect.objectContaining({
+            resolvedFile: dataId,
+            sourceKind: "static-data",
+            sourceOrigin: "data",
+            loaded: true
+          }),
+          expect.objectContaining({
+            resolvedFile: virtualId,
+            sourceKind: "provider-virtual",
+            sourceOrigin: "provider",
+            loaded: true
+          }),
+          expect.objectContaining({
+            resolvedFile: cjsId,
+            sourceKind: "project-source",
+            sourceOrigin: "project",
+            loaded: true
+          })
+        ])
+      );
+    });
+
+    it("cache invalidation follows transitive spread operand source identity", async () => {
+      const fs = await import("node:fs/promises");
+      const componentSource = `
+        import { button } from "./styles";
+
+        function App() {
+          return <div css={button} />;
+        }
+      `;
+      const stylesSource = `import { base } from "./base"; export const button = { ...base } as const;`;
+      const redBaseSource = `export const base = { color: "red" } as const;`;
+      const blueBaseSource = `export const base = { color: "blue" } as const;`;
+      const { filePaths } = await createBabelFixtureFiles(
+        {
+          "component.tsx": componentSource,
+          "styles.ts": stylesSource,
+          "base.ts": redBaseSource
+        },
+        "css-prop-prepass-transitive-spread-invalidation"
+      );
+      const componentId = filePaths["component.tsx"];
+      const stylesId = filePaths["styles.ts"];
+      const baseId = filePaths["base.ts"];
+      const provider = createFileBackedStaticCssEvalSourceProvider({
+        resolutions: {
+          [`${componentId}\0./styles`]: stylesId,
+          [`${stylesId}\0./base`]: baseId
+        }
+      });
+
+      const firstPrepass = await createStaticCssEvalPrepass(
+        componentId,
+        provider
+      );
+      await fs.writeFile(baseId, blueBaseSource, "utf8");
+      const secondPrepass = await createStaticCssEvalPrepass(
+        componentId,
+        provider
+      );
+
+      expect(firstPrepass.result.dependencyFiles).toEqual([stylesId, baseId]);
+      expect(secondPrepass.result.dependencyFiles).toEqual([stylesId, baseId]);
+      expect(firstPrepass.result.resolvedDependencies).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            importerId: stylesId,
+            specifier: "./base",
+            resolvedFile: baseId,
+            loaded: true,
+            sourceIdentity: createTestSourceIdentity(redBaseSource)
+          })
+        ])
+      );
+      expect(secondPrepass.result.resolvedDependencies).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            importerId: stylesId,
+            specifier: "./base",
+            resolvedFile: baseId,
+            loaded: true,
+            sourceIdentity: createTestSourceIdentity(blueBaseSource)
+          })
+        ])
+      );
+      expect(
+        firstPrepass.result.resolvedDependencies.find(
+          (dependency) => dependency.resolvedFile === baseId
+        )?.sourceIdentity?.sourceHash
+      ).not.toBe(
+        secondPrepass.result.resolvedDependencies.find(
+          (dependency) => dependency.resolvedFile === baseId
+        )?.sourceIdentity?.sourceHash
+      );
+    });
+
     it("static css eval metadata preserves dependency files resolved dependencies cache keys and source identity", async () => {
       const fs = await import("node:fs/promises");
       const componentSource = `

--- a/packages/integration/src/staticCssEvalPrepass.ts
+++ b/packages/integration/src/staticCssEvalPrepass.ts
@@ -1,7 +1,10 @@
+import { types as t } from "@babel/core";
 import {
   internalCollectJsxCssPropStaticCssEvalCandidates as collectJsxCssPropStaticCssEvalCandidates,
   internalCreateImportedStaticCssEvalModuleRecord as createImportedStaticCssEvalModuleRecord,
   internalCreateImportedStaticCssEvalProvider as createImportedStaticCssEvalProvider,
+  internalGetStaticCssEvalMemberReference as getStaticCssEvalMemberReference,
+  internalUnwrapTransparentCssRuleExpression as unwrapTransparentCssRuleExpression,
   type InternalImportedStaticCssEvalImportResolution as ImportedStaticCssEvalImportResolution,
   type InternalImportedStaticCssEvalLoadedModule as ImportedStaticCssEvalLoadedModule,
   type InternalImportedStaticCssEvalModuleRecord as ImportedStaticCssEvalModuleRecord,
@@ -103,6 +106,40 @@ interface StaticCssEvalPrepassWholeNamespaceWalk {
   seen: Set<string>;
 }
 
+interface StaticCssEvalPrepassReference {
+  readonly bindingName: string;
+  readonly memberPath: readonly string[];
+}
+
+interface StaticCssEvalPrepassLocalWalkFrame {
+  readonly recordId: string;
+  readonly bindingName: string;
+  readonly memberPath: readonly string[];
+}
+
+interface StaticCssEvalPrepassExpressionWalkOptions {
+  readonly moduleRecord: ImportedStaticCssEvalModuleRecord;
+  readonly expression: t.Expression;
+  readonly memberPath: readonly string[];
+  readonly context: StaticCssEvalPrepassContext;
+  readonly localStack: readonly StaticCssEvalPrepassLocalWalkFrame[];
+}
+
+interface StaticCssEvalPrepassReferenceWalkOptions {
+  readonly moduleRecord: ImportedStaticCssEvalModuleRecord;
+  readonly reference: StaticCssEvalPrepassReference;
+  readonly context: StaticCssEvalPrepassContext;
+  readonly localStack: readonly StaticCssEvalPrepassLocalWalkFrame[];
+}
+
+interface StaticCssEvalPrepassLocalBindingWalkOptions {
+  readonly moduleRecord: ImportedStaticCssEvalModuleRecord;
+  readonly bindingName: string;
+  readonly memberPath: readonly string[];
+  readonly context: StaticCssEvalPrepassContext;
+  readonly localStack: readonly StaticCssEvalPrepassLocalWalkFrame[];
+}
+
 interface CreateLoadedModuleOptions {
   resolution?: NormalizedStaticCssEvalSourceResolution;
   sourceText?: string;
@@ -197,6 +234,16 @@ export async function createStaticCssEvalPrepass(
     );
 
     if (!dependencyRequest) {
+      if (candidate.bindingName) {
+        await loadStaticCssEvalPrepassLocalBindingDependencies({
+          moduleRecord: ownerRecord,
+          bindingName: candidate.bindingName,
+          memberPath: candidate.memberPath ?? [],
+          context: prepassContext,
+          localStack: []
+        });
+      }
+
       continue;
     }
 
@@ -218,6 +265,11 @@ export async function createStaticCssEvalPrepass(
       );
     }
   }
+
+  await loadStaticCssEvalPrepassOwnerLiteralDependencies(
+    ownerRecord,
+    prepassContext
+  );
 
   const ownerToDependencies = new Map<string, string[]>([
     [ownerId, prepassState.ownerDependencies]
@@ -507,6 +559,277 @@ async function loadStaticCssEvalPrepassGraphDependencies(
   );
 }
 
+async function loadStaticCssEvalPrepassOwnerLiteralDependencies(
+  moduleRecord: ImportedStaticCssEvalModuleRecord,
+  context: StaticCssEvalPrepassContext
+): Promise<void> {
+  const expressions: t.Expression[] = [];
+
+  moduleRecord.programPath.traverse({
+    JSXAttribute(attributePath) {
+      if (!isStaticCssEvalPrepassCssAttribute(attributePath.node)) {
+        return;
+      }
+
+      const expression = getStaticCssEvalPrepassJsxExpression(
+        attributePath.node
+      );
+
+      if (!expression) {
+        return;
+      }
+
+      const unwrappedExpression =
+        unwrapTransparentCssRuleExpression(expression);
+
+      if (
+        t.isObjectExpression(unwrappedExpression) ||
+        t.isArrayExpression(unwrappedExpression)
+      ) {
+        expressions.push(unwrappedExpression);
+      }
+    }
+  });
+
+  for (const expression of expressions) {
+    await loadStaticCssEvalPrepassExpressionDependencies({
+      moduleRecord,
+      expression,
+      memberPath: [],
+      context,
+      localStack: []
+    });
+  }
+}
+
+async function loadStaticCssEvalPrepassExpressionDependencies(
+  options: StaticCssEvalPrepassExpressionWalkOptions
+): Promise<void> {
+  const expression = unwrapTransparentCssRuleExpression(options.expression);
+
+  if (t.isObjectExpression(expression)) {
+    await loadStaticCssEvalPrepassObjectExpressionDependencies({
+      ...options,
+      expression
+    });
+    return;
+  }
+
+  if (t.isArrayExpression(expression)) {
+    await loadStaticCssEvalPrepassArrayExpressionDependencies({
+      ...options,
+      expression
+    });
+    return;
+  }
+
+  const reference = getStaticCssEvalMemberReference(expression);
+
+  if (reference?.kind !== "supported") {
+    return;
+  }
+
+  await loadStaticCssEvalPrepassReferenceDependencies({
+    moduleRecord: options.moduleRecord,
+    reference: {
+      bindingName: reference.bindingName,
+      memberPath: [...reference.memberPath, ...options.memberPath]
+    },
+    context: options.context,
+    localStack: options.localStack
+  });
+}
+
+async function loadStaticCssEvalPrepassObjectExpressionDependencies(
+  options: StaticCssEvalPrepassExpressionWalkOptions & {
+    readonly expression: t.ObjectExpression;
+  }
+): Promise<void> {
+  if (options.memberPath.length > 0) {
+    await loadStaticCssEvalPrepassObjectMemberDependencies(options);
+    return;
+  }
+
+  for (const property of options.expression.properties) {
+    if (t.isSpreadElement(property)) {
+      await loadStaticCssEvalPrepassExpressionDependencies({
+        ...options,
+        expression: property.argument,
+        memberPath: []
+      });
+      continue;
+    }
+
+    if (!t.isObjectProperty(property) || !t.isExpression(property.value)) {
+      continue;
+    }
+
+    await loadStaticCssEvalPrepassExpressionDependencies({
+      ...options,
+      expression: property.value,
+      memberPath: []
+    });
+  }
+}
+
+async function loadStaticCssEvalPrepassObjectMemberDependencies(
+  options: StaticCssEvalPrepassExpressionWalkOptions & {
+    readonly expression: t.ObjectExpression;
+  }
+): Promise<void> {
+  const [memberName, ...remainingMemberPath] = options.memberPath;
+
+  if (memberName === undefined) {
+    return;
+  }
+
+  for (
+    let index = options.expression.properties.length - 1;
+    index >= 0;
+    index -= 1
+  ) {
+    const property = options.expression.properties[index];
+
+    if (!property) {
+      continue;
+    }
+
+    if (t.isSpreadElement(property)) {
+      await loadStaticCssEvalPrepassExpressionDependencies({
+        ...options,
+        expression: property.argument,
+        memberPath: options.memberPath
+      });
+      continue;
+    }
+
+    if (!t.isObjectProperty(property) || !t.isExpression(property.value)) {
+      continue;
+    }
+
+    if (getStaticCssEvalPrepassObjectPropertyName(property) !== memberName) {
+      continue;
+    }
+
+    await loadStaticCssEvalPrepassExpressionDependencies({
+      ...options,
+      expression: property.value,
+      memberPath: remainingMemberPath
+    });
+    return;
+  }
+}
+
+async function loadStaticCssEvalPrepassArrayExpressionDependencies(
+  options: StaticCssEvalPrepassExpressionWalkOptions & {
+    readonly expression: t.ArrayExpression;
+  }
+): Promise<void> {
+  for (const element of options.expression.elements) {
+    if (!element) {
+      continue;
+    }
+
+    if (t.isSpreadElement(element)) {
+      await loadStaticCssEvalPrepassExpressionDependencies({
+        ...options,
+        expression: element.argument,
+        memberPath: []
+      });
+      continue;
+    }
+
+    if (!t.isExpression(element)) {
+      continue;
+    }
+
+    await loadStaticCssEvalPrepassExpressionDependencies({
+      ...options,
+      expression: element,
+      memberPath: []
+    });
+  }
+}
+
+async function loadStaticCssEvalPrepassReferenceDependencies(
+  options: StaticCssEvalPrepassReferenceWalkOptions
+): Promise<void> {
+  const dependencyRequest = createStaticCssEvalPrepassDependencyRequest(
+    options.moduleRecord,
+    options.reference.bindingName,
+    options.reference.memberPath
+  );
+
+  if (!dependencyRequest) {
+    await loadStaticCssEvalPrepassLocalBindingDependencies({
+      moduleRecord: options.moduleRecord,
+      bindingName: options.reference.bindingName,
+      memberPath: options.reference.memberPath,
+      context: options.context,
+      localStack: options.localStack
+    });
+    return;
+  }
+
+  const dependencyRecord = await loadStaticCssEvalPrepassDependency(
+    options.moduleRecord.id,
+    dependencyRequest.importPath,
+    options.context
+  );
+
+  if (!dependencyRecord || !dependencyRequest.exportRequest) {
+    return;
+  }
+
+  await loadStaticCssEvalPrepassGraphDependencies(
+    dependencyRecord,
+    dependencyRequest.exportRequest,
+    options.context
+  );
+}
+
+async function loadStaticCssEvalPrepassLocalBindingDependencies(
+  options: StaticCssEvalPrepassLocalBindingWalkOptions
+): Promise<void> {
+  const currentFrame: StaticCssEvalPrepassLocalWalkFrame = {
+    recordId: options.moduleRecord.id,
+    bindingName: options.bindingName,
+    memberPath: [...options.memberPath]
+  };
+  const currentKey = createStaticCssEvalPrepassLocalWalkKey(currentFrame);
+
+  if (
+    options.localStack.some(
+      (frame) => createStaticCssEvalPrepassLocalWalkKey(frame) === currentKey
+    )
+  ) {
+    return;
+  }
+
+  const expression = getStaticCssEvalPrepassConstBindingInitExpression(
+    options.moduleRecord,
+    options.bindingName
+  );
+
+  if (!expression) {
+    return;
+  }
+
+  await loadStaticCssEvalPrepassExpressionDependencies({
+    moduleRecord: options.moduleRecord,
+    expression,
+    memberPath: options.memberPath,
+    context: options.context,
+    localStack: [...options.localStack, currentFrame]
+  });
+}
+
+function createStaticCssEvalPrepassLocalWalkKey(
+  frame: StaticCssEvalPrepassLocalWalkFrame
+): string {
+  return `${frame.recordId}\0${frame.bindingName}\0${frame.memberPath.join(".")}`;
+}
+
 async function loadExportNamePrepassDependencies(
   moduleRecord: ImportedStaticCssEvalModuleRecord,
   walk: StaticCssEvalPrepassExportWalk,
@@ -614,29 +937,52 @@ async function loadExplicitExportEntryPrepassDependencies(
   walk: StaticCssEvalPrepassExportWalk,
   context: StaticCssEvalPrepassContext
 ): Promise<void> {
-  if (exportEntry.kind !== "reexport") {
-    return;
+  switch (exportEntry.kind) {
+    case "expression":
+      await loadStaticCssEvalPrepassExpressionDependencies({
+        moduleRecord,
+        expression: exportEntry.expression,
+        memberPath: walk.memberPath,
+        context,
+        localStack: []
+      });
+      return;
+    case "local":
+      await loadStaticCssEvalPrepassLocalBindingDependencies({
+        moduleRecord,
+        bindingName: exportEntry.localName,
+        memberPath: walk.memberPath,
+        context,
+        localStack: []
+      });
+      return;
+    case "reexport": {
+      const dependencyRecord = await loadStaticCssEvalPrepassDependency(
+        moduleRecord.id,
+        exportEntry.source,
+        context
+      );
+
+      if (!dependencyRecord) {
+        return;
+      }
+
+      await loadExportNamePrepassDependencies(
+        dependencyRecord,
+        {
+          exportName: exportEntry.importedName,
+          memberPath: walk.memberPath,
+          seen: walk.seen
+        },
+        context
+      );
+      return;
+    }
+    case "unsupported":
+      return;
+    default:
+      return assertNever(exportEntry);
   }
-
-  const dependencyRecord = await loadStaticCssEvalPrepassDependency(
-    moduleRecord.id,
-    exportEntry.source,
-    context
-  );
-
-  if (!dependencyRecord) {
-    return;
-  }
-
-  await loadExportNamePrepassDependencies(
-    dependencyRecord,
-    {
-      exportName: exportEntry.importedName,
-      memberPath: walk.memberPath,
-      seen: walk.seen
-    },
-    context
-  );
 }
 
 function createStaticCssEvalPrepassWalkKey(
@@ -649,6 +995,68 @@ function createStaticCssEvalPrepassWalkKey(
 
 function assertNever(value: never): never {
   throw new TypeError(`Unexpected static css eval prepass value: ${value}`);
+}
+
+function isStaticCssEvalPrepassCssAttribute(
+  attribute: t.JSXAttribute
+): boolean {
+  return t.isJSXIdentifier(attribute.name) && attribute.name.name === "css";
+}
+
+function getStaticCssEvalPrepassJsxExpression(
+  attribute: t.JSXAttribute
+): t.Expression | null {
+  if (!t.isJSXExpressionContainer(attribute.value)) {
+    return null;
+  }
+
+  return t.isJSXEmptyExpression(attribute.value.expression)
+    ? null
+    : attribute.value.expression;
+}
+
+function getStaticCssEvalPrepassObjectPropertyName(
+  property: t.ObjectProperty
+): string | null {
+  const key = property.key;
+
+  if (!property.computed && t.isIdentifier(key)) {
+    return key.name;
+  }
+
+  if (t.isStringLiteral(key)) {
+    return key.value;
+  }
+
+  if (t.isNumericLiteral(key)) {
+    return String(key.value);
+  }
+
+  return null;
+}
+
+function getStaticCssEvalPrepassConstBindingInitExpression(
+  moduleRecord: ImportedStaticCssEvalModuleRecord,
+  bindingName: string
+): t.Expression | null {
+  const binding = moduleRecord.programPath.scope.getBinding(bindingName);
+  const bindingPath = binding?.path;
+
+  if (!bindingPath?.isVariableDeclarator()) {
+    return null;
+  }
+
+  if (
+    !t.isIdentifier(bindingPath.node.id) ||
+    !bindingPath.parentPath.isVariableDeclaration() ||
+    bindingPath.parentPath.node.kind !== "const"
+  ) {
+    return null;
+  }
+
+  const initPath = bindingPath.get("init");
+
+  return initPath.node && initPath.isExpression() ? initPath.node : null;
 }
 
 function createLoadedModule(
@@ -1279,6 +1687,18 @@ if (import.meta.vitest) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
   const { describe, expect, it } = import.meta.vitest;
+
+  describe("static css eval prepass object property names", () => {
+    it("does not treat computed identifier keys as static names", () => {
+      const property = t.objectProperty(
+        t.identifier("dynamicKey"),
+        t.stringLiteral("value"),
+        true
+      );
+
+      expect(getStaticCssEvalPrepassObjectPropertyName(property)).toBeNull();
+    });
+  });
 
   const YARN_NODE_LINKERS = ["pnp", "pnpm", "node-modules"] as const;
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -83,22 +83,30 @@ Supported expression-valued primitive `css` props lower through `cx(...)`:
 <div css={getClassName()} />
 ```
 
-### Static Evaluation v1
+### Static Evaluation
 
-V1 can statically evaluate CSS-rule candidates when the value is a direct object or array, a mutation-free same-file `const`, or a direct project-local ESM named/default import that resolves to a supported object or array. Static member paths over those objects are supported, including `styles.button`, `styles.button.primary`, `styles["button"]`, and `styles["button"].primary`.
+Static evaluation can resolve CSS-rule candidates when the value is a direct object or array, a mutation-free same-file `const`, or an import that the integration/provider can resolve to deterministic source or a literal payload. Supported provider-backed sources include project files, package files, data modules, virtual modules, and static CommonJS shapes when the provider also supplies stable identity metadata. Static member paths over those values are supported, including `styles.button`, `styles.button.primary`, `styles["button"]`, and `styles["button"].primary`.
 
-The practical literal grammar is intentionally small: string, number, boolean, `null`, unary numeric expressions such as `-1`, no-expression template literals such as `` `grid` ``, and nested object/array literals. Supported values are reconstructed as AST literals and then use the same CSS-rule extraction path as inline `css={{ ... }}`.
+The practical literal grammar is intentionally small: string, number, boolean, `null`, unary numeric expressions such as `-1`, no-expression template literals such as `` `grid` ``, nested object/array literals, static object/array spreads, and static identifier/member operands inside proven CSS-rule literals. Object spreads merge left to right, and later keys win. Array spreads inline each static array operand at the spread position. Supported values are reconstructed as AST literals and then use the same CSS-rule extraction path as inline `css={{ ... }}`.
+
+Top-level primitive identifiers remain class values, so `css={activeClass}` still lowers through `cx(...)` when it is not proven to be a static CSS rule. Primitive identifiers and member values are only statically resolved inside object/array literals that are already proven CSS-rule candidates.
 
 Same-file examples:
 
 ```tsx
-const button = { color: "red" } as const;
-const stack = [{ display: "flex" }, { gap: 8 }] as const;
+const color = "red" as const;
+const metrics = { gap: 8 } as const;
+const buttonBase = { display: "inline-flex", color: "blue" } as const;
+const buttonPressed = { color: "darkred" } as const;
+const button = { ...buttonBase, ...buttonPressed, gap: metrics.gap } as const;
+const stackParts = [{ display: "flex" }] as const;
+const stack = [...stackParts, { gap: metrics.gap }] as const;
 const styles = {
   button: { color: "blue" },
   media: { wide: { padding: 24 } }
 } as const;
 
+<div css={{ ...buttonBase, color }} />
 <div css={button} />
 <div css={stack} />
 <div css={styles.button} />
@@ -109,25 +117,57 @@ Project-local import examples:
 
 ```tsx
 // styles.ts
-export const card = { padding: 16 } as const;
+export const tone = "green" as const;
+export const spacing = { card: 16 } as const;
+export const cardBase = { padding: 12 } as const;
+export const stackParts = [{ display: "flex" }] as const;
 export const layout = { stack: [{ display: "flex" }, { gap: 8 }] } as const;
 
 const panel = { color: "green" } as const;
+export { cardBase as surface };
 export default panel;
 
 // App.tsx
-import panel, { card, layout } from "./styles";
+import panel, { cardBase, layout, spacing, stackParts, surface as surfaceStyle, tone } from "./styles";
+
+const card = { ...cardBase, color: tone, padding: spacing.card } as const;
+const stack = [...stackParts, { gap: spacing.card }] as const;
 
 <div css={card} />
+<div css={stack} />
+<div css={surfaceStyle} />
 <div css={panel} />
 <div css={layout.stack} />
 ```
 
-Static CommonJS sources can also participate when the integration supplies deterministic source text. Supported shapes are narrow: literal `require("./styles")` namespace, member, and shallow destructure bindings; direct `module.exports` or `exports.name` export maps; static compiler output from tsc/Babel/SWC/Rollup/Vite; and recognized esbuild helper fingerprints. Mincho parses those files as AST only. It does not call Node `require()`, run package runtime resolution, or emulate Webpack/Turbopack/Parcel runtime bundles.
+Provider-backed package, data, and virtual operands use the same static rules when the integration/provider supplies deterministic source or literal payloads plus identity metadata:
 
-Bundlers provide source resolution and loading only. Vite and esbuild give Mincho project-local source text plus dependency edges. Mincho parses that source and statically evaluates the supported AST subset. No module execution is used. Mincho never executes user modules to obtain `css` prop values, and it does not call Node `require()`, use VM or `eval`, evaluate dynamic imports, or run bundler runtime code for static evaluation.
+```tsx
+import { palette, reset, stackParts } from "@pkg/styles";
+import tokens, { brandColor } from "@pkg/styles/tokens.json";
+import virtualStyles from "virtual:mincho-styles";
 
-Provider-backed namespace imports, explicit/star reexports and barrels, package/node_modules/outside-root ESM sources, static-data literal payloads, and virtual modules are supported when deterministic parseable source or literal ESM payload plus source identity/dependency metadata are supplied. Namespace reexports (export * as ns), provider/external modules without loadable source, remote/http and runtime/dynamic cases remain unsupported. Mincho doesn't support dynamic CommonJS, package runtime resolution, calls/functions/mixins as CSS-rule values, object/array spreads, computed dynamic keys, optional chaining, template expressions, runtime dynamic values, SWC-native integration, or full Webpack/Turbopack/Parcel bundle runtime emulation.
+<div css={{ ...reset, color: palette.primary }} />
+<div css={{ color: brandColor, padding: tokens.card.padding }} />
+<div css={[...stackParts, { color: palette.primary }]} />
+<div css={virtualStyles.card} />
+```
+
+Provider-backed namespace imports, explicit and star reexports/barrels, package, `node_modules`, and outside-root ESM sources, static-data literal payloads, and virtual modules are supported when deterministic parseable source or literal ESM payload plus source identity and dependency metadata are supplied. Namespace reexports (`export * as ns`) and provider or external modules without loadable source remain unsupported.
+
+Static CommonJS sources can also participate when the integration supplies deterministic source text and identity metadata. Supported shapes are narrow: literal `require("./styles")` namespace, member, and shallow destructure bindings; direct `module.exports` or `exports.name` export maps; static compiler output from tsc/Babel/SWC/Rollup/Vite; and recognized esbuild helper fingerprints. Mincho parses those files as AST only. It does not call Node `require()`, run package runtime resolution, or emulate Webpack/Turbopack/Parcel runtime bundles.
+
+```tsx
+const cjsStyles = require("./styles.cjs");
+const { base: cjsBase, stack: cjsStack } = require("./styles.cjs");
+
+<div css={{ ...cjsBase, color: cjsStyles.color }} />
+<div css={[...cjsStack, { padding: 16 }]} />
+```
+
+Bundlers provide source resolution and loading only. Vite and esbuild give Mincho provider-backed project, package, data, virtual, and static CommonJS source or literal payloads plus identity metadata and dependency edges. Mincho parses that source and statically evaluates the supported AST subset. No module execution is used. Mincho never executes user modules to obtain `css` prop values, and it does not call Node `require()`, use VM or `eval`, evaluate dynamic imports, or run bundler runtime code for static evaluation.
+
+Function, factory, mixin, and call evaluation all remain deferred and out of scope. Mincho never executes a factory to discover returned styles. Unsupported cases include remote/http modules, dynamic CommonJS, package runtime resolution, function/factory/mixin/call values as CSS-rule values, dynamic or wrong-shape object/array spread operands, computed dynamic keys, optional chaining, template expressions with expressions, dynamic imports, runtime dynamic values, SWC-native integration, and full Webpack/Turbopack/Parcel bundle runtime emulation.
 
 Failure policy:
 
@@ -137,19 +177,28 @@ Failure policy:
 Unsupported examples:
 
 ```tsx
-const color = "red";
-const badIdentifierValue = { color };
-const badSpread = { ...base, color: "red" };
+const dynamicBase = getBase();
+const wrongShape = [{ display: "flex" }] as const;
+const runtimeColor = props.color;
+const makeRule = () => ({ color: "red" });
 const styles = { button: { color: "red" } } as const;
 const variant = "button";
+const dynamicModule = import("./styles");
+const cjsPath = "./styles.cjs";
+const cjsRuntime = require(cjsPath);
 
-<div css={badIdentifierValue} />
-<div css={badSpread} />
+<div css={{ ...dynamicBase, color: "red" }} />
+<div css={{ ...wrongShape, color: "red" }} />
+<div css={{ color: getColor() }} />
+<div css={{ ...makeRule() }} />
 <div css={styles[variant]} />
 <div css={styles?.button} />
+<div css={{ color: `${runtimeColor}` }} />
+<div css={dynamicModule} />
+<div css={cjsRuntime.card} />
 ```
 
-`badIdentifierValue` fails because object values cannot reference identifiers in v1. `badSpread` fails because object and array spreads are not part of the static literal grammar. `styles[variant]` fails because computed dynamic member paths are unsupported. `styles?.button` fails because optional member paths are unsupported.
+These examples fail as static CSS-rule candidates because static evaluation rejects dynamic or wrong-shape spread operands, function/factory/call values, computed dynamic member paths, optional member paths, template expressions with expressions, dynamic import graphs, unsupported dynamic CommonJS, and runtime values.
 
 Static JSX `css` arrays stay on the `css([...])` composition path. They are static `ComplexCSSRule` composition arrays, not recursive `ClassValue` arrays, and they do not lower to `cx(...)` just because they contain string items.
 
@@ -238,7 +287,7 @@ Static-left `&&` object and array rules are truthy guards only. The left rule is
 <div css={{ color: "red" } && { color: "blue" }} />
 ```
 
-The static-rule support is first-level only. Nested dynamic arrays, array spreads, chained branches, permutation-style branches, and sequence-expression object/array CSS-rule branches remain unsupported:
+The dynamic branch support is first-level only. Nested dynamic arrays, dynamic array spreads, chained branches, permutation-style branches, and sequence-expression object/array CSS-rule branches remain unsupported. Static array spreads inside proven CSS-rule literals remain on the static composition path described above, not recursive `ClassValue` array handling:
 
 ```tsx
 <div css={["base", ["nested", condition && { color: "red" }]]} />
@@ -259,7 +308,7 @@ Class-value-only `||` and `??` still lower through `cx(...)` without CSS-rule ex
 <div css={maybeClass ?? "panel-fallback"} />
 ```
 
-The transform treats direct object/array syntax plus proven same-file or imported static `const` references as CSS rules. Unresolved identifiers, unsupported imports, calls, and runtime expressions remain class-value expressions when they are not proven CSS-rule candidates.
+The transform treats direct object/array syntax plus proven same-file or provider-backed static operands as CSS rules. Unresolved identifiers, unsupported imports, calls, and runtime expressions remain class-value expressions when they are not proven CSS-rule candidates.
 
 ### Targets and Forwarding
 
@@ -283,7 +332,7 @@ Spread-only css values are not transformed by Babel. If an own `css` prop reache
 
 `@mincho-js/react/jsx-runtime` and `@mincho-js/react/jsx-dev-runtime` are thin wrappers around React's automatic JSX runtimes. They only guard missed transforms for own `css` props.
 
-Supported static rule branches are converted to generated class names before JSX reaches the runtime. Static imported values are resolved before runtime through the project-local AST evaluator described above. Mincho does not provide StyleX `stylex.props` fallback behavior, inject a StyleX helper namespace, execute imported files, or fall back to runtime CSS generation.
+Supported static rule branches are converted to generated class names before JSX reaches the runtime. Static imported values are resolved before runtime through the provider-backed AST evaluator described above. Mincho does not provide StyleX `stylex.props` fallback behavior, inject a StyleX helper namespace, execute imported files, or fall back to runtime CSS generation.
 
 If an own `css` prop reaches either runtime, Mincho throws:
 
@@ -307,13 +356,13 @@ When `jsxCssProp: true` is enabled, unsupported css prop cases fail during the t
 | Explicit `key` or `ref` on a spread css-prop element | `Mincho JSX css prop does not support key/ref on spread elements in compile-away mode` |
 | Shorthand `css` | `Mincho JSX css prop requires an expression value` |
 | Function value | `Mincho JSX css prop does not support function values in compile-away mode` |
-| Spread element inside a `css` array | `Mincho JSX css prop array values do not support spread elements in compile-away mode` |
+| Dynamic spread element inside a `css` array | `Mincho JSX css prop array values do not support spread elements in compile-away mode` |
 | Nested dynamic array branch inside a `css` array | `Mincho JSX css prop array branch extraction only supports first-level dynamic branches` |
 | Nested, chained, sequence, unsupported logical, or dynamically resolved object/array CSS-rule value | `Mincho JSX css prop does not support conditional, logical, or wrapped object/array CSS rule values in compile-away mode` |
 | Duplicate `css` | `Mincho JSX css prop must appear only once` |
 | Duplicate `className` | `Mincho JSX css prop cannot merge duplicate className attributes` |
 | Shorthand or unsupported `className` value | `Mincho JSX css prop requires className to be a string literal or expression` |
 
-Static evaluation failures use diagnostics that start with `Cannot statically evaluate css prop value`, followed by the unsupported reason such as `identifier-object-value`, `object-or-array-spread`, `dynamic-member-path`, `optional-member-path`, `template-expression`, `reexport-or-barrel`, `node-modules-import`, or `virtual-module`.
+Static evaluation failures use diagnostics that start with `Cannot statically evaluate css prop value`, followed by the unsupported reason. Reasons include dynamic or wrong-shape spread operands, function/factory/call values, dynamic member paths, optional member paths, template expressions with expressions, dynamic import graphs, unsupported source kinds such as `external-no-source` or `provider-virtual-no-source`, and unsupported dynamic CommonJS.
 
 The same `jsxCssProp: true` transform flag is exposed through `@mincho-js/babel`, `@mincho-js/integration`, `@mincho-js/vite`, and `@mincho-js/esbuild`.

--- a/site/src/content/styled.mdx
+++ b/site/src/content/styled.mdx
@@ -406,34 +406,48 @@ function MyComponent() {
 }
 ```
 
-Static evaluation supports direct object/array values, mutation-free same-file `const` object/array values, and provider-backed ESM sources. Supported sources include project files, package files such as `@pkg/styles`, package barrels, static data modules, and provider-backed virtual modules when the bundler supplies deterministic source text or a literal payload. Named imports, aliased named imports, default imports/exports, selected namespace members such as `styles.button`, whole namespace objects such as `css={styles}`, direct named reexports, and `export *` barrels use the same ESM rules across all supported source kinds:
+Static evaluation supports direct object/array values, mutation-free same-file `const` values, static object/array spreads, static identifier/member operands inside proven CSS-rule literals, and provider-backed ESM sources. Supported sources include project files, package files such as `@pkg/styles`, package barrels, static data modules, and provider-backed virtual modules when the bundler supplies deterministic source text or a literal payload plus identity metadata. Named imports, aliased named imports, default imports/exports, selected namespace members such as `styles.button`, whole namespace objects such as `css={styles}`, direct named reexports, and `export *` barrels use the same ESM rules across all supported source kinds. Object spreads merge left to right, and later keys win. Array spreads inline each static array operand at the spread position:
 
 ```tsx
-const button = { color: 'blue' } as const;
-const stack = [{ display: 'flex' }, { gap: 8 }] as const;
+const color = 'blue' as const;
+const spacing = { gap: 8 } as const;
+const buttonBase = { display: 'flex', color: 'green' } as const;
+const buttonOverride = { color: 'blue' } as const;
+const stackParts = [{ alignItems: 'center' }] as const;
 const styles = {
   button: { color: 'green' },
 } as const;
 
-<div css={button} />
-<div css={stack} />
+<div css={{ ...buttonBase, ...buttonOverride, gap: spacing.gap }} />
+<div css={{ ...buttonBase, color }} />
+<div css={[...stackParts, { gap: spacing.gap }]} />
 <div css={styles.button} />
 ```
 
+Top-level primitive identifiers remain class values, so `css={activeClass}` still lowers through `cx(...)` when it is not proven to be a static CSS rule. Primitive identifiers and member values are only resolved inside object/array literals that are already proven CSS-rule candidates.
+
 ```tsx
 // styles.ts
-export const card = { padding: 16 } as const;
+export const tone = 'green' as const;
+export const cardBase = { padding: 16 } as const;
+export const stackParts = [{ display: 'flex' }] as const;
 
 const panel = { color: 'green' } as const;
+export { cardBase as surface };
 export default panel;
 
 // App.tsx
-import panel, { card } from './styles';
+import panel, { cardBase, stackParts, surface as surfaceStyle, tone } from './styles';
 import * as styles from './styles';
 
+const card = { ...cardBase, color: tone } as const;
+const stack = [...stackParts, { gap: 8 }] as const;
+
 <div css={card} />
+<div css={stack} />
+<div css={surfaceStyle} />
 <div css={panel} />
-<div css={styles.card} />
+<div css={styles.cardBase} />
 ```
 
 Whole namespace objects are supported when every exported value is a static literal CSS property object or fragment:
@@ -468,18 +482,19 @@ import * as styles from './styles';
 <div css={styles.button} />
 ```
 
-Package, data, and virtual sources are supported only through the source provider. Mincho does not resolve package exports on its own; Vite, esbuild, or another integration must provide the source/literal payload and stable identity metadata:
+Package, data, and virtual sources are supported only through the source provider. Mincho does not resolve package exports on its own; Vite, esbuild, or another integration must provide the source/literal payload and stable identity metadata before those operands can be used in static values or spreads:
 
 ```tsx
 // App.tsx
-import pkgStyles, { card as packageCard } from '@pkg/styles';
+import pkgStyles, { palette, reset as packageReset, stackParts as packageStackParts } from '@pkg/styles';
 import { button as packageButton } from '@pkg/styles/barrel';
 import tokens, { brandColor } from '@pkg/styles/tokens.json';
 import rawColor from '@pkg/styles/color.txt?raw';
 import wasmUrl from '@pkg/styles/icon.wasm?url';
 import virtualStyles from 'virtual:mincho-styles';
 
-<div css={packageCard} />
+<div css={{ ...packageReset, color: palette.primary }} />
+<div css={[...packageStackParts, { color: rawColor }]} />
 <div css={pkgStyles.root} />
 <div css={packageButton} />
 <div css={tokens.card} />
@@ -489,21 +504,25 @@ import virtualStyles from 'virtual:mincho-styles';
 <div css={virtualStyles.button} />
 ```
 
-CommonJS sources are supported when the provider supplies deterministic source text. Mincho parses the CommonJS AST, then follows only static shapes: literal `require("./styles")` bindings, shallow destructuring, direct `module.exports` or `exports.name` export maps, static `Object.defineProperty` value/getter descriptors, tsc/Babel/SWC/Rollup/Vite static output, and recognized esbuild helper fingerprints. The helper body must match a known side-effect-free shape; helper names alone are not trusted.
+CommonJS sources are supported when the provider supplies deterministic source text and stable identity metadata. Mincho parses the CommonJS AST, then follows only static shapes: literal `require("./styles")` bindings, shallow destructuring, direct `module.exports` or `exports.name` export maps, static `Object.defineProperty` value/getter descriptors, tsc/Babel/SWC/Rollup/Vite static output, and recognized esbuild helper fingerprints. The helper body must match a known side-effect-free shape; helper names alone are not trusted.
 
 ```tsx
 // styles.cjs
 const button = { color: 'red' };
 const card = { padding: 16 };
+const stack = [{ display: 'flex' }];
+const color = 'blue';
 
-module.exports = { button, card };
+module.exports = { button, card, stack, color };
 
 // App.tsx
 const styles = require('./styles.cjs');
 const { card: cardStyle } = require('./styles.cjs');
 
 <div css={styles.button} />
+<div css={{ ...styles.button, color: styles.color }} />
 <div css={cardStyle} />
+<div css={[...styles.stack, cardStyle]} />
 <div css={styles} />
 ```
 
@@ -526,30 +545,39 @@ import rootDefault, { root } from './styles';
 <div css={root} />
 ```
 
-The practical literal grammar is small: string, number, boolean, `null`, unary numeric values, no-expression template literals such as `` `grid` ``, and nested object/array literals.
+The practical literal grammar is small: string, number, boolean, `null`, unary numeric values, no-expression template literals such as `` `grid` ``, nested object/array literals, static object/array spreads, and static identifier/member operands inside proven CSS-rule literals.
 
-Bundlers provide source resolution and loading only. Vite and esbuild give Mincho provider-backed project/package/data/virtual source text, literal payloads, identity metadata, and dependency edges through the source provider. Mincho then parses source, reads AST export manifests, and statically evaluates only the supported literal subset. No module execution is used. Mincho never executes user modules to obtain `css` prop values, and it does not call Node `require()`, use VM or `eval`, evaluate dynamic imports, or run bundler runtime code for static evaluation.
+Bundlers provide source resolution and loading only. Vite and esbuild give Mincho provider-backed project/package/data/virtual/static CommonJS source text, literal payloads, identity metadata, and dependency edges through the source provider. Mincho then parses source, reads AST export manifests, and statically evaluates only the supported literal subset. No module execution is used. Mincho never executes user modules to obtain `css` prop values, and it does not call Node `require()`, use VM or `eval`, evaluate dynamic imports, or run bundler runtime code for static evaluation.
 
-Explicit exclusions remain: remote/http modules, dynamic `require(expr)`, template or conditional require paths, full Webpack/Turbopack/Parcel bundle runtime graph parsing, runtime wasm init/function exports such as `.wasm?init`, arbitrary virtual modules without provider-supplied source, dynamic import graphs, non-literal loader output, namespace reexports such as `export * as ns from './styles'`, calls/functions/mixins as CSS-rule values, object/array spreads, computed dynamic keys, optional chaining, template expressions, runtime dynamic values, and SWC native integration remain unsupported. Static wasm support is limited to provider-supplied raw/url string forms that arrive as literals; runtime wasm initialization is not evaluated.
+Explicit exclusions remain: remote/http modules, dynamic `require(expr)`, template or conditional require paths, full Webpack/Turbopack/Parcel bundle runtime graph parsing, runtime wasm init/function exports such as `.wasm?init`, arbitrary virtual modules without provider-supplied source, dynamic import graphs, non-literal loader output, namespace reexports such as `export * as ns from './styles'`, function/factory/mixin/call values as CSS-rule values, dynamic or wrong-shape object/array spread operands, computed dynamic keys, optional chaining, template expressions with expressions, runtime dynamic values, and SWC native integration. Static wasm support is limited to provider-supplied raw/url string forms that arrive as literals; runtime wasm initialization is not evaluated.
+
+Function, factory, mixin, and call evaluation all remain deferred and out of scope. Mincho never executes a factory to discover returned styles, and no module execution is used.
 
 Existing dynamic class-value identifiers keep class-value behavior when they cannot be proven static. Proven CSS-rule candidates with unsupported internals fail with `Cannot statically evaluate css prop value` diagnostics.
 
 ```tsx
-const color = 'red';
-const badIdentifierValue = { color };
-const badSpread = { ...base, color: 'red' };
+const dynamicBase = getBase();
+const wrongShape = [{ display: 'flex' }] as const;
+const runtimeColor = props.color;
+const makeRule = () => ({ color: 'red' });
 const styles = { button: { color: 'red' } } as const;
 const variant = 'button';
 const dynamicModule = import('./styles');
+const cjsPath = './styles.cjs';
+const cjsRuntime = require(cjsPath);
 
-<div css={badIdentifierValue} />
-<div css={badSpread} />
+<div css={{ ...dynamicBase, color: 'red' }} />
+<div css={{ ...wrongShape, color: 'red' }} />
+<div css={{ color: getColor() }} />
+<div css={{ ...makeRule() }} />
 <div css={styles[variant]} />
 <div css={styles?.button} />
+<div css={{ color: `${runtimeColor}` }} />
 <div css={dynamicModule} />
+<div css={cjsRuntime.card} />
 ```
 
-These examples fail because static evaluation does not evaluate identifier object values, object spreads, dynamic member paths, optional member paths, or dynamic import graphs inside static CSS-rule candidates.
+These examples fail as static CSS-rule candidates because static evaluation rejects dynamic or wrong-shape spread operands, function/factory/call values, computed dynamic member paths, optional member paths, template expressions with expressions, dynamic import graphs, unsupported dynamic CommonJS, and runtime values.
 
 Ambiguous star barrels fail instead of picking a value:
 


### PR DESCRIPTION
## Description
- Extend the Babel JSX `css` prop path so same-file constants, imported static operands, and direct inline object/array spreads are normalized into static CSS-rule candidates before class-value fallback.
- Teach the integration static-eval prepass to follow only reachable spread/member dependencies and record source identity, cache, and dependency metadata for project, package, data, virtual, and static CommonJS inputs.
- Document the expanded static evaluation semantics, supported sources, failure policy, and examples in the React README and styled docs.

## Related Issue
- #355

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Expanded static `css` prop support for object/array spreads, nested aliases, member paths, and same-file references.
* Added support for provider-backed imports, packages, virtual/data sources, and static CommonJS modules.
* Improved normalization, duplicate-key handling, and dependency tracking.

## Bug Fixes
* Improved resolution of static member expressions and fallback values.
* Added clearer diagnostics for dynamic values, invalid spreads, cycles, and unresolved references.

## Documentation
* Updated CSS prop guidance with supported syntax, examples, provider behavior, and unsupported cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
- Static evaluation remains AST-only and compile-time only: the new operand support still does not execute user modules, `require()`, or runtime factories.
- Coverage was added around inline spreads, same-file and imported operands, provider-backed package/data/virtual modules, CommonJS shapes, and unsupported dynamic-expression diagnostics.

## Checklist
- Review JSX `css` prop classification for inline object/array spreads and static operand resolution before `cx(...)` fallback.
- Confirm dependency/cache metadata and reachable-module tracking for package/data/virtual/CommonJS-backed static evaluation.
- Spot-check the documentation examples and unsupported-case descriptions against the implemented behavior.
