### PR TITLE
Feat: CSS Prop - Support dynamic declaration values

### DIFF
--- a/examples/react-babel/src/App.tsx
+++ b/examples/react-babel/src/App.tsx
@@ -2,7 +2,7 @@ import "@examples/shared-component/style.css";
 import { SharedExampleCard } from "@examples/shared-component";
 import { css } from "@mincho-js/css";
 import { styled } from "@mincho-js/react";
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
 import { sharedCardHostClassName } from "./App.css.ts";
 import importedDefaultStyle, { importedNamedStyle } from "./staticStyles";
@@ -14,11 +14,17 @@ const styleA = css({
 function ClassNameForwardingExample({
   children,
   className,
+  style,
 }: {
   children: ReactNode;
   className?: string;
+  style?: CSSProperties;
 }) {
-  return <section className={className}>{children}</section>;
+  return (
+    <section className={className} style={style}>
+      {children}
+    </section>
+  );
 }
 
 const BaseComponent = styled.div({

--- a/examples/react-swc/src/App.tsx
+++ b/examples/react-swc/src/App.tsx
@@ -1,7 +1,7 @@
 import "@examples/shared-component/style.css";
 import { SharedExampleCard } from "@examples/shared-component";
 import { css } from "@mincho-js/css";
-import { type ReactNode, useState } from "react";
+import { type CSSProperties, type ReactNode, useState } from "react";
 import reactLogo from "./assets/react.svg";
 import importedDefaultStyle, { importedNamedStyle } from "./staticStyles";
 import viteLogo from "/vite.svg";
@@ -19,11 +19,17 @@ const sharedCardContainerClassName = `${cardClassName} shared-card-consumer`;
 function ClassNameForwardingExample({
   children,
   className,
+  style,
 }: {
   children: ReactNode;
   className?: string;
+  style?: CSSProperties;
 }) {
-  return <section className={className}>{children}</section>;
+  return (
+    <section className={className} style={style}>
+      {children}
+    </section>
+  );
 }
 
 function App() {

--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -1,13 +1,20 @@
-import { type PluginObj, transformSync, types as t } from "@babel/core";
+import {
+  type NodePath,
+  type PluginObj,
+  transformSync,
+  types as t
+} from "@babel/core";
 import { transformCallExpression } from "./transforms/callExpression.js";
 import {
   preprocessJsxCssProp,
   removeUnusedJsxCssPropCssModuleImports
 } from "./jsxCssProp.js";
+import { getDynamicCssVariableRule } from "./jsxCssProp/preprocess.js";
 import { supportedJsxCssPropTags } from "./jsxCssPropTags.js";
 import { createImportedStaticCssEvalProvider } from "./staticCssEval/importedModules.js";
 import postprocess from "./transforms/postprocess.js";
 import basePreprocess from "./transforms/preprocess.js";
+import type { DynamicCssVariableRule } from "./jsxCssProp/types.js";
 import type {
   MinchoBabelFileMetadata,
   PluginOptions,
@@ -409,6 +416,96 @@ if (import.meta.vitest) {
     styleValue:
       "Mincho JSX css prop requires style to be an expression value when merging dynamic CSS variables"
   } as const;
+
+  type DynamicCssVariableRuleSnapshot = {
+    readonly kind: DynamicCssVariableRule["kind"];
+    readonly expressionType: string;
+    readonly leafProperties: readonly string[];
+    readonly branches?: readonly DynamicCssVariableRuleSnapshot[];
+  };
+
+  function collectDynamicCssVariableRuleSnapshot(
+    source: string
+  ): DynamicCssVariableRuleSnapshot | null {
+    let snapshot: DynamicCssVariableRuleSnapshot | null = null;
+    let hasVisitedCssCandidate = false;
+
+    transformSync(source, {
+      plugins: [
+        () => ({
+          visitor: {
+            JSXOpeningElement(path: NodePath<t.JSXOpeningElement>) {
+              if (hasVisitedCssCandidate) {
+                return;
+              }
+
+              const cssAttribute = path.node.attributes.find(
+                (attribute): attribute is t.JSXAttribute =>
+                  t.isJSXAttribute(attribute) &&
+                  t.isJSXIdentifier(attribute.name) &&
+                  attribute.name.name === "css"
+              );
+
+              if (
+                !cssAttribute ||
+                !t.isJSXExpressionContainer(cssAttribute.value)
+              ) {
+                return;
+              }
+
+              const { expression } = cssAttribute.value;
+
+              if (
+                t.isJSXEmptyExpression(expression) ||
+                !t.isExpression(expression)
+              ) {
+                return;
+              }
+
+              const rule = getDynamicCssVariableRule({
+                expression,
+                scope: path.scope
+              });
+              hasVisitedCssCandidate = true;
+              snapshot = rule
+                ? createDynamicCssVariableRuleSnapshot(rule)
+                : null;
+            }
+          }
+        })
+      ],
+      presets: ["@babel/preset-typescript"],
+      filename: "collector-test.tsx"
+    });
+
+    return snapshot;
+  }
+
+  function createDynamicCssVariableRuleSnapshot(
+    rule: DynamicCssVariableRule
+  ): DynamicCssVariableRuleSnapshot {
+    switch (rule.kind) {
+      case "direct":
+        return {
+          kind: rule.kind,
+          expressionType: rule.expression.type,
+          leafProperties: rule.leaves.map((leaf) => leaf.propertyName)
+        };
+      case "branch":
+        return {
+          kind: rule.kind,
+          expressionType: rule.expression.type,
+          leafProperties: rule.leaves.map((leaf) => leaf.propertyName),
+          branches: rule.branches.map(createDynamicCssVariableRuleSnapshot)
+        };
+      default: {
+        const unexpectedRule: never = rule;
+        throw new Error(
+          `Unexpected dynamic CSS variable rule: ${unexpectedRule}`
+        );
+      }
+    }
+  }
 
   function expectJsxCssPropError(fixture: string, message: string) {
     expect(() =>
@@ -3529,7 +3626,6 @@ if (import.meta.vitest) {
       );
       expect(code).not.toContain(" css=");
       expect(code).not.toContain("_css(");
-      expect(code).not.toContain('from "@mincho-js/css"');
       expect(code).not.toContain("createVar");
       expect(code).not.toContain("getVarName");
     });
@@ -3946,7 +4042,8 @@ if (import.meta.vitest) {
       const fixtures = [
         `<div style css={{ color: props.color }} />`,
         `<div style="color:red" css={{ color: props.color }} />`,
-        `<div style={"color:red"} css={{ color: props.color }} />`
+        `<div style={"color:red"} css={{ color: props.color }} />`,
+        `<div style={\`color:red\`} css={{ color: props.color }} />`
       ] as const;
 
       for (const fixture of fixtures) {
@@ -4022,7 +4119,6 @@ if (import.meta.vitest) {
       expect(code).toContain("props.outlineColor");
       expect(code).not.toContain(" css=");
       expect(code).not.toContain("_css(");
-      expect(code).not.toContain('from "@mincho-js/css"');
       expect(code).not.toContain("createVar");
       expect(code).not.toContain("getVarName");
     });
@@ -4055,6 +4151,501 @@ if (import.meta.vitest) {
       expect(result[1]).toContain('"&:hover": {');
       expect(result[1]).not.toContain("createVar(");
       expect(result[1]).not.toContain("getVarName(");
+    });
+
+    it("branch dynamic css variable evaluates once", () => {
+      const source = `
+        const events: string[] = [];
+        const reads = {
+          condition: 0,
+          active: 0,
+          inactive: 0
+        };
+        const state = {
+          get condition() {
+            reads.condition += 1;
+            events.push("condition");
+            return true;
+          }
+        };
+        const active = {
+          get color() {
+            reads.active += 1;
+            events.push("active");
+            return "tomato";
+          }
+        };
+        const inactive = {
+          get color() {
+            reads.inactive += 1;
+            events.push("inactive");
+            return "blue";
+          }
+        };
+
+        function App() {
+          return <div css={state.condition ? { color: active.color } : { color: inactive.color }} />;
+        }
+      `;
+      const { result, code } = babelTransform(source, { jsxCssProp: true });
+      const artifact = result[1];
+      const observed = runJsxCssPropRuntime(
+        source,
+        "return { props: App(), events, reads };"
+      ) as {
+        props: Record<string, unknown>;
+        events: string[];
+        reads: Record<string, number>;
+      };
+
+      expect(artifact).toContain(
+        'import { css as _css } from "@mincho-js/css";'
+      );
+      expect(artifact).toContain(
+        'import { createVar as _minchoCreateVar, getVarName as _minchoGetVarName } from "@mincho-js/css";'
+      );
+      expect(
+        artifact.match(
+          /export var _\$mincho\$\$App\w*ColorVar\d* = _minchoCreateVar\("color"\);/g
+        ) ?? []
+      ).toHaveLength(2);
+      expect(
+        artifact.match(
+          /export var _\$mincho\$\$App\w*ColorVarKey\d* = _minchoGetVarName\(_\$mincho\$\$App\w*ColorVar\d*\);/g
+        ) ?? []
+      ).toHaveLength(2);
+      expect(
+        artifact.match(
+          /export var _\$mincho\$\$App\d* = _css\(\{\s+color: _\$mincho\$\$App\w*ColorVar\d*\s+\}\);/g
+        ) ?? []
+      ).toHaveLength(2);
+      expect(code).toMatch(
+        /import \{ _\$mincho\$\$App as _\$mincho\$\$App2, _\$mincho\$\$App3 as _\$mincho\$\$App4 \} from "extracted_[^"]+\.css\.ts";/
+      );
+      expect(code).toMatch(
+        /import \{ _\$mincho\$\$App\w*ColorVarKey as _\$mincho\$\$App\w*ColorVarKey2, _\$mincho\$\$App\w*ColorVarKey3 as _\$mincho\$\$App\w*ColorVarKey4 \} from "extracted_[^"]+\.css\.ts";/
+      );
+      expect(code).toContain("const _minchoCssBranch = state.condition;");
+      expect(code).toContain("className={_minchoCssBranch ?");
+      expect(code).toContain("...(_minchoCssBranch ?");
+      expect(code).not.toContain(" css=");
+      expect(code).not.toContain("_css(");
+      expect(code).not.toContain('from "@mincho-js/css"');
+      expect(code).not.toContain("createVar");
+      expect(code).not.toContain("getVarName");
+      expect(code.match(/state\.condition/g) ?? []).toHaveLength(1);
+      expect(observed.events).toEqual(["condition", "active"]);
+      expect(observed.reads).toEqual({ condition: 1, active: 1, inactive: 0 });
+      expect(observed.props).toMatchObject({
+        className: "css-rule",
+        style: { "css-rule": "tomato" }
+      });
+    });
+
+    it("nested branch dynamic css variable decisions evaluate once", () => {
+      const source = `
+        const events: string[] = [];
+        const reads = { outer: 0, inner: 0, inactive: 0 };
+        const colors = { active: "tomato", other: "blue", fallback: "gray" };
+        let inner = false;
+        const decide = (name, value) => {
+          reads[name] += 1;
+          events.push(name);
+          return value;
+        };
+        const flip = () => {
+          events.push("flip");
+          inner = true;
+          return "flipped";
+        };
+
+        function App() {
+          return <div css={decide("outer", true) ? decide("inner", inner) ? { color: colors.active } : { color: colors.other } : decide("inactive", false) && { color: colors.fallback }} data-flip={flip()} />;
+        }
+      `;
+      const observed = runJsxCssPropRuntime(
+        source,
+        "return { props: App(), events, reads };"
+      ) as {
+        props: Record<string, unknown>;
+        events: string[];
+        reads: Record<string, number>;
+      };
+
+      expect(observed.events).toEqual(["outer", "inner", "flip"]);
+      expect(observed.reads).toEqual({
+        outer: 1,
+        inner: 1,
+        inactive: 0
+      });
+      expect(observed.props).toMatchObject({
+        className: "css-rule",
+        style: { "css-rule": "blue" },
+        "data-flip": "flipped"
+      });
+    });
+
+    it("conditional dynamic css variable style", () => {
+      const source = `
+        const events: string[] = [];
+        const state = { condition: false };
+        const primary = {
+          get color() {
+            events.push("primary");
+            return "tomato";
+          }
+        };
+        const fallback = {
+          get color() {
+            events.push("fallback");
+            return "blue";
+          }
+        };
+
+        function App() {
+          return <div style={{ opacity: 0.5 }} css={state.condition ? { color: primary.color } : { color: fallback.color }} />;
+        }
+      `;
+      const { code } = babelTransform(source, { jsxCssProp: true });
+      const observed = runJsxCssPropRuntime(
+        source,
+        `
+        const props = App();
+        return { props, events, styleKeys: Object.keys(props.style) };
+      `
+      ) as {
+        props: Record<string, unknown>;
+        events: string[];
+        styleKeys: string[];
+      };
+
+      expect(code).not.toContain(" css=");
+      expect(code).not.toContain("_css(");
+      expect(code).not.toContain("createVar");
+      expect(code).not.toContain("getVarName");
+      expect(observed.events).toEqual(["fallback"]);
+      expect(observed.styleKeys).toEqual(["opacity", "css-rule"]);
+      expect(observed.props).toMatchObject({
+        className: "css-rule",
+        style: { opacity: 0.5, "css-rule": "blue" }
+      });
+    });
+
+    it("logical dynamic css variable style", () => {
+      const source = `
+        const events: string[] = [];
+        const reads = {
+          condition: 0,
+          guarded: 0,
+          provided: 0,
+          skippedFallback: 0,
+          empty: 0,
+          fallback: 0
+        };
+        const guard = {
+          get condition() {
+            reads.condition += 1;
+            events.push("condition");
+            return false;
+          }
+        };
+        const provided = {
+          get className() {
+            reads.provided += 1;
+            events.push("provided");
+            return "provided";
+          }
+        };
+        const empty = {
+          get className() {
+            reads.empty += 1;
+            events.push("empty");
+            return "";
+          }
+        };
+        const guarded = {
+          get color() {
+            reads.guarded += 1;
+            events.push("guarded");
+            return "tomato";
+          }
+        };
+        const skippedFallback = {
+          get color() {
+            reads.skippedFallback += 1;
+            events.push("skipped-fallback");
+            return "red";
+          }
+        };
+        const fallback = {
+          get color() {
+            reads.fallback += 1;
+            events.push("fallback");
+            return "blue";
+          }
+        };
+
+        function GuardedApp() {
+          return <div css={guard.condition && { color: guarded.color }} />;
+        }
+
+        function ProvidedApp() {
+          return <div css={provided.className || { color: skippedFallback.color }} />;
+        }
+
+        function FallbackApp() {
+          return <div css={empty.className || { color: fallback.color }} />;
+        }
+      `;
+      const { code } = babelTransform(source, { jsxCssProp: true });
+      const observed = runJsxCssPropRuntime(
+        source,
+        `
+        const guardedProps = GuardedApp();
+        const providedProps = ProvidedApp();
+        const fallbackProps = FallbackApp();
+        return { guardedProps, providedProps, fallbackProps, events, reads };
+      `
+      ) as {
+        guardedProps: Record<string, unknown>;
+        providedProps: Record<string, unknown>;
+        fallbackProps: Record<string, unknown>;
+        events: string[];
+        reads: Record<string, number>;
+      };
+
+      expect(code).not.toContain(" css=");
+      expect(code).not.toContain("_css(");
+      expect(code).not.toContain("createVar");
+      expect(code).not.toContain("getVarName");
+      expect(code.match(/guard\.condition/g) ?? []).toHaveLength(1);
+      expect(code.match(/provided\.className/g) ?? []).toHaveLength(1);
+      expect(code.match(/empty\.className/g) ?? []).toHaveLength(1);
+      expect(observed.events).toEqual([
+        "condition",
+        "provided",
+        "empty",
+        "fallback"
+      ]);
+      expect(observed.reads).toEqual({
+        condition: 1,
+        guarded: 0,
+        provided: 1,
+        skippedFallback: 0,
+        empty: 1,
+        fallback: 1
+      });
+      expect(observed.guardedProps.style).toEqual({});
+      expect(observed.guardedProps.style).not.toBe(false);
+      expect(observed.providedProps).toMatchObject({
+        className: "provided",
+        style: {}
+      });
+      expect(observed.fallbackProps).toMatchObject({
+        className: "css-rule",
+        style: { "css-rule": "blue" }
+      });
+    });
+
+    it("branch dynamic css variable spread", () => {
+      const source = `
+        const events: string[] = [];
+        const pre = {
+          id: "from-pre",
+          className: "from-pre",
+          css: "leak-pre",
+          style: { padding: 4 }
+        };
+        const post = {
+          title: "from-post",
+          className: "from-post",
+          css: "leak-post",
+          style: { margin: 8 }
+        };
+        const state = {
+          get condition() {
+            events.push("condition");
+            return true;
+          }
+        };
+        const active = {
+          get color() {
+            events.push("active");
+            return "tomato";
+          }
+        };
+        const inactive = {
+          get color() {
+            events.push("inactive");
+            return "blue";
+          }
+        };
+
+        function App() {
+          const renderValue = () => <div {...pre} css={state.condition ? { color: active.color } : { color: inactive.color }} {...post} />;
+          return renderValue();
+        }
+      `;
+      const { code } = babelTransform(source, { jsxCssProp: true });
+      const observed = runJsxCssPropRuntime(
+        source,
+        `
+        const props = App();
+        return { props, events, styleKeys: Object.keys(props.style), hasCss: "css" in props };
+      `
+      ) as {
+        props: Record<string, unknown>;
+        events: string[];
+        styleKeys: string[];
+        hasCss: boolean;
+      };
+
+      expect(code).toContain("(() =>");
+      expect(code).not.toContain(" css=");
+      expect(code).not.toContain("_css(");
+      expect(code).not.toContain('from "@mincho-js/css"');
+      expect(code).not.toContain("createVar");
+      expect(code).not.toContain("getVarName");
+      expect(observed.events).toEqual(["condition", "active"]);
+      expect(observed.styleKeys).toEqual(["padding", "margin", "css-rule"]);
+      expect(observed.hasCss).toBe(false);
+      expect(observed.props).toMatchObject({
+        id: "from-pre",
+        title: "from-post",
+        className: "from-pre css-rule from-post",
+        style: { padding: 4, margin: 8, "css-rule": "tomato" }
+      });
+    });
+
+    it("collects conditional dynamic css variable branch rules at model level", () => {
+      const fixtures = [
+        {
+          source: `
+            const condition = true;
+            function App(props) {
+              return <div css={condition ? { color: props.color } : { color: "red" }} />;
+            }
+          `,
+          leafProperties: ["color"],
+          branchLeafProperties: [["color"], []]
+        },
+        {
+          source: `
+            const condition = true;
+            function App(props) {
+              return <div css={condition ? { color: props.color } : { color: props.fallbackColor }} />;
+            }
+          `,
+          leafProperties: ["color", "color"],
+          branchLeafProperties: [["color"], ["color"]]
+        }
+      ] as const;
+
+      for (const { source, leafProperties, branchLeafProperties } of fixtures) {
+        const snapshot = collectDynamicCssVariableRuleSnapshot(source);
+
+        expect(snapshot).toMatchObject({
+          kind: "branch",
+          expressionType: "ConditionalExpression",
+          leafProperties
+        });
+        expect(
+          snapshot?.branches?.map((branch) => branch.leafProperties)
+        ).toEqual(branchLeafProperties);
+      }
+    });
+
+    it("collects logical dynamic css variable branch rules at model level", () => {
+      const fixtures = [
+        `
+          const condition = true;
+          function App(props) {
+            return <div css={condition && { color: props.color }} />;
+          }
+        `,
+        `
+          const providedClass = "provided";
+          function App(props) {
+            return <div css={providedClass || { color: props.color }} />;
+          }
+        `
+      ] as const;
+
+      for (const source of fixtures) {
+        const snapshot = collectDynamicCssVariableRuleSnapshot(source);
+
+        expect(snapshot).toMatchObject({
+          kind: "branch",
+          expressionType: "LogicalExpression",
+          leafProperties: ["color"]
+        });
+        expect(
+          snapshot?.branches?.map((branch) => branch.leafProperties)
+        ).toEqual([["color"]]);
+      }
+    });
+
+    it("rejects unsupported branch dynamic css variable rules at collector level", () => {
+      const templateLiteralFixture = `
+        const condition = true;
+        function App(props) {
+          return <div css={condition ? { color: \`${"${props.color}"}\` } : { color: "red" }} />;
+        }
+      `;
+      const fixtures = [
+        `
+          const condition = true;
+          function App(props) {
+            return <div css={condition ? { [props.key]: props.color } : { color: "red" }} />;
+          }
+        `,
+        `
+          const condition = true;
+          function App(props) {
+            return <div css={condition ? { ...props.styles, color: props.color } : { color: "red" }} />;
+          }
+        `,
+        `
+          const condition = true;
+          function App(props) {
+            return <div css={condition ? [...props.styles, { color: props.color }] : [{ color: "red" }]} />;
+          }
+        `,
+        `
+          const condition = true;
+          function makeRule(color) {
+            return { color };
+          }
+          function App(props) {
+            return <div css={condition ? makeRule(props.color) : { color: "red" }} />;
+          }
+        `,
+        `
+          function App(props) {
+            return <div css={() => ({ color: props.color })} />;
+          }
+        `,
+        `
+          const condition = true;
+          function App(props) {
+            return <div css={condition ? (props.touch(), { color: props.color }) : { color: "red" }} />;
+          }
+        `,
+        templateLiteralFixture
+      ] as const;
+
+      for (const source of fixtures) {
+        expect(collectDynamicCssVariableRuleSnapshot(source)).toBeNull();
+      }
+
+      const templateLiteralFailure = captureJsxCssPropFailure(
+        templateLiteralFixture,
+        { jsxCssProp: true }
+      );
+      expect(templateLiteralFailure.error.message).toContain(
+        jsxCssPropErrorMessages.unsupportedDynamicCssRule
+      );
+      expect(templateLiteralFailure.code).not.toContain("_css(");
     });
 
     it("rejects unsupported dynamic css variable shapes with compile-away diagnostics", () => {
@@ -4117,17 +4708,6 @@ if (import.meta.vitest) {
           source: `
             function App(props) {
               return <div css={props.ruleFactory()} />;
-            }
-          `,
-          expected:
-            /conditional, logical, or wrapped object\/array CSS rule values in compile-away mode/
-        },
-        {
-          label: "branch-shaped rule objects",
-          source: `
-            const condition = true;
-            function App(props) {
-              return <div css={condition ? { color: props.color } : { color: "red" }} />;
             }
           `,
           expected:

--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -217,7 +217,9 @@ if (import.meta.vitest) {
                 return t.variableDeclaration("const", [
                   t.variableDeclarator(
                     t.cloneNode(specifier.local),
-                    t.stringLiteral("css-rule")
+                    isGeneratedCxImportSpecifier(specifier)
+                      ? t.identifier("__minchoCx")
+                      : t.stringLiteral("css-rule")
                   )
                 ]);
               }
@@ -291,6 +293,13 @@ if (import.meta.vitest) {
     }
 
     return null;
+  }
+
+  function isGeneratedCxImportSpecifier(specifier: t.ImportSpecifier): boolean {
+    return (
+      t.isIdentifier(specifier.imported) &&
+      /Cx\d*$/.test(specifier.imported.name)
+    );
   }
 
   function createRuntimeJsxTagExpression(
@@ -396,7 +405,9 @@ if (import.meta.vitest) {
     duplicateClassName:
       "Mincho JSX css prop cannot merge duplicate className attributes",
     classNameValue:
-      "Mincho JSX css prop requires className to be a string literal or expression"
+      "Mincho JSX css prop requires className to be a string literal or expression",
+    styleValue:
+      "Mincho JSX css prop requires style to be an expression value when merging dynamic CSS variables"
   } as const;
 
   function expectJsxCssPropError(fixture: string, message: string) {
@@ -3495,6 +3506,678 @@ if (import.meta.vitest) {
       expect(result[1]).not.toContain('color: "red"');
       expect(result[1]).not.toContain("makeRule");
       expect(result[1]).not.toContain("getClassName");
+    });
+
+    it("lowers simple dynamic css variable leaf into generated artifact and inline style", () => {
+      const { result, code } = babelTransform(
+        `
+        function App(props) {
+          return <div css={{ color: props.color }} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(result[1]).toMatch(/_minchoCreateVar\d*\(/);
+      expect(result[1]).toMatch(/_minchoGetVarName\d*\(/);
+      expect(result[1]).toContain("_css({");
+      expect(result[1]).toMatch(/color: _\$mincho\$\$App\w*ColorVar/);
+      expect(code).toMatch(/from "extracted_[^"]+\.css\.ts"/);
+      expect(code).toContain("className=");
+      expect(code).toMatch(
+        /style=\{\{\s+\[_\$mincho\$\$App\w*ColorVarKey\d*\]: props\.color\s+\}\}/
+      );
+      expect(code).not.toContain(" css=");
+      expect(code).not.toContain("_css(");
+      expect(code).not.toContain('from "@mincho-js/css"');
+      expect(code).not.toContain("createVar");
+      expect(code).not.toContain("getVarName");
+    });
+
+    it("lowers dynamic css variable and static css prop without duplicate css helper aliases", () => {
+      const { result, code } = babelTransform(
+        `
+        function App(props) {
+          return <>
+            <div css={{ color: "red" }} />
+            <section css={{ color: props.color }} />
+          </>;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+      const artifact = result[1];
+
+      expect(artifact.match(/css as _css/g) ?? []).toHaveLength(1);
+      expect(artifact).toMatch(/_minchoCreateVar\d*\(/);
+      expect(artifact).toMatch(/_minchoGetVarName\d*\(/);
+      expect(artifact).toContain('color: "red"');
+      expect(artifact).toMatch(/color: _\$mincho\$\$App\w*ColorVar/);
+      expect(code).not.toContain('from "@mincho-js/css"');
+      expect(code).not.toContain("_css(");
+      expect(code).not.toContain("createVar");
+      expect(code).not.toContain("getVarName");
+    });
+
+    it("lowers dynamic css variable source helper imports without duplicate helper declarations", () => {
+      const createVarCase = babelTransform(
+        `
+        import { createVar } from "@mincho-js/css";
+
+        const external = createVar("external");
+
+        function App(props) {
+          return <div data-var={external} css={{ color: props.color }} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+      const getVarNameCase = babelTransform(
+        `
+        import { getVarName } from "@mincho-js/css";
+
+        const external = getVarName("external");
+
+        function App(props) {
+          return <div data-var={external} css={{ color: props.color }} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(createVarCase.result[1].match(/css as _css/g) ?? []).toHaveLength(
+        1
+      );
+      expect(createVarCase.result[1]).toContain('createVar("external")');
+      expect(createVarCase.result[1]).toMatch(
+        /createVar as _minchoCreateVar\d*/
+      );
+      expect(createVarCase.result[1]).toMatch(
+        /getVarName as _minchoGetVarName\d*/
+      );
+      expect(createVarCase.result[1]).toMatch(
+        /color: _\$mincho\$\$App\w*ColorVar/
+      );
+      expect(createVarCase.code).not.toContain("_css(");
+      expect(createVarCase.code).not.toContain("createVar(");
+      expect(createVarCase.code).not.toContain("getVarName(");
+
+      expect(getVarNameCase.result[1].match(/css as _css/g) ?? []).toHaveLength(
+        1
+      );
+      expect(getVarNameCase.result[1]).toMatch(
+        /createVar as _minchoCreateVar\d*/
+      );
+      expect(getVarNameCase.result[1]).toMatch(
+        /getVarName as _minchoGetVarName\d*/
+      );
+      expect(getVarNameCase.result[1]).toMatch(
+        /color: _\$mincho\$\$App\w*ColorVar/
+      );
+      expect(getVarNameCase.code).toContain('getVarName("external")');
+      expect(getVarNameCase.code).not.toContain("_css(");
+    });
+
+    it("emits dynamic css variable style merge without existing style", () => {
+      const { code } = babelTransform(
+        `
+        function App(props) {
+          return <div css={{ color: props.color }} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(code).toMatch(
+        /style=\{\{\s+\[_\$mincho\$\$App\w*ColorVarKey\d*\]: props\.color\s+\}\}/
+      );
+      expect(code).not.toContain(" css=");
+      expect(code).not.toContain('from "@mincho-js/css"');
+      expect(code).not.toContain("createVar");
+      expect(code).not.toContain("getVarName");
+      expect(code).not.toContain("_css(");
+    });
+
+    it("merges dynamic css variable style merge after object and expression styles", () => {
+      const objectStyle = babelTransform(
+        `
+        function App(props) {
+          const baseStyle = props.baseStyle;
+          return <div
+            style={{ ...baseStyle, opacity: props.opacity }}
+            css={{ color: props.color, backgroundColor: props.backgroundColor }}
+          />;
+        }
+      `,
+        { jsxCssProp: true }
+      ).code;
+      const expressionStyle = babelTransform(
+        `
+        function App(props) {
+          return <section
+            style={props.style}
+            css={{ borderColor: props.borderColor }}
+          />;
+        }
+      `,
+        { jsxCssProp: true }
+      ).code;
+
+      expect(objectStyle).toMatch(
+        /style=\{\{\s+\.\.\.baseStyle,\s+opacity: props\.opacity,\s+\[_\$mincho\$\$App\w*ColorVarKey\d*\]: props\.color,\s+\[_\$mincho\$\$App\w*BackgroundColorVarKey\d*\]: props\.backgroundColor\s+\}\}/
+      );
+      expect(expressionStyle).toMatch(
+        /style=\{\{\s+\.\.\.props\.style,\s+\[_\$mincho\$\$App\w*BorderColorVarKey\d*\]: props\.borderColor\s+\}\}/
+      );
+
+      for (const output of [objectStyle, expressionStyle]) {
+        expect(output).not.toContain(" css=");
+        expect(output).not.toContain('from "@mincho-js/css"');
+        expect(output).not.toContain("createVar");
+        expect(output).not.toContain("getVarName");
+        expect(output).not.toContain("_css(");
+      }
+    });
+
+    it("merges dynamic css variable style merge after existing className", () => {
+      const { code } = babelTransform(
+        `
+        function App(props) {
+          return <div className={props.className} css={{ color: props.color }} />;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(code).toMatch(
+        /className=\{_\$mincho\$\$App\w*Cx\d*\(props\.className, _\$mincho\$\$App\d*\)\}/
+      );
+      expect(code).toMatch(
+        /style=\{\{\s+\[_\$mincho\$\$App\w*ColorVarKey\d*\]: props\.color\s+\}\}/
+      );
+      expect(code).not.toContain(" css=");
+      expect(code).not.toContain('from "@mincho-js/css"');
+      expect(code).not.toContain("createVar");
+      expect(code).not.toContain("getVarName");
+      expect(code).not.toContain("_css(");
+    });
+
+    it("dynamic css variable spread aggregates pre and post styles before generated vars", () => {
+      const source = `
+        const pre = {
+          className: "from-pre",
+          css: "leak-pre",
+          id: "from-pre",
+          style: { color: "pre" }
+        };
+        const post = {
+          className: "from-post",
+          css: "leak-post",
+          title: "from-post",
+          style: { backgroundColor: "post" }
+        };
+
+        function App() {
+          const props = { color: "tomato" };
+          return <div {...pre} css={{ color: props.color }} {...post} />;
+        }
+      `;
+      const { result, code } = babelTransform(source, { jsxCssProp: true });
+      const observed = runJsxCssPropRuntime(
+        source,
+        `
+        const props = App();
+        return {
+          props,
+          styleKeys: Object.keys(props.style),
+          hasCss: "css" in props
+        };
+      `
+      );
+
+      expect(result[1]).toMatch(/_minchoCreateVar\d*\(/);
+      expect(result[1]).toMatch(/_minchoGetVarName\d*\(/);
+      expect(result[1]).toContain("_css({");
+      expect(result[1]).toContain("cx as");
+      expect(code).not.toContain('from "@mincho-js/css"');
+      expect(code).not.toContain("createVar");
+      expect(code).not.toContain("getVarName");
+      expect(code).not.toContain("_css(");
+      expect(code).not.toContain(" css=");
+      expect(observed).toEqual({
+        hasCss: false,
+        styleKeys: ["color", "backgroundColor", "css-rule"],
+        props: expect.objectContaining({
+          className: "from-pre css-rule from-post",
+          id: "from-pre",
+          title: "from-post",
+          style: {
+            color: "pre",
+            backgroundColor: "post",
+            "css-rule": "tomato"
+          }
+        })
+      });
+    });
+
+    it("dynamic css variable spread preserves explicit style before and after css", () => {
+      const beforeCssStyle = runJsxCssPropRuntime(
+        `
+        const pre = {
+          className: "from-pre",
+          css: "leak-pre",
+          style: { padding: 4 }
+        };
+
+        function App() {
+          const props = { color: "tomato" };
+          return <div {...pre} style={{ opacity: 0.5 }} css={{ color: props.color }} />;
+        }
+      `,
+        `
+        const props = App();
+        return {
+          props,
+          styleKeys: Object.keys(props.style),
+          hasCss: "css" in props
+        };
+      `
+      );
+      const afterCssStyle = runJsxCssPropRuntime(
+        `
+        const post = {
+          className: "from-post",
+          css: "leak-post",
+          style: { margin: 8 }
+        };
+
+        function App() {
+          const props = { color: "tomato" };
+          return <div css={{ color: props.color }} style={{ opacity: 0.75 }} {...post} />;
+        }
+      `,
+        `
+        const props = App();
+        return {
+          props,
+          styleKeys: Object.keys(props.style),
+          hasCss: "css" in props
+        };
+      `
+      );
+
+      expect(beforeCssStyle).toEqual({
+        hasCss: false,
+        styleKeys: ["padding", "opacity", "css-rule"],
+        props: expect.objectContaining({
+          className: "from-pre css-rule",
+          style: { padding: 4, opacity: 0.5, "css-rule": "tomato" }
+        })
+      });
+      expect(afterCssStyle).toEqual({
+        hasCss: false,
+        styleKeys: ["opacity", "margin", "css-rule"],
+        props: expect.objectContaining({
+          className: "css-rule from-post",
+          style: { opacity: 0.75, margin: 8, "css-rule": "tomato" }
+        })
+      });
+    });
+
+    it("style getter source order for dynamic css variable spread reads each contribution once", () => {
+      const observed = runJsxCssPropRuntime(
+        `
+        const events: string[] = [];
+        const reads = {
+          preStyle: 0,
+          preClassName: 0,
+          preCss: 0,
+          explicitStyle: 0,
+          postStyle: 0,
+          postClassName: 0,
+          postCss: 0,
+          dynamic: 0
+        };
+        const pre = {
+          id: "from-pre",
+          get style() {
+            reads.preStyle += 1;
+            events.push("pre.style");
+            return { color: "pre" };
+          },
+          get className() {
+            reads.preClassName += 1;
+            events.push("pre.className");
+            return "from-pre";
+          },
+          get css() {
+            reads.preCss += 1;
+            events.push("pre.css");
+            return "leak-pre";
+          }
+        };
+        const explicitStyle = {
+          get value() {
+            reads.explicitStyle += 1;
+            events.push("explicit.style");
+            return { opacity: 0.5 };
+          }
+        };
+        const post = {
+          title: "from-post",
+          get style() {
+            reads.postStyle += 1;
+            events.push("post.style");
+            return { backgroundColor: "post" };
+          },
+          get className() {
+            reads.postClassName += 1;
+            events.push("post.className");
+            return "from-post";
+          },
+          get css() {
+            reads.postCss += 1;
+            events.push("post.css");
+            return "leak-post";
+          }
+        };
+        const model = {
+          get color() {
+            reads.dynamic += 1;
+            events.push("dynamic");
+            return "tomato";
+          }
+        };
+
+        function App(props) {
+          return <div {...pre} style={explicitStyle.value} css={{ color: props.color }} {...post} />;
+        }
+      `,
+        `
+        const props = App(model);
+        return {
+          props,
+          events,
+          reads,
+          styleKeys: Object.keys(props.style),
+          hasCss: "css" in props
+        };
+      `
+      );
+
+      expect(observed).toEqual({
+        events: [
+          "pre.style",
+          "pre.className",
+          "pre.css",
+          "explicit.style",
+          "post.style",
+          "post.className",
+          "post.css",
+          "dynamic"
+        ],
+        reads: {
+          preStyle: 1,
+          preClassName: 1,
+          preCss: 1,
+          explicitStyle: 1,
+          postStyle: 1,
+          postClassName: 1,
+          postCss: 1,
+          dynamic: 1
+        },
+        styleKeys: ["color", "opacity", "backgroundColor", "css-rule"],
+        hasCss: false,
+        props: expect.objectContaining({
+          className: "from-pre css-rule from-post",
+          id: "from-pre",
+          title: "from-post",
+          style: {
+            color: "pre",
+            opacity: 0.5,
+            backgroundColor: "post",
+            "css-rule": "tomato"
+          }
+        })
+      });
+    });
+
+    it("rejects invalid dynamic css variable style merge values", () => {
+      const fixtures = [
+        `<div style css={{ color: props.color }} />`,
+        `<div style="color:red" css={{ color: props.color }} />`,
+        `<div style={"color:red"} css={{ color: props.color }} />`
+      ] as const;
+
+      for (const fixture of fixtures) {
+        const failure = captureJsxCssPropFailure(
+          `
+          function App(props) {
+            return ${fixture};
+          }
+        `,
+          { jsxCssProp: true }
+        );
+
+        expect(failure.error.message).toContain(
+          jsxCssPropErrorMessages.styleValue
+        );
+        expect(failure.code).not.toContain("_css(");
+      }
+    });
+
+    it("lowers dynamic css variable leaves across static object and array shapes", () => {
+      const { result, code } = babelTransform(
+        `
+        function App(props) {
+          return <>
+            <div css={{
+              color: props.color,
+              backgroundColor: "white",
+              borderColor: props.borderColor,
+              selectors: {
+                "&:hover": {
+                  color: props.hoverColor
+                }
+              },
+              "@media": {
+                "screen and (min-width: 700px)": {
+                  color: props.mediaColor
+                }
+              },
+              opacity: {
+                $disabled: props.disabledOpacity
+              }
+            }} />
+            <section css={[
+              { display: "block", color: props.sectionColor },
+              { selectors: { "&:focus": { outlineColor: props.outlineColor } } }
+            ]} />
+          </>;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+      const artifact = result[1];
+
+      expect(artifact.match(/_minchoCreateVar\d*\(/g) ?? []).toHaveLength(7);
+      expect(artifact.match(/_minchoGetVarName\d*\(/g) ?? []).toHaveLength(7);
+      expect(artifact).toContain("_css({");
+      expect(artifact).toContain("_css([");
+      expect(artifact).toContain('backgroundColor: "white"');
+      expect(artifact).toContain('display: "block"');
+      expect(artifact).toContain("selectors: {");
+      expect(artifact).toContain('"@media": {');
+      expect(artifact).toContain('"&:hover": {');
+      expect(artifact).toContain("$disabled: ");
+      expect(artifact).not.toContain("props.");
+      expect(code).toMatch(/from "extracted_[^"]+\.css\.ts"/);
+      expect(code.match(/style=\{\{/g) ?? []).toHaveLength(2);
+      expect(code).toContain("props.color");
+      expect(code).toContain("props.borderColor");
+      expect(code).toContain("props.hoverColor");
+      expect(code).toContain("props.mediaColor");
+      expect(code).toContain("props.disabledOpacity");
+      expect(code).toContain("props.sectionColor");
+      expect(code).toContain("props.outlineColor");
+      expect(code).not.toContain(" css=");
+      expect(code).not.toContain("_css(");
+      expect(code).not.toContain('from "@mincho-js/css"');
+      expect(code).not.toContain("createVar");
+      expect(code).not.toContain("getVarName");
+    });
+
+    it("keeps static css prop still unchanged without dynamic style emission", () => {
+      const { result, code } = babelTransform(
+        `
+        function App() {
+          return <>
+            <div css={{
+              color: "red",
+              selectors: {
+                "&:hover": {
+                  color: "blue"
+                }
+              }
+            }} />
+            <section css={[{ display: "block" }, { color: "green" }]} />
+          </>;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(code).not.toContain(" css=");
+      expect(code).not.toContain("style=");
+      expect(result[1]).toContain("_css({");
+      expect(result[1]).toContain("_css([");
+      expect(result[1]).toContain('color: "red"');
+      expect(result[1]).toContain('"&:hover": {');
+      expect(result[1]).not.toContain("createVar(");
+      expect(result[1]).not.toContain("getVarName(");
+    });
+
+    it("rejects unsupported dynamic css variable shapes with compile-away diagnostics", () => {
+      const fixtures = [
+        {
+          label: "dynamic keys",
+          source: `
+            function App(props) {
+              return <div css={{ [props.key]: props.color }} />;
+            }
+          `,
+          expected:
+            /computed member access is unsupported|dynamic expression is unsupported/
+        },
+        {
+          label: "computed keys",
+          source: `
+            function App(props) {
+              return <div css={{ ["color"]: props.color }} />;
+            }
+          `,
+          expected:
+            /dynamic expression is unsupported|unsupported identifier-object-value/
+        },
+        {
+          label: "dynamic object spreads",
+          source: `
+            function App(props) {
+              return <div css={{ ...props.styles, color: props.color }} />;
+            }
+          `,
+          expected:
+            /dynamic expression is unsupported|object spread is unsupported|unsupported identifier-object-value/
+        },
+        {
+          label: "dynamic array spreads",
+          source: `
+            function App(props) {
+              return <div css={[...props.styles, { color: props.color }]} />;
+            }
+          `,
+          expected:
+            /array values do not support spread elements in compile-away mode/
+        },
+        {
+          label: "call-return CSS shapes",
+          source: `
+            function makeRule(color) {
+              return { color };
+            }
+            function App(props) {
+              return <div css={makeRule(props.color)} />;
+            }
+          `,
+          expected:
+            /conditional, logical, or wrapped object\/array CSS rule values in compile-away mode/
+        },
+        {
+          label: "member call-return CSS shapes",
+          source: `
+            function App(props) {
+              return <div css={props.ruleFactory()} />;
+            }
+          `,
+          expected:
+            /conditional, logical, or wrapped object\/array CSS rule values in compile-away mode/
+        },
+        {
+          label: "branch-shaped rule objects",
+          source: `
+            const condition = true;
+            function App(props) {
+              return <div css={condition ? { color: props.color } : { color: "red" }} />;
+            }
+          `,
+          expected:
+            /conditional, logical, or wrapped object\/array CSS rule values in compile-away mode/
+        },
+        {
+          label: "function values",
+          source: `
+            function App(props) {
+              return <div css={{ color: () => props.color }} />;
+            }
+          `,
+          expected: /dynamic expression is unsupported: ArrowFunctionExpression/
+        },
+        {
+          label: "sequence-wrapped CSS rules",
+          source: `
+            function App(props) {
+              return <div css={(0, { color: props.color })} />;
+            }
+          `,
+          expected:
+            /conditional, logical, or wrapped object\/array CSS rule values in compile-away mode/
+        },
+        {
+          label: "broad template interpolation",
+          source: `
+            function App(props) {
+              return <div css={{ color: \`${"${props.color}"}\` }} />;
+            }
+          `,
+          expected:
+            /dynamic expression is unsupported|unsupported identifier-object-value/
+        }
+      ] as const;
+
+      for (const { label, source, expected } of fixtures) {
+        let failure: ReturnType<typeof captureJsxCssPropFailure>;
+
+        try {
+          failure = captureJsxCssPropFailure(source, { jsxCssProp: true });
+        } catch (error) {
+          throw new Error(
+            `${label}: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
+
+        expect(failure.error.message).toMatch(expected);
+        expect(failure.code).not.toContain("_css(");
+      }
     });
 
     it("keeps optional call and nested call guardrails out of rule-call lowering", () => {

--- a/packages/babel/src/jsxCssProp/classNameLowering.ts
+++ b/packages/babel/src/jsxCssProp/classNameLowering.ts
@@ -26,8 +26,33 @@ import type {
   CssClassNameBranchResultLoweringRequest,
   CssClassNameLoweringRequest,
   CssClassNameRootResultLoweringRequest,
+  DynamicCssVariableLowering,
   CssPropValueClassification
 } from "./types.js";
+
+type DynamicCssVariableRuntimeLowering = {
+  readonly declarations: readonly t.VariableDeclaration[];
+  readonly styleProperties: readonly t.ObjectExpression["properties"][number][];
+};
+
+const dynamicCssVariableRuntimeLowerings = new WeakMap<
+  DynamicCssVariableLowering,
+  DynamicCssVariableRuntimeLowering
+>();
+
+export function registerDynamicCssVariableRuntimeLowering(
+  lowering: DynamicCssVariableLowering,
+  runtimeLowering: DynamicCssVariableRuntimeLowering
+): DynamicCssVariableLowering {
+  dynamicCssVariableRuntimeLowerings.set(lowering, runtimeLowering);
+  return lowering;
+}
+
+export function getDynamicCssVariableRuntimeLowering(
+  lowering: DynamicCssVariableLowering
+): DynamicCssVariableRuntimeLowering | null {
+  return dynamicCssVariableRuntimeLowerings.get(lowering) ?? null;
+}
 
 export function createClassNameExpression(
   path: NodePath<t.JSXOpeningElement>,

--- a/packages/babel/src/jsxCssProp/constants.ts
+++ b/packages/babel/src/jsxCssProp/constants.ts
@@ -2,6 +2,7 @@ import type { ProgramScope } from "../types.js";
 
 export const cssAttributeName = "css";
 export const classNameAttributeName = "className";
+export const styleAttributeName = "style";
 export const cssModuleName = "@mincho-js/css";
 
 export const fragmentTargetErrorMessage =
@@ -32,4 +33,6 @@ export const duplicateClassNameErrorMessage =
   "Mincho JSX css prop cannot merge duplicate className attributes";
 export const classNameValueErrorMessage =
   "Mincho JSX css prop requires className to be a string literal or expression";
+export const styleValueErrorMessage =
+  "Mincho JSX css prop requires style to be an expression value when merging dynamic CSS variables";
 export const cssModuleHelperImportCleanupScopes = new WeakSet<ProgramScope>();

--- a/packages/babel/src/jsxCssProp/preprocess.ts
+++ b/packages/babel/src/jsxCssProp/preprocess.ts
@@ -20,7 +20,10 @@ import {
 } from "./classification.js";
 import {
   createClassNameAttributeValue,
-  getClassNameExpression
+  createClassNameExpression,
+  getDynamicCssVariableRuntimeLowering,
+  getClassNameExpression,
+  registerDynamicCssVariableRuntimeLowering
 } from "./classNameLowering.js";
 import {
   classNameAttributeName,
@@ -34,11 +37,13 @@ import {
   fragmentTargetErrorMessage,
   keyRefSpreadErrorMessage,
   namespacedTargetErrorMessage,
+  styleAttributeName,
   unsupportedArraySpreadCssValueErrorMessage,
   unsupportedDynamicCssRuleValueErrorMessage,
   unsupportedFunctionCssValueErrorMessage,
   unsupportedTargetErrorMessage
 } from "./constants.js";
+import { getStyleExpression } from "./styleExpression.js";
 import {
   registerImportedStaticCssEvalProviderResultMetadata,
   registerStaticCssEvalDiagnosticMetadata,
@@ -56,17 +61,16 @@ import {
   transformSpreadAggregatedCssProp
 } from "./spreadAggregation.js";
 import type {
+  DynamicCssVariableBranchRule,
+  DynamicCssVariableDirectRule,
   DynamicCssVariableLowering,
   DynamicCssVariableLeaf,
   DynamicCssVariableRule,
   NormalizedJsxCssPropElement
 } from "./types.js";
 
-const styleAttributeName = "style";
 const duplicateStyleErrorMessage =
   "Mincho JSX css prop cannot merge duplicate style attributes";
-const styleValueErrorMessage =
-  "Mincho JSX css prop requires style to be an expression value when merging dynamic CSS variables";
 type DynamicCssVariableHelperImportBindings = {
   readonly createVarIdentifier: t.Identifier;
   readonly getVarNameIdentifier: t.Identifier;
@@ -75,6 +79,7 @@ const dynamicCssVariableHelperImportBindings = new WeakMap<
   ProgramScope,
   DynamicCssVariableHelperImportBindings
 >();
+const dynamicCssVariableCssImportScopes = new WeakSet<ProgramScope>();
 
 export function preprocessJsxCssProp(
   path: NodePath<t.Program>,
@@ -111,6 +116,19 @@ export function preprocessJsxCssProp(
 
       const dynamicCssVariableLowering =
         normalizedElement.dynamicCssVariableLowering;
+      const dynamicCssVariableRuntimeLowering = dynamicCssVariableLowering
+        ? getDynamicCssVariableRuntimeLowering(dynamicCssVariableLowering)
+        : null;
+
+      if (
+        dynamicCssVariableRuntimeLowering &&
+        dynamicCssVariableRuntimeLowering.declarations.length > 0
+      ) {
+        transformSpreadAggregatedCssProp(openingElementPath, normalizedElement);
+        transformed = true;
+        return;
+      }
+
       const classNameValue = dynamicCssVariableLowering
         ? createDynamicCssVariableClassNameAttributeValue(
             openingElementPath,
@@ -138,10 +156,14 @@ export function preprocessJsxCssProp(
       attributes.splice(attributes.indexOf(cssAttribute), 1);
 
       if (dynamicCssVariableLowering) {
+        const runtimeLowering = getDynamicCssVariableRuntimeLowering(
+          dynamicCssVariableLowering
+        );
         const styleAttributeValue = createDynamicCssVariableStyleAttributeValue(
           openingElementPath,
           styleAttribute,
-          dynamicCssVariableLowering.styleProperties
+          runtimeLowering?.styleProperties ??
+            dynamicCssVariableLowering.styleProperties
         );
 
         if (styleAttribute) {
@@ -332,7 +354,10 @@ function normalizeOpeningElement(
         path: openingElementPath,
         rule: dynamicCssVariableRule,
         needsClassNameMerge:
-          classNameAttributes.length > 0 || requiresSpreadAggregation
+          classNameAttributes.length > 0 ||
+          requiresSpreadAggregation ||
+          (dynamicCssVariableRule.kind === "branch" &&
+            (attributesBeforeCss.length > 0 || attributesAfterCss.length > 0))
       })
     : null;
 
@@ -363,11 +388,6 @@ function createDynamicCssVariableLowering(options: {
     : "$mincho$$unknown";
   const classNameIdentifier =
     programParent.generateUidIdentifier(identifierBase);
-  const cssIdentifier = registerImportMethod(
-    options.path,
-    "css",
-    cssModuleName
-  );
   const cxIdentifier = options.needsClassNameMerge
     ? programParent.generateUidIdentifier(`${identifierBase}Cx`)
     : null;
@@ -392,11 +412,6 @@ function createDynamicCssVariableLowering(options: {
       )
     };
   });
-  const importedClassNameIdentifier = registerImportMethod(
-    options.path,
-    classNameIdentifier.name,
-    programParent.minchoData.cssFile
-  );
   const importedCxIdentifier = cxIdentifier
     ? registerImportMethod(
         options.path,
@@ -420,35 +435,35 @@ function createDynamicCssVariableLowering(options: {
       helperImportBindings
     );
     cssModuleHelperImportCleanupScopes.add(programParent);
-    let cssBinding = programParent.getBinding(cssIdentifier.name);
-
-    if (!cssBinding) {
-      programParent.crawl();
-      cssBinding = programParent.getBinding(cssIdentifier.name);
-    }
-
-    invariant(
-      cssBinding !== undefined,
-      "Dynamic CSS variable lowering requires a registered css import binding"
-    );
-
-    programParent.minchoData.bindings.push(cssBinding.path);
-
-    const cssImportSpecifierPath = cssBinding.path;
-
-    invariant(
-      cssImportSpecifierPath.isImportSpecifier(),
-      "Dynamic CSS variable css import binding must be an import specifier"
-    );
 
     generatedNodes.push(
-      t.importDeclaration(
-        [t.cloneNode(cssImportSpecifierPath.node)],
-        t.stringLiteral(cssModuleName)
-      ),
       createDynamicCssVariableHelperImportDeclaration(helperImportBindings)
     );
   }
+
+  invariant(
+    helperImportBindings !== undefined,
+    "Dynamic CSS variable lowering requires helper import bindings"
+  );
+
+  const stylePropertyByLeaf = new Map<DynamicCssVariableLeaf, t.ObjectProperty>(
+    preparedLeaves.map(({ leaf, importedVariableKeyIdentifier }) => [
+      leaf,
+      t.objectProperty(
+        t.cloneNode(importedVariableKeyIdentifier),
+        t.cloneNode(leaf.value),
+        true
+      )
+    ])
+  );
+  const branchLowering =
+    options.rule.kind === "branch"
+      ? createDynamicCssVariableBranchLowering({
+          path: options.path,
+          rule: options.rule,
+          stylePropertyByLeaf
+        })
+      : null;
 
   generatedNodes.push(
     ...(cxIdentifier
@@ -479,33 +494,473 @@ function createDynamicCssVariableLowering(options: {
           )
         ])
       )
-    ),
-    t.exportNamedDeclaration(
-      t.variableDeclaration("var", [
-        t.variableDeclarator(
-          classNameIdentifier,
-          t.callExpression(t.cloneNode(cssIdentifier), [
-            t.cloneNode(options.rule.expression)
-          ])
-        )
-      ])
     )
   );
 
+  if (options.rule.kind === "direct") {
+    const cssIdentifier = registerImportMethod(
+      options.path,
+      "css",
+      cssModuleName
+    );
+
+    if (!dynamicCssVariableCssImportScopes.has(programParent)) {
+      generatedNodes.unshift(
+        createDynamicCssVariableCssImportDeclaration(
+          options.path,
+          cssIdentifier
+        )
+      );
+      dynamicCssVariableCssImportScopes.add(programParent);
+    }
+
+    generatedNodes.push(
+      t.exportNamedDeclaration(
+        t.variableDeclaration("var", [
+          t.variableDeclarator(
+            classNameIdentifier,
+            t.callExpression(t.cloneNode(cssIdentifier), [
+              t.cloneNode(options.rule.expression)
+            ])
+          )
+        ])
+      )
+    );
+  }
+
   programParent.minchoData.nodes.push(...generatedNodes);
+
+  if (branchLowering) {
+    return registerDynamicCssVariableRuntimeLowering(
+      {
+        classNameExpression: branchLowering.classNameExpression,
+        cxExpression: importedCxIdentifier,
+        styleProperties: []
+      },
+      {
+        declarations: branchLowering.declarations,
+        styleProperties: branchLowering.styleProperties
+      }
+    );
+  }
+
+  const importedClassNameIdentifier = registerImportMethod(
+    options.path,
+    classNameIdentifier.name,
+    programParent.minchoData.cssFile
+  );
 
   return {
     classNameExpression: importedClassNameIdentifier,
     cxExpression: importedCxIdentifier,
-    styleProperties: preparedLeaves.map(
-      ({ leaf, importedVariableKeyIdentifier }) =>
-        t.objectProperty(
-          t.cloneNode(importedVariableKeyIdentifier),
-          t.cloneNode(leaf.value),
-          true
-        )
+    styleProperties: options.rule.leaves.map((leaf) =>
+      cloneDynamicCssVariableStyleProperty(stylePropertyByLeaf, leaf)
     )
   };
+}
+
+function createDynamicCssVariableCssImportDeclaration(
+  path: NodePath<t.JSXOpeningElement>,
+  cssIdentifier: t.Identifier
+): t.ImportDeclaration {
+  const programParent = path.scope.getProgramParent() as ProgramScope;
+  let cssBinding = programParent.getBinding(cssIdentifier.name);
+
+  if (!cssBinding) {
+    programParent.crawl();
+    cssBinding = programParent.getBinding(cssIdentifier.name);
+  }
+
+  invariant(
+    cssBinding !== undefined,
+    "Dynamic CSS variable lowering requires a registered css import binding"
+  );
+
+  programParent.minchoData.bindings.push(cssBinding.path);
+
+  const cssImportSpecifierPath = cssBinding.path;
+
+  invariant(
+    cssImportSpecifierPath.isImportSpecifier(),
+    "Dynamic CSS variable css import binding must be an import specifier"
+  );
+
+  return t.importDeclaration(
+    [t.cloneNode(cssImportSpecifierPath.node)],
+    t.stringLiteral(cssModuleName)
+  );
+}
+
+function createDynamicCssVariableBranchLowering(options: {
+  readonly path: NodePath<t.JSXOpeningElement>;
+  readonly rule: DynamicCssVariableBranchRule;
+  readonly stylePropertyByLeaf: ReadonlyMap<
+    DynamicCssVariableLeaf,
+    t.ObjectProperty
+  >;
+}): {
+  readonly declarations: readonly t.VariableDeclaration[];
+  readonly classNameExpression: t.Expression;
+  readonly styleProperties: readonly t.ObjectExpression["properties"][number][];
+} {
+  const declarations: t.VariableDeclaration[] = [];
+  const decisionIdentifierByRule = new Map<
+    DynamicCssVariableBranchRule,
+    t.Identifier
+  >();
+  const branchRules: Array<{
+    readonly rule: DynamicCssVariableBranchRule;
+    readonly activeExpression: t.Expression | null;
+  }> = [{ rule: options.rule, activeExpression: null }];
+
+  for (const { rule, activeExpression } of branchRules) {
+    const decisionIdentifier =
+      options.path.scope.generateUidIdentifier("minchoCssBranch");
+    const decisionExpression =
+      createDynamicCssVariableBranchDecisionExpression(rule);
+
+    declarations.push(
+      t.variableDeclaration("const", [
+        t.variableDeclarator(
+          t.cloneNode(decisionIdentifier),
+          activeExpression
+            ? t.conditionalExpression(
+                t.cloneNode(activeExpression),
+                t.cloneNode(decisionExpression),
+                t.unaryExpression("void", t.numericLiteral(0))
+              )
+            : t.cloneNode(decisionExpression)
+        )
+      ])
+    );
+    decisionIdentifierByRule.set(rule, decisionIdentifier);
+
+    for (const [branchIndex, branch] of rule.branches.entries()) {
+      if (branch.kind === "branch") {
+        const branchActiveExpression =
+          createDynamicCssVariableNestedBranchActiveExpression(
+            rule,
+            decisionIdentifier,
+            branchIndex
+          );
+        branchRules.push({
+          rule: branch,
+          activeExpression: activeExpression
+            ? t.logicalExpression(
+                "&&",
+                t.cloneNode(activeExpression),
+                branchActiveExpression
+              )
+            : branchActiveExpression
+        });
+      }
+    }
+  }
+
+  const decisionIdentifier = getDynamicCssVariableBranchDecisionIdentifier(
+    decisionIdentifierByRule,
+    options.rule
+  );
+  const cssExpression = createDynamicCssVariableBranchClassNameExpression({
+    rule: options.rule,
+    decisionExpression: decisionIdentifier,
+    decisionIdentifierByRule
+  });
+  const classNameExpression = createClassNameExpression(options.path, {
+    cssExpression,
+    cssValueClassification: "branch-css-rule",
+    classNameAttribute: null
+  });
+  const styleProperties = [
+    t.spreadElement(
+      createDynamicCssVariableBranchStyleExpression({
+        rule: options.rule,
+        stylePropertyByLeaf: options.stylePropertyByLeaf,
+        decisionExpression: decisionIdentifier,
+        decisionIdentifierByRule
+      })
+    )
+  ];
+
+  return { declarations, classNameExpression, styleProperties };
+}
+
+function createDynamicCssVariableBranchDecisionExpression(
+  rule: DynamicCssVariableBranchRule
+): t.Expression {
+  if (t.isConditionalExpression(rule.expression)) {
+    return t.cloneNode(rule.expression.test);
+  }
+
+  return t.cloneNode(rule.expression.left);
+}
+
+function createDynamicCssVariableNestedBranchActiveExpression(
+  rule: DynamicCssVariableBranchRule,
+  decisionIdentifier: t.Identifier,
+  branchIndex: number
+): t.Expression {
+  if (t.isConditionalExpression(rule.expression)) {
+    return branchIndex === 0
+      ? t.cloneNode(decisionIdentifier)
+      : t.unaryExpression("!", t.cloneNode(decisionIdentifier));
+  }
+
+  if (rule.expression.operator === "&&") {
+    return t.cloneNode(decisionIdentifier);
+  }
+
+  if (rule.expression.operator === "??") {
+    return createDynamicCssVariableNullishDecisionExpression(
+      decisionIdentifier
+    );
+  }
+
+  return t.unaryExpression("!", t.cloneNode(decisionIdentifier));
+}
+
+function createDynamicCssVariableNullishDecisionExpression(
+  decisionExpression: t.Expression
+): t.LogicalExpression {
+  return t.logicalExpression(
+    "||",
+    t.binaryExpression("===", t.cloneNode(decisionExpression), t.nullLiteral()),
+    t.binaryExpression(
+      "===",
+      t.cloneNode(decisionExpression),
+      t.unaryExpression("void", t.numericLiteral(0))
+    )
+  );
+}
+
+function createDynamicCssVariableBranchClassNameExpression(options: {
+  readonly rule: DynamicCssVariableBranchRule;
+  readonly decisionExpression: t.Expression;
+  readonly decisionIdentifierByRule: ReadonlyMap<
+    DynamicCssVariableBranchRule,
+    t.Identifier
+  >;
+}): t.ConditionalExpression | t.LogicalExpression {
+  if (t.isConditionalExpression(options.rule.expression)) {
+    const consequent = options.rule.branches[0];
+    const alternate = options.rule.branches[1];
+
+    invariant(
+      consequent !== undefined && alternate !== undefined,
+      "Conditional dynamic CSS variable branch requires both branches"
+    );
+
+    return t.conditionalExpression(
+      t.cloneNode(options.decisionExpression),
+      createDynamicCssVariableRuleClassNameExpression(
+        consequent,
+        options.decisionIdentifierByRule
+      ),
+      createDynamicCssVariableRuleClassNameExpression(
+        alternate,
+        options.decisionIdentifierByRule
+      )
+    );
+  }
+
+  const right = options.rule.branches[0];
+
+  invariant(
+    right !== undefined,
+    "Logical dynamic CSS variable branch requires a right branch"
+  );
+
+  return t.logicalExpression(
+    options.rule.expression.operator,
+    t.cloneNode(options.decisionExpression),
+    createDynamicCssVariableRuleClassNameExpression(
+      right,
+      options.decisionIdentifierByRule
+    )
+  );
+}
+
+function createDynamicCssVariableRuleClassNameExpression(
+  rule: DynamicCssVariableRule,
+  decisionIdentifierByRule: ReadonlyMap<
+    DynamicCssVariableBranchRule,
+    t.Identifier
+  >
+): t.Expression {
+  if (rule.kind === "direct") {
+    return t.cloneNode(rule.expression);
+  }
+
+  return createDynamicCssVariableBranchClassNameExpression({
+    rule,
+    decisionExpression: getDynamicCssVariableBranchDecisionIdentifier(
+      decisionIdentifierByRule,
+      rule
+    ),
+    decisionIdentifierByRule
+  });
+}
+
+function getDynamicCssVariableBranchDecisionIdentifier(
+  decisionIdentifierByRule: ReadonlyMap<
+    DynamicCssVariableBranchRule,
+    t.Identifier
+  >,
+  rule: DynamicCssVariableBranchRule
+): t.Identifier {
+  const identifier = decisionIdentifierByRule.get(rule);
+
+  invariant(
+    identifier !== undefined,
+    "Dynamic CSS variable branch requires a prepared decision binding"
+  );
+
+  return identifier;
+}
+
+function createDynamicCssVariableBranchStyleExpression(options: {
+  readonly rule: DynamicCssVariableBranchRule;
+  readonly stylePropertyByLeaf: ReadonlyMap<
+    DynamicCssVariableLeaf,
+    t.ObjectProperty
+  >;
+  readonly decisionExpression: t.Expression;
+  readonly decisionIdentifierByRule: ReadonlyMap<
+    DynamicCssVariableBranchRule,
+    t.Identifier
+  >;
+}): t.Expression {
+  if (t.isConditionalExpression(options.rule.expression)) {
+    const consequent = options.rule.branches[0];
+    const alternate = options.rule.branches[1];
+
+    invariant(
+      consequent !== undefined && alternate !== undefined,
+      "Conditional dynamic CSS variable style requires both branches"
+    );
+
+    return t.conditionalExpression(
+      t.cloneNode(options.decisionExpression),
+      createDynamicCssVariableStyleObjectExpression({
+        rule: consequent,
+        stylePropertyByLeaf: options.stylePropertyByLeaf,
+        decisionExpression:
+          consequent.kind === "branch"
+            ? getDynamicCssVariableBranchDecisionIdentifier(
+                options.decisionIdentifierByRule,
+                consequent
+              )
+            : null,
+        decisionIdentifierByRule: options.decisionIdentifierByRule
+      }),
+      createDynamicCssVariableStyleObjectExpression({
+        rule: alternate,
+        stylePropertyByLeaf: options.stylePropertyByLeaf,
+        decisionExpression:
+          alternate.kind === "branch"
+            ? getDynamicCssVariableBranchDecisionIdentifier(
+                options.decisionIdentifierByRule,
+                alternate
+              )
+            : null,
+        decisionIdentifierByRule: options.decisionIdentifierByRule
+      })
+    );
+  }
+
+  const right = options.rule.branches[0];
+
+  invariant(
+    right !== undefined,
+    "Logical dynamic CSS variable style requires a right branch"
+  );
+
+  const decisionExpression = t.cloneNode(options.decisionExpression);
+  const rightStyle = createDynamicCssVariableStyleObjectExpression({
+    rule: right,
+    stylePropertyByLeaf: options.stylePropertyByLeaf,
+    decisionExpression:
+      right.kind === "branch"
+        ? getDynamicCssVariableBranchDecisionIdentifier(
+            options.decisionIdentifierByRule,
+            right
+          )
+        : null,
+    decisionIdentifierByRule: options.decisionIdentifierByRule
+  });
+  const emptyStyle = t.objectExpression([]);
+
+  if (options.rule.expression.operator === "&&") {
+    return t.conditionalExpression(decisionExpression, rightStyle, emptyStyle);
+  }
+
+  if (options.rule.expression.operator === "??") {
+    return t.conditionalExpression(
+      createDynamicCssVariableNullishDecisionExpression(decisionExpression),
+      rightStyle,
+      emptyStyle
+    );
+  }
+
+  return t.conditionalExpression(decisionExpression, emptyStyle, rightStyle);
+}
+
+function createDynamicCssVariableStyleObjectExpression(options: {
+  readonly rule: DynamicCssVariableRule;
+  readonly stylePropertyByLeaf: ReadonlyMap<
+    DynamicCssVariableLeaf,
+    t.ObjectProperty
+  >;
+  readonly decisionExpression: t.Expression | null;
+  readonly decisionIdentifierByRule: ReadonlyMap<
+    DynamicCssVariableBranchRule,
+    t.Identifier
+  >;
+}): t.ObjectExpression {
+  switch (options.rule.kind) {
+    case "direct":
+      return t.objectExpression(
+        options.rule.leaves.map((leaf) =>
+          cloneDynamicCssVariableStyleProperty(
+            options.stylePropertyByLeaf,
+            leaf
+          )
+        )
+      );
+    case "branch":
+      invariant(
+        options.decisionExpression !== null,
+        "Dynamic CSS variable branch style requires a decision expression"
+      );
+      return t.objectExpression([
+        t.spreadElement(
+          createDynamicCssVariableBranchStyleExpression({
+            rule: options.rule,
+            stylePropertyByLeaf: options.stylePropertyByLeaf,
+            decisionExpression: options.decisionExpression,
+            decisionIdentifierByRule: options.decisionIdentifierByRule
+          })
+        )
+      ]);
+    default: {
+      const exhaustive: never = options.rule;
+      return exhaustive;
+    }
+  }
+}
+
+function cloneDynamicCssVariableStyleProperty(
+  stylePropertyByLeaf: ReadonlyMap<DynamicCssVariableLeaf, t.ObjectProperty>,
+  leaf: DynamicCssVariableLeaf
+): t.ObjectProperty {
+  const property = stylePropertyByLeaf.get(leaf);
+
+  invariant(
+    property !== undefined,
+    "Dynamic CSS variable style property requires a prepared leaf"
+  );
+
+  return t.cloneNode(property);
 }
 
 function createDynamicCssVariableClassNameAttributeValue(
@@ -533,7 +988,7 @@ function createDynamicCssVariableClassNameAttributeValue(
 function createDynamicCssVariableStyleAttributeValue(
   path: NodePath<t.JSXOpeningElement>,
   styleAttribute: t.JSXAttribute | null,
-  styleProperties: readonly t.ObjectProperty[]
+  styleProperties: readonly t.ObjectExpression["properties"][number][]
 ): t.JSXAttribute["value"] {
   if (!styleAttribute) {
     return t.jsxExpressionContainer(
@@ -567,27 +1022,6 @@ function assertDynamicCssVariableStyleAttributeValue(
   getStyleExpression(path, styleAttribute);
 }
 
-function getStyleExpression(
-  path: NodePath<t.JSXOpeningElement>,
-  attribute: t.JSXAttribute
-): t.Expression {
-  if (attribute.value === null || t.isStringLiteral(attribute.value)) {
-    throw path.buildCodeFrameError(styleValueErrorMessage);
-  }
-
-  if (!t.isJSXExpressionContainer(attribute.value)) {
-    throw path.buildCodeFrameError(styleValueErrorMessage);
-  }
-
-  const { expression } = attribute.value;
-
-  if (t.isJSXEmptyExpression(expression) || t.isStringLiteral(expression)) {
-    throw path.buildCodeFrameError(styleValueErrorMessage);
-  }
-
-  return expression;
-}
-
 function createDynamicCssVariableCxExportDeclaration(
   exportedIdentifier: t.Identifier
 ): t.ExportNamedDeclaration {
@@ -616,7 +1050,20 @@ function createDynamicCssVariableHelperImportDeclaration(
   );
 }
 
-function getDynamicCssVariableRule(options: {
+export function getDynamicCssVariableRule(options: {
+  readonly expression: t.Expression;
+  readonly scope: NodePath<t.JSXOpeningElement>["scope"];
+}): DynamicCssVariableRule | null {
+  const rule = collectDynamicCssVariableRule(options);
+
+  if (!rule || rule.leaves.length === 0) {
+    return null;
+  }
+
+  return rule;
+}
+
+function collectDynamicCssVariableRule(options: {
   readonly expression: t.Expression;
   readonly scope: NodePath<t.JSXOpeningElement>["scope"];
 }): DynamicCssVariableRule | null {
@@ -624,24 +1071,105 @@ function getDynamicCssVariableRule(options: {
     options.expression
   );
 
-  const result = t.isObjectExpression(unwrappedExpression)
+  if (
+    t.isObjectExpression(unwrappedExpression) ||
+    t.isArrayExpression(unwrappedExpression)
+  ) {
+    return collectDirectDynamicCssVariableRule({
+      expression: unwrappedExpression,
+      scope: options.scope
+    });
+  }
+
+  if (t.isConditionalExpression(unwrappedExpression)) {
+    return collectConditionalDynamicCssVariableRule({
+      expression: unwrappedExpression,
+      scope: options.scope
+    });
+  }
+
+  if (t.isLogicalExpression(unwrappedExpression)) {
+    return collectLogicalDynamicCssVariableRule({
+      expression: unwrappedExpression,
+      scope: options.scope
+    });
+  }
+
+  return null;
+}
+
+function collectDirectDynamicCssVariableRule(options: {
+  readonly expression: t.ObjectExpression | t.ArrayExpression;
+  readonly scope: NodePath<t.JSXOpeningElement>["scope"];
+}): DynamicCssVariableDirectRule | null {
+  const result = t.isObjectExpression(options.expression)
     ? collectDynamicCssVariableObjectExpression({
-        expression: unwrappedExpression,
+        expression: options.expression,
         declarationName: null,
         scope: options.scope
       })
-    : t.isArrayExpression(unwrappedExpression)
-      ? collectDynamicCssVariableArrayExpression({
-          expression: unwrappedExpression,
-          scope: options.scope
-        })
-      : null;
+    : collectDynamicCssVariableArrayExpression({
+        expression: options.expression,
+        scope: options.scope
+      });
 
-  if (!result || result.leaves.length === 0) {
+  return result
+    ? { kind: "direct", expression: result.expression, leaves: result.leaves }
+    : null;
+}
+
+function collectConditionalDynamicCssVariableRule(options: {
+  readonly expression: t.ConditionalExpression;
+  readonly scope: NodePath<t.JSXOpeningElement>["scope"];
+}): DynamicCssVariableRule | null {
+  const consequent = collectDynamicCssVariableRule({
+    expression: options.expression.consequent,
+    scope: options.scope
+  });
+  const alternate = collectDynamicCssVariableRule({
+    expression: options.expression.alternate,
+    scope: options.scope
+  });
+
+  if (!consequent || !alternate) {
     return null;
   }
 
-  return result;
+  return {
+    kind: "branch",
+    expression: t.conditionalExpression(
+      t.cloneNode(options.expression.test),
+      t.cloneNode(consequent.expression),
+      t.cloneNode(alternate.expression)
+    ),
+    leaves: [...consequent.leaves, ...alternate.leaves],
+    branches: [consequent, alternate]
+  };
+}
+
+function collectLogicalDynamicCssVariableRule(options: {
+  readonly expression: t.LogicalExpression;
+  readonly scope: NodePath<t.JSXOpeningElement>["scope"];
+}): DynamicCssVariableRule | null {
+  const right = collectDynamicCssVariableRule({
+    expression: options.expression.right,
+    scope: options.scope
+  });
+
+  if (!right) {
+    return null;
+  }
+
+  return {
+    kind: "branch",
+    expression: t.logicalExpression(
+      options.expression.operator,
+      t.cloneNode(options.expression.left),
+      t.cloneNode(right.expression)
+    ),
+    leaves: right.leaves,
+    branches: [right]
+  };
 }
 
 type DynamicCssVariableObjectWalkResult = {
@@ -1155,7 +1683,7 @@ function isUnsupportedDynamicCssRuleCallExpression(options: {
 
   if (
     !t.isCallExpression(unwrappedExpression) ||
-    !isTopLevelCssRuleCallExpression(unwrappedExpression)
+    !isTopLevelCssRuleCallExpression(unwrappedExpression, options.scope)
   ) {
     return false;
   }
@@ -1189,7 +1717,16 @@ function containsDynamicCssVariableRuleBranch(options: {
 }): boolean {
   const expression = unwrapTransparentCssRuleExpression(options.expression);
 
-  if (t.isObjectExpression(expression) || t.isArrayExpression(expression)) {
+  if (t.isObjectExpression(expression)) {
+    return (
+      getDynamicCssVariableRule({
+        expression,
+        scope: options.scope
+      }) !== null || !isStaticCssShapeExpression(expression)
+    );
+  }
+
+  if (t.isArrayExpression(expression)) {
     return (
       getDynamicCssVariableRule({
         expression,

--- a/packages/babel/src/jsxCssProp/preprocess.ts
+++ b/packages/babel/src/jsxCssProp/preprocess.ts
@@ -8,11 +8,20 @@ import {
 import { resolveSameFileStaticCssEvalExpression } from "../staticCssEval/sameFile.js";
 import type { PluginState, ProgramScope } from "../types.js";
 import {
+  getNearestIdentifier,
+  invariant,
+  registerImportMethod
+} from "../utils.js";
+import {
   classifyCssPropValue,
   containsArraySpreadElement,
-  isArrayClassValueExpression
+  isArrayClassValueExpression,
+  isTopLevelCssRuleCallExpression
 } from "./classification.js";
-import { createClassNameAttributeValue } from "./classNameLowering.js";
+import {
+  createClassNameAttributeValue,
+  getClassNameExpression
+} from "./classNameLowering.js";
 import {
   classNameAttributeName,
   cssAttributeName,
@@ -46,7 +55,26 @@ import {
   assertSupportedSpreadAggregationContext,
   transformSpreadAggregatedCssProp
 } from "./spreadAggregation.js";
-import type { NormalizedJsxCssPropElement } from "./types.js";
+import type {
+  DynamicCssVariableLowering,
+  DynamicCssVariableLeaf,
+  DynamicCssVariableRule,
+  NormalizedJsxCssPropElement
+} from "./types.js";
+
+const styleAttributeName = "style";
+const duplicateStyleErrorMessage =
+  "Mincho JSX css prop cannot merge duplicate style attributes";
+const styleValueErrorMessage =
+  "Mincho JSX css prop requires style to be an expression value when merging dynamic CSS variables";
+type DynamicCssVariableHelperImportBindings = {
+  readonly createVarIdentifier: t.Identifier;
+  readonly getVarNameIdentifier: t.Identifier;
+};
+const dynamicCssVariableHelperImportBindings = new WeakMap<
+  ProgramScope,
+  DynamicCssVariableHelperImportBindings
+>();
 
 export function preprocessJsxCssProp(
   path: NodePath<t.Program>,
@@ -70,7 +98,8 @@ export function preprocessJsxCssProp(
         return;
       }
 
-      const { cssAttribute, classNameAttribute } = normalizedElement;
+      const { cssAttribute, classNameAttribute, styleAttribute } =
+        normalizedElement;
       if (
         normalizedElement.hasSpreadBeforeCss ||
         normalizedElement.hasSpreadAfterCss
@@ -80,10 +109,15 @@ export function preprocessJsxCssProp(
         return;
       }
 
-      const classNameValue = createClassNameAttributeValue(
-        openingElementPath,
-        normalizedElement
-      );
+      const dynamicCssVariableLowering =
+        normalizedElement.dynamicCssVariableLowering;
+      const classNameValue = dynamicCssVariableLowering
+        ? createDynamicCssVariableClassNameAttributeValue(
+            openingElementPath,
+            classNameAttribute,
+            dynamicCssVariableLowering
+          )
+        : createClassNameAttributeValue(openingElementPath, normalizedElement);
 
       const attributes = openingElementPath.node.attributes;
 
@@ -102,6 +136,26 @@ export function preprocessJsxCssProp(
       }
 
       attributes.splice(attributes.indexOf(cssAttribute), 1);
+
+      if (dynamicCssVariableLowering) {
+        const styleAttributeValue = createDynamicCssVariableStyleAttributeValue(
+          openingElementPath,
+          styleAttribute,
+          dynamicCssVariableLowering.styleProperties
+        );
+
+        if (styleAttribute) {
+          styleAttribute.value = styleAttributeValue;
+        } else {
+          attributes.push(
+            t.jsxAttribute(
+              t.jsxIdentifier(styleAttributeName),
+              styleAttributeValue
+            )
+          );
+        }
+      }
+
       transformed = true;
     }
   });
@@ -214,6 +268,7 @@ function normalizeOpeningElement(
     openingElement,
     classNameAttributeName
   );
+  const styleAttributes = getJsxAttributes(openingElement, styleAttributeName);
 
   if (classNameAttributes.length > 1) {
     throw openingElementPath.buildCodeFrameError(
@@ -221,12 +276,34 @@ function normalizeOpeningElement(
     );
   }
 
-  const cssExpression = getResolvedCssExpression(
+  const unresolvedCssExpression = getCssExpression(
     openingElementPath,
-    programPath,
-    state,
     cssAttribute
   );
+  const dynamicCssVariableRule = getDynamicCssVariableRule({
+    expression: unresolvedCssExpression,
+    scope: openingElementPath.scope
+  });
+
+  if (dynamicCssVariableRule && styleAttributes.length > 1) {
+    throw openingElementPath.buildCodeFrameError(duplicateStyleErrorMessage);
+  }
+
+  if (dynamicCssVariableRule) {
+    assertDynamicCssVariableStyleAttributeValue(
+      openingElementPath,
+      styleAttributes[0] ?? null
+    );
+  }
+
+  const cssExpression = dynamicCssVariableRule
+    ? dynamicCssVariableRule.expression
+    : getResolvedCssExpression(
+        openingElementPath,
+        programPath,
+        state,
+        cssAttribute
+      );
   const cssValueClassification = classifyCssPropValue(
     cssExpression,
     openingElementPath.scope
@@ -250,16 +327,664 @@ function normalizeOpeningElement(
     );
   }
 
+  const dynamicCssVariableLowering = dynamicCssVariableRule
+    ? createDynamicCssVariableLowering({
+        path: openingElementPath,
+        rule: dynamicCssVariableRule,
+        needsClassNameMerge:
+          classNameAttributes.length > 0 || requiresSpreadAggregation
+      })
+    : null;
+
   return {
     cssAttribute,
     cssExpression,
     cssValueClassification,
+    dynamicCssVariableRule,
+    dynamicCssVariableLowering,
     classNameAttribute: classNameAttributes[0] ?? null,
+    styleAttribute: styleAttributes[0] ?? null,
     attributesBeforeCss,
     attributesAfterCss,
     hasSpreadBeforeCss,
     hasSpreadAfterCss
   };
+}
+
+function createDynamicCssVariableLowering(options: {
+  readonly path: NodePath<t.JSXOpeningElement>;
+  readonly rule: DynamicCssVariableRule;
+  readonly needsClassNameMerge: boolean;
+}): DynamicCssVariableLowering {
+  const programParent = options.path.scope.getProgramParent() as ProgramScope;
+  const nearestIdentifier = getNearestIdentifier(options.path);
+  const identifierBase = nearestIdentifier
+    ? `$mincho$$${nearestIdentifier.node.name}`
+    : "$mincho$$unknown";
+  const classNameIdentifier =
+    programParent.generateUidIdentifier(identifierBase);
+  const cssIdentifier = registerImportMethod(
+    options.path,
+    "css",
+    cssModuleName
+  );
+  const cxIdentifier = options.needsClassNameMerge
+    ? programParent.generateUidIdentifier(`${identifierBase}Cx`)
+    : null;
+  const preparedLeaves = options.rule.leaves.map((leaf) => {
+    const propertyFragment = createIdentifierNameFragment(leaf.propertyName);
+    const variableIdentifier = programParent.generateUidIdentifier(
+      `${identifierBase}${propertyFragment}Var`
+    );
+    const variableKeyIdentifier = programParent.generateUidIdentifier(
+      `${identifierBase}${propertyFragment}VarKey`
+    );
+
+    leaf.variableIdentifier.name = variableIdentifier.name;
+
+    return {
+      leaf,
+      variableKeyIdentifier,
+      importedVariableKeyIdentifier: registerImportMethod(
+        options.path,
+        variableKeyIdentifier.name,
+        programParent.minchoData.cssFile
+      )
+    };
+  });
+  const importedClassNameIdentifier = registerImportMethod(
+    options.path,
+    classNameIdentifier.name,
+    programParent.minchoData.cssFile
+  );
+  const importedCxIdentifier = cxIdentifier
+    ? registerImportMethod(
+        options.path,
+        cxIdentifier.name,
+        programParent.minchoData.cssFile
+      )
+    : null;
+  const generatedNodes: t.Statement[] = [];
+  let helperImportBindings =
+    dynamicCssVariableHelperImportBindings.get(programParent);
+
+  if (!helperImportBindings) {
+    helperImportBindings = {
+      createVarIdentifier:
+        programParent.generateUidIdentifier("minchoCreateVar"),
+      getVarNameIdentifier:
+        programParent.generateUidIdentifier("minchoGetVarName")
+    };
+    dynamicCssVariableHelperImportBindings.set(
+      programParent,
+      helperImportBindings
+    );
+    cssModuleHelperImportCleanupScopes.add(programParent);
+    let cssBinding = programParent.getBinding(cssIdentifier.name);
+
+    if (!cssBinding) {
+      programParent.crawl();
+      cssBinding = programParent.getBinding(cssIdentifier.name);
+    }
+
+    invariant(
+      cssBinding !== undefined,
+      "Dynamic CSS variable lowering requires a registered css import binding"
+    );
+
+    programParent.minchoData.bindings.push(cssBinding.path);
+
+    const cssImportSpecifierPath = cssBinding.path;
+
+    invariant(
+      cssImportSpecifierPath.isImportSpecifier(),
+      "Dynamic CSS variable css import binding must be an import specifier"
+    );
+
+    generatedNodes.push(
+      t.importDeclaration(
+        [t.cloneNode(cssImportSpecifierPath.node)],
+        t.stringLiteral(cssModuleName)
+      ),
+      createDynamicCssVariableHelperImportDeclaration(helperImportBindings)
+    );
+  }
+
+  generatedNodes.push(
+    ...(cxIdentifier
+      ? [createDynamicCssVariableCxExportDeclaration(cxIdentifier)]
+      : []),
+    ...preparedLeaves.map(({ leaf }) =>
+      t.exportNamedDeclaration(
+        t.variableDeclaration("var", [
+          t.variableDeclarator(
+            t.cloneNode(leaf.variableIdentifier),
+            t.callExpression(
+              t.cloneNode(helperImportBindings.createVarIdentifier),
+              [t.stringLiteral(leaf.propertyName)]
+            )
+          )
+        ])
+      )
+    ),
+    ...preparedLeaves.map(({ leaf, variableKeyIdentifier }) =>
+      t.exportNamedDeclaration(
+        t.variableDeclaration("var", [
+          t.variableDeclarator(
+            variableKeyIdentifier,
+            t.callExpression(
+              t.cloneNode(helperImportBindings.getVarNameIdentifier),
+              [t.cloneNode(leaf.variableIdentifier)]
+            )
+          )
+        ])
+      )
+    ),
+    t.exportNamedDeclaration(
+      t.variableDeclaration("var", [
+        t.variableDeclarator(
+          classNameIdentifier,
+          t.callExpression(t.cloneNode(cssIdentifier), [
+            t.cloneNode(options.rule.expression)
+          ])
+        )
+      ])
+    )
+  );
+
+  programParent.minchoData.nodes.push(...generatedNodes);
+
+  return {
+    classNameExpression: importedClassNameIdentifier,
+    cxExpression: importedCxIdentifier,
+    styleProperties: preparedLeaves.map(
+      ({ leaf, importedVariableKeyIdentifier }) =>
+        t.objectProperty(
+          t.cloneNode(importedVariableKeyIdentifier),
+          t.cloneNode(leaf.value),
+          true
+        )
+    )
+  };
+}
+
+function createDynamicCssVariableClassNameAttributeValue(
+  path: NodePath<t.JSXOpeningElement>,
+  classNameAttribute: t.JSXAttribute | null,
+  lowering: DynamicCssVariableLowering
+): t.JSXAttribute["value"] {
+  if (!classNameAttribute) {
+    return t.jsxExpressionContainer(t.cloneNode(lowering.classNameExpression));
+  }
+
+  invariant(
+    lowering.cxExpression !== null,
+    "Dynamic CSS variable className merge requires a generated cx export"
+  );
+
+  return t.jsxExpressionContainer(
+    t.callExpression(t.cloneNode(lowering.cxExpression), [
+      getClassNameExpression(path, classNameAttribute),
+      t.cloneNode(lowering.classNameExpression)
+    ])
+  );
+}
+
+function createDynamicCssVariableStyleAttributeValue(
+  path: NodePath<t.JSXOpeningElement>,
+  styleAttribute: t.JSXAttribute | null,
+  styleProperties: readonly t.ObjectProperty[]
+): t.JSXAttribute["value"] {
+  if (!styleAttribute) {
+    return t.jsxExpressionContainer(
+      t.objectExpression(
+        styleProperties.map((property) => t.cloneNode(property))
+      )
+    );
+  }
+
+  const styleExpression = getStyleExpression(path, styleAttribute);
+  const userStyleProperties = t.isObjectExpression(styleExpression)
+    ? styleExpression.properties.map((property) => t.cloneNode(property))
+    : [t.spreadElement(t.cloneNode(styleExpression))];
+
+  return t.jsxExpressionContainer(
+    t.objectExpression([
+      ...userStyleProperties,
+      ...styleProperties.map((property) => t.cloneNode(property))
+    ])
+  );
+}
+
+function assertDynamicCssVariableStyleAttributeValue(
+  path: NodePath<t.JSXOpeningElement>,
+  styleAttribute: t.JSXAttribute | null
+): void {
+  if (!styleAttribute) {
+    return;
+  }
+
+  getStyleExpression(path, styleAttribute);
+}
+
+function getStyleExpression(
+  path: NodePath<t.JSXOpeningElement>,
+  attribute: t.JSXAttribute
+): t.Expression {
+  if (attribute.value === null || t.isStringLiteral(attribute.value)) {
+    throw path.buildCodeFrameError(styleValueErrorMessage);
+  }
+
+  if (!t.isJSXExpressionContainer(attribute.value)) {
+    throw path.buildCodeFrameError(styleValueErrorMessage);
+  }
+
+  const { expression } = attribute.value;
+
+  if (t.isJSXEmptyExpression(expression) || t.isStringLiteral(expression)) {
+    throw path.buildCodeFrameError(styleValueErrorMessage);
+  }
+
+  return expression;
+}
+
+function createDynamicCssVariableCxExportDeclaration(
+  exportedIdentifier: t.Identifier
+): t.ExportNamedDeclaration {
+  return t.exportNamedDeclaration(
+    null,
+    [t.exportSpecifier(t.identifier("cx"), t.cloneNode(exportedIdentifier))],
+    t.stringLiteral(cssModuleName)
+  );
+}
+
+function createDynamicCssVariableHelperImportDeclaration(
+  bindings: DynamicCssVariableHelperImportBindings
+): t.ImportDeclaration {
+  return t.importDeclaration(
+    [
+      t.importSpecifier(
+        t.cloneNode(bindings.createVarIdentifier),
+        t.identifier("createVar")
+      ),
+      t.importSpecifier(
+        t.cloneNode(bindings.getVarNameIdentifier),
+        t.identifier("getVarName")
+      )
+    ],
+    t.stringLiteral(cssModuleName)
+  );
+}
+
+function getDynamicCssVariableRule(options: {
+  readonly expression: t.Expression;
+  readonly scope: NodePath<t.JSXOpeningElement>["scope"];
+}): DynamicCssVariableRule | null {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(
+    options.expression
+  );
+
+  const result = t.isObjectExpression(unwrappedExpression)
+    ? collectDynamicCssVariableObjectExpression({
+        expression: unwrappedExpression,
+        declarationName: null,
+        scope: options.scope
+      })
+    : t.isArrayExpression(unwrappedExpression)
+      ? collectDynamicCssVariableArrayExpression({
+          expression: unwrappedExpression,
+          scope: options.scope
+        })
+      : null;
+
+  if (!result || result.leaves.length === 0) {
+    return null;
+  }
+
+  return result;
+}
+
+type DynamicCssVariableObjectWalkResult = {
+  readonly expression: t.ObjectExpression;
+  readonly leaves: DynamicCssVariableRule["leaves"];
+};
+
+type DynamicCssVariableArrayWalkResult = {
+  readonly expression: t.ArrayExpression;
+  readonly leaves: DynamicCssVariableRule["leaves"];
+};
+
+function collectDynamicCssVariableObjectExpression(options: {
+  readonly expression: t.ObjectExpression;
+  readonly declarationName: string | null;
+  readonly scope: NodePath<t.JSXOpeningElement>["scope"];
+}): DynamicCssVariableObjectWalkResult | null {
+  const properties: t.ObjectExpression["properties"] = [];
+  const leaves: DynamicCssVariableLeaf[] = [];
+
+  for (const property of options.expression.properties) {
+    if (
+      !t.isObjectProperty(property) ||
+      property.computed ||
+      property.shorthand ||
+      !t.isExpression(property.value)
+    ) {
+      return null;
+    }
+
+    const propertyName = getStaticObjectPropertyKeyName(property.key);
+
+    if (!propertyName) {
+      return null;
+    }
+
+    const value = unwrapTransparentCssRuleExpression(property.value);
+    const nextProperty = t.cloneNode(property);
+    nextProperty.shorthand = false;
+
+    if (t.isObjectExpression(value)) {
+      const nestedResult = collectDynamicCssVariableObjectExpression({
+        expression: value,
+        declarationName: getNestedDeclarationName({
+          propertyName,
+          declarationName: options.declarationName
+        }),
+        scope: options.scope
+      });
+
+      if (!nestedResult) {
+        return null;
+      }
+
+      nextProperty.value = nestedResult.expression;
+      properties.push(nextProperty);
+      leaves.push(...nestedResult.leaves);
+      continue;
+    }
+
+    if (t.isArrayExpression(value)) {
+      if (!isStaticCssShapeExpression(value)) {
+        return null;
+      }
+
+      nextProperty.value = t.cloneNode(property.value);
+      properties.push(nextProperty);
+      continue;
+    }
+
+    if (isStaticCssPrimitiveExpression(value)) {
+      nextProperty.value = t.cloneNode(property.value);
+      properties.push(nextProperty);
+      continue;
+    }
+
+    const leafPropertyName = getLeafDeclarationName({
+      propertyName,
+      declarationName: options.declarationName
+    });
+
+    if (
+      !leafPropertyName ||
+      !isSupportedDynamicCssVariableValueExpression({
+        expression: property.value,
+        scope: options.scope
+      })
+    ) {
+      return null;
+    }
+
+    const leaf = {
+      propertyName: leafPropertyName,
+      value: t.cloneNode(property.value),
+      variableIdentifier: t.identifier("minchoDynamicCssVariable")
+    };
+    nextProperty.value = leaf.variableIdentifier;
+    properties.push(nextProperty);
+    leaves.push(leaf);
+  }
+
+  return { expression: t.objectExpression(properties), leaves };
+}
+
+function collectDynamicCssVariableArrayExpression(options: {
+  readonly expression: t.ArrayExpression;
+  readonly scope: NodePath<t.JSXOpeningElement>["scope"];
+}): DynamicCssVariableArrayWalkResult | null {
+  const elements: t.ArrayExpression["elements"] = [];
+  const leaves: DynamicCssVariableLeaf[] = [];
+
+  for (const element of options.expression.elements) {
+    if (!element || t.isSpreadElement(element)) {
+      return null;
+    }
+
+    const value = unwrapTransparentCssRuleExpression(element);
+
+    if (!t.isObjectExpression(value)) {
+      return null;
+    }
+
+    const elementResult = collectDynamicCssVariableObjectExpression({
+      expression: value,
+      declarationName: null,
+      scope: options.scope
+    });
+
+    if (!elementResult) {
+      return null;
+    }
+
+    elements.push(elementResult.expression);
+    leaves.push(...elementResult.leaves);
+  }
+
+  return { expression: t.arrayExpression(elements), leaves };
+}
+
+function getNestedDeclarationName(options: {
+  readonly propertyName: string;
+  readonly declarationName: string | null;
+}): string | null {
+  if (options.declarationName) {
+    return options.declarationName;
+  }
+
+  return isNestedCssObjectKey(options.propertyName)
+    ? null
+    : options.propertyName;
+}
+
+function getLeafDeclarationName(options: {
+  readonly propertyName: string;
+  readonly declarationName: string | null;
+}): string | null {
+  return (
+    options.declarationName ??
+    (isNestedCssObjectKey(options.propertyName) ? null : options.propertyName)
+  );
+}
+
+function isNestedCssObjectKey(propertyName: string): boolean {
+  return (
+    propertyName === "selectors" ||
+    propertyName === "vars" ||
+    propertyName.startsWith("@") ||
+    propertyName.startsWith("_") ||
+    propertyName.startsWith("$") ||
+    propertyName.includes("&") ||
+    propertyName.includes(":") ||
+    propertyName.includes(" ")
+  );
+}
+
+function isSupportedDynamicCssVariableValueExpression(options: {
+  readonly expression: t.Expression;
+  readonly scope: NodePath<t.JSXOpeningElement>["scope"];
+}): boolean {
+  const expression = unwrapTransparentCssRuleExpression(options.expression);
+
+  if (!isDirectMemberReferenceExpression(expression)) {
+    return false;
+  }
+
+  const rootIdentifier = getDirectReferenceRootIdentifier(expression.object);
+
+  return rootIdentifier
+    ? !isImportedBindingIdentifier(options.scope, rootIdentifier)
+    : true;
+}
+
+function isDirectMemberReferenceExpression(
+  expression: t.Expression
+): expression is t.MemberExpression | t.OptionalMemberExpression {
+  if (t.isMemberExpression(expression)) {
+    return (
+      !expression.computed &&
+      isDirectReferenceObjectExpression(expression.object)
+    );
+  }
+
+  if (t.isOptionalMemberExpression(expression)) {
+    return (
+      !expression.computed &&
+      isDirectReferenceObjectExpression(expression.object)
+    );
+  }
+
+  return false;
+}
+
+function isDirectReferenceExpression(expression: t.Expression): boolean {
+  if (t.isIdentifier(expression) || t.isThisExpression(expression)) {
+    return true;
+  }
+
+  return isDirectMemberReferenceExpression(expression);
+}
+
+function isDirectReferenceObjectExpression(
+  expression: t.Expression | t.Super
+): boolean {
+  return !t.isSuper(expression) && isDirectReferenceExpression(expression);
+}
+
+function getDirectReferenceRootIdentifier(
+  expression: t.Expression | t.Super
+): t.Identifier | null {
+  if (t.isSuper(expression) || t.isThisExpression(expression)) {
+    return null;
+  }
+
+  if (t.isIdentifier(expression)) {
+    return expression;
+  }
+
+  if (!isDirectMemberReferenceExpression(expression)) {
+    return null;
+  }
+
+  return getDirectReferenceRootIdentifier(expression.object);
+}
+
+function isImportedBindingIdentifier(
+  scope: NodePath<t.JSXOpeningElement>["scope"],
+  identifier: t.Identifier
+): boolean {
+  const binding = scope.getBinding(identifier.name);
+  const bindingPath = binding?.path;
+
+  return !!(
+    bindingPath &&
+    (bindingPath.isImportSpecifier() ||
+      bindingPath.isImportDefaultSpecifier() ||
+      bindingPath.isImportNamespaceSpecifier())
+  );
+}
+
+function isStaticCssShapeExpression(expression: t.Expression): boolean {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(expression);
+
+  if (isStaticCssPrimitiveExpression(unwrappedExpression)) {
+    return true;
+  }
+
+  if (t.isObjectExpression(unwrappedExpression)) {
+    return unwrappedExpression.properties.every((property) => {
+      return (
+        t.isObjectProperty(property) &&
+        !property.computed &&
+        !property.shorthand &&
+        !!getStaticObjectPropertyKeyName(property.key) &&
+        t.isExpression(property.value) &&
+        isStaticCssShapeExpression(property.value)
+      );
+    });
+  }
+
+  if (t.isArrayExpression(unwrappedExpression)) {
+    return unwrappedExpression.elements.every((element) => {
+      return (
+        !!element &&
+        !t.isSpreadElement(element) &&
+        isStaticCssShapeExpression(element)
+      );
+    });
+  }
+
+  return false;
+}
+
+function isStaticCssPrimitiveExpression(expression: t.Expression): boolean {
+  return (
+    t.isStringLiteral(expression) ||
+    t.isNumericLiteral(expression) ||
+    t.isBooleanLiteral(expression) ||
+    t.isNullLiteral(expression) ||
+    isUnaryNumericLiteral(expression) ||
+    (t.isTemplateLiteral(expression) && expression.expressions.length === 0)
+  );
+}
+
+function isUnaryNumericLiteral(
+  expression: t.Expression
+): expression is t.UnaryExpression & { argument: t.NumericLiteral } {
+  return (
+    t.isUnaryExpression(expression) &&
+    (expression.operator === "+" || expression.operator === "-") &&
+    t.isNumericLiteral(expression.argument)
+  );
+}
+
+function createIdentifierNameFragment(value: string): string {
+  const fragments = value.match(/[A-Za-z0-9_$]+/g);
+
+  if (!fragments) {
+    return "Value";
+  }
+
+  return fragments.map(capitalizeIdentifierFragment).join("");
+}
+
+function capitalizeIdentifierFragment(fragment: string): string {
+  return `${fragment.charAt(0).toUpperCase()}${fragment.slice(1)}`;
+}
+
+function getStaticObjectPropertyKeyName(
+  key: t.ObjectProperty["key"]
+): string | null {
+  if (t.isIdentifier(key)) {
+    return key.name;
+  }
+
+  if (t.isStringLiteral(key)) {
+    return key.value;
+  }
+
+  if (t.isNumericLiteral(key)) {
+    return String(key.value);
+  }
+
+  return null;
 }
 
 function getResolvedCssExpression(
@@ -399,7 +1124,107 @@ function getResolvedCssExpression(
     );
   }
 
+  if (
+    containsDynamicCssVariableRuleBranch({
+      expression: resolvedCssExpression,
+      scope: path.scope
+    })
+  ) {
+    throw path.buildCodeFrameError(unsupportedDynamicCssRuleValueErrorMessage);
+  }
+
+  if (
+    isUnsupportedDynamicCssRuleCallExpression({
+      expression: resolvedCssExpression,
+      scope: path.scope
+    })
+  ) {
+    throw path.buildCodeFrameError(unsupportedDynamicCssRuleValueErrorMessage);
+  }
+
   return resolvedCssExpression;
+}
+
+function isUnsupportedDynamicCssRuleCallExpression(options: {
+  readonly expression: t.Expression;
+  readonly scope: NodePath<t.JSXOpeningElement>["scope"];
+}): boolean {
+  const unwrappedExpression = unwrapTransparentCssRuleExpression(
+    options.expression
+  );
+
+  if (
+    !t.isCallExpression(unwrappedExpression) ||
+    !isTopLevelCssRuleCallExpression(unwrappedExpression)
+  ) {
+    return false;
+  }
+
+  if (
+    t.isMemberExpression(unwrappedExpression.callee) ||
+    t.isOptionalMemberExpression(unwrappedExpression.callee)
+  ) {
+    const rootIdentifier = getDirectReferenceRootIdentifier(
+      unwrappedExpression.callee.object
+    );
+    const bindingPath = rootIdentifier
+      ? options.scope.getBinding(rootIdentifier.name)?.path
+      : null;
+
+    return !bindingPath?.isVariableDeclarator();
+  }
+
+  return unwrappedExpression.arguments.some((argument) => {
+    return (
+      t.isSpreadElement(argument) ||
+      !t.isExpression(argument) ||
+      !isStaticCssShapeExpression(argument)
+    );
+  });
+}
+
+function containsDynamicCssVariableRuleBranch(options: {
+  readonly expression: t.Expression;
+  readonly scope: NodePath<t.JSXOpeningElement>["scope"];
+}): boolean {
+  const expression = unwrapTransparentCssRuleExpression(options.expression);
+
+  if (t.isObjectExpression(expression) || t.isArrayExpression(expression)) {
+    return (
+      getDynamicCssVariableRule({
+        expression,
+        scope: options.scope
+      }) !== null
+    );
+  }
+
+  if (t.isConditionalExpression(expression)) {
+    return (
+      containsDynamicCssVariableRuleBranch({
+        expression: expression.consequent,
+        scope: options.scope
+      }) ||
+      containsDynamicCssVariableRuleBranch({
+        expression: expression.alternate,
+        scope: options.scope
+      })
+    );
+  }
+
+  if (t.isLogicalExpression(expression)) {
+    return (
+      containsDynamicCssVariableRuleBranch({
+        expression: expression.left,
+        scope: options.scope
+      }) ||
+      containsDynamicCssVariableRuleBranch({
+        expression: expression.right,
+        scope: options.scope
+      })
+    );
+  }
+
+  return false;
 }
 
 function getStaticCssEvalOwnerFile(state: PluginState): string {

--- a/packages/babel/src/jsxCssProp/spreadAggregation.ts
+++ b/packages/babel/src/jsxCssProp/spreadAggregation.ts
@@ -3,6 +3,7 @@ import type { NodePath } from "@babel/core";
 import { invariant } from "../utils.js";
 import {
   createClassNameExpression,
+  getDynamicCssVariableRuntimeLowering,
   getClassNameExpression
 } from "./classNameLowering.js";
 import {
@@ -10,17 +11,15 @@ import {
   classNameValueErrorMessage,
   cssAttributeName,
   nestedAsyncGeneratorErrorMessage,
-  spreadAggregationContextErrorMessage
+  spreadAggregationContextErrorMessage,
+  styleAttributeName
 } from "./constants.js";
+import { getStyleExpression } from "./styleExpression.js";
 import type {
   AggregatePropsBinding,
   NormalizedJsxCssPropElement,
   SpreadAggregatedCssPropLowering
 } from "./types.js";
-
-const styleAttributeName = "style";
-const styleValueErrorMessage =
-  "Mincho JSX css prop requires style to be an expression value when merging dynamic CSS variables";
 
 export function transformSpreadAggregatedCssProp(
   path: NodePath<t.JSXOpeningElement>,
@@ -254,6 +253,14 @@ function createDynamicCssVariableSpreadAggregatedCssPropLowering(
   path: NodePath<t.JSXOpeningElement>,
   normalizedElement: NormalizedJsxCssPropElement
 ): SpreadAggregatedCssPropLowering {
+  const lowering = normalizedElement.dynamicCssVariableLowering;
+
+  invariant(
+    lowering !== null,
+    "Dynamic CSS variable spread aggregation requires dynamic lowering"
+  );
+
+  const runtimeLowering = getDynamicCssVariableRuntimeLowering(lowering);
   const preCssBinding =
     normalizedElement.attributesBeforeCss.length > 0
       ? createAggregatePropsBindingWithStyle(
@@ -294,6 +301,7 @@ function createDynamicCssVariableSpreadAggregatedCssPropLowering(
   return {
     declarations: [
       ...(preCssBinding?.declarations ?? []),
+      ...(runtimeLowering?.declarations ?? []),
       ...(postCssBinding?.declarations ?? [])
     ],
     attributes: [
@@ -349,6 +357,10 @@ function createDynamicCssVariableStyleExpression(
     "Dynamic CSS variable spread aggregation requires dynamic lowering"
   );
 
+  const runtimeLowering = getDynamicCssVariableRuntimeLowering(lowering);
+  const styleProperties =
+    runtimeLowering?.styleProperties ?? lowering.styleProperties;
+
   return t.objectExpression([
     ...(preCssBinding?.styleExpressions.map((expression) =>
       t.spreadElement(t.cloneNode(expression))
@@ -356,7 +368,7 @@ function createDynamicCssVariableStyleExpression(
     ...(postCssBinding?.styleExpressions.map((expression) =>
       t.spreadElement(t.cloneNode(expression))
     ) ?? []),
-    ...lowering.styleProperties.map((property) => t.cloneNode(property))
+    ...styleProperties.map((property) => t.cloneNode(property))
   ]);
 }
 
@@ -622,7 +634,7 @@ function createAggregatePropsExpressionWithStyle(
           t.assignmentExpression(
             "=",
             t.cloneNode(explicitStyleIdentifier),
-            getStyleExpression(path, attribute)
+            t.cloneNode(getStyleExpression(path, attribute))
           )
         )
       );
@@ -695,27 +707,6 @@ function getAggregateAttributeValue(
   }
 
   throw path.buildCodeFrameError(classNameValueErrorMessage);
-}
-
-function getStyleExpression(
-  path: NodePath<t.JSXOpeningElement>,
-  attribute: t.JSXAttribute
-): t.Expression {
-  if (attribute.value === null || t.isStringLiteral(attribute.value)) {
-    throw path.buildCodeFrameError(styleValueErrorMessage);
-  }
-
-  if (!t.isJSXExpressionContainer(attribute.value)) {
-    throw path.buildCodeFrameError(styleValueErrorMessage);
-  }
-
-  const { expression } = attribute.value;
-
-  if (t.isJSXEmptyExpression(expression) || t.isStringLiteral(expression)) {
-    throw path.buildCodeFrameError(styleValueErrorMessage);
-  }
-
-  return t.cloneNode(expression);
 }
 
 function isNamedJsxAttribute(

--- a/packages/babel/src/jsxCssProp/spreadAggregation.ts
+++ b/packages/babel/src/jsxCssProp/spreadAggregation.ts
@@ -1,5 +1,6 @@
 import { types as t } from "@babel/core";
 import type { NodePath } from "@babel/core";
+import { invariant } from "../utils.js";
 import {
   createClassNameExpression,
   getClassNameExpression
@@ -16,6 +17,10 @@ import type {
   NormalizedJsxCssPropElement,
   SpreadAggregatedCssPropLowering
 } from "./types.js";
+
+const styleAttributeName = "style";
+const styleValueErrorMessage =
+  "Mincho JSX css prop requires style to be an expression value when merging dynamic CSS variables";
 
 export function transformSpreadAggregatedCssProp(
   path: NodePath<t.JSXOpeningElement>,
@@ -115,6 +120,13 @@ function createPreCssSpreadAggregatedCssPropLowering(
   path: NodePath<t.JSXOpeningElement>,
   normalizedElement: NormalizedJsxCssPropElement
 ): SpreadAggregatedCssPropLowering {
+  if (normalizedElement.dynamicCssVariableLowering) {
+    return createDynamicCssVariableSpreadAggregatedCssPropLowering(
+      path,
+      normalizedElement
+    );
+  }
+
   const preCssBinding = createAggregatePropsBinding(
     path,
     normalizedElement.attributesBeforeCss,
@@ -155,6 +167,13 @@ function createPostCssSpreadAggregatedCssPropLowering(
   path: NodePath<t.JSXOpeningElement>,
   normalizedElement: NormalizedJsxCssPropElement
 ): SpreadAggregatedCssPropLowering {
+  if (normalizedElement.dynamicCssVariableLowering) {
+    return createDynamicCssVariableSpreadAggregatedCssPropLowering(
+      path,
+      normalizedElement
+    );
+  }
+
   const preCssBinding =
     normalizedElement.attributesBeforeCss.length > 0
       ? createAggregatePropsBinding(
@@ -231,6 +250,116 @@ function createPostCssSpreadAggregatedCssPropLowering(
   };
 }
 
+function createDynamicCssVariableSpreadAggregatedCssPropLowering(
+  path: NodePath<t.JSXOpeningElement>,
+  normalizedElement: NormalizedJsxCssPropElement
+): SpreadAggregatedCssPropLowering {
+  const preCssBinding =
+    normalizedElement.attributesBeforeCss.length > 0
+      ? createAggregatePropsBindingWithStyle(
+          path,
+          normalizedElement.attributesBeforeCss,
+          "minchoPre"
+        )
+      : null;
+  const postCssBinding =
+    normalizedElement.attributesAfterCss.length > 0
+      ? createAggregatePropsBindingWithStyle(
+          path,
+          normalizedElement.attributesAfterCss,
+          preCssBinding ? "minchoPost" : "mincho"
+        )
+      : null;
+  const classNameAttribute = t.jsxAttribute(
+    t.jsxIdentifier(classNameAttributeName),
+    t.jsxExpressionContainer(
+      createDynamicCssVariableClassNameExpression(
+        normalizedElement,
+        preCssBinding,
+        postCssBinding
+      )
+    )
+  );
+  const styleAttribute = t.jsxAttribute(
+    t.jsxIdentifier(styleAttributeName),
+    t.jsxExpressionContainer(
+      createDynamicCssVariableStyleExpression(
+        normalizedElement,
+        preCssBinding,
+        postCssBinding
+      )
+    )
+  );
+
+  return {
+    declarations: [
+      ...(preCssBinding?.declarations ?? []),
+      ...(postCssBinding?.declarations ?? [])
+    ],
+    attributes: [
+      ...(preCssBinding
+        ? [t.jsxSpreadAttribute(t.cloneNode(preCssBinding.restIdentifier))]
+        : []),
+      ...(postCssBinding
+        ? [t.jsxSpreadAttribute(t.cloneNode(postCssBinding.restIdentifier))]
+        : []),
+      classNameAttribute,
+      styleAttribute
+    ]
+  };
+}
+
+function createDynamicCssVariableClassNameExpression(
+  normalizedElement: NormalizedJsxCssPropElement,
+  preCssBinding: AggregatePropsBinding | null,
+  postCssBinding: AggregatePropsBinding | null
+): t.Expression {
+  const lowering = normalizedElement.dynamicCssVariableLowering;
+
+  invariant(
+    lowering !== null,
+    "Dynamic CSS variable spread aggregation requires dynamic lowering"
+  );
+
+  if (!preCssBinding && !postCssBinding) {
+    return t.cloneNode(lowering.classNameExpression);
+  }
+
+  invariant(
+    lowering.cxExpression !== null,
+    "Dynamic CSS variable spread aggregation requires generated cx"
+  );
+
+  return t.callExpression(t.cloneNode(lowering.cxExpression), [
+    ...(preCssBinding ? [t.cloneNode(preCssBinding.classNameIdentifier)] : []),
+    t.cloneNode(lowering.classNameExpression),
+    ...(postCssBinding ? [t.cloneNode(postCssBinding.classNameIdentifier)] : [])
+  ]);
+}
+
+function createDynamicCssVariableStyleExpression(
+  normalizedElement: NormalizedJsxCssPropElement,
+  preCssBinding: AggregatePropsBinding | null,
+  postCssBinding: AggregatePropsBinding | null
+): t.ObjectExpression {
+  const lowering = normalizedElement.dynamicCssVariableLowering;
+
+  invariant(
+    lowering !== null,
+    "Dynamic CSS variable spread aggregation requires dynamic lowering"
+  );
+
+  return t.objectExpression([
+    ...(preCssBinding?.styleExpressions.map((expression) =>
+      t.spreadElement(t.cloneNode(expression))
+    ) ?? []),
+    ...(postCssBinding?.styleExpressions.map((expression) =>
+      t.spreadElement(t.cloneNode(expression))
+    ) ?? []),
+    ...lowering.styleProperties.map((property) => t.cloneNode(property))
+  ]);
+}
+
 export function createAggregatePropsBinding(
   path: NodePath<t.JSXOpeningElement>,
   attributes: readonly (t.JSXAttribute | t.JSXSpreadAttribute)[],
@@ -273,7 +402,66 @@ export function createAggregatePropsBinding(
       ])
     ],
     classNameIdentifier,
-    restIdentifier
+    restIdentifier,
+    styleExpressions: []
+  };
+}
+
+function createAggregatePropsBindingWithStyle(
+  path: NodePath<t.JSXOpeningElement>,
+  attributes: readonly (t.JSXAttribute | t.JSXSpreadAttribute)[],
+  uidPrefix: string
+): AggregatePropsBinding {
+  const aggregateIdentifier = path.scope.generateUidIdentifier(
+    `${uidPrefix}Props`
+  );
+  const cssPropIdentifier = path.scope.generateUidIdentifier(
+    `${uidPrefix}CssProp`
+  );
+  const classNameIdentifier = path.scope.generateUidIdentifier(
+    `${uidPrefix}ClassName`
+  );
+  const styleIdentifier = path.scope.generateUidIdentifier(`${uidPrefix}Style`);
+  const restIdentifier = path.scope.generateUidIdentifier(`${uidPrefix}Rest`);
+  const aggregateExpression = createAggregatePropsExpressionWithStyle(
+    path,
+    attributes,
+    uidPrefix
+  );
+
+  return {
+    declarations: [
+      ...aggregateExpression.declarations,
+      t.variableDeclaration("const", [
+        t.variableDeclarator(
+          t.cloneNode(aggregateIdentifier),
+          aggregateExpression.expression
+        )
+      ]),
+      t.variableDeclaration("const", [
+        t.variableDeclarator(
+          t.objectPattern([
+            t.objectProperty(
+              t.identifier(cssAttributeName),
+              t.cloneNode(cssPropIdentifier)
+            ),
+            t.objectProperty(
+              t.identifier(classNameAttributeName),
+              t.cloneNode(classNameIdentifier)
+            ),
+            t.objectProperty(
+              t.identifier(styleAttributeName),
+              t.cloneNode(styleIdentifier)
+            ),
+            t.restElement(t.cloneNode(restIdentifier))
+          ]),
+          t.cloneNode(aggregateIdentifier)
+        )
+      ])
+    ],
+    classNameIdentifier,
+    restIdentifier,
+    styleExpressions: aggregateExpression.styleExpressions
   };
 }
 
@@ -374,6 +562,84 @@ export function createAggregatePropsExpression(
   );
 }
 
+type AggregatePropsExpressionWithStyle = {
+  readonly declarations: t.VariableDeclaration[];
+  readonly expression: t.ObjectExpression;
+  readonly styleExpressions: readonly t.Expression[];
+};
+
+function createAggregatePropsExpressionWithStyle(
+  path: NodePath<t.JSXOpeningElement>,
+  attributes: readonly (t.JSXAttribute | t.JSXSpreadAttribute)[],
+  uidPrefix: string
+): AggregatePropsExpressionWithStyle {
+  const declarations: t.VariableDeclaration[] = [];
+  const properties: t.ObjectExpression["properties"] = [];
+  const styleExpressions: t.Expression[] = [];
+
+  for (const attribute of attributes) {
+    if (t.isJSXSpreadAttribute(attribute)) {
+      const spreadIdentifier = path.scope.generateUidIdentifier(
+        `${uidPrefix}Spread`
+      );
+      declarations.push(
+        t.variableDeclaration("let", [
+          t.variableDeclarator(t.cloneNode(spreadIdentifier))
+        ])
+      );
+      properties.push(
+        t.spreadElement(
+          t.assignmentExpression(
+            "=",
+            t.cloneNode(spreadIdentifier),
+            t.objectExpression([
+              t.spreadElement(t.cloneNode(attribute.argument))
+            ])
+          )
+        )
+      );
+      styleExpressions.push(
+        t.memberExpression(
+          t.cloneNode(spreadIdentifier),
+          t.identifier(styleAttributeName)
+        )
+      );
+      continue;
+    }
+
+    if (isNamedJsxAttribute(attribute, styleAttributeName)) {
+      const explicitStyleIdentifier = path.scope.generateUidIdentifier(
+        `${uidPrefix}Style`
+      );
+      declarations.push(
+        t.variableDeclaration("let", [
+          t.variableDeclarator(t.cloneNode(explicitStyleIdentifier))
+        ])
+      );
+      properties.push(
+        t.objectProperty(
+          t.identifier(styleAttributeName),
+          t.assignmentExpression(
+            "=",
+            t.cloneNode(explicitStyleIdentifier),
+            getStyleExpression(path, attribute)
+          )
+        )
+      );
+      styleExpressions.push(t.cloneNode(explicitStyleIdentifier));
+      continue;
+    }
+
+    properties.push(createAggregateObjectProperty(path, attribute));
+  }
+
+  return {
+    declarations,
+    expression: t.objectExpression(properties),
+    styleExpressions
+  };
+}
+
 function createAggregateObjectProperty(
   path: NodePath<t.JSXOpeningElement>,
   attribute: t.JSXAttribute
@@ -429,6 +695,27 @@ function getAggregateAttributeValue(
   }
 
   throw path.buildCodeFrameError(classNameValueErrorMessage);
+}
+
+function getStyleExpression(
+  path: NodePath<t.JSXOpeningElement>,
+  attribute: t.JSXAttribute
+): t.Expression {
+  if (attribute.value === null || t.isStringLiteral(attribute.value)) {
+    throw path.buildCodeFrameError(styleValueErrorMessage);
+  }
+
+  if (!t.isJSXExpressionContainer(attribute.value)) {
+    throw path.buildCodeFrameError(styleValueErrorMessage);
+  }
+
+  const { expression } = attribute.value;
+
+  if (t.isJSXEmptyExpression(expression) || t.isStringLiteral(expression)) {
+    throw path.buildCodeFrameError(styleValueErrorMessage);
+  }
+
+  return t.cloneNode(expression);
 }
 
 function isNamedJsxAttribute(

--- a/packages/babel/src/jsxCssProp/styleExpression.ts
+++ b/packages/babel/src/jsxCssProp/styleExpression.ts
@@ -1,0 +1,28 @@
+import { types as t } from "@babel/core";
+import type { NodePath } from "@babel/core";
+import { styleValueErrorMessage } from "./constants.js";
+
+export function getStyleExpression(
+  path: NodePath<t.JSXOpeningElement>,
+  attribute: t.JSXAttribute
+): t.Expression {
+  if (attribute.value === null || t.isStringLiteral(attribute.value)) {
+    throw path.buildCodeFrameError(styleValueErrorMessage);
+  }
+
+  if (!t.isJSXExpressionContainer(attribute.value)) {
+    throw path.buildCodeFrameError(styleValueErrorMessage);
+  }
+
+  const { expression } = attribute.value;
+
+  if (
+    t.isJSXEmptyExpression(expression) ||
+    t.isStringLiteral(expression) ||
+    t.isTemplateLiteral(expression)
+  ) {
+    throw path.buildCodeFrameError(styleValueErrorMessage);
+  }
+
+  return expression;
+}

--- a/packages/babel/src/jsxCssProp/types.ts
+++ b/packages/babel/src/jsxCssProp/types.ts
@@ -58,10 +58,22 @@ export type DynamicCssVariableLeaf = {
   readonly variableIdentifier: t.Identifier;
 };
 
-export type DynamicCssVariableRule = {
+export type DynamicCssVariableDirectRule = {
+  readonly kind: "direct";
   readonly expression: t.ObjectExpression | t.ArrayExpression;
   readonly leaves: readonly DynamicCssVariableLeaf[];
 };
+
+export type DynamicCssVariableBranchRule = {
+  readonly kind: "branch";
+  readonly expression: t.ConditionalExpression | t.LogicalExpression;
+  readonly leaves: readonly DynamicCssVariableLeaf[];
+  readonly branches: readonly DynamicCssVariableRule[];
+};
+
+export type DynamicCssVariableRule =
+  | DynamicCssVariableDirectRule
+  | DynamicCssVariableBranchRule;
 
 export type SpreadAggregatedCssPropLowering = {
   readonly declarations: t.VariableDeclaration[];

--- a/packages/babel/src/jsxCssProp/types.ts
+++ b/packages/babel/src/jsxCssProp/types.ts
@@ -23,13 +23,23 @@ export type AggregatePropsBinding = {
   readonly declarations: t.VariableDeclaration[];
   readonly classNameIdentifier: t.Identifier;
   readonly restIdentifier: t.Identifier;
+  readonly styleExpressions: readonly t.Expression[];
+};
+
+export type DynamicCssVariableLowering = {
+  readonly classNameExpression: t.Expression;
+  readonly cxExpression: t.Expression | null;
+  readonly styleProperties: readonly t.ObjectProperty[];
 };
 
 export type NormalizedJsxCssPropElement = {
   readonly cssAttribute: t.JSXAttribute;
   readonly cssExpression: t.Expression;
   readonly cssValueClassification: CssPropValueClassification;
+  readonly dynamicCssVariableRule: DynamicCssVariableRule | null;
+  readonly dynamicCssVariableLowering: DynamicCssVariableLowering | null;
   readonly classNameAttribute: t.JSXAttribute | null;
+  readonly styleAttribute: t.JSXAttribute | null;
   readonly attributesBeforeCss: readonly (
     | t.JSXAttribute
     | t.JSXSpreadAttribute
@@ -40,6 +50,17 @@ export type NormalizedJsxCssPropElement = {
   )[];
   readonly hasSpreadBeforeCss: boolean;
   readonly hasSpreadAfterCss: boolean;
+};
+
+export type DynamicCssVariableLeaf = {
+  readonly propertyName: string;
+  readonly value: t.Expression;
+  readonly variableIdentifier: t.Identifier;
+};
+
+export type DynamicCssVariableRule = {
+  readonly expression: t.ObjectExpression | t.ArrayExpression;
+  readonly leaves: readonly DynamicCssVariableLeaf[];
 };
 
 export type SpreadAggregatedCssPropLowering = {

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -28,6 +28,7 @@ export {
 
 export { globalCss, css, selector } from "./css/index.js";
 export type { CSSRuleWith } from "./css/types.js";
+export { getVarName } from "./utils.js";
 export { rules } from "./rules/index.js";
 export type {
   VariantStyle,
@@ -93,3 +94,24 @@ export type {
   DefineRulesShortcuts
 } from "./defineRules/types.js";
 export type { DefineRulesConditionObject } from "./defineRules/conditions.js";
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+if (import.meta.vitest) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+  const { describe, it, expect, expectTypeOf } = import.meta.vitest;
+
+  describe("getVarName export", () => {
+    it("is available from the root barrel", async () => {
+      const { getVarName } = await import("./index.js");
+
+      expect(typeof getVarName).toBe("function");
+      expect(getVarName("var(--my-var-name, 1px)")).toBe("--my-var-name");
+      expect(getVarName("--my-var-name")).toBe("--my-var-name");
+      expectTypeOf(getVarName).returns.toEqualTypeOf<
+        import("@mincho-js/transform-to-vanilla").PureCSSVarKey
+      >();
+    });
+  });
+}

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -39,14 +39,15 @@ export default defineConfig({
 ### Usage
 
 ```tsx
+import type { CSSProperties } from "react";
 import { css } from "@mincho-js/css";
 
 const styleA = css({
   display: "block"
 });
 
-function Panel(props: { className?: string; label: string }) {
-  return <section className={props.className}>{props.label}</section>;
+function Panel(props: { className?: string; style?: CSSProperties; label: string }) {
+  return <section className={props.className} style={props.style}>{props.label}</section>;
 }
 
 export function App() {
@@ -61,6 +62,16 @@ export function App() {
 ```
 
 With `jsxCssProp: true`, supported values are lowered to either the existing Mincho `css(...)` extraction path or `cx(...)` class-value merging. If an explicit `className` or pre-css spread aggregate contributes an existing class, merge order is the existing `className` first and the `css` prop class value second, equivalent to `cx(existingClassName, nextCssClassName)`. Post-css spread ordering is covered in Spread Support.
+
+### Dynamic Declaration Values
+
+Static-shape CSS rules can use dynamic declaration values. For example, `<div css={{ color: props.color }} />` keeps the `color` key static while the value comes from runtime props.
+
+Under the A안 model, the generated `.css.ts` owns `createVar`, `getVarName`, and `css`. It creates a CSS variable, uses that variable in the generated class rule, and exports the generated className plus the raw CSS-var key. Component modules only import those generated className/raw CSS-var bindings and write runtime values through inline style via the React `style` prop, for example `style={{ [colorVarKey]: props.color }}`. Component modules do not call `createVar`, `getVarName`, or `css` for this fallback.
+
+A custom component receives typed Mincho `css` only when it accepts and forwards both `className` and React-style-compatible `style`. Forward `className` to the styled element, and forward `style` to the same element so generated CSS variable values can land on the element that owns the generated class.
+
+Unsupported shapes stay unsupported: dynamic keys, computed CSS keys, dynamic object or array spreads as CSS shapes, call-return CSS shapes, branch-shaped rule objects, function-valued css props, sequence-wrapped CSS rules, and broad template interpolation. This is not Emotion-style runtime parity: Mincho does not add a runtime serializer, runtime CSS cache, runtime stylesheet insertion, wrapper component, or runtime CSS generation for the `css` prop.
 
 ### Value Semantics
 
@@ -393,9 +404,9 @@ The transform treats direct object/array syntax plus proven same-file or provide
 
 The transform accepts JSX identifiers and member-expression components, including intrinsic elements, custom React components, member-expression components such as `<motion.div />`, and custom elements.
 
-Custom components and member-expression components are supported only under a className forwarding contract: their props must accept an arbitrary string-compatible `className`, and the component must forward that `className` to the element that should receive the generated styles. The scoped JSX types add `css` through the same `className` compatibility gate.
+Custom components and member-expression components are supported only under a `className` plus `style` forwarding contract: their props must accept an arbitrary string-compatible `className` and a React-style-compatible `style`, and the component must forward both props to the element that should receive the generated styles. The scoped JSX types add `css` through the same `className` and `style` compatibility gate.
 
-User-typed custom elements receive typed `css` only when their React JSX intrinsic props include arbitrary-string-compatible `className`. Transformed custom elements emit `className`, not `class`.
+User-typed custom elements receive typed `css` only when their React JSX intrinsic props include arbitrary-string-compatible `className` and React-style-compatible `style`. Transformed custom elements emit `className`, not `class`.
 
 ### Spread Support
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -67,11 +67,24 @@ With `jsxCssProp: true`, supported values are lowered to either the existing Min
 
 Static-shape CSS rules can use dynamic declaration values. For example, `<div css={{ color: props.color }} />` keeps the `color` key static while the value comes from runtime props.
 
-Under the A안 model, the generated `.css.ts` owns `createVar`, `getVarName`, and `css`. It creates a CSS variable, uses that variable in the generated class rule, and exports the generated className plus the raw CSS-var key. Component modules only import those generated className/raw CSS-var bindings and write runtime values through inline style via the React `style` prop, for example `style={{ [colorVarKey]: props.color }}`. Component modules do not call `createVar`, `getVarName`, or `css` for this fallback.
+Static-shape CSS rule branches can also use branch-local dynamic declarations when each CSS branch is a literal object or array shape:
+
+```tsx
+<div css={condition ? { color: props.color } : { color: "red" }} />
+<div css={condition ? { color: props.color } : { color: props.fallbackColor }} />
+<div css={condition && { color: props.color }} />
+<div css={providedClass || { color: props.color }} />
+```
+
+For conditional and logical branches, the branch predicate or logical left operand is evaluated once and reused for both `className` and `style`. Inactive branch dynamic declaration values are not read.
+
+Generated branch artifacts may export separate CSS variables per branch even when declaration keys match; treat the raw keys as opaque implementation details.
+
+Under this model, the generated `.css.ts` owns `createVar`, `getVarName`, and `css`. It creates a CSS variable, uses that variable in the generated class rule, and exports the generated className plus the raw CSS-var key. Component modules only import those generated className/raw CSS-var bindings and write runtime values through inline style via the React `style` prop, for example `style={{ [colorVarKey]: props.color }}`. Component modules do not call `createVar`, `getVarName`, or `css` for this fallback.
 
 A custom component receives typed Mincho `css` only when it accepts and forwards both `className` and React-style-compatible `style`. Forward `className` to the styled element, and forward `style` to the same element so generated CSS variable values can land on the element that owns the generated class.
 
-Unsupported shapes stay unsupported: dynamic keys, computed CSS keys, dynamic object or array spreads as CSS shapes, call-return CSS shapes, branch-shaped rule objects, function-valued css props, sequence-wrapped CSS rules, and broad template interpolation. This is not Emotion-style runtime parity: Mincho does not add a runtime serializer, runtime CSS cache, runtime stylesheet insertion, wrapper component, or runtime CSS generation for the `css` prop.
+Unsupported dynamic CSS shapes stay unsupported: dynamic keys, computed runtime CSS keys, object or array spreads as branch shapes, call-returned branch objects, function-valued css props, sequence-wrapped branch rules, broad template interpolation, and other dynamic CSS shapes. Static-shape branch rule objects and arrays are supported only when their keys, spreads, and branch shapes are statically analyzable. This is not Emotion-style runtime parity: Mincho does not add a runtime serializer, runtime CSS cache, runtime stylesheet insertion, wrapper component, or runtime CSS generation for the `css` prop.
 
 ### Value Semantics
 

--- a/packages/react/src/jsx-namespace.ts
+++ b/packages/react/src/jsx-namespace.ts
@@ -1,5 +1,5 @@
 import type { ClassPrimitive, ComplexCSSRule } from "@mincho-js/css";
-import type { JSX as ReactJSX } from "react";
+import type { CSSProperties, JSX as ReactJSX } from "react";
 
 type ComplexCSSRuleArrayItem = Extract<ComplexCSSRule, unknown[]>[number];
 type MinchoCssPropRecursiveArrayItem =
@@ -21,7 +21,13 @@ type MinchoCssProp = {
 
 type WithConditionalCSSProp<Props> = "className" extends keyof Props
   ? string extends NonNullable<Props["className"]>
-    ? Props & MinchoCssProp
+    ? "style" extends keyof Props
+      ? CSSProperties extends NonNullable<Props["style"]>
+        ? NonNullable<Props["style"]> extends CSSProperties
+          ? Props & MinchoCssProp
+          : Props
+        : Props
+      : Props
     : Props
   : Props;
 
@@ -364,14 +370,27 @@ if (import.meta.vitest) {
       });
     });
 
-    it("uses the same className gate for user-augmented intrinsic props", () => {
+    it("uses the same className and style gate for user-augmented intrinsic props", () => {
       type UserAugmentedIntrinsicElements = MinchoIntrinsicElements<{
         "literal-class-element": { className?: "base" };
-        "my-element": { className?: string; id?: string };
-        "number-class-element": { className?: number };
-        "required-class-element": { className: string };
-        "undefined-class-element": { className?: string | undefined };
+        "my-element": {
+          className?: string;
+          id?: string;
+          style?: CSSProperties;
+        };
+        "number-class-element": { className?: number; style?: CSSProperties };
+        "required-class-element": { className: string; style: CSSProperties };
+        "string-style-element": { className?: string; style?: string };
+        "union-style-element": {
+          className?: string;
+          style?: CSSProperties | string;
+        };
+        "undefined-class-element": {
+          className?: string | undefined;
+          style?: CSSProperties | undefined;
+        };
         "without-class-element": { id?: string };
+        "without-style-element": { className?: string; id?: string };
       }>;
 
       assertType<UserAugmentedIntrinsicElements["my-element"]>({
@@ -381,6 +400,7 @@ if (import.meta.vitest) {
 
       assertType<UserAugmentedIntrinsicElements["required-class-element"]>({
         className: "root",
+        style: { color: "red" },
         css: false
       });
 
@@ -390,6 +410,24 @@ if (import.meta.vitest) {
 
       assertType<UserAugmentedIntrinsicElements["without-class-element"]>({
         // @ts-expect-error intrinsic props without className do not accept css.
+        css: "base"
+      });
+
+      assertType<UserAugmentedIntrinsicElements["without-style-element"]>({
+        id: "root",
+        // @ts-expect-error intrinsic props without style do not accept css.
+        css: "base"
+      });
+
+      assertType<UserAugmentedIntrinsicElements["union-style-element"]>({
+        style: { color: "red" },
+        // @ts-expect-error style unions broader than CSSProperties do not accept css.
+        css: "base"
+      });
+
+      assertType<UserAugmentedIntrinsicElements["string-style-element"]>({
+        style: "color: red",
+        // @ts-expect-error non-React style props do not accept css.
         css: "base"
       });
 
@@ -406,62 +444,78 @@ if (import.meta.vitest) {
       });
     });
 
-    it("uses the same className gate for custom component props", () => {
+    it("requires className and style-compatible custom component props", () => {
       type Component<Props> = (props: Props) => ReactJSX.Element;
       type ManagedProps<Props> = JSX.LibraryManagedAttributes<
         Component<Props>,
         Props
       >;
+      type ForwardingProps = {
+        className?: string;
+        style?: CSSProperties;
+        label: string;
+      };
 
       const functionCss = () => "base";
       const maybeClass: string | null = Math.random() > 0.5 ? null : "base";
       const getClassName = () => "base";
       const condition = true as boolean;
 
-      assertType<ManagedProps<{ className?: string; label: string }>>({
+      assertType<ManagedProps<ForwardingProps>>({
         css: "base",
         label: "Button"
       });
 
-      assertType<ManagedProps<{ className: string; label: string }>>({
+      assertType<
+        ManagedProps<{
+          className: string;
+          style: CSSProperties;
+          label: string;
+        }>
+      >({
         className: "root",
+        style: { color: "red" },
         css: false,
         label: "Button"
       });
 
       assertType<
-        ManagedProps<{ className?: string | undefined; label: string }>
+        ManagedProps<{
+          className?: string | undefined;
+          style?: CSSProperties | undefined;
+          label: string;
+        }>
       >({
         css: { color: "red" },
         label: "Button"
       });
 
-      assertType<ManagedProps<{ className?: string; label: string }>>({
+      assertType<ManagedProps<ForwardingProps>>({
         css: condition ? "base" : "fallback",
         label: "Button"
       });
 
-      assertType<ManagedProps<{ className?: string; label: string }>>({
+      assertType<ManagedProps<ForwardingProps>>({
         css: condition && "active",
         label: "Button"
       });
 
-      assertType<ManagedProps<{ className?: string; label: string }>>({
+      assertType<ManagedProps<ForwardingProps>>({
         css: condition || "fallback",
         label: "Button"
       });
 
-      assertType<ManagedProps<{ className?: string; label: string }>>({
+      assertType<ManagedProps<ForwardingProps>>({
         css: maybeClass ?? "fallback",
         label: "Button"
       });
 
-      assertType<ManagedProps<{ className?: string; label: string }>>({
+      assertType<ManagedProps<ForwardingProps>>({
         css: getClassName(),
         label: "Button"
       });
 
-      assertType<ManagedProps<{ className?: string; label: string }>>({
+      assertType<ManagedProps<ForwardingProps>>({
         label: "Button",
         // @ts-expect-error function-valued css identifiers are not valid css prop values.
         css: getClassName
@@ -473,21 +527,52 @@ if (import.meta.vitest) {
         css: "base"
       });
 
-      assertType<ManagedProps<{ className?: number; label: string }>>({
+      assertType<ManagedProps<{ className?: string; label: string }>>({
+        label: "Button",
+        // @ts-expect-error custom components without style do not accept css.
+        css: "base"
+      });
+
+      assertType<
+        ManagedProps<{
+          className?: string;
+          style?: string;
+          label: string;
+        }>
+      >({
+        style: "color: red",
+        label: "Button",
+        // @ts-expect-error non-React style props do not accept css.
+        css: "base"
+      });
+
+      assertType<
+        ManagedProps<{
+          className?: number;
+          style?: CSSProperties;
+          label: string;
+        }>
+      >({
         className: 1,
         label: "Button",
         // @ts-expect-error numeric className props do not accept css.
         css: "base"
       });
 
-      assertType<ManagedProps<{ className?: "base"; label: string }>>({
+      assertType<
+        ManagedProps<{
+          className?: "base";
+          style?: CSSProperties;
+          label: string;
+        }>
+      >({
         className: "base",
         label: "Button",
         // @ts-expect-error literal-only className props do not accept css.
         css: "base"
       });
 
-      assertType<ManagedProps<{ className?: string; label: string }>>({
+      assertType<ManagedProps<ForwardingProps>>({
         label: "Button",
         // @ts-expect-error function-valued css identifiers are not valid css prop values.
         css: functionCss

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -21,7 +21,7 @@ import {
   runDefineRulesPresetRegistryStep
 } from "@mincho-js/integration";
 import { normalizePath } from "@rollup/pluginutils";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import * as fs from "node:fs";
 import { fileURLToPath } from "node:url";
 
@@ -517,7 +517,9 @@ export function minchoVitePlugin(
     async transform(this: PluginContext, code: string, id: string) {
       if (id.startsWith("\0")) return;
       const fileId = normalizeStaticCssEvalFileId(id, rootRealpath);
-      invalidateStaticCssEvalDependency(fileId);
+      if (config.command === "serve" || config.build.watch) {
+        invalidateStaticCssEvalDependency(fileId);
+      }
 
       const moduleInfo = idToPluginData.get(id);
 
@@ -565,6 +567,15 @@ export function minchoVitePlugin(
             }) => {
               const id: string = `${fileScope.filePath}${virtualExt}`;
               const cssFileId = normalizePath(resolve(config.root, id));
+              const normalizedId = normalizePath(id);
+              const normalizedRoot = normalizePath(config.root);
+              const relativeId = normalizePath(
+                relative(normalizedRoot, normalizedId)
+              );
+              const importId =
+                relativeId === ".." || relativeId.startsWith("../")
+                  ? customNormalize(normalizedId)
+                  : relativeId;
 
               if (server) {
                 const { moduleGraph } = server;
@@ -579,7 +590,7 @@ export function minchoVitePlugin(
 
               setVirtualCssForSidecar(moduleInfo.filePath, cssFileId, source);
 
-              return `import "${cssFileId}";`;
+              return `import "/${importId}";`;
             }
           });
 
@@ -2554,6 +2565,62 @@ if (import.meta.vitest) {
         );
         expectCssSourceToContainClassNames(virtualCss, generatedClassName);
         expect(virtualCss).toContain("color: red;");
+      } finally {
+        await fs.promises.rm(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    it("retains imported static css prop virtual CSS during builds", async () => {
+      const fixture = await createImportedCssPropViteFixture(
+        "jsx-css-prop-imported-build-retention-"
+      );
+
+      try {
+        // Given
+        await spyOnSourceBabelTransform();
+        const harness = await createViteHarness({
+          configOverrides: {
+            command: "build",
+            mode: "production",
+            root: fixture.root
+          },
+          pluginOptions: {
+            jsxCssProp: true
+          }
+        });
+        const redArtifact = await transformImportedCssPropToVirtualCss(
+          harness,
+          fixture.entryPath,
+          fixture.entrySource
+        );
+        const virtualImportMatch = redArtifact.transformedExtractedCss.match(
+          /import\s+"([^"]+\.vanilla\.css)";/
+        );
+
+        if (virtualImportMatch?.[1] == null) {
+          throw new Error(
+            "Expected imported css-prop output to import virtual CSS"
+          );
+        }
+
+        // When
+        await harness.transform(
+          fixture.stylesPath,
+          await fs.promises.readFile(fixture.stylesPath, "utf8")
+        );
+
+        // Then
+        const resolvedVirtualId = harness.resolveId(virtualImportMatch[1]);
+        assertString(
+          resolvedVirtualId,
+          "Expected build-mode virtual CSS id to remain resolvable after dependency transform"
+        );
+        const virtualCss = await harness.load(resolvedVirtualId);
+        assertString(
+          virtualCss,
+          "Expected build-mode virtual CSS to remain loadable after dependency transform"
+        );
+        expect(virtualCss).toBe(redArtifact.virtualCss);
       } finally {
         await fs.promises.rm(fixture.root, { force: true, recursive: true });
       }
@@ -4823,6 +4890,7 @@ if (import.meta.vitest) {
       const expectedModuleId = normalizePath(
         join(viteConsumerRootPath, virtualCssId)
       );
+      const fileScopePath = expectedModuleId.slice(0, -".vanilla.css".length);
       const hmrModule: Module = {
         lastInvalidationTimestamp: 123
       };
@@ -4847,7 +4915,7 @@ if (import.meta.vitest) {
               (await serializeVirtualCssPath?.({
                 fileName: "src/extracted_rules.css.ts",
                 fileScope: {
-                  filePath: "src/extracted_rules.css.ts"
+                  filePath: fileScopePath
                 },
                 source: cssSource
               })) ?? ""
@@ -4885,9 +4953,7 @@ if (import.meta.vitest) {
         throw new Error("Expected a virtual css import in dev mode");
       }
 
-      expect(transformedExtractedCss).toContain(
-        `import "${expectedModuleId}";`
-      );
+      expect(transformedExtractedCss).toContain(`import "/${virtualCssId}";`);
       expect(transformedExtractedCss).not.toContain("presets");
       const resolvedVirtualId = harness.resolveId(virtualImportMatch[1]);
       expect(resolvedVirtualId).toBe(expectedModuleId);
@@ -4904,6 +4970,66 @@ if (import.meta.vitest) {
         })
       );
       expect(registrySpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("emits root-relative virtual css imports for Windows file scopes", async () => {
+      const integrationModule = await import("@mincho-js/integration");
+      const cssSource = ".shared { color: rebeccapurple; }";
+      const windowsRootPath = "C:\\workspace\\mincho";
+      const windowsFileScopePath =
+        "C:\\workspace\\mincho\\src\\extracted_rules.css.ts";
+
+      vi.spyOn(integrationModule, "babelTransform").mockResolvedValue({
+        code: 'import "extracted_rules.css.ts";\nexport { css, shared };',
+        result: ["extracted_rules.css.ts", "resolver contents"]
+      });
+      vi.spyOn(integrationModule, "compile").mockResolvedValue({
+        source: "compiled source",
+        watchFiles: []
+      } as Awaited<ReturnType<typeof compile>>);
+      vi.spyOn(
+        integrationModule,
+        "processDefineRulesPresetRegistryFile"
+      ).mockImplementation(
+        async ({
+          serializeVirtualCssPath
+        }: Parameters<typeof processDefineRulesPresetRegistryFile>[0]) => {
+          return createRegistryResult(
+            (await serializeVirtualCssPath?.({
+              fileName: "src/extracted_rules.css.ts",
+              fileScope: {
+                filePath: windowsFileScopePath
+              },
+              source: cssSource
+            })) ?? ""
+          );
+        }
+      );
+
+      const harness = await createViteHarness({
+        configOverrides: {
+          command: "serve",
+          mode: "development",
+          root: windowsRootPath
+        }
+      });
+      const { extractedId, extractedSource } =
+        await createExtractedCssFixture(harness);
+      const transformedExtractedCss = await harness.transform(
+        extractedId,
+        extractedSource
+      );
+      assertString(
+        transformedExtractedCss,
+        "Expected Windows virtual css transform to return source text"
+      );
+
+      expect(transformedExtractedCss).toContain(
+        'import "/src/extracted_rules.css.ts.vanilla.css";'
+      );
+      expect(transformedExtractedCss).not.toMatch(
+        /import\s+"(?:\/\/|\/[A-Z]:)/
+      );
     });
   });
 }


### PR DESCRIPTION
## Description
Add compile-away support for dynamic declaration values in JSX css props while keeping static CSS shape requirements.

- Extend Babel JSX css-prop lowering to handle dynamic CSS-variable paths across direct, conditional, and logical branches.
- Preserve merge semantics for className and style, including spread-before/after-css aggregation paths.
- Export getVarName from @mincho-js/css so generated raw CSS variable keys can be consumed consistently.
- Update React JSX typings, examples, and README guidance for dynamic values and className/style forwarding requirements.

## Related Issue
- #359 

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for dynamic CSS values, including conditional and logical branches, in JSX `css` props.
  * Dynamic styles now merge with existing `className`, `style`, and spread props.
  * Custom components support typed CSS props when forwarding `className` and React-compatible `style`.
  * Exported `getVarName` from the CSS package.

* **Bug Fixes**
  * Improved validation and handling of dynamic styles and unsupported CSS expressions.
  * Corrected generated virtual CSS import paths across platforms.

* **Documentation**
  * Expanded guidance for dynamic declarations and required style forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
Stacked follow-up after the recursive-rules css-prop work; this slice focuses on runtime-fed declaration values with compile-time lowering.

## Checklist
- Reviewers should focus on branch/lowering determinism and single-evaluation behavior for conditional/logical guards.
- Reviewers should verify className/style merge order when spreads appear before and after css.
- Reviewers should verify scoped JSX type constraints and docs/examples for custom component forwarding.
