### PR TITLE
Feat: CSS Prop - Optimize defineRules cx conditions

### DIFF
--- a/packages/babel/src/cssProperty.ts
+++ b/packages/babel/src/cssProperty.ts
@@ -1,0 +1,18 @@
+export function isNestedCssObjectKey(propertyName: string): boolean {
+  return (
+    propertyName === "selectors" ||
+    propertyName === "vars" ||
+    propertyName.startsWith("@") ||
+    propertyName.startsWith("_") ||
+    propertyName.startsWith("$") ||
+    propertyName.includes("&") ||
+    propertyName.includes(":") ||
+    propertyName.includes(" ")
+  );
+}
+
+export function isSupportedCssDeclarationProperty(
+  propertyName: string
+): boolean {
+  return !propertyName.startsWith("--") && !isNestedCssObjectKey(propertyName);
+}

--- a/packages/babel/src/defineRulesCxConditions.ts
+++ b/packages/babel/src/defineRulesCxConditions.ts
@@ -1,0 +1,93 @@
+import type { NodePath, types as t } from "@babel/core";
+import type { PluginState } from "./types.js";
+import {
+  countClassOperands,
+  countConditions,
+  collectSupportedOperands
+} from "./defineRulesCxConditionsOperands.js";
+import {
+  isGeneratedDefineRulesCxConditionsCall,
+  optimizeDefineRulesCxConditionsCallExpression
+} from "./defineRulesCxConditionsCodegen.js";
+import { getExpressionRange } from "./defineRulesCxConditionsProvider.js";
+import { resolveDefineRulesCxRuntime } from "./defineRulesCxConditionsRuntime.js";
+import type { DefineRulesCxConditionsMetadata } from "./defineRulesCxConditionsTypes.js";
+
+export { DEFINE_RULES_CX_CONDITIONS_METADATA_KEY } from "./defineRulesCxConditionsTypes.js";
+export type {
+  DefineRulesCxConditionsCallMetadata,
+  DefineRulesCxConditionsMetadata,
+  DefineRulesCxOperandMetadata
+} from "./defineRulesCxConditionsTypes.js";
+
+export const defineRulesCxConditionsOptimizationMetadataKey =
+  "minchoDefineRulesCxConditionsOptimization";
+
+export function isDefineRulesCxConditionsEnabled(state: PluginState): boolean {
+  return state.opts.optimize?.defineRulesCxConditions === true;
+}
+
+export function analyzeDefineRulesCxConditionsCallExpression(
+  path: NodePath<t.CallExpression>,
+  state: PluginState
+): void {
+  if (!isDefineRulesCxConditionsEnabled(state)) {
+    return;
+  }
+
+  if (isGeneratedDefineRulesCxConditionsCall(path)) {
+    return;
+  }
+
+  const runtime = resolveDefineRulesCxRuntime(path, state);
+
+  if (runtime === null) {
+    return;
+  }
+
+  const operands = collectSupportedOperands(
+    path.get("arguments"),
+    runtime,
+    state
+  );
+
+  if (operands === null) {
+    return;
+  }
+
+  const callRange = getExpressionRange(path.node);
+
+  if (callRange === null) {
+    return;
+  }
+
+  const callMetadata = {
+    callee: runtime.callee,
+    ...callRange,
+    operandCount: path.node.arguments.length,
+    conditionCount: countConditions(operands),
+    classOperandCount: countClassOperands(operands),
+    operands
+  };
+
+  getOrCreateDefineRulesCxConditionsMetadata(state).calls.push(callMetadata);
+  optimizeDefineRulesCxConditionsCallExpression(
+    path,
+    callMetadata.operands,
+    runtime
+  );
+}
+
+function getOrCreateDefineRulesCxConditionsMetadata(
+  state: PluginState
+): DefineRulesCxConditionsMetadata {
+  const existing = state.file.metadata.minchoDefineRulesCxConditions;
+
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  const metadata: DefineRulesCxConditionsMetadata = { calls: [] };
+  state.file.metadata.minchoDefineRulesCxConditions = metadata;
+  return metadata;
+}

--- a/packages/babel/src/defineRulesCxConditionsCodegen.ts
+++ b/packages/babel/src/defineRulesCxConditionsCodegen.ts
@@ -1,0 +1,110 @@
+import { type NodePath, types as t } from "@babel/core";
+import { optimizeFallbackChainPlan } from "./defineRulesCxConditionsFallbackCodegen.js";
+import { createFallbackChainPlan } from "./defineRulesCxConditionsFallbackPlan.js";
+import {
+  createTablePlan,
+  type TablePlan
+} from "./defineRulesCxConditionsTablePlan.js";
+import { getProgramInsertionPoint } from "./defineRulesCxConditionsScope.js";
+import type {
+  DefineRulesCxOperandMetadata,
+  DefineRulesRuntimeRef
+} from "./defineRulesCxConditionsTypes.js";
+
+const generatedOptimizedCalls = new WeakSet<t.CallExpression>();
+
+export function optimizeDefineRulesCxConditionsCallExpression(
+  path: NodePath<t.CallExpression>,
+  operands: readonly DefineRulesCxOperandMetadata[],
+  runtime: DefineRulesRuntimeRef
+): boolean {
+  const tablePlan = createTablePlan(path, operands);
+
+  if (tablePlan !== null) {
+    return optimizeTablePlan(path, tablePlan);
+  }
+
+  const fallbackPlan = createFallbackChainPlan(path, operands, runtime);
+  return fallbackPlan === null
+    ? false
+    : optimizeFallbackChainPlan(path, fallbackPlan);
+}
+
+export function isGeneratedDefineRulesCxConditionsCall(
+  path: NodePath<t.CallExpression>
+): boolean {
+  return generatedOptimizedCalls.has(path.node);
+}
+
+function optimizeTablePlan(
+  path: NodePath<t.CallExpression>,
+  plan: TablePlan
+): boolean {
+  const insertionPoint = getProgramInsertionPoint(path, [
+    plan.calleePath,
+    ...plan.classPaths
+  ]);
+
+  if (insertionPoint === null) {
+    return false;
+  }
+  const { programPath, programStatement } = insertionPoint;
+
+  const tableIdentifier = programPath.scope.generateUidIdentifier(
+    "minchoDefineRulesCx"
+  );
+  const tableDeclaration = t.variableDeclaration("const", [
+    t.variableDeclarator(tableIdentifier, createTableExpression(plan))
+  ]);
+
+  programStatement.insertBefore(tableDeclaration);
+  path.replaceWith(
+    t.memberExpression(
+      t.cloneNode(tableIdentifier),
+      createKeyExpression(plan.conditions),
+      true
+    )
+  );
+  return true;
+}
+
+function createTableExpression(plan: TablePlan): t.ArrayExpression {
+  return t.arrayExpression(
+    plan.entries.map((entry) => {
+      const tableCall = t.callExpression(
+        t.cloneNode(plan.callee),
+        entry.map((item) => t.cloneNode(item))
+      );
+      generatedOptimizedCalls.add(tableCall);
+      return tableCall;
+    })
+  );
+}
+
+function createKeyExpression(
+  conditions: readonly t.Expression[]
+): t.Expression {
+  const expressions = conditions.map((condition, index) =>
+    t.binaryExpression(
+      "<<",
+      t.unaryExpression(
+        "!",
+        t.unaryExpression("!", t.cloneNode(condition), true),
+        true
+      ),
+      t.numericLiteral(index)
+    )
+  );
+  const first = expressions[0];
+
+  if (first === undefined) {
+    return t.numericLiteral(0);
+  }
+
+  return expressions
+    .slice(1)
+    .reduce<t.Expression>(
+      (left, right) => t.binaryExpression("|", left, right),
+      first
+    );
+}

--- a/packages/babel/src/defineRulesCxConditionsFallbackCodegen.ts
+++ b/packages/babel/src/defineRulesCxConditionsFallbackCodegen.ts
@@ -1,0 +1,337 @@
+import { type NodePath, types as t } from "@babel/core";
+import { getProgramInsertionPoint } from "./defineRulesCxConditionsScope.js";
+import type {
+  FallbackChainPlan,
+  FallbackExpression,
+  FallbackOperandPlan
+} from "./defineRulesCxConditionsFallbackTypes.js";
+
+// allow: SIZE_OK — deterministic fallback-chain AST emission is one pipeline.
+
+export function optimizeFallbackChainPlan(
+  path: NodePath<t.CallExpression>,
+  plan: FallbackChainPlan
+): boolean {
+  const insertionPoint = getProgramInsertionPoint(path, [
+    plan.calleePath,
+    ...plan.classPaths
+  ]);
+
+  if (insertionPoint === null) {
+    return false;
+  }
+  const { programPath, programStatement } = insertionPoint;
+
+  const hookPrefix = programPath.scope.generateUidIdentifier(
+    "minchoDefineRulesCxHook"
+  ).name;
+  const resolvedIdentifiers = plan.resolvedWrites.map(() =>
+    programPath.scope.generateUidIdentifier("minchoDefineRulesCxResolved")
+  );
+  const switchIdentifiers = plan.conditions.map(() =>
+    programPath.scope.generateUidIdentifier("minchoDefineRulesCxSwitch")
+  );
+  const fallbackClassExpressions = createFallbackClassExpressions(
+    plan.operands,
+    plan.conditions
+  );
+  const switchClassExpressions = createSwitchClassExpressions(
+    plan.conditions,
+    switchIdentifiers
+  );
+  const resolvedDeclarations = createResolvedDeclarations(
+    plan,
+    resolvedIdentifiers,
+    hookPrefix
+  );
+  const switchDeclarations = createSwitchDeclarations(
+    plan,
+    switchIdentifiers,
+    hookPrefix
+  );
+
+  if (
+    fallbackClassExpressions === null ||
+    switchClassExpressions === null ||
+    resolvedDeclarations === null ||
+    switchDeclarations === null
+  ) {
+    return false;
+  }
+
+  const classExpressions = [
+    ...fallbackClassExpressions,
+    ...resolvedIdentifiers.map((identifier) => t.cloneNode(identifier)),
+    ...switchClassExpressions
+  ];
+
+  programStatement.insertBefore([
+    ...resolvedDeclarations,
+    ...switchDeclarations
+  ]);
+  path.replaceWith(createClassNameJoinExpression(classExpressions));
+  return true;
+}
+
+function createResolvedDeclarations(
+  plan: FallbackChainPlan,
+  identifiers: readonly t.Identifier[],
+  hookPrefix: string
+): readonly t.VariableDeclaration[] | null {
+  const declarations: t.VariableDeclaration[] = [];
+
+  for (let index = 0; index < plan.resolvedWrites.length; index += 1) {
+    const write = plan.resolvedWrites[index];
+    const identifier = identifiers[index];
+
+    if (write === undefined || identifier === undefined) {
+      return null;
+    }
+
+    declarations.push(
+      t.variableDeclaration("const", [
+        t.variableDeclarator(
+          t.cloneNode(identifier),
+          t.callExpression(t.cloneNode(plan.cssCallee), [
+            createResolvedStyleExpression(
+              write.property,
+              write.value,
+              hookPrefix
+            )
+          ])
+        )
+      ])
+    );
+  }
+
+  return declarations;
+}
+
+function createSwitchDeclarations(
+  plan: FallbackChainPlan,
+  identifiers: readonly t.Identifier[],
+  hookPrefix: string
+): readonly t.VariableDeclaration[] | null {
+  const declarations: t.VariableDeclaration[] = [];
+
+  for (
+    let conditionIndex = 0;
+    conditionIndex < plan.conditions.length;
+    conditionIndex += 1
+  ) {
+    const identifier = identifiers[conditionIndex];
+
+    if (identifier === undefined) {
+      return null;
+    }
+
+    declarations.push(
+      t.variableDeclaration("const", [
+        t.variableDeclarator(
+          t.cloneNode(identifier),
+          t.callExpression(t.cloneNode(plan.cssCallee), [
+            createSwitchStyleExpression(hookPrefix, conditionIndex)
+          ])
+        )
+      ])
+    );
+  }
+
+  return declarations;
+}
+
+function createResolvedStyleExpression(
+  property: string,
+  value: FallbackExpression,
+  hookPrefix: string
+): t.ObjectExpression {
+  const properties = collectFallbackExpressionConditionIndices(value).flatMap(
+    (conditionIndex) => [
+      createStringProperty(hookName(hookPrefix, conditionIndex, 0), "initial"),
+      createStringProperty(hookName(hookPrefix, conditionIndex, 1), "")
+    ]
+  );
+
+  properties.push(
+    createStringProperty(
+      property,
+      serializeFallbackExpression(value, hookPrefix)
+    )
+  );
+  return t.objectExpression(properties);
+}
+
+function createSwitchStyleExpression(
+  hookPrefix: string,
+  conditionIndex: number
+): t.ObjectExpression {
+  return t.objectExpression([
+    createStringProperty(hookName(hookPrefix, conditionIndex, 0), ""),
+    createStringProperty(hookName(hookPrefix, conditionIndex, 1), "initial")
+  ]);
+}
+
+function createStringProperty(
+  property: string,
+  value: string
+): t.ObjectProperty {
+  return t.objectProperty(t.stringLiteral(property), t.stringLiteral(value));
+}
+
+function collectFallbackExpressionConditionIndices(
+  expression: FallbackExpression
+): readonly number[] {
+  const indices = new Set<number>();
+  collectFallbackExpressionConditionIndex(expression, indices);
+  return [...indices].sort((left, right) => left - right);
+}
+
+function collectFallbackExpressionConditionIndex(
+  expression: FallbackExpression,
+  indices: Set<number>
+): void {
+  if (expression.kind === "value") {
+    return;
+  }
+
+  indices.add(expression.conditionIndex);
+  collectFallbackExpressionConditionIndex(expression.whenTrue, indices);
+  collectFallbackExpressionConditionIndex(expression.whenFalse, indices);
+}
+
+function serializeFallbackExpression(
+  expression: FallbackExpression,
+  hookPrefix: string
+): string {
+  if (expression.kind === "value") {
+    return expression.value;
+  }
+
+  return `var(${hookName(
+    hookPrefix,
+    expression.conditionIndex,
+    1
+  )}, ${serializeFallbackExpression(expression.whenTrue, hookPrefix)}) var(${hookName(
+    hookPrefix,
+    expression.conditionIndex,
+    0
+  )}, ${serializeFallbackExpression(expression.whenFalse, hookPrefix)})`;
+}
+
+function hookName(
+  hookPrefix: string,
+  conditionIndex: number,
+  branch: 0 | 1
+): string {
+  return `--${hookPrefix}-${conditionIndex}-${branch}`;
+}
+
+function createFallbackClassExpressions(
+  operands: readonly FallbackOperandPlan[],
+  conditions: readonly t.Expression[]
+): readonly t.Expression[] | null {
+  const expressions: t.Expression[] = [];
+
+  for (const operand of operands) {
+    if (!appendFallbackClassExpression(operand, conditions, expressions)) {
+      return null;
+    }
+  }
+
+  return expressions;
+}
+
+function appendFallbackClassExpression(
+  operand: FallbackOperandPlan,
+  conditions: readonly t.Expression[],
+  expressions: t.Expression[]
+): boolean {
+  switch (operand.kind) {
+    case "class":
+      expressions.push(t.cloneNode(operand.classOperand.expression));
+      return true;
+    case "condition": {
+      const condition = conditions[operand.conditionIndex];
+
+      if (condition === undefined) {
+        return false;
+      }
+
+      expressions.push(
+        t.logicalExpression(
+          "&&",
+          t.cloneNode(condition),
+          t.cloneNode(operand.classOperand.expression)
+        )
+      );
+      return true;
+    }
+    case "ternary": {
+      const condition = conditions[operand.conditionIndex];
+
+      if (condition === undefined) {
+        return false;
+      }
+
+      expressions.push(
+        t.conditionalExpression(
+          t.cloneNode(condition),
+          t.cloneNode(operand.consequent.expression),
+          t.cloneNode(operand.alternate.expression)
+        )
+      );
+      return true;
+    }
+    case "array":
+      for (const child of operand.operands) {
+        if (!appendFallbackClassExpression(child, conditions, expressions)) {
+          return false;
+        }
+      }
+      return true;
+  }
+}
+
+function createSwitchClassExpressions(
+  conditions: readonly t.Expression[],
+  identifiers: readonly t.Identifier[]
+): readonly t.Expression[] | null {
+  const expressions: t.Expression[] = [];
+
+  for (
+    let conditionIndex = 0;
+    conditionIndex < identifiers.length;
+    conditionIndex += 1
+  ) {
+    const condition = conditions[conditionIndex];
+    const identifier = identifiers[conditionIndex];
+
+    if (condition === undefined || identifier === undefined) {
+      return null;
+    }
+
+    expressions.push(
+      t.logicalExpression("&&", t.cloneNode(condition), t.cloneNode(identifier))
+    );
+  }
+
+  return expressions;
+}
+
+function createClassNameJoinExpression(
+  classExpressions: readonly t.Expression[]
+): t.Expression {
+  return t.callExpression(
+    t.memberExpression(
+      t.callExpression(
+        t.memberExpression(
+          t.arrayExpression([...classExpressions]),
+          t.identifier("filter")
+        ),
+        [t.identifier("Boolean")]
+      ),
+      t.identifier("join")
+    ),
+    [t.stringLiteral(" ")]
+  );
+}

--- a/packages/babel/src/defineRulesCxConditionsFallbackCss.ts
+++ b/packages/babel/src/defineRulesCxConditionsFallbackCss.ts
@@ -1,0 +1,147 @@
+import { type NodePath, types as t } from "@babel/core";
+import {
+  getConstantBindingInitPath,
+  isScopedCssCall
+} from "./defineRulesCxConditionsRuntime.js";
+import type {
+  DefineRulesCxClassOperandMetadata,
+  DefineRulesRuntimeRef
+} from "./defineRulesCxConditionsTypes.js";
+import type {
+  ClassPlan,
+  CssWrite,
+  FallbackPlanBuilder
+} from "./defineRulesCxConditionsFallbackTypes.js";
+import { isSupportedCssDeclarationProperty } from "./cssProperty.js";
+import { mayHaveShorthandConflict } from "./defineRulesCxConditionsShorthands.js";
+
+export function createFallbackClassPlan(
+  path: NodePath<t.Expression>,
+  metadata: DefineRulesCxClassOperandMetadata,
+  runtime: DefineRulesRuntimeRef,
+  builder: FallbackPlanBuilder
+): ClassPlan | null {
+  if (
+    !path.isExpression() ||
+    path.node.start !== metadata.start ||
+    path.node.end !== metadata.end
+  ) {
+    return null;
+  }
+
+  const cssCallPath = getCssCallForClassOperand(path, runtime);
+
+  if (cssCallPath === null) {
+    return null;
+  }
+
+  const writes = getCssCallWrites(cssCallPath);
+
+  if (writes === null || writes.length === 0) {
+    return null;
+  }
+
+  builder.classPaths.push(path);
+  return { expression: t.cloneNode(path.node), path, writes };
+}
+
+function getCssCallForClassOperand(
+  path: NodePath<t.Expression>,
+  runtime: DefineRulesRuntimeRef
+): NodePath<t.CallExpression> | null {
+  if (!path.isIdentifier()) {
+    return null;
+  }
+
+  const binding = path.scope.getBinding(path.node.name);
+  const initPath =
+    binding === undefined ? null : getConstantBindingInitPath(binding);
+
+  return initPath !== null &&
+    initPath.isCallExpression() &&
+    isScopedCssCall(initPath, runtime)
+    ? initPath
+    : null;
+}
+
+function getCssCallWrites(
+  path: NodePath<t.CallExpression>
+): readonly CssWrite[] | null {
+  const argumentPaths = path.get("arguments");
+  const firstArgument = argumentPaths[0];
+
+  if (argumentPaths.length !== 1 || firstArgument === undefined) {
+    return null;
+  }
+
+  if (!firstArgument.isObjectExpression()) {
+    return null;
+  }
+
+  const writes: CssWrite[] = [];
+
+  for (const propertyPath of firstArgument.get("properties")) {
+    if (!propertyPath.isObjectProperty() || propertyPath.node.computed) {
+      return null;
+    }
+
+    const property = getObjectPropertyName(propertyPath.node.key);
+    const valuePath = propertyPath.get("value");
+
+    if (
+      property === null ||
+      !isSupportedCssDeclarationProperty(property) ||
+      !valuePath.isStringLiteral() ||
+      valuePath.node.value.endsWith("!")
+    ) {
+      return null;
+    }
+
+    writes.push({
+      property,
+      value: { kind: "value", value: valuePath.node.value }
+    });
+  }
+
+  return hasPossibleShorthandConflict(writes.map((write) => write.property))
+    ? null
+    : writes;
+}
+
+function getObjectPropertyName(
+  property: t.ObjectProperty["key"]
+): string | null {
+  if (t.isIdentifier(property)) {
+    return property.name;
+  }
+
+  if (t.isStringLiteral(property)) {
+    return property.value;
+  }
+
+  return null;
+}
+
+function hasPossibleShorthandConflict(properties: readonly string[]): boolean {
+  for (let leftIndex = 0; leftIndex < properties.length; leftIndex += 1) {
+    const left = properties[leftIndex];
+
+    if (left === undefined) {
+      continue;
+    }
+
+    for (
+      let rightIndex = leftIndex + 1;
+      rightIndex < properties.length;
+      rightIndex += 1
+    ) {
+      const right = properties[rightIndex];
+
+      if (right !== undefined && mayHaveShorthandConflict(left, right)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}

--- a/packages/babel/src/defineRulesCxConditionsFallbackPlan.ts
+++ b/packages/babel/src/defineRulesCxConditionsFallbackPlan.ts
@@ -1,0 +1,235 @@
+import { type NodePath, types as t } from "@babel/core";
+import { createFallbackClassPlan } from "./defineRulesCxConditionsFallbackCss.js";
+import { createFallbackResolvedWrites } from "./defineRulesCxConditionsFallbackResolve.js";
+import type {
+  FallbackChainPlan,
+  FallbackOperandPlan,
+  FallbackPlanBuilder
+} from "./defineRulesCxConditionsFallbackTypes.js";
+import { TABLE_CONDITION_LIMIT } from "./defineRulesCxConditionsTablePlan.js";
+import type {
+  DefineRulesCxOperandMetadata,
+  DefineRulesRuntimeRef
+} from "./defineRulesCxConditionsTypes.js";
+
+export function createFallbackChainPlan(
+  path: NodePath<t.CallExpression>,
+  operands: readonly DefineRulesCxOperandMetadata[],
+  runtime: DefineRulesRuntimeRef
+): FallbackChainPlan | null {
+  const cssCallee = createCssCallee(runtime);
+  const calleePath = path.get("callee");
+
+  if (cssCallee === null || !calleePath.isExpression()) {
+    return null;
+  }
+
+  const builder: FallbackPlanBuilder = { conditions: [], classPaths: [] };
+  const argumentPaths = path.get("arguments");
+  const operandPlans: FallbackOperandPlan[] = [];
+
+  if (operands.length !== argumentPaths.length) {
+    return null;
+  }
+
+  for (let index = 0; index < operands.length; index += 1) {
+    const argumentPath = argumentPaths[index];
+    const metadata = operands[index];
+
+    if (
+      argumentPath === undefined ||
+      metadata === undefined ||
+      !argumentPath.isExpression()
+    ) {
+      return null;
+    }
+
+    const operandPlan = createOperandPlan(
+      argumentPath,
+      metadata,
+      runtime,
+      builder
+    );
+
+    if (operandPlan === null) {
+      return null;
+    }
+    operandPlans.push(operandPlan);
+  }
+
+  if (builder.conditions.length <= TABLE_CONDITION_LIMIT) {
+    return null;
+  }
+
+  const resolvedWrites = createFallbackResolvedWrites(operandPlans);
+
+  if (resolvedWrites === null || resolvedWrites.length === 0) {
+    return null;
+  }
+
+  return {
+    callee: t.cloneNode(calleePath.node),
+    calleePath,
+    cssCallee,
+    conditions: builder.conditions,
+    operands: operandPlans,
+    resolvedWrites,
+    classPaths: builder.classPaths
+  };
+}
+
+function createCssCallee(runtime: DefineRulesRuntimeRef): t.Expression | null {
+  if (runtime.callee !== "local-defineRules") {
+    return null;
+  }
+
+  if (runtime.cssBinding !== undefined) {
+    return t.identifier(runtime.cssBinding.identifier.name);
+  }
+
+  if (runtime.namespaceBinding !== undefined) {
+    return t.memberExpression(
+      t.identifier(runtime.namespaceBinding.identifier.name),
+      t.identifier("css")
+    );
+  }
+
+  return null;
+}
+
+function createOperandPlan(
+  path: NodePath<t.Expression>,
+  metadata: DefineRulesCxOperandMetadata,
+  runtime: DefineRulesRuntimeRef,
+  builder: FallbackPlanBuilder
+): FallbackOperandPlan | null {
+  switch (metadata.kind) {
+    case "class": {
+      const classOperand = createFallbackClassPlan(
+        path,
+        metadata,
+        runtime,
+        builder
+      );
+      return classOperand === null ? null : { kind: "class", classOperand };
+    }
+    case "condition":
+      return createConditionOperandPlan(path, metadata, runtime, builder);
+    case "ternary":
+      return createTernaryOperandPlan(path, metadata, runtime, builder);
+    case "array":
+      return createArrayOperandPlan(path, metadata.operands, runtime, builder);
+  }
+}
+
+function createConditionOperandPlan(
+  path: NodePath<t.Expression>,
+  metadata: Extract<
+    DefineRulesCxOperandMetadata,
+    { readonly kind: "condition" }
+  >,
+  runtime: DefineRulesRuntimeRef,
+  builder: FallbackPlanBuilder
+): FallbackOperandPlan | null {
+  if (
+    !path.isLogicalExpression() ||
+    path.node.operator !== "&&" ||
+    !path.get("left").isIdentifier()
+  ) {
+    return null;
+  }
+
+  const conditionIndex = builder.conditions.length;
+  const classOperand = createFallbackClassPlan(
+    path.get("right"),
+    metadata.classOperand,
+    runtime,
+    builder
+  );
+
+  if (classOperand === null) {
+    return null;
+  }
+
+  builder.conditions.push(t.cloneNode(path.node.left));
+  return { kind: "condition", conditionIndex, classOperand };
+}
+
+function createTernaryOperandPlan(
+  path: NodePath<t.Expression>,
+  metadata: Extract<DefineRulesCxOperandMetadata, { readonly kind: "ternary" }>,
+  runtime: DefineRulesRuntimeRef,
+  builder: FallbackPlanBuilder
+): FallbackOperandPlan | null {
+  if (!path.isConditionalExpression() || !path.get("test").isIdentifier()) {
+    return null;
+  }
+
+  const conditionIndex = builder.conditions.length;
+  const consequent = createFallbackClassPlan(
+    path.get("consequent"),
+    metadata.consequent,
+    runtime,
+    builder
+  );
+  const alternate = createFallbackClassPlan(
+    path.get("alternate"),
+    metadata.alternate,
+    runtime,
+    builder
+  );
+
+  if (consequent === null || alternate === null) {
+    return null;
+  }
+
+  builder.conditions.push(t.cloneNode(path.node.test));
+  return { kind: "ternary", conditionIndex, consequent, alternate };
+}
+
+function createArrayOperandPlan(
+  path: NodePath<t.Expression>,
+  operands: readonly DefineRulesCxOperandMetadata[],
+  runtime: DefineRulesRuntimeRef,
+  builder: FallbackPlanBuilder
+): FallbackOperandPlan | null {
+  if (!path.isArrayExpression()) {
+    return null;
+  }
+
+  const elementPaths = path.get("elements");
+  const operandPlans: FallbackOperandPlan[] = [];
+
+  if (elementPaths.length !== operands.length) {
+    return null;
+  }
+
+  for (let index = 0; index < operands.length; index += 1) {
+    const elementPath = elementPaths[index];
+    const metadata = operands[index];
+
+    if (elementPath === undefined || metadata === undefined) {
+      return null;
+    }
+
+    const expressionPath = elementPath.isExpression() ? elementPath : null;
+
+    if (expressionPath === null) {
+      return null;
+    }
+
+    const operandPlan = createOperandPlan(
+      expressionPath,
+      metadata,
+      runtime,
+      builder
+    );
+
+    if (operandPlan === null) {
+      return null;
+    }
+    operandPlans.push(operandPlan);
+  }
+
+  return { kind: "array", operands: operandPlans };
+}

--- a/packages/babel/src/defineRulesCxConditionsFallbackResolve.ts
+++ b/packages/babel/src/defineRulesCxConditionsFallbackResolve.ts
@@ -1,0 +1,219 @@
+import type {
+  ClassPlan,
+  CssWrite,
+  FallbackExpression,
+  FallbackOperandPlan,
+  FallbackResolvedWrite
+} from "./defineRulesCxConditionsFallbackTypes.js";
+
+type ChainState = {
+  readonly value: FallbackExpression;
+};
+
+export function createFallbackResolvedWrites(
+  operands: readonly FallbackOperandPlan[]
+): readonly FallbackResolvedWrite[] | null {
+  const propertyCounts = countWriteProperties(operands);
+  const candidateProperties = new Set(
+    [...propertyCounts]
+      .filter(([, count]) => count > 1)
+      .map(([property]) => property)
+  );
+
+  if (candidateProperties.size === 0) {
+    return null;
+  }
+
+  const states = new Map<string, ChainState>();
+
+  for (const operand of operands) {
+    if (!applyOperandWrites(operand, candidateProperties, states)) {
+      return null;
+    }
+  }
+
+  return collectResolvedWrites(candidateProperties, states);
+}
+
+function collectResolvedWrites(
+  candidateProperties: ReadonlySet<string>,
+  states: ReadonlyMap<string, ChainState>
+): readonly FallbackResolvedWrite[] | null {
+  const resolvedWrites: FallbackResolvedWrite[] = [];
+
+  for (const property of candidateProperties) {
+    const state = states.get(property);
+
+    if (state === undefined) {
+      return null;
+    }
+
+    resolvedWrites.push({ property, value: state.value });
+  }
+
+  return resolvedWrites;
+}
+
+function countWriteProperties(
+  operands: readonly FallbackOperandPlan[]
+): ReadonlyMap<string, number> {
+  const counts = new Map<string, number>();
+
+  for (const operand of operands) {
+    countOperandWriteProperties(operand, counts);
+  }
+
+  return counts;
+}
+
+function countOperandWriteProperties(
+  operand: FallbackOperandPlan,
+  counts: Map<string, number>
+): void {
+  switch (operand.kind) {
+    case "class":
+      countClassWriteProperties(operand.classOperand, counts);
+      return;
+    case "condition":
+      countClassWriteProperties(operand.classOperand, counts);
+      return;
+    case "ternary":
+      countClassWriteProperties(operand.consequent, counts);
+      countClassWriteProperties(operand.alternate, counts);
+      return;
+    case "array":
+      for (const child of operand.operands) {
+        countOperandWriteProperties(child, counts);
+      }
+      return;
+  }
+}
+
+function countClassWriteProperties(
+  classPlan: ClassPlan,
+  counts: Map<string, number>
+): void {
+  for (const write of classPlan.writes) {
+    counts.set(write.property, (counts.get(write.property) ?? 0) + 1);
+  }
+}
+
+function applyOperandWrites(
+  operand: FallbackOperandPlan,
+  candidateProperties: ReadonlySet<string>,
+  states: Map<string, ChainState>
+): boolean {
+  switch (operand.kind) {
+    case "class":
+      applyAlwaysWrites(operand.classOperand, candidateProperties, states);
+      return true;
+    case "condition":
+      return applyConditionWrites(
+        operand.classOperand,
+        operand.conditionIndex,
+        candidateProperties,
+        states
+      );
+    case "ternary":
+      return applyTernaryWrites(operand, candidateProperties, states);
+    case "array":
+      for (const child of operand.operands) {
+        if (!applyOperandWrites(child, candidateProperties, states)) {
+          return false;
+        }
+      }
+      return true;
+  }
+}
+
+function applyAlwaysWrites(
+  classPlan: ClassPlan,
+  candidateProperties: ReadonlySet<string>,
+  states: Map<string, ChainState>
+): void {
+  for (const write of classPlan.writes) {
+    if (candidateProperties.has(write.property)) {
+      states.set(write.property, { value: write.value });
+    }
+  }
+}
+
+function applyConditionWrites(
+  classPlan: ClassPlan,
+  conditionIndex: number,
+  candidateProperties: ReadonlySet<string>,
+  states: Map<string, ChainState>
+): boolean {
+  for (const write of classPlan.writes) {
+    if (!candidateProperties.has(write.property)) {
+      continue;
+    }
+
+    const previous = states.get(write.property);
+
+    if (previous === undefined) {
+      return false;
+    }
+
+    states.set(write.property, {
+      value: {
+        kind: "condition",
+        conditionIndex,
+        whenTrue: write.value,
+        whenFalse: previous.value
+      }
+    });
+  }
+
+  return true;
+}
+
+function applyTernaryWrites(
+  operand: Extract<FallbackOperandPlan, { readonly kind: "ternary" }>,
+  candidateProperties: ReadonlySet<string>,
+  states: Map<string, ChainState>
+): boolean {
+  const consequentWrites = groupWritesByProperty(operand.consequent.writes);
+  const alternateWrites = groupWritesByProperty(operand.alternate.writes);
+  const properties = new Set([
+    ...Object.keys(consequentWrites),
+    ...Object.keys(alternateWrites)
+  ]);
+
+  for (const property of properties) {
+    if (!candidateProperties.has(property)) {
+      continue;
+    }
+
+    const previous = states.get(property);
+    const whenTrue = consequentWrites[property] ?? previous?.value;
+    const whenFalse = alternateWrites[property] ?? previous?.value;
+
+    if (whenTrue === undefined || whenFalse === undefined) {
+      return false;
+    }
+
+    states.set(property, {
+      value: {
+        kind: "condition",
+        conditionIndex: operand.conditionIndex,
+        whenTrue,
+        whenFalse
+      }
+    });
+  }
+
+  return true;
+}
+
+function groupWritesByProperty(
+  writes: readonly CssWrite[]
+): Record<string, FallbackExpression> {
+  const grouped: Record<string, FallbackExpression> = Object.create(null);
+
+  for (const write of writes) {
+    grouped[write.property] = write.value;
+  }
+
+  return grouped;
+}

--- a/packages/babel/src/defineRulesCxConditionsFallbackTypes.ts
+++ b/packages/babel/src/defineRulesCxConditionsFallbackTypes.ts
@@ -1,0 +1,59 @@
+import type { NodePath, types as t } from "@babel/core";
+
+export type FallbackExpression =
+  | { readonly kind: "value"; readonly value: string }
+  | {
+      readonly kind: "condition";
+      readonly conditionIndex: number;
+      readonly whenTrue: FallbackExpression;
+      readonly whenFalse: FallbackExpression;
+    };
+
+export type CssWrite = {
+  readonly property: string;
+  readonly value: FallbackExpression;
+};
+
+export type ClassPlan = {
+  readonly expression: t.Expression;
+  readonly path: NodePath<t.Expression>;
+  readonly writes: readonly CssWrite[];
+};
+
+export type FallbackOperandPlan =
+  | { readonly kind: "class"; readonly classOperand: ClassPlan }
+  | {
+      readonly kind: "condition";
+      readonly conditionIndex: number;
+      readonly classOperand: ClassPlan;
+    }
+  | {
+      readonly kind: "ternary";
+      readonly conditionIndex: number;
+      readonly consequent: ClassPlan;
+      readonly alternate: ClassPlan;
+    }
+  | {
+      readonly kind: "array";
+      readonly operands: readonly FallbackOperandPlan[];
+    };
+
+export type FallbackResolvedWrite = {
+  readonly property: string;
+  readonly value: FallbackExpression;
+};
+
+export type FallbackChainPlan = {
+  readonly callee: t.Expression;
+  readonly calleePath: NodePath<t.Expression>;
+  readonly cssCallee: t.Expression;
+  readonly conditions: readonly t.Expression[];
+  readonly operands: readonly FallbackOperandPlan[];
+  readonly resolvedWrites: readonly FallbackResolvedWrite[];
+  readonly classPaths: readonly NodePath<t.Expression>[];
+};
+
+export type FallbackPlanBuilder = {
+  readonly conditions: t.Expression[];
+  readonly classPaths: NodePath<t.Expression>[];
+};

--- a/packages/babel/src/defineRulesCxConditionsOperands.ts
+++ b/packages/babel/src/defineRulesCxConditionsOperands.ts
@@ -1,0 +1,232 @@
+import { type NodePath, types as t } from "@babel/core";
+import type { PluginState } from "./types.js";
+import {
+  type DefineRulesCxClassOperandMetadata,
+  type DefineRulesCxOperandMetadata,
+  type DefineRulesRuntimeRef
+} from "./defineRulesCxConditionsTypes.js";
+import {
+  getExpressionRange,
+  isMarkerBearingClassName,
+  resolveProviderStaticValue
+} from "./defineRulesCxConditionsProvider.js";
+import {
+  getConstantBindingInitPath,
+  isScopedCssCall
+} from "./defineRulesCxConditionsRuntime.js";
+import { hasUnsafeConditionExpression } from "./defineRulesCxConditionsSafety.js";
+
+export function collectSupportedOperands(
+  argumentPaths: readonly NodePath[],
+  runtime: DefineRulesRuntimeRef,
+  state: PluginState
+): DefineRulesCxOperandMetadata[] | null {
+  const operands: DefineRulesCxOperandMetadata[] = [];
+
+  for (const argumentPath of argumentPaths) {
+    if (!argumentPath.isExpression()) {
+      return null;
+    }
+
+    const operand = collectSupportedOperand(argumentPath, runtime, state);
+
+    if (operand === null) {
+      return null;
+    }
+    operands.push(operand);
+  }
+
+  return operands;
+}
+
+export function countConditions(
+  operands: readonly DefineRulesCxOperandMetadata[]
+): number {
+  return operands.reduce(
+    (total, operand) => total + countOperandConditions(operand),
+    0
+  );
+}
+
+export function countClassOperands(
+  operands: readonly DefineRulesCxOperandMetadata[]
+): number {
+  return operands.reduce(
+    (total, operand) => total + countOperandClassOperands(operand),
+    0
+  );
+}
+
+function collectSupportedOperand(
+  path: NodePath<t.Expression>,
+  runtime: DefineRulesRuntimeRef,
+  state: PluginState
+): DefineRulesCxOperandMetadata | null {
+  if (path.isArrayExpression()) {
+    return collectArrayOperand(path, runtime, state);
+  }
+
+  if (path.isLogicalExpression()) {
+    return collectLogicalOperand(path, runtime, state);
+  }
+
+  if (path.isConditionalExpression()) {
+    return collectTernaryOperand(path, runtime, state);
+  }
+
+  return resolveKnownClassOperand(path, runtime, state);
+}
+
+function collectArrayOperand(
+  path: NodePath<t.ArrayExpression>,
+  runtime: DefineRulesRuntimeRef,
+  state: PluginState
+): DefineRulesCxOperandMetadata | null {
+  const operands: DefineRulesCxOperandMetadata[] = [];
+  const range = getExpressionRange(path.node);
+
+  if (range === null) {
+    return null;
+  }
+
+  for (const elementPath of path.get("elements")) {
+    if (!elementPath.isExpression()) {
+      return null;
+    }
+
+    const operand = collectSupportedOperand(elementPath, runtime, state);
+
+    if (operand === null) {
+      return null;
+    }
+    operands.push(operand);
+  }
+
+  return { kind: "array", operands, ...range };
+}
+
+function collectLogicalOperand(
+  path: NodePath<t.LogicalExpression>,
+  runtime: DefineRulesRuntimeRef,
+  state: PluginState
+): DefineRulesCxOperandMetadata | null {
+  if (path.node.operator !== "&&") {
+    return null;
+  }
+
+  const conditionPath = path.get("left");
+  const condition = getExpressionRange(conditionPath.node);
+  const classOperand = resolveKnownClassOperand(
+    path.get("right"),
+    runtime,
+    state
+  );
+
+  if (
+    condition === null ||
+    classOperand === null ||
+    hasUnsafeConditionExpression(conditionPath)
+  ) {
+    return null;
+  }
+
+  return {
+    kind: "condition",
+    operator: "&&",
+    condition,
+    classOperand
+  };
+}
+
+function collectTernaryOperand(
+  path: NodePath<t.ConditionalExpression>,
+  runtime: DefineRulesRuntimeRef,
+  state: PluginState
+): DefineRulesCxOperandMetadata | null {
+  const testPath = path.get("test");
+  const condition = getExpressionRange(testPath.node);
+  const consequent = resolveKnownClassOperand(
+    path.get("consequent"),
+    runtime,
+    state
+  );
+  const alternate = resolveKnownClassOperand(
+    path.get("alternate"),
+    runtime,
+    state
+  );
+
+  if (
+    condition === null ||
+    consequent === null ||
+    alternate === null ||
+    hasUnsafeConditionExpression(testPath)
+  ) {
+    return null;
+  }
+
+  return {
+    kind: "ternary",
+    condition,
+    consequent,
+    alternate
+  };
+}
+
+function resolveKnownClassOperand(
+  path: NodePath<t.Expression>,
+  runtime: DefineRulesRuntimeRef,
+  state: PluginState
+): DefineRulesCxClassOperandMetadata | null {
+  const range = getExpressionRange(path.node);
+
+  if (range === null) {
+    return null;
+  }
+
+  if (isMarkerBearingClassName(resolveProviderStaticValue(path, state))) {
+    return { kind: "class", source: "provider-marker", ...range };
+  }
+
+  if (isScopedCssCall(path, runtime)) {
+    return { kind: "class", source: "local-css-call", ...range };
+  }
+
+  if (!path.isIdentifier()) {
+    return null;
+  }
+
+  const binding = path.scope.getBinding(path.node.name);
+  const initPath = binding ? getConstantBindingInitPath(binding) : null;
+
+  return initPath !== null && isScopedCssCall(initPath, runtime)
+    ? { kind: "class", source: "local-css-call", ...range }
+    : null;
+}
+
+function countOperandConditions(operand: DefineRulesCxOperandMetadata): number {
+  switch (operand.kind) {
+    case "class":
+      return 0;
+    case "condition":
+    case "ternary":
+      return 1;
+    case "array":
+      return countConditions(operand.operands);
+  }
+}
+
+function countOperandClassOperands(
+  operand: DefineRulesCxOperandMetadata
+): number {
+  switch (operand.kind) {
+    case "class":
+      return 1;
+    case "condition":
+      return 1;
+    case "ternary":
+      return 2;
+    case "array":
+      return countClassOperands(operand.operands);
+  }
+}

--- a/packages/babel/src/defineRulesCxConditionsProvider.ts
+++ b/packages/babel/src/defineRulesCxConditionsProvider.ts
@@ -1,0 +1,132 @@
+import { type NodePath, types as t } from "@babel/core";
+import type { Binding } from "@babel/traverse";
+import type { StaticCssLiteral } from "./staticCssEval/types.js";
+import type { PluginState } from "./types.js";
+import {
+  DEFINE_RULES_CX_RUNTIME_IMPORT_NAME,
+  DEFINE_RULES_CX_RUNTIME_IMPORT_PATH,
+  DEFINE_RULES_SEGMENT_MARKER_PREFIX,
+  type DefineRulesCxExpressionRange,
+  type StaticReference
+} from "./defineRulesCxConditionsTypes.js";
+
+export function resolveProviderStaticValue(
+  path: NodePath<t.Expression>,
+  state: PluginState
+): StaticCssLiteral | null {
+  const provider = state.opts.staticCssEvalProvider;
+  const reference = getStaticReference(path.node);
+
+  if (provider === undefined || reference === null) {
+    return null;
+  }
+
+  const binding = path.scope.getBinding(reference.bindingName);
+
+  if (binding === undefined || !isImportBinding(binding)) {
+    return null;
+  }
+
+  const range = getExpressionRange(path.node);
+
+  if (range === null) {
+    return null;
+  }
+
+  const result = provider.getResolvedCssValue({
+    importerId: state.file.opts.filename ?? "",
+    expressionStart: range.start,
+    expressionEnd: range.end,
+    bindingName: reference.bindingName,
+    ...(reference.memberPath.length > 0
+      ? { memberPath: [...reference.memberPath] }
+      : {})
+  });
+
+  return result.kind === "resolved" ? result.value : null;
+}
+
+export function isDefineRulesCxRuntimeRecipe(
+  value: StaticCssLiteral | null
+): boolean {
+  if (!isStaticObject(value)) {
+    return false;
+  }
+
+  return (
+    value.importPath === DEFINE_RULES_CX_RUNTIME_IMPORT_PATH &&
+    value.importName === DEFINE_RULES_CX_RUNTIME_IMPORT_NAME &&
+    Array.isArray(value.args)
+  );
+}
+
+export function isMarkerBearingClassName(
+  value: StaticCssLiteral | null
+): boolean {
+  return (
+    typeof value === "string" &&
+    value
+      .split(/\s+/)
+      .some((token) => token.startsWith(DEFINE_RULES_SEGMENT_MARKER_PREFIX))
+  );
+}
+
+export function getExpressionRange(
+  node: t.Node
+): DefineRulesCxExpressionRange | null {
+  return typeof node.start === "number" && typeof node.end === "number"
+    ? { start: node.start, end: node.end }
+    : null;
+}
+
+function getStaticReference(node: t.Expression): StaticReference | null {
+  if (t.isIdentifier(node)) {
+    return { bindingName: node.name, memberPath: [] };
+  }
+
+  if (!t.isMemberExpression(node) || node.computed) {
+    return null;
+  }
+
+  const propertyName = getMemberPropertyName(node.property);
+
+  if (propertyName === null || !t.isExpression(node.object)) {
+    return null;
+  }
+
+  const objectReference = getStaticReference(node.object);
+  return objectReference === null
+    ? null
+    : {
+        bindingName: objectReference.bindingName,
+        memberPath: [...objectReference.memberPath, propertyName]
+      };
+}
+
+function getMemberPropertyName(
+  property: t.MemberExpression["property"]
+): string | null {
+  if (t.isIdentifier(property)) {
+    return property.name;
+  }
+
+  if (t.isStringLiteral(property)) {
+    return property.value;
+  }
+
+  return null;
+}
+
+function isStaticObject(
+  value: StaticCssLiteral | null
+): value is { readonly [key: string]: StaticCssLiteral } {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isImportBinding(binding: Binding): boolean {
+  return (
+    binding.path.isImportSpecifier() ||
+    binding.path.isImportDefaultSpecifier() ||
+    binding.path.isImportNamespaceSpecifier()
+  );
+}

--- a/packages/babel/src/defineRulesCxConditionsRuntime.ts
+++ b/packages/babel/src/defineRulesCxConditionsRuntime.ts
@@ -1,0 +1,263 @@
+import { type NodePath, types as t } from "@babel/core";
+import type { Binding } from "@babel/traverse";
+import type { PluginState } from "./types.js";
+import {
+  DEFINE_RULES_CX_RUNTIME_IMPORT_NAME,
+  DEFINE_RULES_CX_RUNTIME_IMPORT_PATH,
+  DEFINE_RULES_IMPORT_NAME,
+  DEFINE_RULES_IMPORT_PATH,
+  type DefineRulesRuntimeRef
+} from "./defineRulesCxConditionsTypes.js";
+import {
+  isDefineRulesCxRuntimeRecipe,
+  resolveProviderStaticValue
+} from "./defineRulesCxConditionsProvider.js";
+
+export function resolveDefineRulesCxRuntime(
+  path: NodePath<t.CallExpression>,
+  state: PluginState
+): DefineRulesRuntimeRef | null {
+  const calleePath = path.get("callee");
+
+  if (calleePath.isMemberExpression()) {
+    const localMemberRuntime = resolveLocalMemberCxRuntime(calleePath);
+
+    if (localMemberRuntime !== null) {
+      return localMemberRuntime;
+    }
+  }
+
+  if (calleePath.isIdentifier()) {
+    const binding = path.scope.getBinding(calleePath.node.name);
+
+    if (binding !== undefined) {
+      const localRuntime = resolveLocalIdentifierCxRuntime(binding);
+
+      if (localRuntime !== null) {
+        return localRuntime;
+      }
+    }
+  }
+
+  if (!calleePath.isExpression()) {
+    return null;
+  }
+
+  const providerValue = resolveProviderStaticValue(calleePath, state);
+  return isDefineRulesCxRuntimeRecipe(providerValue)
+    ? { callee: "provider-createDefineRulesCxRuntime" }
+    : null;
+}
+
+export function isScopedCssCall(
+  path: NodePath<t.Expression>,
+  runtime: DefineRulesRuntimeRef
+): boolean {
+  if (runtime.callee !== "local-defineRules" || !path.isCallExpression()) {
+    return false;
+  }
+
+  const calleePath = path.get("callee");
+
+  if (calleePath.isIdentifier()) {
+    const binding = path.scope.getBinding(calleePath.node.name);
+    return binding !== undefined && binding === runtime.cssBinding;
+  }
+
+  if (
+    !calleePath.isMemberExpression() ||
+    calleePath.node.computed ||
+    !t.isIdentifier(calleePath.node.object) ||
+    !t.isIdentifier(calleePath.node.property) ||
+    calleePath.node.property.name !== "css"
+  ) {
+    return false;
+  }
+
+  const objectBinding = path.scope.getBinding(calleePath.node.object.name);
+  return (
+    objectBinding !== undefined && objectBinding === runtime.namespaceBinding
+  );
+}
+
+function resolveLocalMemberCxRuntime(
+  path: NodePath<t.MemberExpression>
+): DefineRulesRuntimeRef | null {
+  if (path.node.computed || !t.isIdentifier(path.node.property)) {
+    return null;
+  }
+
+  if (path.node.property.name !== "cx" || !t.isIdentifier(path.node.object)) {
+    return null;
+  }
+
+  const binding = path.scope.getBinding(path.node.object.name);
+  const initPath = binding ? getConstantBindingInitPath(binding) : null;
+  return initPath !== null && isDefineRulesCall(initPath)
+    ? { callee: "local-defineRules", namespaceBinding: binding }
+    : null;
+}
+
+function resolveLocalIdentifierCxRuntime(
+  binding: Binding
+): DefineRulesRuntimeRef | null {
+  if (!isConstBinding(binding)) {
+    return null;
+  }
+
+  const defineRulesRuntime = resolveDestructuredDefineRulesRuntime(binding);
+
+  if (defineRulesRuntime !== null) {
+    return defineRulesRuntime;
+  }
+
+  const initPath = getConstantBindingInitPath(binding);
+  return initPath !== null && isCreateDefineRulesCxRuntimeCall(initPath)
+    ? { callee: "local-createDefineRulesCxRuntime" }
+    : null;
+}
+
+function resolveDestructuredDefineRulesRuntime(
+  binding: Binding
+): DefineRulesRuntimeRef | null {
+  const declaratorPath = findVariableDeclaratorPath(binding);
+
+  if (declaratorPath === null || !isConstVariableDeclarator(declaratorPath)) {
+    return null;
+  }
+
+  const initPath = declaratorPath.get("init");
+
+  if (!initPath.isExpression() || !isDefineRulesCall(initPath)) {
+    return null;
+  }
+
+  const cxBinding = getObjectPatternPropertyBinding(declaratorPath, "cx");
+
+  if (cxBinding !== binding) {
+    return null;
+  }
+
+  const cssBinding = getObjectPatternPropertyBinding(declaratorPath, "css");
+  return {
+    callee: "local-defineRules",
+    ...(cssBinding !== null ? { cssBinding } : {})
+  };
+}
+
+export function getConstantBindingInitPath(
+  binding: Binding
+): NodePath<t.Expression> | null {
+  if (binding.kind !== "const" || !isConstBinding(binding)) {
+    return null;
+  }
+
+  const declaratorPath = findVariableDeclaratorPath(binding);
+
+  if (declaratorPath === null || !isConstVariableDeclarator(declaratorPath)) {
+    return null;
+  }
+
+  const initPath = declaratorPath.get("init");
+  return initPath.isExpression() ? initPath : null;
+}
+
+function isDefineRulesCall(path: NodePath<t.Expression>): boolean {
+  return (
+    path.isCallExpression() &&
+    path
+      .get("callee")
+      .referencesImport(DEFINE_RULES_IMPORT_PATH, DEFINE_RULES_IMPORT_NAME)
+  );
+}
+
+function isCreateDefineRulesCxRuntimeCall(
+  path: NodePath<t.Expression>
+): boolean {
+  return (
+    path.isCallExpression() &&
+    path
+      .get("callee")
+      .referencesImport(
+        DEFINE_RULES_CX_RUNTIME_IMPORT_PATH,
+        DEFINE_RULES_CX_RUNTIME_IMPORT_NAME
+      )
+  );
+}
+
+function findVariableDeclaratorPath(
+  binding: Binding
+): NodePath<t.VariableDeclarator> | null {
+  if (binding.kind !== "const") {
+    return null;
+  }
+
+  let current: NodePath<t.Node> | null = binding.path;
+
+  while (current !== null && !current.isProgram()) {
+    if (current.isVariableDeclarator()) {
+      return current;
+    }
+    current = current.parentPath;
+  }
+
+  return null;
+}
+
+function isConstBinding(binding: Binding): boolean {
+  const declaratorPath = findVariableDeclaratorPath(binding);
+  return (
+    binding.constant &&
+    declaratorPath !== null &&
+    isConstVariableDeclarator(declaratorPath)
+  );
+}
+
+function isConstVariableDeclarator(
+  path: NodePath<t.VariableDeclarator>
+): boolean {
+  return (
+    path.parentPath?.isVariableDeclaration() === true &&
+    path.parentPath.node.kind === "const"
+  );
+}
+
+function getObjectPatternPropertyBinding(
+  declaratorPath: NodePath<t.VariableDeclarator>,
+  propertyName: string
+): Binding | null {
+  const { id } = declaratorPath.node;
+
+  if (!t.isObjectPattern(id)) {
+    return null;
+  }
+
+  for (const property of id.properties) {
+    if (!t.isObjectProperty(property) || property.computed) {
+      continue;
+    }
+
+    if (
+      getObjectPropertyName(property.key) === propertyName &&
+      t.isIdentifier(property.value)
+    ) {
+      return declaratorPath.scope.getBinding(property.value.name) ?? null;
+    }
+  }
+
+  return null;
+}
+
+function getObjectPropertyName(
+  property: t.ObjectProperty["key"]
+): string | null {
+  if (t.isIdentifier(property)) {
+    return property.name;
+  }
+
+  if (t.isStringLiteral(property)) {
+    return property.value;
+  }
+
+  return null;
+}

--- a/packages/babel/src/defineRulesCxConditionsSafety.ts
+++ b/packages/babel/src/defineRulesCxConditionsSafety.ts
@@ -1,0 +1,68 @@
+import type { NodePath, types as t } from "@babel/core";
+
+export function hasUnsafeConditionExpression(
+  path: NodePath<t.Expression>
+): boolean {
+  if (
+    path.isAssignmentExpression() ||
+    path.isUpdateExpression() ||
+    path.isCallExpression() ||
+    path.isOptionalCallExpression() ||
+    path.isTaggedTemplateExpression() ||
+    path.isNewExpression() ||
+    path.isAwaitExpression() ||
+    path.isYieldExpression() ||
+    (path.isLogicalExpression() &&
+      (path.node.operator === "||" || path.node.operator === "??"))
+  ) {
+    return true;
+  }
+
+  let unsafe = false;
+
+  path.traverse({
+    AssignmentExpression(expressionPath) {
+      unsafe = true;
+      expressionPath.stop();
+    },
+    LogicalExpression(expressionPath) {
+      if (
+        expressionPath.node.operator === "||" ||
+        expressionPath.node.operator === "??"
+      ) {
+        unsafe = true;
+        expressionPath.stop();
+      }
+    },
+    UpdateExpression(expressionPath) {
+      unsafe = true;
+      expressionPath.stop();
+    },
+    CallExpression(expressionPath) {
+      unsafe = true;
+      expressionPath.stop();
+    },
+    OptionalCallExpression(expressionPath) {
+      unsafe = true;
+      expressionPath.stop();
+    },
+    TaggedTemplateExpression(expressionPath) {
+      unsafe = true;
+      expressionPath.stop();
+    },
+    NewExpression(expressionPath) {
+      unsafe = true;
+      expressionPath.stop();
+    },
+    AwaitExpression(expressionPath) {
+      unsafe = true;
+      expressionPath.stop();
+    },
+    YieldExpression(expressionPath) {
+      unsafe = true;
+      expressionPath.stop();
+    }
+  });
+
+  return unsafe;
+}

--- a/packages/babel/src/defineRulesCxConditionsScope.ts
+++ b/packages/babel/src/defineRulesCxConditionsScope.ts
@@ -1,0 +1,142 @@
+import { type NodePath, types as t } from "@babel/core";
+import type { Binding } from "@babel/traverse";
+
+export function collectTopLevelDependencies(
+  paths: readonly NodePath<t.Expression>[]
+): readonly NodePath<t.Statement>[] | null {
+  const statements: NodePath<t.Statement>[] = [];
+  const seen = new Set<t.Statement>();
+
+  for (const path of paths) {
+    const bindings = collectReferencedBindings(path);
+
+    for (const binding of bindings) {
+      const statement = getTopLevelBindingStatement(binding);
+
+      if (statement === null) {
+        return null;
+      }
+
+      if (!seen.has(statement.node)) {
+        seen.add(statement.node);
+        statements.push(statement);
+      }
+    }
+  }
+
+  return statements;
+}
+
+export function dependenciesPrecedeStatement(
+  dependencies: readonly NodePath<t.Statement>[],
+  statement: NodePath<t.Statement>
+): boolean {
+  const statementStart = statement.node.start;
+
+  if (typeof statementStart !== "number") {
+    return false;
+  }
+
+  return dependencies.every((dependency) => {
+    if (dependency.node === statement.node) {
+      return false;
+    }
+
+    const dependencyStart = dependency.node.start;
+    return (
+      typeof dependencyStart === "number" && dependencyStart < statementStart
+    );
+  });
+}
+
+export function getEnclosingProgramStatement(
+  path: NodePath<t.Node>
+): NodePath<t.Statement> | null {
+  let current: NodePath<t.Node> | null = path;
+
+  while (current !== null && current.parentPath?.isProgram() !== true) {
+    current = current.parentPath;
+  }
+
+  return current !== null && current.isStatement() ? current : null;
+}
+
+export function getProgramInsertionPoint(
+  path: NodePath<t.Node>,
+  dependencyPaths: readonly NodePath<t.Expression>[]
+): {
+  readonly programStatement: NodePath<t.Statement>;
+  readonly programPath: NodePath<t.Program>;
+} | null {
+  const programStatement = getEnclosingProgramStatement(path);
+
+  if (programStatement === null) {
+    return null;
+  }
+
+  const dependencies = collectTopLevelDependencies(dependencyPaths);
+
+  if (
+    dependencies === null ||
+    !dependenciesPrecedeStatement(dependencies, programStatement)
+  ) {
+    return null;
+  }
+
+  const programPath = programStatement.findParent((parentPath) =>
+    parentPath.isProgram()
+  );
+
+  return programPath !== null && programPath.isProgram()
+    ? { programStatement, programPath }
+    : null;
+}
+
+function collectReferencedBindings(
+  path: NodePath<t.Expression>
+): readonly Binding[] {
+  const bindings: Binding[] = [];
+  const seen = new Set<Binding>();
+
+  collectReferencedBinding(path, bindings, seen);
+  path.traverse({
+    Identifier(identifierPath) {
+      if (identifierPath.isReferencedIdentifier()) {
+        collectReferencedBinding(identifierPath, bindings, seen);
+      }
+    }
+  });
+
+  return bindings;
+}
+
+function collectReferencedBinding(
+  path: NodePath<t.Node>,
+  bindings: Binding[],
+  seen: Set<Binding>
+): void {
+  if (!path.isIdentifier() || !path.isReferencedIdentifier()) {
+    return;
+  }
+
+  const binding = path.scope.getBinding(path.node.name);
+
+  if (binding === undefined || seen.has(binding)) {
+    return;
+  }
+
+  seen.add(binding);
+  bindings.push(binding);
+}
+
+function getTopLevelBindingStatement(
+  binding: Binding
+): NodePath<t.Statement> | null {
+  const statement = binding.path.getStatementParent();
+
+  if (statement === null || statement.parentPath?.isProgram() !== true) {
+    return null;
+  }
+
+  return statement;
+}

--- a/packages/babel/src/defineRulesCxConditionsShorthands.ts
+++ b/packages/babel/src/defineRulesCxConditionsShorthands.ts
@@ -1,0 +1,175 @@
+import { isSupportedCssDeclarationProperty } from "./cssProperty.js";
+
+const shorthandLonghands = {
+  all: [],
+  animation: [
+    "animationComposition",
+    "animationDelay",
+    "animationDirection",
+    "animationDuration",
+    "animationFillMode",
+    "animationIterationCount",
+    "animationName",
+    "animationPlayState",
+    "animationRangeEnd",
+    "animationRangeStart",
+    "animationTimeline",
+    "animationTimingFunction"
+  ],
+  background: [
+    "backgroundAttachment",
+    "backgroundBlendMode",
+    "backgroundClip",
+    "backgroundColor",
+    "backgroundImage",
+    "backgroundOrigin",
+    "backgroundPosition",
+    "backgroundRepeat",
+    "backgroundSize"
+  ],
+  border: [
+    "borderBottom",
+    "borderBottomColor",
+    "borderBottomStyle",
+    "borderBottomWidth",
+    "borderColor",
+    "borderLeft",
+    "borderLeftColor",
+    "borderLeftStyle",
+    "borderLeftWidth",
+    "borderRight",
+    "borderRightColor",
+    "borderRightStyle",
+    "borderRightWidth",
+    "borderStyle",
+    "borderTop",
+    "borderTopColor",
+    "borderTopStyle",
+    "borderTopWidth",
+    "borderWidth"
+  ],
+  borderBlock: [
+    "borderBlockColor",
+    "borderBlockEnd",
+    "borderBlockStart",
+    "borderBlockStyle",
+    "borderBlockWidth"
+  ],
+  borderInline: [
+    "borderInlineColor",
+    "borderInlineEnd",
+    "borderInlineStart",
+    "borderInlineStyle",
+    "borderInlineWidth"
+  ],
+  borderRadius: [
+    "borderBottomLeftRadius",
+    "borderBottomRightRadius",
+    "borderEndEndRadius",
+    "borderEndStartRadius",
+    "borderStartEndRadius",
+    "borderStartStartRadius",
+    "borderTopLeftRadius",
+    "borderTopRightRadius"
+  ],
+  columns: ["columnCount", "columnWidth"],
+  columnRule: ["columnRuleColor", "columnRuleStyle", "columnRuleWidth"],
+  flex: ["flexBasis", "flexGrow", "flexShrink"],
+  flexFlow: ["flexDirection", "flexWrap"],
+  font: [
+    "fontFamily",
+    "fontSize",
+    "fontStretch",
+    "fontStyle",
+    "fontVariant",
+    "fontWeight",
+    "lineHeight"
+  ],
+  gap: ["columnGap", "rowGap"],
+  grid: [
+    "gridAutoColumns",
+    "gridAutoFlow",
+    "gridAutoRows",
+    "gridTemplateAreas",
+    "gridTemplateColumns",
+    "gridTemplateRows"
+  ],
+  gridArea: ["gridColumnEnd", "gridColumnStart", "gridRowEnd", "gridRowStart"],
+  gridColumn: ["gridColumnEnd", "gridColumnStart"],
+  gridRow: ["gridRowEnd", "gridRowStart"],
+  gridTemplate: [
+    "gridTemplateAreas",
+    "gridTemplateColumns",
+    "gridTemplateRows"
+  ],
+  inset: ["bottom", "insetBlock", "insetInline", "left", "right", "top"],
+  insetBlock: ["insetBlockEnd", "insetBlockStart"],
+  insetInline: ["insetInlineEnd", "insetInlineStart"],
+  listStyle: ["listStyleImage", "listStylePosition", "listStyleType"],
+  margin: ["marginBottom", "marginLeft", "marginRight", "marginTop"],
+  marginBlock: ["marginBlockEnd", "marginBlockStart"],
+  marginInline: ["marginInlineEnd", "marginInlineStart"],
+  outline: ["outlineColor", "outlineStyle", "outlineWidth"],
+  overflow: ["overflowX", "overflowY"],
+  overscrollBehavior: ["overscrollBehaviorX", "overscrollBehaviorY"],
+  padding: ["paddingBottom", "paddingLeft", "paddingRight", "paddingTop"],
+  paddingBlock: ["paddingBlockEnd", "paddingBlockStart"],
+  paddingInline: ["paddingInlineEnd", "paddingInlineStart"],
+  placeContent: ["alignContent", "justifyContent"],
+  placeItems: ["alignItems", "justifyItems"],
+  placeSelf: ["alignSelf", "justifySelf"],
+  scrollMargin: [
+    "scrollMarginBottom",
+    "scrollMarginLeft",
+    "scrollMarginRight",
+    "scrollMarginTop"
+  ],
+  scrollPadding: [
+    "scrollPaddingBottom",
+    "scrollPaddingLeft",
+    "scrollPaddingRight",
+    "scrollPaddingTop"
+  ],
+  textDecoration: [
+    "textDecorationColor",
+    "textDecorationLine",
+    "textDecorationStyle",
+    "textDecorationThickness"
+  ],
+  textEmphasis: ["textEmphasisColor", "textEmphasisStyle"],
+  transition: [
+    "transitionBehavior",
+    "transitionDelay",
+    "transitionDuration",
+    "transitionProperty",
+    "transitionTimingFunction"
+  ]
+} as const satisfies Readonly<Record<string, readonly string[]>>;
+
+export function mayHaveShorthandConflict(left: string, right: string): boolean {
+  if (
+    left === right ||
+    !isSupportedCssDeclarationProperty(left) ||
+    !isSupportedCssDeclarationProperty(right)
+  ) {
+    return false;
+  }
+
+  return (
+    left === "all" ||
+    right === "all" ||
+    isShorthandFor(left, right) ||
+    isShorthandFor(right, left)
+  );
+}
+
+function isShorthandFor(shorthand: string, longhand: string): boolean {
+  return Object.entries(shorthandLonghands).some(
+    ([candidate, longhands]) =>
+      candidate === shorthand &&
+      longhands.some(
+        (property) =>
+          property === longhand || isShorthandFor(property, longhand)
+      )
+  );
+}

--- a/packages/babel/src/defineRulesCxConditionsTablePlan.ts
+++ b/packages/babel/src/defineRulesCxConditionsTablePlan.ts
@@ -1,0 +1,303 @@
+import { type NodePath, types as t } from "@babel/core";
+import type {
+  DefineRulesCxClassOperandMetadata,
+  DefineRulesCxOperandMetadata
+} from "./defineRulesCxConditionsTypes.js";
+
+export const TABLE_CONDITION_LIMIT = 4;
+
+type ClassPlan = {
+  readonly expression: t.Expression;
+  readonly path: NodePath<t.Expression>;
+};
+
+type OperandPlan =
+  | { readonly kind: "class"; readonly classOperand: ClassPlan }
+  | {
+      readonly kind: "condition";
+      readonly conditionIndex: number;
+      readonly classOperand: ClassPlan;
+    }
+  | {
+      readonly kind: "ternary";
+      readonly conditionIndex: number;
+      readonly consequent: ClassPlan;
+      readonly alternate: ClassPlan;
+    }
+  | { readonly kind: "array"; readonly operands: readonly OperandPlan[] };
+
+type PlanBuilder = {
+  readonly conditions: t.Expression[];
+  readonly classPaths: NodePath<t.Expression>[];
+};
+
+export type TablePlan = {
+  readonly callee: t.Expression;
+  readonly calleePath: NodePath<t.Expression>;
+  readonly conditions: readonly t.Expression[];
+  readonly entries: readonly (readonly t.Expression[])[];
+  readonly classPaths: readonly NodePath<t.Expression>[];
+};
+
+export function createTablePlan(
+  path: NodePath<t.CallExpression>,
+  operands: readonly DefineRulesCxOperandMetadata[]
+): TablePlan | null {
+  const builder: PlanBuilder = { conditions: [], classPaths: [] };
+  const argumentPaths = path.get("arguments");
+  const operandPlans: OperandPlan[] = [];
+  const calleePath = path.get("callee");
+
+  if (!calleePath.isExpression() || operands.length !== argumentPaths.length) {
+    return null;
+  }
+
+  for (let index = 0; index < operands.length; index += 1) {
+    const argumentPath = argumentPaths[index];
+    const metadata = operands[index];
+
+    if (
+      argumentPath === undefined ||
+      metadata === undefined ||
+      !argumentPath.isExpression()
+    ) {
+      return null;
+    }
+
+    const operandPlan = createOperandPlan({
+      path: argumentPath,
+      metadata,
+      builder
+    });
+
+    if (operandPlan === null) {
+      return null;
+    }
+    operandPlans.push(operandPlan);
+  }
+
+  if (
+    builder.conditions.length === 0 ||
+    builder.conditions.length > TABLE_CONDITION_LIMIT
+  ) {
+    return null;
+  }
+
+  return {
+    callee: t.cloneNode(calleePath.node),
+    calleePath,
+    conditions: builder.conditions,
+    entries: createPermutationEntries(operandPlans, builder.conditions.length),
+    classPaths: builder.classPaths
+  };
+}
+
+function createOperandPlan(input: {
+  readonly path: NodePath<t.Expression>;
+  readonly metadata: DefineRulesCxOperandMetadata;
+  readonly builder: PlanBuilder;
+}): OperandPlan | null {
+  switch (input.metadata.kind) {
+    case "class":
+      return createClassOperandPlan(input.path, input.metadata, input.builder);
+    case "condition":
+      return createConditionOperandPlan(
+        input.path,
+        input.metadata,
+        input.builder
+      );
+    case "ternary":
+      return createTernaryOperandPlan(
+        input.path,
+        input.metadata,
+        input.builder
+      );
+    case "array":
+      return createArrayOperandPlan(
+        input.path,
+        input.metadata.operands,
+        input.builder
+      );
+  }
+}
+
+function createClassOperandPlan(
+  path: NodePath<t.Expression>,
+  metadata: DefineRulesCxClassOperandMetadata,
+  builder: PlanBuilder
+): OperandPlan | null {
+  const classOperand = createClassPlan(path, metadata, builder);
+
+  return classOperand === null ? null : { kind: "class", classOperand };
+}
+
+function createConditionOperandPlan(
+  path: NodePath<t.Expression>,
+  metadata: Extract<
+    DefineRulesCxOperandMetadata,
+    { readonly kind: "condition" }
+  >,
+  builder: PlanBuilder
+): OperandPlan | null {
+  if (!path.isLogicalExpression() || path.node.operator !== "&&") {
+    return null;
+  }
+
+  const conditionPath = path.get("left");
+  const conditionIndex = builder.conditions.length;
+  const classOperand = createClassPlan(
+    path.get("right"),
+    metadata.classOperand,
+    builder
+  );
+
+  if (classOperand === null) {
+    return null;
+  }
+
+  builder.conditions.push(t.cloneNode(conditionPath.node));
+  return { kind: "condition", conditionIndex, classOperand };
+}
+
+function createTernaryOperandPlan(
+  path: NodePath<t.Expression>,
+  metadata: Extract<DefineRulesCxOperandMetadata, { readonly kind: "ternary" }>,
+  builder: PlanBuilder
+): OperandPlan | null {
+  if (!path.isConditionalExpression()) {
+    return null;
+  }
+
+  const conditionIndex = builder.conditions.length;
+  const consequent = createClassPlan(
+    path.get("consequent"),
+    metadata.consequent,
+    builder
+  );
+  const alternate = createClassPlan(
+    path.get("alternate"),
+    metadata.alternate,
+    builder
+  );
+
+  if (consequent === null || alternate === null) {
+    return null;
+  }
+
+  builder.conditions.push(t.cloneNode(path.node.test));
+  return { kind: "ternary", conditionIndex, consequent, alternate };
+}
+
+function createArrayOperandPlan(
+  path: NodePath<t.Expression>,
+  operands: readonly DefineRulesCxOperandMetadata[],
+  builder: PlanBuilder
+): OperandPlan | null {
+  if (!path.isArrayExpression()) {
+    return null;
+  }
+
+  const elementPaths = path.get("elements");
+  const operandPlans: OperandPlan[] = [];
+
+  if (elementPaths.length !== operands.length) {
+    return null;
+  }
+
+  for (let index = 0; index < operands.length; index += 1) {
+    const elementPath = elementPaths[index];
+    const metadata = operands[index];
+
+    if (elementPath === undefined || metadata === undefined) {
+      return null;
+    }
+
+    const expressionPath = elementPath.isExpression() ? elementPath : null;
+
+    if (expressionPath === null) {
+      return null;
+    }
+
+    const operandPlan = createOperandPlan({
+      path: expressionPath,
+      metadata,
+      builder
+    });
+
+    if (operandPlan === null) {
+      return null;
+    }
+    operandPlans.push(operandPlan);
+  }
+
+  return { kind: "array", operands: operandPlans };
+}
+
+function createClassPlan(
+  path: NodePath<t.Expression>,
+  metadata: DefineRulesCxClassOperandMetadata,
+  builder: PlanBuilder
+): ClassPlan | null {
+  if (!path.isExpression() || !path.isIdentifier()) {
+    return null;
+  }
+
+  if (path.node.start !== metadata.start || path.node.end !== metadata.end) {
+    return null;
+  }
+
+  builder.classPaths.push(path);
+  return { expression: t.cloneNode(path.node), path };
+}
+
+function createPermutationEntries(
+  operands: readonly OperandPlan[],
+  conditionCount: number
+): readonly (readonly t.Expression[])[] {
+  const entries: (readonly t.Expression[])[] = [];
+
+  for (let mask = 0; mask < 1 << conditionCount; mask += 1) {
+    const output: t.Expression[] = [];
+
+    for (const operand of operands) {
+      appendOperandEntry(operand, { mask, output });
+    }
+    entries.push(output);
+  }
+
+  return entries;
+}
+
+function appendOperandEntry(
+  operand: OperandPlan,
+  context: { readonly mask: number; readonly output: t.Expression[] }
+): void {
+  switch (operand.kind) {
+    case "class":
+      context.output.push(t.cloneNode(operand.classOperand.expression));
+      return;
+    case "condition":
+      if (isConditionEnabled(context.mask, operand.conditionIndex)) {
+        context.output.push(t.cloneNode(operand.classOperand.expression));
+      }
+      return;
+    case "ternary":
+      context.output.push(
+        t.cloneNode(
+          isConditionEnabled(context.mask, operand.conditionIndex)
+            ? operand.consequent.expression
+            : operand.alternate.expression
+        )
+      );
+      return;
+    case "array":
+      for (const child of operand.operands) {
+        appendOperandEntry(child, context);
+      }
+      return;
+  }
+}
+
+function isConditionEnabled(mask: number, conditionIndex: number): boolean {
+  return (mask & (1 << conditionIndex)) !== 0;
+}

--- a/packages/babel/src/defineRulesCxConditionsTypes.ts
+++ b/packages/babel/src/defineRulesCxConditionsTypes.ts
@@ -1,0 +1,87 @@
+import type { Binding } from "@babel/traverse";
+
+export const DEFINE_RULES_IMPORT_PATH = "@mincho-js/css";
+export const DEFINE_RULES_IMPORT_NAME = "defineRules";
+export const DEFINE_RULES_CX_RUNTIME_IMPORT_PATH =
+  "@mincho-js/css/defineRules/createDefineRulesCxRuntime";
+export const DEFINE_RULES_CX_RUNTIME_IMPORT_NAME = "createDefineRulesCxRuntime";
+export const DEFINE_RULES_SEGMENT_MARKER_PREFIX = "__mincho_seg_";
+export const DEFINE_RULES_CX_CONDITIONS_METADATA_KEY =
+  "minchoDefineRulesCxConditions";
+
+export type DefineRulesCxCalleeKind =
+  | "local-defineRules"
+  | "local-createDefineRulesCxRuntime"
+  | "provider-createDefineRulesCxRuntime";
+
+export type DefineRulesCxClassOperandSource =
+  | "local-css-call"
+  | "provider-marker";
+
+export type DefineRulesCxOperandMetadata =
+  | {
+      readonly kind: "class";
+      readonly source: DefineRulesCxClassOperandSource;
+      readonly start: number;
+      readonly end: number;
+    }
+  | {
+      readonly kind: "condition";
+      readonly operator: "&&";
+      readonly condition: DefineRulesCxExpressionRange;
+      readonly classOperand: DefineRulesCxClassOperandMetadata;
+    }
+  | {
+      readonly kind: "ternary";
+      readonly condition: DefineRulesCxExpressionRange;
+      readonly consequent: DefineRulesCxClassOperandMetadata;
+      readonly alternate: DefineRulesCxClassOperandMetadata;
+    }
+  | {
+      readonly kind: "array";
+      readonly operands: readonly DefineRulesCxOperandMetadata[];
+      readonly start: number;
+      readonly end: number;
+    };
+
+export type DefineRulesCxClassOperandMetadata = Extract<
+  DefineRulesCxOperandMetadata,
+  { readonly kind: "class" }
+>;
+
+export interface DefineRulesCxExpressionRange {
+  readonly start: number;
+  readonly end: number;
+}
+
+export interface DefineRulesCxConditionsCallMetadata {
+  readonly callee: DefineRulesCxCalleeKind;
+  readonly start: number;
+  readonly end: number;
+  readonly operandCount: number;
+  readonly conditionCount: number;
+  readonly classOperandCount: number;
+  readonly operands: readonly DefineRulesCxOperandMetadata[];
+}
+
+export interface DefineRulesCxConditionsMetadata {
+  calls: DefineRulesCxConditionsCallMetadata[];
+}
+
+export type DefineRulesRuntimeRef =
+  | {
+      readonly callee: "local-defineRules";
+      readonly namespaceBinding?: Binding;
+      readonly cssBinding?: Binding;
+    }
+  | {
+      readonly callee: "local-createDefineRulesCxRuntime";
+    }
+  | {
+      readonly callee: "provider-createDefineRulesCxRuntime";
+    };
+
+export interface StaticReference {
+  readonly bindingName: string;
+  readonly memberPath: readonly string[];
+}

--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -9,6 +9,11 @@ import {
   preprocessJsxCssProp,
   removeUnusedJsxCssPropCssModuleImports
 } from "./jsxCssProp.js";
+import {
+  analyzeDefineRulesCxConditionsCallExpression,
+  defineRulesCxConditionsOptimizationMetadataKey,
+  isDefineRulesCxConditionsEnabled
+} from "./defineRulesCxConditions.js";
 import { getDynamicCssVariableRule } from "./jsxCssProp/preprocess.js";
 import { supportedJsxCssPropTags } from "./jsxCssPropTags.js";
 import { createImportedStaticCssEvalProvider } from "./staticCssEval/importedModules.js";
@@ -34,6 +39,11 @@ export function minchoBabelPlugin(): PluginObj<PluginState> {
     visitor: {
       Program: {
         enter(path, state) {
+          if (isDefineRulesCxConditionsEnabled(state)) {
+            state.file.metadata[
+              defineRulesCxConditionsOptimizationMetadataKey
+            ] = true;
+          }
           preprocess(path, state);
           state.opts.jsxCssPropTransformed = preprocessJsxCssProp(path, state);
         },
@@ -42,7 +52,13 @@ export function minchoBabelPlugin(): PluginObj<PluginState> {
           postprocess(path, state);
         }
       },
-      CallExpression: transformCallExpression
+      CallExpression(path, state) {
+        analyzeDefineRulesCxConditionsCallExpression(path, state);
+
+        if (path.isCallExpression()) {
+          transformCallExpression(path);
+        }
+      }
     }
   };
 }
@@ -87,7 +103,7 @@ if (import.meta.vitest) {
   function babelTransform(
     code: string,
     pluginOptions: Partial<
-      Pick<PluginOptions, "jsxCssProp" | "staticCssEvalProvider">
+      Pick<PluginOptions, "jsxCssProp" | "staticCssEvalProvider" | "optimize">
     > = {},
     transformOptions: { filename?: string } = {}
   ) {
@@ -115,6 +131,7 @@ if (import.meta.vitest) {
   ) => Record<string, unknown>;
   type RuntimeCx = (...values: unknown[]) => string;
   type RuntimeCss = (styles: unknown) => string;
+  type DefineRulesCxRuntimeButton = (...args: unknown[]) => string;
   type RuntimeVx = (
     value: string | number | boolean | null | undefined,
     suffix?: string | null
@@ -151,6 +168,520 @@ if (import.meta.vitest) {
         };
       }
     };
+  }
+
+  function createDefineRulesCxRuntimeRecipeValue(): StaticCssEvalValue {
+    return {
+      importPath: "@mincho-js/css/defineRules/createDefineRulesCxRuntime",
+      importName: "createDefineRulesCxRuntime",
+      args: [{ properties: { color: true } }]
+    };
+  }
+
+  function createDefineRulesCxPermutationSource(
+    conditionCount: number
+  ): string {
+    const classImports = Array.from(
+      { length: conditionCount },
+      (_, index) => `class${index}`
+    );
+    const parameters = Array.from(
+      { length: conditionCount },
+      (_, index) => `flag${index}: boolean`
+    );
+    const operands = Array.from({ length: conditionCount }, (_, index) =>
+      index % 2 === 0
+        ? `flag${index} && class${index}`
+        : `flag${index} ? class${index} : base`
+    );
+
+    return `
+      import { cx, base, ${classImports.join(", ")} } from "./styles";
+
+      export function button(${parameters.join(", ")}) {
+        return cx(base, ${operands.join(", ")});
+      }
+    `;
+  }
+
+  function createLocalDefineRulesCxFallbackSource(
+    conditionCount: number
+  ): string {
+    const colorValues = ["red", "blue", "green", "purple", "orange", "pink"];
+    const classDeclarations = Array.from(
+      { length: conditionCount },
+      (_, index) =>
+        `const color${index} = css({ color: "${colorValues[index] ?? `color-${index}`}" });`
+    ).join("\n");
+    const parameters = Array.from(
+      { length: conditionCount },
+      (_, index) => `flag${index}: boolean`
+    );
+    const operands = Array.from({ length: conditionCount }, (_, index) => {
+      if (index % 3 === 1) {
+        return `flag${index} ? color${index} : base`;
+      }
+      if (index % 3 === 2) {
+        return `[flag${index} && color${index}]`;
+      }
+      return `flag${index} && color${index}`;
+    });
+
+    return `
+      import { defineRules } from "@mincho-js/css";
+
+      const { css, cx } = defineRules({
+        properties: { color: true }
+      });
+      const base = css({ color: "black" });
+      ${classDeclarations}
+
+      export function button(${parameters.join(", ")}) {
+        return cx(base, ${operands.join(", ")});
+      }
+    `;
+  }
+
+  function createDefineRulesCxRuntimeClasses(
+    conditionCount: number
+  ): Record<string, string> {
+    const classes: Record<string, string> = {
+      base: "__mincho_seg_base base"
+    };
+
+    for (let index = 0; index < conditionCount; index += 1) {
+      classes[`class${index}`] = `__mincho_seg_class_${index} class-${index}`;
+    }
+
+    return classes;
+  }
+
+  function createJoiningCx(onCall?: () => void): RuntimeCx {
+    return (...values) => {
+      onCall?.();
+      const strings = values.filter((value): value is string => {
+        if (typeof value !== "string") {
+          return false;
+        }
+
+        return value.length > 0;
+      });
+
+      return strings.join(" ");
+    };
+  }
+
+  function forEachBooleanPermutation(
+    conditionCount: number,
+    callback: (flags: readonly boolean[]) => void
+  ): void {
+    for (let mask = 0; mask < 1 << conditionCount; mask += 1) {
+      callback(
+        Array.from(
+          { length: conditionCount },
+          (_, index) => (mask & (1 << index)) !== 0
+        )
+      );
+    }
+  }
+
+  function runDefineRulesCxModule(
+    code: string,
+    classes: Readonly<Record<string, string>>,
+    cx: RuntimeCx
+  ): DefineRulesCxRuntimeButton {
+    const result = transformSync(code, {
+      plugins: [defineRulesCxRuntimeTransformPlugin()],
+      presets: ["@babel/preset-typescript"],
+      filename: "runtime-test.ts"
+    });
+
+    if (result === null || result.code == null) {
+      throw new Error("Failed to transform defineRules cx runtime test code");
+    }
+
+    const execute = new Function(
+      "__minchoCx",
+      "__minchoClasses",
+      `${result.code}\nreturn button;`
+    ) as (
+      runtimeCx: RuntimeCx,
+      runtimeClasses: Readonly<Record<string, string>>
+    ) => unknown;
+    const button = execute(cx, classes);
+
+    if (typeof button !== "function") {
+      throw new Error("Runtime test did not produce a button function");
+    }
+
+    return (...args) => {
+      const value: unknown = button(...args);
+
+      if (typeof value !== "string") {
+        throw new Error("Runtime test button did not return a string");
+      }
+
+      return value;
+    };
+  }
+
+  type RuntimeDefineRules = (config: unknown) => {
+    readonly css: RuntimeCss;
+    readonly cx: RuntimeCx;
+  };
+
+  interface InspectableDefineRulesRuntime {
+    readonly defineRules: RuntimeDefineRules;
+    computeClassNameStyle(className: string): Readonly<Record<string, string>>;
+  }
+
+  interface InspectableClassStyle {
+    readonly order: number;
+    readonly style: Readonly<Record<string, string>>;
+  }
+
+  function runLocalDefineRulesCxModule(
+    code: string,
+    defineRules: RuntimeDefineRules
+  ): DefineRulesCxRuntimeButton {
+    const result = transformSync(code, {
+      plugins: [localDefineRulesCxRuntimeTransformPlugin()],
+      presets: ["@babel/preset-typescript"],
+      filename: "runtime-test.ts"
+    });
+
+    if (result === null || result.code == null) {
+      throw new Error(
+        "Failed to transform local defineRules cx runtime test code"
+      );
+    }
+
+    const execute = new Function(
+      "__minchoDefineRules",
+      `${result.code}\nreturn button;`
+    ) as (runtimeDefineRules: RuntimeDefineRules) => unknown;
+    const button = execute(defineRules);
+
+    if (typeof button !== "function") {
+      throw new Error("Runtime test did not produce a button function");
+    }
+
+    return (...args) => {
+      const value: unknown = button(...args);
+
+      if (typeof value !== "string") {
+        throw new Error("Runtime test button did not return a string");
+      }
+
+      return value;
+    };
+  }
+
+  function localDefineRulesCxRuntimeTransformPlugin(): PluginObj {
+    return {
+      visitor: {
+        ImportDeclaration(importPath) {
+          if (importPath.node.source.value !== "@mincho-js/css") {
+            return;
+          }
+
+          const declarations = importPath.node.specifiers.flatMap(
+            (specifier) => {
+              if (
+                !t.isImportSpecifier(specifier) ||
+                !t.isIdentifier(specifier.imported) ||
+                !t.isIdentifier(specifier.local) ||
+                specifier.imported.name !== "defineRules"
+              ) {
+                return [];
+              }
+
+              return t.variableDeclaration("const", [
+                t.variableDeclarator(
+                  t.cloneNode(specifier.local),
+                  t.identifier("__minchoDefineRules")
+                )
+              ]);
+            }
+          );
+
+          if (declarations.length === 0) {
+            importPath.remove();
+            return;
+          }
+
+          importPath.replaceWithMultiple(declarations);
+        },
+        ExportNamedDeclaration(exportPath) {
+          const { declaration } = exportPath.node;
+
+          if (declaration !== null && declaration !== undefined) {
+            exportPath.replaceWith(declaration);
+          }
+        }
+      }
+    };
+  }
+
+  function createInspectableDefineRulesRuntime(): InspectableDefineRulesRuntime {
+    let nextClassId = 0;
+    const styles = new Map<string, InspectableClassStyle>();
+    const css: RuntimeCss = (styleInput) => {
+      if (!isInspectableStyle(styleInput)) {
+        throw new Error("Inspectable css() only accepts string-valued styles");
+      }
+
+      const className = `class-${nextClassId}`;
+      nextClassId += 1;
+      styles.set(className, { order: nextClassId, style: styleInput });
+      return className;
+    };
+    const cx: RuntimeCx = (...values) =>
+      mergeInspectableClassValues(styles, values).join(" ");
+
+    return {
+      defineRules: () => ({ css, cx }),
+      computeClassNameStyle(className) {
+        return computeInspectableClassNameStyle(styles, className);
+      }
+    };
+  }
+
+  function isInspectableStyle(
+    value: unknown
+  ): value is Readonly<Record<string, string>> {
+    return (
+      typeof value === "object" &&
+      value !== null &&
+      !Array.isArray(value) &&
+      Object.values(value).every((entry) => typeof entry === "string")
+    );
+  }
+
+  function flattenInspectableClassValues(values: readonly unknown[]): string[] {
+    const classNames: string[] = [];
+
+    for (const value of values) {
+      if (typeof value === "string") {
+        if (value.length > 0) {
+          classNames.push(value);
+        }
+        continue;
+      }
+
+      if (typeof value === "number") {
+        if (value !== 0) {
+          classNames.push(String(value));
+        }
+        continue;
+      }
+
+      if (Array.isArray(value)) {
+        classNames.push(...flattenInspectableClassValues(value));
+        continue;
+      }
+
+      if (typeof value === "object" && value !== null) {
+        for (const [className, enabled] of Object.entries(value)) {
+          if (enabled) {
+            classNames.push(className);
+          }
+        }
+      }
+    }
+
+    return classNames;
+  }
+
+  function mergeInspectableClassValues(
+    styles: ReadonlyMap<string, InspectableClassStyle>,
+    values: readonly unknown[]
+  ): string[] {
+    const classNames = flattenInspectableClassValues(values);
+    const keptClassNames: string[] = [];
+    const seenProperties = new Set<string>();
+
+    for (let index = classNames.length - 1; index >= 0; index -= 1) {
+      const className = classNames[index];
+      const style = className === undefined ? undefined : styles.get(className);
+
+      if (className === undefined || style === undefined) {
+        continue;
+      }
+
+      const properties = Object.keys(style.style);
+
+      if (properties.every((property) => seenProperties.has(property))) {
+        continue;
+      }
+
+      keptClassNames.push(className);
+      for (const property of properties) {
+        seenProperties.add(property);
+      }
+    }
+
+    return keptClassNames.reverse();
+  }
+
+  function computeInspectableClassNameStyle(
+    styles: ReadonlyMap<string, InspectableClassStyle>,
+    className: string
+  ): Readonly<Record<string, string>> {
+    const selectedTokens = new Set(
+      className.trim().split(/\s+/).filter(Boolean)
+    );
+    const selectedStyles = [...styles]
+      .filter(([token]) => selectedTokens.has(token))
+      .map(([, style]) => style)
+      .sort((left, right) => left.order - right.order);
+    const customProperties: Record<string, string> = {};
+    const properties: Record<string, string> = {};
+
+    for (const { style } of selectedStyles) {
+      for (const [property, value] of Object.entries(style)) {
+        if (property.startsWith("--")) {
+          customProperties[property] = value;
+          continue;
+        }
+
+        properties[property] = value;
+      }
+    }
+
+    for (const [property, value] of Object.entries(properties)) {
+      properties[property] = resolveInspectableCssValue(
+        value,
+        customProperties
+      );
+    }
+
+    return properties;
+  }
+
+  function resolveInspectableCssValue(
+    value: string,
+    customProperties: Readonly<Record<string, string>>
+  ): string {
+    let output = "";
+    let index = 0;
+
+    while (index < value.length) {
+      if (!value.startsWith("var(", index)) {
+        output += value[index] ?? "";
+        index += 1;
+        continue;
+      }
+
+      const parsed = parseInspectableVar(value, index);
+
+      if (parsed === null) {
+        output += value.slice(index);
+        break;
+      }
+
+      const customValue = customProperties[parsed.name];
+      output +=
+        customValue === undefined || customValue === "initial"
+          ? resolveInspectableCssValue(parsed.fallback, customProperties)
+          : customValue;
+      index = parsed.end;
+    }
+
+    return output.trim().replace(/\s+/g, " ");
+  }
+
+  function parseInspectableVar(
+    value: string,
+    start: number
+  ): {
+    readonly name: string;
+    readonly fallback: string;
+    readonly end: number;
+  } | null {
+    let depth = 1;
+    let comma = -1;
+
+    for (let index = start + 4; index < value.length; index += 1) {
+      const char = value[index];
+
+      if (char === "(") {
+        depth += 1;
+        continue;
+      }
+
+      if (char === ")") {
+        depth -= 1;
+
+        if (depth === 0) {
+          return comma === -1
+            ? null
+            : {
+                name: value.slice(start + 4, comma).trim(),
+                fallback: value.slice(comma + 1, index).trim(),
+                end: index + 1
+              };
+        }
+        continue;
+      }
+
+      if (char === "," && depth === 1 && comma === -1) {
+        comma = index;
+      }
+    }
+
+    return null;
+  }
+
+  function defineRulesCxRuntimeTransformPlugin(): PluginObj {
+    return {
+      visitor: {
+        ImportDeclaration(importPath) {
+          if (importPath.node.source.value !== "./styles") {
+            return;
+          }
+
+          const declarations = importPath.node.specifiers.flatMap(
+            (specifier) => {
+              if (
+                !t.isImportSpecifier(specifier) ||
+                !t.isIdentifier(specifier.imported) ||
+                !t.isIdentifier(specifier.local)
+              ) {
+                return [];
+              }
+
+              const importedName = specifier.imported.name;
+              const init =
+                importedName === "cx"
+                  ? t.identifier("__minchoCx")
+                  : t.memberExpression(
+                      t.identifier("__minchoClasses"),
+                      t.stringLiteral(importedName),
+                      true
+                    );
+
+              return t.variableDeclaration("const", [
+                t.variableDeclarator(t.cloneNode(specifier.local), init)
+              ]);
+            }
+          );
+
+          importPath.replaceWithMultiple(declarations);
+        },
+        ExportNamedDeclaration(exportPath) {
+          const { declaration } = exportPath.node;
+
+          if (declaration !== null && declaration !== undefined) {
+            exportPath.replaceWith(declaration);
+          }
+        }
+      }
+    };
+  }
+
+  function getDefineRulesCxConditionCalls(metadata: MinchoBabelFileMetadata) {
+    return metadata.minchoDefineRulesCxConditions?.calls ?? [];
   }
 
   function createUnsupportedReexportStaticCssEvalProvider(): StaticCssEvalProvider {
@@ -744,7 +1275,7 @@ if (import.meta.vitest) {
   function captureJsxCssPropFailure(
     code: string,
     pluginOptions: Partial<
-      Pick<PluginOptions, "jsxCssProp" | "staticCssEvalProvider">
+      Pick<PluginOptions, "jsxCssProp" | "staticCssEvalProvider" | "optimize">
     > = {},
     transformOptions: { filename?: string } = {}
   ): {
@@ -837,6 +1368,508 @@ if (import.meta.vitest) {
       expect(explicitFalse.code).toBe(omitted.code);
     });
 
+    it("leaves output unchanged when defineRules cx optimization is inactive", () => {
+      const source = `
+        import { defineRules } from '@mincho-js/css';
+
+        const rules = defineRules({
+          active: { color: "red" },
+          idle: { color: "blue" }
+        });
+
+        export function button(active: boolean) {
+          return rules.cx(rules.css("idle"), active && rules.css("active"));
+        }
+      `;
+      const omitted = babelTransform(source);
+      const emptyOptimize = babelTransform(source, { optimize: {} });
+      const disabledOptimize = babelTransform(source, {
+        optimize: { defineRulesCxConditions: false }
+      });
+
+      expect(emptyOptimize.result).toEqual(omitted.result);
+      expect(emptyOptimize.code).toBe(omitted.code);
+      expect(
+        emptyOptimize.metadata[defineRulesCxConditionsOptimizationMetadataKey]
+      ).toBeUndefined();
+      expect(disabledOptimize.result).toEqual(omitted.result);
+      expect(disabledOptimize.code).toBe(omitted.code);
+      expect(
+        disabledOptimize.metadata[
+          defineRulesCxConditionsOptimizationMetadataKey
+        ]
+      ).toBeUndefined();
+    });
+
+    it("accepts defineRules cx optimization independently from jsx css prop", () => {
+      const source = `
+        import { defineRules } from '@mincho-js/css';
+
+        const rules = defineRules({
+          active: { color: "red" },
+          idle: { color: "blue" }
+        });
+
+        export function button(active: boolean) {
+          return rules.cx(rules.css("idle"), active && rules.css("active"));
+        }
+      `;
+      const disabled = babelTransform(source, { jsxCssProp: false });
+      const enabled = babelTransform(source, {
+        jsxCssProp: false,
+        optimize: { defineRulesCxConditions: true }
+      });
+
+      expect(enabled.result).toEqual(disabled.result);
+      expect(enabled.code).toBe(disabled.code);
+      expect(
+        disabled.metadata[defineRulesCxConditionsOptimizationMetadataKey]
+      ).toBeUndefined();
+      expect(
+        enabled.metadata[defineRulesCxConditionsOptimizationMetadataKey]
+      ).toBe(true);
+    });
+
+    it("marks and precomputes safe in-file defineRules cx condition operands", () => {
+      const source = `
+        import { defineRules } from '@mincho-js/css';
+
+        const { css, cx } = defineRules({
+          properties: { color: true }
+        });
+        const base = css({ color: "blue" });
+        const activeClass = css({ color: "red" });
+
+        export function button(active: boolean, danger: boolean) {
+          return cx(base, active && activeClass, [danger ? activeClass : base]);
+        }
+      `;
+      const disabled = babelTransform(source, {
+        optimize: { defineRulesCxConditions: false }
+      });
+      const enabled = babelTransform(source, {
+        optimize: { defineRulesCxConditions: true }
+      });
+
+      expect(enabled.result).toEqual(disabled.result);
+      expect(disabled.code).toContain("return cx(");
+      expect(enabled.code).toContain("const _minchoDefineRulesCx = [");
+      expect(enabled.code).toContain("return _minchoDefineRulesCx[");
+      expect(getDefineRulesCxConditionCalls(enabled.metadata)).toMatchObject([
+        {
+          callee: "local-defineRules",
+          operandCount: 3,
+          conditionCount: 2,
+          classOperandCount: 4,
+          operands: [
+            { kind: "class", source: "local-css-call" },
+            {
+              kind: "condition",
+              operator: "&&",
+              classOperand: { kind: "class", source: "local-css-call" }
+            },
+            {
+              kind: "array",
+              operands: [
+                {
+                  kind: "ternary",
+                  consequent: { kind: "class", source: "local-css-call" },
+                  alternate: { kind: "class", source: "local-css-call" }
+                }
+              ]
+            }
+          ]
+        }
+      ]);
+    });
+
+    it("marks and precomputes provider-backed serialized defineRules cx calls and marker operands", () => {
+      const source = `
+        import { cx, base, activeClass } from "./styles";
+
+        export function button(active: boolean) {
+          return cx(base, active ? activeClass : base);
+        }
+      `;
+      const disabled = babelTransform(source, {
+        staticCssEvalProvider: createResolvedStaticCssEvalProvider({
+          cx: createDefineRulesCxRuntimeRecipeValue(),
+          base: "__mincho_seg_base base",
+          activeClass: "__mincho_seg_active active"
+        }),
+        optimize: { defineRulesCxConditions: false }
+      });
+      const enabled = babelTransform(source, {
+        staticCssEvalProvider: createResolvedStaticCssEvalProvider({
+          cx: createDefineRulesCxRuntimeRecipeValue(),
+          base: "__mincho_seg_base base",
+          activeClass: "__mincho_seg_active active"
+        }),
+        optimize: { defineRulesCxConditions: true }
+      });
+
+      expect(enabled.result).toEqual(disabled.result);
+      expect(disabled.code).toContain("return cx(");
+      expect(enabled.code).toContain("const _minchoDefineRulesCx = [");
+      expect(enabled.code).toContain("return _minchoDefineRulesCx[");
+      expect(getDefineRulesCxConditionCalls(enabled.metadata)).toMatchObject([
+        {
+          callee: "provider-createDefineRulesCxRuntime",
+          operandCount: 2,
+          conditionCount: 1,
+          classOperandCount: 3,
+          operands: [
+            { kind: "class", source: "provider-marker" },
+            {
+              kind: "ternary",
+              consequent: { kind: "class", source: "provider-marker" },
+              alternate: { kind: "class", source: "provider-marker" }
+            }
+          ]
+        }
+      ]);
+    });
+
+    it("bails out unchanged for unsupported defineRules cx condition shapes", () => {
+      const unsupportedReturns = [
+        "return cx(base || activeClass);",
+        "return cx(...classes);",
+        "return cx({ [base]: active });",
+        "return cx((active || activeClass) && base);",
+        "return cx(active.valueOf?.() && base);",
+        "return cx(String.raw`active` && base);"
+      ];
+
+      for (const returnStatement of unsupportedReturns) {
+        const source = `
+          import { defineRules } from '@mincho-js/css';
+
+          const { css, cx } = defineRules({
+            properties: { color: true }
+          });
+          const base = css({ color: "blue" });
+          const activeClass = css({ color: "red" });
+          const classes = [base, activeClass];
+
+          export function button(active: boolean) {
+            ${returnStatement}
+          }
+        `;
+        const disabled = babelTransform(source, {
+          optimize: { defineRulesCxConditions: false }
+        });
+        const enabled = babelTransform(source, {
+          optimize: { defineRulesCxConditions: true }
+        });
+
+        expect(enabled.result).toEqual(disabled.result);
+        expect(enabled.code).toBe(disabled.code);
+        expect(getDefineRulesCxConditionCalls(enabled.metadata)).toEqual([]);
+        expect(enabled.metadata.minchoStaticCssEval?.diagnostics ?? []).toEqual(
+          []
+        );
+      }
+    });
+
+    it("leaves provider-backed external class operands on the runtime path", () => {
+      const source = `
+        import { cx, base, externalClass } from "./styles";
+
+        export function button(active: boolean) {
+          return cx(base, active && externalClass);
+        }
+      `;
+      const staticCssEvalProvider = createResolvedStaticCssEvalProvider({
+        cx: createDefineRulesCxRuntimeRecipeValue(),
+        base: "__mincho_seg_base base",
+        externalClass: "external-class"
+      });
+      const disabled = babelTransform(source, {
+        staticCssEvalProvider,
+        optimize: { defineRulesCxConditions: false }
+      });
+      const enabled = babelTransform(source, {
+        staticCssEvalProvider,
+        optimize: { defineRulesCxConditions: true }
+      });
+
+      expect(enabled.code).toBe(disabled.code);
+      expect(getDefineRulesCxConditionCalls(enabled.metadata)).toEqual([]);
+    });
+
+    it("bails out without evaluating inactive function-call class operands", () => {
+      const source = `
+        import { defineRules } from '@mincho-js/css';
+
+        const { cx } = defineRules({
+          properties: { color: true }
+        });
+
+        function makeClass(): string {
+          throw new Error("inactive branch evaluated");
+        }
+
+        export function button(active: boolean) {
+          return cx(active && makeClass());
+        }
+      `;
+      const disabled = babelTransform(source, {
+        optimize: { defineRulesCxConditions: false }
+      });
+      const enabled = babelTransform(source, {
+        optimize: { defineRulesCxConditions: true }
+      });
+
+      expect(enabled.result).toEqual(disabled.result);
+      expect(enabled.code).toBe(disabled.code);
+      expect(enabled.code).toContain("active && makeClass()");
+      expect(getDefineRulesCxConditionCalls(enabled.metadata)).toEqual([]);
+      expect(enabled.metadata.minchoStaticCssEval?.diagnostics ?? []).toEqual(
+        []
+      );
+    });
+
+    it("precomputes 1-4 condition defineRules cx tables that match runtime cx", () => {
+      for (let conditionCount = 1; conditionCount <= 4; conditionCount += 1) {
+        const source = createDefineRulesCxPermutationSource(conditionCount);
+        const staticCssEvalProvider = createResolvedStaticCssEvalProvider({
+          cx: createDefineRulesCxRuntimeRecipeValue(),
+          ...createDefineRulesCxRuntimeClasses(conditionCount)
+        });
+        const disabled = babelTransform(source, {
+          staticCssEvalProvider,
+          optimize: { defineRulesCxConditions: false }
+        });
+        const enabled = babelTransform(source, {
+          staticCssEvalProvider,
+          optimize: { defineRulesCxConditions: true }
+        });
+        const classes = createDefineRulesCxRuntimeClasses(conditionCount);
+        let optimizedCxCalls = 0;
+        const optimizedButton = runDefineRulesCxModule(
+          enabled.code,
+          classes,
+          createJoiningCx(() => {
+            optimizedCxCalls += 1;
+          })
+        );
+        const optimizedCxCallsAfterInit = optimizedCxCalls;
+        const referenceButton = runDefineRulesCxModule(
+          disabled.code,
+          classes,
+          createJoiningCx()
+        );
+
+        expect(getDefineRulesCxConditionCalls(enabled.metadata)).toMatchObject([
+          { conditionCount }
+        ]);
+        expect(enabled.code).toContain("const _minchoDefineRulesCx = [");
+        expect(enabled.code).toContain("return _minchoDefineRulesCx[");
+        expect(enabled.code).not.toContain("return cx(");
+        expect(optimizedCxCallsAfterInit).toBe(1 << conditionCount);
+
+        forEachBooleanPermutation(conditionCount, (flags) => {
+          expect(optimizedButton(...flags)).toBe(referenceButton(...flags));
+        });
+        expect(optimizedCxCalls).toBe(optimizedCxCallsAfterInit);
+      }
+    });
+
+    it("preserves condition evaluation count and order for optimized tables", () => {
+      const source = `
+        import { cx, base, class0, class1 } from "./styles";
+
+        export function button(probe: { first: boolean; second: boolean }) {
+          return cx(base, probe.first && class0, probe.second && class1);
+        }
+      `;
+      const staticCssEvalProvider = createResolvedStaticCssEvalProvider({
+        cx: createDefineRulesCxRuntimeRecipeValue(),
+        base: "__mincho_seg_base base",
+        class0: "__mincho_seg_class_0 class-0",
+        class1: "__mincho_seg_class_1 class-1"
+      });
+      const enabled = babelTransform(source, {
+        staticCssEvalProvider,
+        optimize: { defineRulesCxConditions: true }
+      });
+      const events: string[] = [];
+      let optimizedCxCalls = 0;
+      const button = runDefineRulesCxModule(
+        enabled.code,
+        createDefineRulesCxRuntimeClasses(2),
+        createJoiningCx(() => {
+          optimizedCxCalls += 1;
+        })
+      );
+      const optimizedCxCallsAfterInit = optimizedCxCalls;
+      const probe = {
+        get first() {
+          events.push("first");
+          return true;
+        },
+        get second() {
+          events.push("second");
+          return false;
+        }
+      };
+
+      expect(button(probe)).toBe(
+        "__mincho_seg_base base __mincho_seg_class_0 class-0"
+      );
+      expect(events).toEqual(["first", "second"]);
+      expect(optimizedCxCalls).toBe(optimizedCxCallsAfterInit);
+    });
+
+    it("leaves more than 4 defineRules cx conditions on the runtime path", () => {
+      const source = createDefineRulesCxPermutationSource(5);
+      const staticCssEvalProvider = createResolvedStaticCssEvalProvider({
+        cx: createDefineRulesCxRuntimeRecipeValue(),
+        ...createDefineRulesCxRuntimeClasses(5)
+      });
+      const disabled = babelTransform(source, {
+        staticCssEvalProvider,
+        optimize: { defineRulesCxConditions: false }
+      });
+      const enabled = babelTransform(source, {
+        staticCssEvalProvider,
+        optimize: { defineRulesCxConditions: true }
+      });
+
+      expect(getDefineRulesCxConditionCalls(enabled.metadata)).toMatchObject([
+        { conditionCount: 5 }
+      ]);
+      expect(enabled.code).toBe(disabled.code);
+      expect(enabled.code).toContain("return cx(");
+      expect(enabled.code).not.toContain("_minchoDefineRulesCx");
+    });
+
+    it("folds 5+ local defineRules cx conflicts with fallback chains", () => {
+      const conditionCount = 5;
+      const source = createLocalDefineRulesCxFallbackSource(conditionCount);
+      const disabled = babelTransform(source, {
+        optimize: { defineRulesCxConditions: false }
+      });
+      const enabled = babelTransform(source, {
+        optimize: { defineRulesCxConditions: true }
+      });
+      const referenceRuntime = createInspectableDefineRulesRuntime();
+      const optimizedRuntime = createInspectableDefineRulesRuntime();
+      const referenceButton = runLocalDefineRulesCxModule(
+        disabled.code,
+        referenceRuntime.defineRules
+      );
+      const optimizedButton = runLocalDefineRulesCxModule(
+        enabled.code,
+        optimizedRuntime.defineRules
+      );
+      const cssCallCount = enabled.code.match(/css\(\{/g)?.length ?? 0;
+
+      expect(getDefineRulesCxConditionCalls(enabled.metadata)).toMatchObject([
+        { conditionCount }
+      ]);
+      expect(disabled.code).toContain("return cx(");
+      expect(enabled.code).not.toContain("const _minchoDefineRulesCx = [");
+      expect(enabled.code).not.toContain("return cx(");
+      expect(enabled.code).toContain('.filter(Boolean).join(" ")');
+      expect(cssCallCount).toBeLessThanOrEqual(conditionCount * 2 + 2);
+
+      forEachBooleanPermutation(conditionCount, (flags) => {
+        expect(
+          optimizedRuntime.computeClassNameStyle(optimizedButton(...flags)),
+          `flags: ${flags.join(",")}`
+        ).toEqual(
+          referenceRuntime.computeClassNameStyle(referenceButton(...flags))
+        );
+      });
+    });
+
+    it("bails out fallback chains for explicit shorthand conflicts", () => {
+      const propertyPairs = [
+        ["all", "color"],
+        ["inset", "top"],
+        ["placeItems", "alignItems"],
+        ["font", "fontFamily"],
+        ["border", "borderTopColor"]
+      ] as const;
+
+      for (const [shorthand, longhand] of propertyPairs) {
+        const source = `
+          import { defineRules } from "@mincho-js/css";
+
+          const { css, cx } = defineRules({
+            properties: { ${shorthand}: true, ${longhand}: true }
+          });
+          const base = css({ ${shorthand}: "initial", ${longhand}: "initial" });
+
+          export function button(
+            flag0: boolean,
+            flag1: boolean,
+            flag2: boolean,
+            flag3: boolean,
+            flag4: boolean
+          ) {
+            return cx(base, ${Array.from(
+              { length: 5 },
+              (_, index) => `flag${index} && base`
+            ).join(", ")});
+          }
+        `;
+        const disabled = babelTransform(source, {
+          optimize: { defineRulesCxConditions: false }
+        });
+        const enabled = babelTransform(source, {
+          optimize: { defineRulesCxConditions: true }
+        });
+
+        expect(enabled.code).toBe(disabled.code);
+      }
+    });
+
+    it("bails out fallback chains for missing-declaration branches", () => {
+      const source = `
+        import { defineRules } from "@mincho-js/css";
+
+        const { css, cx } = defineRules({
+          properties: { color: true }
+        });
+        const color0 = css({ color: "red" });
+        const color1 = css({ color: "blue" });
+        const color2 = css({ color: "green" });
+        const color3 = css({ color: "purple" });
+        const color4 = css({ color: "orange" });
+
+        export function button(
+          flag0: boolean,
+          flag1: boolean,
+          flag2: boolean,
+          flag3: boolean,
+          flag4: boolean
+        ) {
+          return cx(
+            flag0 && color0,
+            flag1 && color1,
+            flag2 && color2,
+            flag3 && color3,
+            flag4 && color4
+          );
+        }
+      `;
+      const disabled = babelTransform(source, {
+        optimize: { defineRulesCxConditions: false }
+      });
+      const enabled = babelTransform(source, {
+        optimize: { defineRulesCxConditions: true }
+      });
+
+      expect(getDefineRulesCxConditionCalls(enabled.metadata)).toMatchObject([
+        { conditionCount: 5 }
+      ]);
+      expect(enabled.code).toBe(disabled.code);
+      expect(enabled.code).toContain("return cx(");
+      expect(enabled.code).not.toContain("_minchoDefineRulesCx");
+    });
+
     it("accepts enabled jsx css prop mode when JSX has no css prop", () => {
       const source = `
         import { style } from '@mincho-js/css';
@@ -915,6 +1948,36 @@ if (import.meta.vitest) {
       expect(code).not.toContain("_cx(styles.button)");
       expect(result[1]).toContain("_css({");
       expect(result[1]).toContain('color: "red"');
+    });
+
+    it("lowers static computed keys and optional members like inline css rules", () => {
+      const { result, code } = babelTransform(
+        `
+        const colorKey = "color" as const;
+        const variantKey = "button" as const;
+        const styles = {
+          button: { color: "blue" },
+          optional: { card: { padding: 16 } }
+        } as const;
+
+        function App() {
+          return <>
+            <div css={{ [colorKey]: "red" }} />
+            <div css={styles[variantKey]} />
+            <div css={styles.optional?.card} />
+          </>;
+        }
+      `,
+        { jsxCssProp: true }
+      );
+
+      expect(code).not.toContain(" css=");
+      expect(code).not.toContain("_cx(");
+      expect(code.match(/className=\{_\$mincho\$\$App\d+\}/g)).toHaveLength(3);
+      expect(result[1].match(/_css\(/g) ?? []).toHaveLength(3);
+      expect(result[1]).toContain('color: "red"');
+      expect(result[1]).toContain('color: "blue"');
+      expect(result[1]).toContain("padding: 16");
     });
 
     it("lowers provider-resolved imported css props like inline object and array literals", () => {

--- a/packages/babel/src/jsxCssProp/preprocess.ts
+++ b/packages/babel/src/jsxCssProp/preprocess.ts
@@ -21,6 +21,7 @@ import { STATIC_CSS_API_POLICIES } from "../staticCssEval/policy.js";
 import type { StaticCssApiPolicy } from "../staticCssEval/policy.js";
 import { resolveSameFileStaticCssEvalExpression } from "../staticCssEval/sameFile.js";
 import type { PluginState, ProgramScope } from "../types.js";
+import { isNestedCssObjectKey } from "../cssProperty.js";
 import {
   getNearestIdentifier,
   invariant,
@@ -2722,19 +2723,6 @@ function getLeafDeclarationName(options: {
   return (
     options.declarationName ??
     (isNestedCssObjectKey(options.propertyName) ? null : options.propertyName)
-  );
-}
-
-function isNestedCssObjectKey(propertyName: string): boolean {
-  return (
-    propertyName === "selectors" ||
-    propertyName === "vars" ||
-    propertyName.startsWith("@") ||
-    propertyName.startsWith("_") ||
-    propertyName.startsWith("$") ||
-    propertyName.includes("&") ||
-    propertyName.includes(":") ||
-    propertyName.includes(" ")
   );
 }
 

--- a/packages/babel/src/types.ts
+++ b/packages/babel/src/types.ts
@@ -6,11 +6,15 @@ import type {
   StaticCssEvalDiagnostic,
   StaticCssEvalProvider
 } from "./staticCssEval/types.js";
+import type { DefineRulesCxConditionsMetadata } from "./defineRulesCxConditionsTypes.js";
 
 export interface PluginOptions {
   result: [string, string];
   jsxCssProp?: boolean;
   jsxCssPropTransformed?: boolean;
+  optimize?: {
+    defineRulesCxConditions?: boolean;
+  };
   /** @internal Prepared sync provider supplied by bundler prepasses only. */
   staticCssEvalProvider?: StaticCssEvalProvider;
 }
@@ -24,6 +28,7 @@ export interface MinchoStaticCssEvalMetadata {
 
 export interface MinchoBabelFileMetadata {
   minchoStaticCssEval?: MinchoStaticCssEvalMetadata;
+  minchoDefineRulesCxConditions?: DefineRulesCxConditionsMetadata;
   [key: string]: unknown;
 }
 

--- a/packages/css/src/defineRules/index.ts
+++ b/packages/css/src/defineRules/index.ts
@@ -10,7 +10,9 @@ import { identifierName } from "../utils.js";
 import { createDefineRulesRuntime } from "./runtime.js";
 import { defineRulesPropertyValues } from "./propertyValues.js";
 import { cx } from "../classname/cx.js";
+import { css as rootCss } from "../css/index.js";
 import type { DefineRulesRuntimeResult } from "./runtime.js";
+import { SEGMENT_MARKER_PREFIX } from "./metadata.js";
 import {
   normalizeDefineRulesConditions,
   normalizeDefineRulesConditionValue
@@ -370,6 +372,42 @@ if (import.meta.vitest) {
   const debugId = "myCSS";
   setFileScope("test");
 
+  const segmentMarkerPattern = new RegExp(
+    `^${SEGMENT_MARKER_PREFIX}[A-Za-z0-9_-]+$`
+  );
+  const splitClassNames = (className: string) =>
+    className.split(/\s+/).filter(Boolean);
+  const getSegmentMarkers = (className: string) =>
+    splitClassNames(className).filter((token) =>
+      segmentMarkerPattern.test(token)
+    );
+  const getAtomicClassNames = (className: string) =>
+    splitClassNames(className).filter(
+      (token) => !segmentMarkerPattern.test(token)
+    );
+  const withoutSegmentMarkers = (className: string) =>
+    getAtomicClassNames(className).join(" ");
+  const expectSingleSegmentMarker = (className: string) => {
+    const markers = getSegmentMarkers(className);
+    expect(markers).toHaveLength(1);
+    const marker = markers[0];
+
+    if (marker == null) {
+      throw new Error("Expected one Mincho segment marker");
+    }
+
+    return marker;
+  };
+  const expectFirstAtomicClassName = (className: string) => {
+    const atomicClassName = getAtomicClassNames(className)[0];
+
+    if (atomicClassName == null) {
+      throw new Error("Expected one atomic class name");
+    }
+
+    return atomicClassName;
+  };
+
   afterEach(() => {
     while (getActiveDefineRulesRegistrySession() != null) {
       endDefineRulesRegistrySession();
@@ -422,14 +460,16 @@ if (import.meta.vitest) {
     );
     const className = bindings.css({ display: "flex" });
 
-    expect(bindings.cx(className, "external")).toBe(`${className} external`);
+    expect(bindings.cx(className, "external")).toBe(
+      `${withoutSegmentMarkers(className)} external`
+    );
     expect(bindings.css.raw({ display: "flex" })).toEqual({
       display: "flex"
     });
 
-    expect(Object.values(bindings.preset.classNameByCache)).toEqual([
-      className
-    ]);
+    expect(Object.values(bindings.preset.classNameByCache)).toEqual(
+      getAtomicClassNames(className)
+    );
   }
 
   describe("defineRules", () => {
@@ -728,15 +768,17 @@ if (import.meta.vitest) {
         expect({ ...helperProperties }).toEqual(manualProperties);
         expect(helperCss.raw(input)).toEqual(manualCss.raw(input));
         expect(helperCss.raw(input)).toEqual(input);
-        expect(helperCss({ color: themeVars.colors.text.muted })).toMatch(
-          identifierName("propertyValuesLeafHelper")
-        );
+        expect(
+          expectFirstAtomicClassName(
+            helperCss({ color: themeVars.colors.text.muted })
+          )
+        ).toMatch(identifierName("propertyValuesLeafHelper"));
         expect(helperCss.raw(missingArrayValueInput)).toEqual({
           color: missingArrayValue
         });
-        expect(helperCss(missingArrayValueInput)).toMatch(
-          identifierName("propertyValuesLeafHelper")
-        );
+        expect(
+          expectFirstAtomicClassName(helperCss(missingArrayValueInput))
+        ).toMatch(identifierName("propertyValuesLeafHelper"));
       });
 
       it("matches hand-written properties for object maps", async () => {
@@ -771,7 +813,7 @@ if (import.meta.vitest) {
         expect(helperCss.raw(input)).toEqual({
           color: themeVars.colors.text.muted
         });
-        expect(helperCss(input)).toMatch(
+        expect(expectFirstAtomicClassName(helperCss(input))).toMatch(
           identifierName("propertyValuesObjectMapHelper")
         );
       });
@@ -813,7 +855,7 @@ if (import.meta.vitest) {
         expect({ ...helperProperties }).toEqual(manualProperties);
         expect(helperCss.raw(input)).toEqual(manualCss.raw(input));
         expect(helperCss.raw(input)).toEqual(input);
-        expect(helperCss(input).split(" ")).toEqual([
+        expect(getAtomicClassNames(helperCss(input))).toEqual([
           expect.stringMatching(identifierName("propertyValuesSpacingHelper")),
           expect.stringMatching(identifierName("propertyValuesSpacingHelper"))
         ]);
@@ -882,7 +924,7 @@ if (import.meta.vitest) {
 
         assertType<DefineRulesAuthoringShapeOwner>(presetOwner);
         expect(presetOwner.cx(className, "external")).toBe(
-          `${className} external`
+          `${withoutSegmentMarkers(className)} external`
         );
         expectDefineRulesAuthoringShapeBindings(presetOwner);
       });
@@ -896,7 +938,9 @@ if (import.meta.vitest) {
         assertType<DefineRulesAuthoringShapeOwner["css"]>(css);
         assertType<DefineRulesAuthoringShapeOwner["cx"]>(cx);
         assertType<DefineRulesPresetArtifactV4>(preset);
-        expect(cx(className, "external")).toBe(`${className} external`);
+        expect(cx(className, "external")).toBe(
+          `${withoutSegmentMarkers(className)} external`
+        );
         expectDefineRulesAuthoringShapeBindings({ css, cx, preset });
       });
 
@@ -911,7 +955,9 @@ if (import.meta.vitest) {
         assertType<DefineRulesAuthoringShapeOwner["css"]>(sharedCss);
         assertType<DefineRulesAuthoringShapeOwner["cx"]>(compose);
         assertType<DefineRulesPresetArtifactV4>(sharedPreset);
-        expect(compose(className, "external")).toBe(`${className} external`);
+        expect(compose(className, "external")).toBe(
+          `${withoutSegmentMarkers(className)} external`
+        );
         expectDefineRulesAuthoringShapeBindings({
           css: sharedCss,
           cx: compose,
@@ -1187,12 +1233,12 @@ if (import.meta.vitest) {
         const inverseColorClass = css({ color: themeVars.colors.text.inverse });
 
         expect(cardClass).not.toBe("");
-        expect(cardClass.split(" ").filter(Boolean).length).toBeGreaterThan(0);
+        expect(getAtomicClassNames(cardClass).length).toBeGreaterThan(0);
         expect(scopedCx(themeClass, cardClass)).toBe(
-          `${themeClass} ${cardClass}`
+          `${themeClass} ${withoutSegmentMarkers(cardClass)}`
         );
         expect(scopedCx(themeClass, baseColorClass, inverseColorClass)).toBe(
-          `${themeClass} ${inverseColorClass}`
+          `${themeClass} ${withoutSegmentMarkers(inverseColorClass)}`
         );
         expect(
           Object.getOwnPropertyDescriptor(themeVars, "fallbackVar")
@@ -1403,7 +1449,7 @@ if (import.meta.vitest) {
             }
           }
         });
-        expect(className.split(" ")).toHaveLength(5);
+        expect(getAtomicClassNames(className)).toHaveLength(5);
         expect(Object.values(preset.conditionById)).toEqual(
           expect.arrayContaining([
             {
@@ -1505,7 +1551,12 @@ if (import.meta.vitest) {
         const desktopPrimary = css({ _desktop: { color: "primary" } });
         const desktopInverse = css({ _desktop: { color: "inverse" } });
 
-        expect(scopedCx(desktopPrimary, desktopInverse)).toBe(desktopInverse);
+        const result = scopedCx(desktopPrimary, desktopInverse);
+
+        expect(withoutSegmentMarkers(result)).toBe(
+          withoutSegmentMarkers(desktopInverse)
+        );
+        expectSingleSegmentMarker(result);
       });
 
       it("keeps known classes for different conditions", () => {
@@ -1524,9 +1575,14 @@ if (import.meta.vitest) {
         const mobileMuted = css({ _mobile: { color: "muted" } });
         const desktopInverse = css({ _desktop: { color: "inverse" } });
 
-        expect(scopedCx(mobileMuted, desktopInverse)).toBe(
-          `${mobileMuted} ${desktopInverse}`
+        const result = scopedCx(mobileMuted, desktopInverse);
+
+        expect(withoutSegmentMarkers(result)).toBe(
+          `${withoutSegmentMarkers(mobileMuted)} ${withoutSegmentMarkers(
+            desktopInverse
+          )}`
         );
+        expectSingleSegmentMarker(result);
       });
 
       it("preserves unknown duplicate strings in order around known classes", () => {
@@ -1539,7 +1595,7 @@ if (import.meta.vitest) {
         const colorRed = owner.css({ color: "red" });
 
         expect(owner.cx("external external", colorRed, "external")).toBe(
-          `external external ${colorRed} external`
+          `external external ${withoutSegmentMarkers(colorRed)} external`
         );
       });
 
@@ -1571,10 +1627,23 @@ if (import.meta.vitest) {
           }
         });
 
-        expect(consumer.cx(providerColor, providerColor)).toBe(providerColor);
-        expect(
-          consumer.cx(providerColor, providerBackground, providerColor)
-        ).toBe(`${providerBackground} ${providerColor}`);
+        const deduped = consumer.cx(providerColor, providerColor);
+        const merged = consumer.cx(
+          providerColor,
+          providerBackground,
+          providerColor
+        );
+
+        expect(withoutSegmentMarkers(deduped)).toBe(
+          withoutSegmentMarkers(providerColor)
+        );
+        expectSingleSegmentMarker(deduped);
+        expect(withoutSegmentMarkers(merged)).toBe(
+          `${withoutSegmentMarkers(providerBackground)} ${withoutSegmentMarkers(
+            providerColor
+          )}`
+        );
+        expectSingleSegmentMarker(merged);
       });
 
       it("filters falsy values like root cx", () => {
@@ -1594,7 +1663,14 @@ if (import.meta.vitest) {
           active: [displayNone, displayFlex]
         });
 
-        expect(result).toEqual({ base: displayNone, active: displayFlex });
+        expect(withoutSegmentMarkers(result.base)).toBe(
+          withoutSegmentMarkers(displayNone)
+        );
+        expect(withoutSegmentMarkers(result.active)).toBe(
+          withoutSegmentMarkers(displayFlex)
+        );
+        expectSingleSegmentMarker(result.base);
+        expectSingleSegmentMarker(result.active);
       });
 
       it("merges known atomic classes through cx.with() and with().multiple()", () => {
@@ -1607,16 +1683,238 @@ if (import.meta.vitest) {
         ]);
         const composed = owner.cx.with(callback);
 
-        expect(composed(displayNone, displayFlex)).toBe(displayFlex);
+        const composedResult = composed(displayNone, displayFlex);
+        const composedMultiple = composed.multiple({
+          inactive: [displayNone],
+          active: [displayNone, displayFlex]
+        } as const);
+
+        expect(withoutSegmentMarkers(composedResult)).toBe(
+          withoutSegmentMarkers(displayFlex)
+        );
+        expectSingleSegmentMarker(composedResult);
         expect(callback).toHaveBeenNthCalledWith(1, displayNone, displayFlex);
-        expect(
-          composed.multiple({
-            inactive: [displayNone],
-            active: [displayNone, displayFlex]
-          } as const)
-        ).toEqual({ inactive: displayNone, active: displayFlex });
+        expect(withoutSegmentMarkers(composedMultiple.inactive)).toBe(
+          withoutSegmentMarkers(displayNone)
+        );
+        expect(withoutSegmentMarkers(composedMultiple.active)).toBe(
+          withoutSegmentMarkers(displayFlex)
+        );
+        expectSingleSegmentMarker(composedMultiple.inactive);
+        expectSingleSegmentMarker(composedMultiple.active);
         expect(callback).toHaveBeenNthCalledWith(2, displayNone);
         expect(callback).toHaveBeenNthCalledWith(3, displayNone, displayFlex);
+      });
+
+      describe("aggressive marker contract", () => {
+        it("returns marker-bearing css() strings while keeping atomic classes", () => {
+          const owner = defineRules({
+            debugId: "cxMarkerCssOutput",
+            properties: {
+              color: true,
+              display: ["none", "flex"]
+            }
+          });
+          const className = owner.css({ color: "red", display: "flex" });
+          const tokens = splitClassNames(className);
+
+          expectSingleSegmentMarker(className);
+          for (const atomicClassName of Object.values(
+            owner.preset.classNameByCache
+          )) {
+            expect(tokens).toContain(atomicClassName);
+          }
+        });
+
+        it("keeps marker tokens inert outside the atomic class artifact", () => {
+          const owner = defineRules({
+            debugId: "cxMarkerInert",
+            properties: {
+              color: true
+            }
+          });
+          const className = owner.css({ color: "red" });
+          const marker = expectSingleSegmentMarker(className);
+
+          expect(Object.values(owner.preset.classNameByCache)).not.toContain(
+            marker
+          );
+          expect(owner.css.raw({ color: "red" })).toEqual({ color: "red" });
+        });
+
+        it("keeps empty custom-property declarations available to scoped css", () => {
+          const owner = defineRules({
+            debugId: "cxEmptyCustomPropertyHook",
+            properties: {
+              "--mincho-cx-hook": {
+                "": { vars: { "--mincho-cx-hook": "" } }
+              }
+            }
+          });
+
+          expect(owner.css.raw({ "--mincho-cx-hook": "" })).toEqual({
+            vars: { "--mincho-cx-hook": "" }
+          });
+          expectSingleSegmentMarker(owner.css({ "--mincho-cx-hook": "" }));
+        });
+
+        it("keeps ordinary css() output marker-free", () => {
+          const className = rootCss({ color: "red" });
+
+          expect(getSegmentMarkers(className)).toEqual([]);
+        });
+
+        it("derives the same marker for equivalent hydrated preset segments", () => {
+          const provider = defineRules({
+            debugId: "cxMarkerStableProvider",
+            properties: {
+              color: true,
+              display: ["none", "flex"]
+            }
+          });
+          const providerClassName = provider.css({
+            color: "red",
+            display: "flex"
+          });
+          const consumerA = defineRules({
+            debugId: "cxMarkerStableConsumerA",
+            presets: provider.preset,
+            properties: {
+              color: true,
+              display: ["none", "flex"]
+            }
+          });
+          const consumerB = defineRules({
+            debugId: "cxMarkerStableConsumerB",
+            presets: [provider.preset],
+            properties: {
+              color: true,
+              display: ["none", "flex"]
+            }
+          });
+
+          expect(
+            expectSingleSegmentMarker(
+              consumerA.css({ color: "red", display: "flex" })
+            )
+          ).toBe(expectSingleSegmentMarker(providerClassName));
+          expect(
+            expectSingleSegmentMarker(
+              consumerB.css({ color: "red", display: "flex" })
+            )
+          ).toBe(expectSingleSegmentMarker(providerClassName));
+        });
+
+        it("dedupes cx(cssA, cssB) with a single marker-bearing result", () => {
+          const owner = createDefineRulesAuthoringShapeOwner("cxMarkerDedupe");
+          const displayNone = owner.css({ display: "none" });
+          const displayFlex = owner.css({ display: "flex" });
+          const result = owner.cx(displayNone, displayFlex);
+
+          expectSingleSegmentMarker(result);
+          expect(result).not.toContain(expectFirstAtomicClassName(displayNone));
+          expect(result).toContain(expectFirstAtomicClassName(displayFlex));
+          expect(result).not.toContain(expectSingleSegmentMarker(displayNone));
+        });
+
+        it("keeps nested cx(cx(a, b), c) equal to flat cx(a, b, c)", () => {
+          const owner = defineRules({
+            debugId: "cxNestedMarker",
+            properties: {
+              background: true,
+              color: true
+            }
+          });
+          const colorRed = owner.css({ color: "red" });
+          const backgroundBlue = owner.css({ background: "blue" });
+          const colorGreen = owner.css({ color: "green" });
+          const flat = owner.cx(colorRed, backgroundBlue, colorGreen);
+          const nested = owner.cx(
+            owner.cx(colorRed, backgroundBlue),
+            colorGreen
+          );
+
+          expect(nested).toBe(flat);
+          expectSingleSegmentMarker(nested);
+        });
+
+        it("uses a marker segment inside interpolated class strings", () => {
+          const owner = createDefineRulesAuthoringShapeOwner(
+            "cxInterpolatedMarker"
+          );
+          const colorRed = owner.css({ color: "red" });
+          const result = owner.cx(`before ${colorRed} external`);
+          const tokens = splitClassNames(result);
+          const colorClassName = expectFirstAtomicClassName(colorRed);
+          const marker = expectSingleSegmentMarker(colorRed);
+          const beforeIndex = tokens.indexOf("before");
+          const colorIndex = tokens.indexOf(colorClassName);
+          const externalIndex = tokens.indexOf("external");
+
+          expect(getSegmentMarkers(result)).toEqual([]);
+          expect(result).not.toContain(marker);
+          expect(beforeIndex).toBeGreaterThanOrEqual(0);
+          expect(colorIndex).toBeGreaterThanOrEqual(0);
+          expect(colorIndex).toBeGreaterThan(beforeIndex);
+          expect(externalIndex).toBeGreaterThan(colorIndex);
+        });
+
+        it("keeps unknown-only input compatible without a fake marker", () => {
+          const owner = createDefineRulesAuthoringShapeOwner(
+            "cxMarkerUnknownOnly"
+          );
+          const result = owner.cx("external", ["external"], { active: true });
+
+          expect(result).toBe(cx("external", ["external"], { active: true }));
+          expect(getSegmentMarkers(result)).toEqual([]);
+        });
+
+        it("preserves unregistered marker-looking user class tokens safely", () => {
+          const owner =
+            createDefineRulesAuthoringShapeOwner("cxMarkerCollision");
+          const markerLikeClassName = "__mincho_seg_user_supplied";
+          const displayNone = owner.css({ display: "none" });
+          const displayFlex = owner.css({ display: "flex" });
+          const result = owner.cx(
+            markerLikeClassName,
+            displayNone,
+            displayFlex
+          );
+          const tokens = splitClassNames(result);
+
+          expect(tokens).toContain(markerLikeClassName);
+          expect(result).not.toContain(expectFirstAtomicClassName(displayNone));
+          expect(result).toContain(expectFirstAtomicClassName(displayFlex));
+        });
+
+        it("keeps cx.multiple() and cx.with() marker-bearing", () => {
+          const owner = createDefineRulesAuthoringShapeOwner(
+            "cxMarkerMultipleWith"
+          );
+          const displayNone = owner.css({ display: "none" });
+          const displayFlex = owner.css({ display: "flex" });
+          const composed = owner.cx.with((base: string, override?: string) => [
+            base,
+            override
+          ]);
+          const multiple = owner.cx.multiple({
+            base: displayNone,
+            active: [displayNone, displayFlex]
+          });
+          const composedResult = composed(displayNone, displayFlex);
+          const composedMultiple = composed.multiple({
+            base: [displayNone],
+            active: [displayNone, displayFlex]
+          } as const);
+
+          expectSingleSegmentMarker(multiple.base);
+          expectSingleSegmentMarker(multiple.active);
+          expectSingleSegmentMarker(composedResult);
+          expectSingleSegmentMarker(composedMultiple.base);
+          expectSingleSegmentMarker(composedMultiple.active);
+          expect(multiple.active).toBe(composedResult);
+          expect(composedMultiple.active).toBe(composedResult);
+        });
       });
 
       it("preserves repeated full cx inputs while using the private full-result cache", () => {
@@ -1630,7 +1928,9 @@ if (import.meta.vitest) {
         const colorRed = owner.css({ color: "red" });
         const colorBlue = owner.css({ color: "blue" });
         const backgroundBlue = owner.css({ background: "blue" });
-        const expected = `external external ${backgroundBlue} ${colorBlue} external`;
+        const expected = `external external ${withoutSegmentMarkers(
+          backgroundBlue
+        )} ${withoutSegmentMarkers(colorBlue)} external`;
 
         expect(
           owner.cx(
@@ -1724,13 +2024,13 @@ if (import.meta.vitest) {
             consumer.preset
           );
           expect(Object.values(provider.preset.classNameByCache)).toEqual([
-            providerColor
+            expectFirstAtomicClassName(providerColor)
           ]);
           expect(Object.values(middle.preset.classNameByCache)).toEqual([
-            middleColor
+            expectFirstAtomicClassName(middleColor)
           ]);
           expect(Object.values(consumer.preset.classNameByCache)).toEqual([
-            consumerBackground
+            expectFirstAtomicClassName(consumerBackground)
           ]);
         } finally {
           expect(endDefineRulesRegistrySession()).toBe(session);
@@ -1896,12 +2196,16 @@ if (import.meta.vitest) {
         const repeatedClassName = css({ background: "blue" });
 
         expect(repeatedClassName).toBe(className);
-        expect(Object.values(preset.classNameByCache)).toContain(className);
+        expect(Object.values(preset.classNameByCache)).toContain(
+          expectFirstAtomicClassName(className)
+        );
         expect(Object.values(preset.classNameByCache)).toHaveLength(1);
         expect(Object.keys(preset.writeKeyByCacheKey)).toEqual(
           Object.keys(preset.classNameByCache)
         );
-        expect(JSON.stringify(preset).split(className)).toHaveLength(2);
+        expect(
+          JSON.stringify(preset).split(expectFirstAtomicClassName(className))
+        ).toHaveLength(2);
       });
 
       it("serializes an empty v4 preset object without static calls", () => {
@@ -1934,7 +2238,9 @@ if (import.meta.vitest) {
 
         const className = css({ background: "blue" });
 
-        expect(Object.values(preset.classNameByCache)).toEqual([className]);
+        expect(Object.values(preset.classNameByCache)).toEqual(
+          getAtomicClassNames(className)
+        );
         expect(Object.keys(preset.writeKeyByCacheKey)).toEqual(
           Object.keys(preset.classNameByCache)
         );
@@ -2011,9 +2317,14 @@ if (import.meta.vitest) {
         const reconstructedCx = createDefineRulesCxRuntime(recipeConfig);
 
         expect(reconstructedCx).not.toBe(cx);
-        expect(reconstructedCx(red, blue)).toBe(blue);
+        const reconstructedResult = reconstructedCx(red, blue);
+
+        expect(withoutSegmentMarkers(reconstructedResult)).toBe(
+          withoutSegmentMarkers(blue)
+        );
+        expectSingleSegmentMarker(reconstructedResult);
         expect(reconstructedCx("external external", red, "external")).toBe(
-          `external external ${red} external`
+          `external external ${withoutSegmentMarkers(red)} external`
         );
       });
 
@@ -2316,7 +2627,10 @@ if (import.meta.vitest) {
         const consumerBackground = consumer.css({ background: "blue" });
 
         expect(Object.values(consumer.preset.classNameByCache)).toEqual(
-          expect.arrayContaining([providerColor, consumerBackground])
+          expect.arrayContaining([
+            expectFirstAtomicClassName(providerColor),
+            expectFirstAtomicClassName(consumerBackground)
+          ])
         );
         expect(Object.values(consumer.preset.classNameByCache)).toHaveLength(2);
         expect(artifact).toEqual(artifactSnapshot);
@@ -2357,14 +2671,14 @@ if (import.meta.vitest) {
 
         expect(Object.values(consumer.preset.classNameByCache)).toEqual(
           expect.arrayContaining([
-            colorClassName,
-            displayClassName,
-            consumerBackground
+            expectFirstAtomicClassName(colorClassName),
+            expectFirstAtomicClassName(displayClassName),
+            expectFirstAtomicClassName(consumerBackground)
           ])
         );
         expect(Object.values(consumer.preset.classNameByCache)).toHaveLength(3);
         expect(Object.values(colorProvider.preset.classNameByCache)).toEqual([
-          colorClassName
+          expectFirstAtomicClassName(colorClassName)
         ]);
         expect(displayArtifact).toEqual(displayArtifactSnapshot);
       });
@@ -2396,10 +2710,13 @@ if (import.meta.vitest) {
         expect(reusedBackground).toBe(providerBackground);
         expect(reusedBackground).not.toMatch(identifierName("consumer"));
         expect(presetHandle).toEqual(importedSnapshot.classNameByCache);
-        expect(Object.values(presetHandle)).toEqual([providerBackground]);
+        expect(Object.values(presetHandle)).toEqual([
+          expectFirstAtomicClassName(providerBackground)
+        ]);
         expect(
           Object.values(presetHandle).filter(
-            (className) => className === reusedBackground
+            (className) =>
+              className === expectFirstAtomicClassName(reusedBackground)
           )
         ).toHaveLength(1);
         expect(presetHandle).toBe(consumer.preset.classNameByCache);
@@ -2440,23 +2757,29 @@ if (import.meta.vitest) {
         const consumerABackground = consumerA.css({ background: "blue" });
 
         expect(Object.values(consumerA.preset.classNameByCache)).toEqual(
-          expect.arrayContaining([providerColor, consumerABackground])
+          expect.arrayContaining([
+            expectFirstAtomicClassName(providerColor),
+            expectFirstAtomicClassName(consumerABackground)
+          ])
         );
         expect(Object.values(consumerA.preset.classNameByCache)).toHaveLength(
           2
         );
         expect(Object.values(consumerB.preset.classNameByCache)).toEqual([
-          providerColor
+          expectFirstAtomicClassName(providerColor)
         ]);
 
         const consumerBBackground = consumerB.css({ background: "blue" });
 
         expect(consumerABackground).not.toBe(consumerBBackground);
         expect(Object.values(consumerB.preset.classNameByCache)).toEqual(
-          expect.arrayContaining([providerColor, consumerBBackground])
+          expect.arrayContaining([
+            expectFirstAtomicClassName(providerColor),
+            expectFirstAtomicClassName(consumerBBackground)
+          ])
         );
         expect(Object.values(consumerB.preset.classNameByCache)).not.toContain(
-          consumerABackground
+          expectFirstAtomicClassName(consumerABackground)
         );
         expect(sharedPreset).toEqual(sharedSnapshot);
       });
@@ -2674,12 +2997,20 @@ if (import.meta.vitest) {
         const combined = css({ color: "red", background: "blue" });
         const reversedCombined = css({ background: "blue", color: "red" });
 
-        expect(colorRed).toMatch(identifierName(debugId));
+        expect(expectFirstAtomicClassName(colorRed)).toMatch(
+          identifierName(debugId)
+        );
 
         expect(colorRed).toBe(css({ color: "red" }));
         expect(backgroundBlue).toBe(css({ background: "blue" }));
-        expect(combined).toBe(`${colorRed} ${backgroundBlue}`);
-        expect(reversedCombined).toBe(`${backgroundBlue} ${colorRed}`);
+        expect(getAtomicClassNames(combined)).toEqual([
+          ...getAtomicClassNames(colorRed),
+          ...getAtomicClassNames(backgroundBlue)
+        ]);
+        expect(getAtomicClassNames(reversedCombined)).toEqual([
+          ...getAtomicClassNames(backgroundBlue),
+          ...getAtomicClassNames(colorRed)
+        ]);
       });
 
       it("preserves surviving class source order instead of lexicographic order", () => {
@@ -2715,9 +3046,14 @@ if (import.meta.vitest) {
         if (sourceFirst == null || lexicographicFirst == null) return;
         expect(sourceFirst.className > lexicographicFirst.className).toBe(true);
 
-        expect(css([sourceFirst.input, lexicographicFirst.input])).toBe(
-          `${sourceFirst.className} ${lexicographicFirst.className}`
-        );
+        expect(
+          getAtomicClassNames(
+            css([sourceFirst.input, lexicographicFirst.input])
+          )
+        ).toEqual([
+          ...getAtomicClassNames(sourceFirst.className),
+          ...getAtomicClassNames(lexicographicFirst.className)
+        ]);
       });
 
       it("css() reuses equivalent atomic fragments when object key order differs", () => {
@@ -2742,12 +3078,16 @@ if (import.meta.vitest) {
           }
         });
 
-        const redFirstClassNames = css({
-          background: { red: 255, blue: 255 }
-        }).split(" ");
-        const blueFirstClassNames = css({
-          background: { blue: 255, red: 255 }
-        }).split(" ");
+        const redFirstClassNames = getAtomicClassNames(
+          css({
+            background: { red: 255, blue: 255 }
+          })
+        );
+        const blueFirstClassNames = getAtomicClassNames(
+          css({
+            background: { blue: 255, red: 255 }
+          })
+        );
 
         expect(new Set(redFirstClassNames)).toEqual(
           new Set(blueFirstClassNames)
@@ -2794,24 +3134,26 @@ if (import.meta.vitest) {
         });
 
         const cssFullFirst = createCss();
-        const fullRed = cssFullFirst({ background: "red" }).split(" ");
+        const fullRed = getAtomicClassNames(
+          cssFullFirst({ background: "red" })
+        );
         const prunedAfterFull = cssFullFirst([
           { background: "red" },
           { background: "blue" }
-        ]).split(" ");
+        ]);
+        const prunedAfterFullClassNames = getAtomicClassNames(prunedAfterFull);
 
         expect(fullRed).toHaveLength(2);
-        expect(prunedAfterFull).toHaveLength(2);
-        expect(prunedAfterFull[0]).toBe(fullRed[0]);
-        expect(prunedAfterFull[1]).not.toBe(fullRed[1]);
+        expect(prunedAfterFullClassNames).toHaveLength(2);
+        expect(prunedAfterFullClassNames[0]).toBe(fullRed[0]);
+        expect(prunedAfterFullClassNames[1]).not.toBe(fullRed[1]);
 
         const cssPrunedFirst = createCss();
-        const prunedBeforeFull = cssPrunedFirst([
-          { background: "red" },
-          { background: "blue" }
-        ]).split(" ");
-        const fullAfterPruned = cssPrunedFirst({ background: "red" }).split(
-          " "
+        const prunedBeforeFull = getAtomicClassNames(
+          cssPrunedFirst([{ background: "red" }, { background: "blue" }])
+        );
+        const fullAfterPruned = getAtomicClassNames(
+          cssPrunedFirst({ background: "red" })
         );
 
         expect(prunedBeforeFull).toHaveLength(2);
@@ -3024,7 +3366,7 @@ if (import.meta.vitest) {
             paddingRight: 4
           })
         );
-        expect(css({ center: "inline" }).split(" ")).toHaveLength(3);
+        expect(getAtomicClassNames(css({ center: "inline" }))).toHaveLength(3);
       });
 
       it("resolves shortcut conflicts by transformed property within each condition", () => {

--- a/packages/css/src/defineRules/metadata.ts
+++ b/packages/css/src/defineRules/metadata.ts
@@ -20,6 +20,7 @@ export type CompiledEntry =
   | CompiledUnknownEntry;
 export interface CompiledSegment extends DefineRulesPresetCompiledSegment {
   entries: CompiledEntry[];
+  marker?: string;
 }
 
 export interface EngineMetadataOptions {
@@ -45,7 +46,13 @@ export interface EngineMetadata {
       "classNameByCache" | "writeKeyByCacheKey"
     >
   ): void;
-  registerSegment(input: string, compiledSegment: CompiledSegment): void;
+  registerSegment(
+    input: string,
+    compiledSegment: CompiledSegment
+  ): string | undefined;
+  getRegisteredSegment(input: string): CompiledSegment | undefined;
+  getSegmentByMarker(marker: string): CompiledSegment | undefined;
+  getSegmentByMarkerToken(token: string): CompiledSegment | undefined;
   getCompiledSegment(input: string): CompiledSegment;
   compileSegment(input: string): CompiledSegment;
   mergeCompiledSegments(segments: readonly CompiledSegment[]): string;
@@ -63,6 +70,7 @@ export interface EngineMetadata {
 const DEFAULT_SEGMENT_CACHE_SIZE = 2048;
 const DEFAULT_FULL_RESULT_CACHE_SIZE = 4;
 const MAX_EPOCH = 0xffffffff;
+export const SEGMENT_MARKER_PREFIX = "__mincho_seg_";
 
 class BoundedLru<K, V> {
   private readonly entries = new Map<K, V>();
@@ -84,23 +92,28 @@ class BoundedLru<K, V> {
     return value;
   }
 
-  set(key: K, value: V): void {
+  set(key: K, value: V): readonly [K, V] | undefined {
     if (this.maxSize === 0) {
-      return;
+      return undefined;
     }
 
     this.entries.delete(key);
     this.entries.set(key, value);
 
+    let evicted: readonly [K, V] | undefined;
+
     while (this.entries.size > this.maxSize) {
-      const oldest = this.entries.keys().next();
+      const oldest = this.entries.entries().next();
 
       if (oldest.done) {
-        return;
+        return evicted;
       }
 
-      this.entries.delete(oldest.value);
+      evicted = oldest.value;
+      this.entries.delete(oldest.value[0]);
     }
+
+    return evicted;
   }
 
   clear(): void {
@@ -115,6 +128,22 @@ class BoundedLru<K, V> {
     return this.entries.size;
   }
 }
+
+type CachedCompiledSegment = {
+  readonly segment: CompiledSegment;
+  readonly atomicRegistryVersion: number;
+};
+
+type CachedFullResult = {
+  readonly result: string;
+  readonly hasUnknownClass: boolean;
+  readonly atomicRegistryVersion: number;
+};
+
+type CachedTransientSegment = {
+  readonly marker: string;
+  readonly segment: CompiledSegment;
+};
 
 export function createEngineMetadata(
   options: EngineMetadataOptions = {}
@@ -132,14 +161,28 @@ export function createEngineMetadata(
   > = {};
   const writeKeyIdByClassName = new Map<string, WriteKeyId>();
   const registeredSegments = new Map<string, CompiledSegment>();
-  const segmentCache = new BoundedLru<string, CompiledSegment>(
-    options.segmentCacheSize ?? DEFAULT_SEGMENT_CACHE_SIZE
+  const segmentByMarker = new Map<string, CompiledSegment>();
+  const markerBySegmentPayload = new Map<string, string>();
+  const segmentPayloadByMarker = new Map<string, string>();
+  const segmentCacheSize =
+    options.segmentCacheSize ?? DEFAULT_SEGMENT_CACHE_SIZE;
+  const segmentCache = new BoundedLru<string, CachedCompiledSegment>(
+    segmentCacheSize
   );
-  const fullResultCache = new BoundedLru<string, string>(
+  const fullResultCache = new BoundedLru<string, CachedFullResult>(
     options.fullResultCacheSize ?? DEFAULT_FULL_RESULT_CACHE_SIZE
   );
+  const segmentMarkerPayloadCache = new BoundedLru<string, string>(
+    segmentCacheSize
+  );
+  const transientSegmentByPayload = new BoundedLru<
+    string,
+    CachedTransientSegment
+  >(segmentCacheSize);
+  const transientPayloadByMarker = new Map<string, string>();
   let seenEpoch = new Uint32Array(options.initialEpochCapacity ?? 16);
   let currentEpoch = options.initialEpoch ?? 0;
+  let atomicRegistryVersion = 0;
 
   function internCondition(condition: NormalizedCondition): ConditionId {
     const key = conditionCacheKey(condition);
@@ -190,7 +233,11 @@ export function createEngineMetadata(
     writeKeyId: WriteKeyId
   ): void {
     writeKeyIdByClassName.set(className, writeKeyId);
-    clearRuntimeCaches();
+    registerSegment(className, {
+      entries: [{ kind: "known", className, writeKeyId }],
+      hasKnownAtomicClass: true
+    });
+    atomicRegistryVersion += 1;
   }
 
   function registerAtomicCacheEntry(
@@ -223,9 +270,59 @@ export function createEngineMetadata(
   function registerSegment(
     input: string,
     compiledSegment: CompiledSegment
-  ): void {
-    registeredSegments.set(input, compiledSegment);
+  ): string | undefined {
+    const registeredSegment = withRegisteredMarker(compiledSegment);
+
+    registeredSegments.set(input, registeredSegment);
     fullResultCache.delete(input);
+
+    if (registeredSegment.marker === undefined) {
+      return undefined;
+    }
+
+    segmentByMarker.set(registeredSegment.marker, registeredSegment);
+
+    const markerClassName = joinClassNames(
+      registeredSegment.marker,
+      serializeSegmentEntries(registeredSegment.entries)
+    );
+
+    registeredSegments.set(markerClassName, registeredSegment);
+    fullResultCache.delete(markerClassName);
+    return registeredSegment.marker;
+  }
+
+  function getRegisteredSegment(input: string): CompiledSegment | undefined {
+    return registeredSegments.get(input);
+  }
+
+  function getSegmentByMarker(marker: string): CompiledSegment | undefined {
+    const registeredSegment = segmentByMarker.get(marker);
+
+    if (registeredSegment !== undefined) {
+      return registeredSegment;
+    }
+
+    const payload = transientPayloadByMarker.get(marker);
+
+    if (payload === undefined) {
+      return undefined;
+    }
+
+    const cachedSegment = transientSegmentByPayload.get(payload);
+
+    if (cachedSegment === undefined || cachedSegment.marker !== marker) {
+      transientPayloadByMarker.delete(marker);
+      return undefined;
+    }
+
+    return cachedSegment.segment;
+  }
+
+  function getSegmentByMarkerToken(token: string): CompiledSegment | undefined {
+    return token.startsWith(SEGMENT_MARKER_PREFIX)
+      ? getSegmentByMarker(token)
+      : undefined;
   }
 
   function getCompiledSegment(input: string): CompiledSegment {
@@ -238,11 +335,18 @@ export function createEngineMetadata(
     const cachedSegment = segmentCache.get(input);
 
     if (cachedSegment !== undefined) {
-      return cachedSegment;
+      if (isCachedSegmentFresh(cachedSegment)) {
+        return cachedSegment.segment;
+      }
+
+      segmentCache.delete(input);
     }
 
     const compiledSegment = compileSegment(input);
-    segmentCache.set(input, compiledSegment);
+    segmentCache.set(input, {
+      segment: compiledSegment,
+      atomicRegistryVersion
+    });
     return compiledSegment;
   }
 
@@ -257,6 +361,14 @@ export function createEngineMetadata(
     let hasKnownAtomicClass = false;
 
     for (const className of trimmed.split(/\s+/)) {
+      const markedSegment = getSegmentByMarker(className);
+
+      if (markedSegment !== undefined) {
+        entries.push(...markedSegment.entries);
+        hasKnownAtomicClass ||= markedSegment.hasKnownAtomicClass;
+        continue;
+      }
+
       const writeKeyId = writeKeyIdByClassName.get(className);
 
       if (writeKeyId === undefined) {
@@ -272,6 +384,16 @@ export function createEngineMetadata(
   }
 
   function mergeCompiledSegments(segments: readonly CompiledSegment[]): string {
+    if (segments.length === 0) {
+      return "";
+    }
+
+    if (segments.length === 1) {
+      const segment = segments[0];
+
+      return segment === undefined ? "" : mergeCompiledEntries(segment.entries);
+    }
+
     const epoch = nextEpoch();
     const keptEntries: CompiledEntry[] = [];
 
@@ -282,7 +404,7 @@ export function createEngineMetadata(
     ) {
       const segment = segments[segmentIndex];
 
-      if (segment == null) {
+      if (segment === undefined) {
         continue;
       }
 
@@ -291,57 +413,106 @@ export function createEngineMetadata(
         entryIndex >= 0;
         entryIndex -= 1
       ) {
-        const entry = segment.entries[entryIndex];
-
-        if (entry == null) {
-          continue;
-        }
-
-        if (entry.kind === "unknown") {
-          keptEntries.push(entry);
-          continue;
-        }
-
-        ensureSeenEpochCapacity(entry.writeKeyId);
-
-        if (seenEpoch[entry.writeKeyId] === epoch) {
-          continue;
-        }
-
-        seenEpoch[entry.writeKeyId] = epoch;
-        keptEntries.push(entry);
+        keepMergedEntry(keptEntries, segment.entries[entryIndex], epoch);
       }
     }
 
-    return keptEntries
-      .reverse()
-      .map((entry) => entry.className)
-      .join(" ");
+    return serializeMergedEntries(keptEntries);
+  }
+
+  function mergeCompiledEntries(entries: readonly CompiledEntry[]): string {
+    const epoch = nextEpoch();
+    const keptEntries: CompiledEntry[] = [];
+
+    for (
+      let entryIndex = entries.length - 1;
+      entryIndex >= 0;
+      entryIndex -= 1
+    ) {
+      keepMergedEntry(keptEntries, entries[entryIndex], epoch);
+    }
+
+    return serializeMergedEntries(keptEntries);
+  }
+
+  function keepMergedEntry(
+    keptEntries: CompiledEntry[],
+    entry: CompiledEntry | undefined,
+    epoch: number
+  ): void {
+    if (entry === undefined) {
+      return;
+    }
+
+    if (entry.kind === "unknown") {
+      keptEntries.push(entry);
+      return;
+    }
+
+    ensureSeenEpochCapacity(entry.writeKeyId);
+
+    if (seenEpoch[entry.writeKeyId] === epoch) {
+      return;
+    }
+
+    seenEpoch[entry.writeKeyId] = epoch;
+    keptEntries.push(entry);
+  }
+
+  function serializeMergedEntries(keptEntries: CompiledEntry[]): string {
+    const entries = keptEntries.reverse();
+    const classList = serializeSegmentEntries(entries);
+    const marker = getTransientMarkerForEntries(entries);
+
+    return marker === undefined ? classList : joinClassNames(marker, classList);
   }
 
   function mergeClassList(input: string): string {
-    const cachedResult = fullResultCache.get(input);
+    const cachedResult = getCachedFullResult(input);
 
     if (cachedResult !== undefined) {
       return cachedResult;
     }
 
-    const result = mergeCompiledSegments([getCompiledSegment(input)]);
-    fullResultCache.set(input, result);
+    const segment = getCompiledSegment(input);
+    const result = mergeCompiledSegments([segment]);
+    fullResultCache.set(input, {
+      result,
+      hasUnknownClass: hasUnknownEntry(segment.entries),
+      atomicRegistryVersion
+    });
     return result;
   }
 
   function getCachedFullResult(input: string): string | undefined {
-    return fullResultCache.get(input);
+    const cachedResult = fullResultCache.get(input);
+
+    if (cachedResult === undefined) {
+      return undefined;
+    }
+
+    if (isCachedFullResultFresh(cachedResult)) {
+      return cachedResult.result;
+    }
+
+    fullResultCache.delete(input);
+    return undefined;
   }
 
   function setCachedFullResult(input: string, result: string): void {
-    fullResultCache.set(input, result);
+    fullResultCache.set(input, {
+      result,
+      hasUnknownClass: true,
+      atomicRegistryVersion
+    });
   }
 
   function clearRuntimeCaches(): void {
     segmentCache.clear();
     fullResultCache.clear();
+    segmentMarkerPayloadCache.clear();
+    transientSegmentByPayload.clear();
+    transientPayloadByMarker.clear();
   }
 
   function exportArtifact(): DefineRulesPresetArtifactV4 {
@@ -389,6 +560,175 @@ export function createEngineMetadata(
     seenEpoch = nextSeenEpoch;
   }
 
+  function isCachedSegmentFresh(cachedSegment: CachedCompiledSegment): boolean {
+    return (
+      !hasUnknownEntry(cachedSegment.segment.entries) ||
+      cachedSegment.atomicRegistryVersion === atomicRegistryVersion
+    );
+  }
+
+  function isCachedFullResultFresh(cachedResult: CachedFullResult): boolean {
+    return (
+      !cachedResult.hasUnknownClass ||
+      cachedResult.atomicRegistryVersion === atomicRegistryVersion
+    );
+  }
+
+  function withRegisteredMarker(
+    compiledSegment: CompiledSegment
+  ): CompiledSegment {
+    const payload = createSegmentMarkerPayload(compiledSegment);
+
+    if (payload === undefined) {
+      return compiledSegment;
+    }
+
+    const existingMarker = markerBySegmentPayload.get(payload);
+    const transientSegment = transientSegmentByPayload.get(payload);
+    const marker =
+      existingMarker ??
+      transientSegment?.marker ??
+      createSegmentMarker(payload);
+
+    if (existingMarker === undefined) {
+      const existingPayload = segmentPayloadByMarker.get(marker);
+      const transientPayload = transientPayloadByMarker.get(marker);
+
+      if (
+        (existingPayload !== undefined && existingPayload !== payload) ||
+        (transientPayload !== undefined && transientPayload !== payload)
+      ) {
+        throw new Error(`Mincho segment marker collision for ${marker}`);
+      }
+
+      markerBySegmentPayload.set(payload, marker);
+      segmentPayloadByMarker.set(marker, payload);
+      transientSegmentByPayload.delete(payload);
+      transientPayloadByMarker.delete(marker);
+    }
+
+    return { ...compiledSegment, marker };
+  }
+
+  function getTransientMarkerForEntries(
+    entries: readonly CompiledEntry[]
+  ): string | undefined {
+    if (segmentCacheSize === 0) {
+      return undefined;
+    }
+
+    const segment: CompiledSegment = {
+      entries: [...entries],
+      hasKnownAtomicClass: entries.some((entry) => entry.kind === "known")
+    };
+    const payload = createSegmentMarkerPayload(segment);
+
+    if (payload === undefined) {
+      return undefined;
+    }
+
+    const registeredMarker = markerBySegmentPayload.get(payload);
+
+    if (registeredMarker !== undefined) {
+      return registeredMarker;
+    }
+
+    const cachedSegment = transientSegmentByPayload.get(payload);
+
+    if (cachedSegment !== undefined) {
+      return cachedSegment.marker;
+    }
+
+    const marker = createSegmentMarker(payload);
+    const registeredPayload = segmentPayloadByMarker.get(marker);
+    const transientPayload = transientPayloadByMarker.get(marker);
+
+    if (
+      (registeredPayload !== undefined && registeredPayload !== payload) ||
+      (transientPayload !== undefined && transientPayload !== payload)
+    ) {
+      throw new Error(`Mincho segment marker collision for ${marker}`);
+    }
+
+    const evicted = transientSegmentByPayload.set(payload, { marker, segment });
+
+    if (evicted !== undefined) {
+      transientPayloadByMarker.delete(evicted[1].marker);
+    }
+
+    transientPayloadByMarker.set(marker, payload);
+    return marker;
+  }
+
+  function createSegmentMarkerPayload(
+    compiledSegment: CompiledSegment
+  ): string | undefined {
+    if (
+      compiledSegment.entries.length === 0 ||
+      compiledSegment.entries.some((entry) => entry.kind === "unknown")
+    ) {
+      return undefined;
+    }
+
+    const cacheKey = compiledSegment.entries
+      .flatMap((entry) =>
+        entry.kind === "known"
+          ? [`${entry.className.length}:${entry.className}:${entry.writeKeyId}`]
+          : []
+      )
+      .join("|");
+    const cachedPayload = segmentMarkerPayloadCache.get(cacheKey);
+
+    if (cachedPayload !== undefined) {
+      return cachedPayload;
+    }
+
+    const payload: Array<
+      readonly [
+        className: string,
+        layer: string | null,
+        supports: string | null,
+        media: string | null,
+        container: string | null,
+        selector: string,
+        property: string
+      ]
+    > = [];
+
+    for (const entry of compiledSegment.entries) {
+      if (entry.kind === "unknown") {
+        return undefined;
+      }
+
+      const writeKey = writeKeyById[entry.writeKeyId];
+
+      if (writeKey === undefined) {
+        return undefined;
+      }
+
+      const condition = conditionById[writeKey.conditionId];
+      const property = propertyById[writeKey.propertyId];
+
+      if (condition === undefined || property === undefined) {
+        return undefined;
+      }
+
+      payload.push([
+        entry.className,
+        condition.layer,
+        condition.supports,
+        condition.media,
+        condition.container,
+        condition.selector,
+        property
+      ]);
+    }
+
+    const serializedPayload = JSON.stringify(payload);
+    segmentMarkerPayloadCache.set(cacheKey, serializedPayload);
+    return serializedPayload;
+  }
+
   return {
     internCondition,
     internProperty,
@@ -397,6 +737,9 @@ export function createEngineMetadata(
     registerAtomicCacheEntry,
     hydrateAtomicClassesFromArtifact,
     registerSegment,
+    getRegisteredSegment,
+    getSegmentByMarker,
+    getSegmentByMarkerToken,
     getCompiledSegment,
     compileSegment,
     mergeCompiledSegments,
@@ -452,6 +795,35 @@ function cloneWriteKeyById(
   return clone;
 }
 
+function createSegmentMarker(payload: string): string {
+  return `${SEGMENT_MARKER_PREFIX}${hashSegmentMarkerPayload(
+    payload,
+    0x811c9dc5
+  )}_${hashSegmentMarkerPayload(payload, 0x9e3779b9)}`;
+}
+
+function hashSegmentMarkerPayload(payload: string, seed: number): string {
+  let hash = seed >>> 0;
+
+  for (let index = 0; index < payload.length; index += 1) {
+    hash = Math.imul(hash ^ payload.charCodeAt(index), 0x01000193) >>> 0;
+  }
+
+  return hash.toString(36);
+}
+
+function serializeSegmentEntries(entries: readonly CompiledEntry[]): string {
+  return entries.map((entry) => entry.className).join(" ");
+}
+
+function hasUnknownEntry(entries: readonly CompiledEntry[]): boolean {
+  return entries.some((entry) => entry.kind === "unknown");
+}
+
+function joinClassNames(...classNames: readonly string[]): string {
+  return classNames.filter((className) => className.length > 0).join(" ");
+}
+
 // == Tests ====================================================================
 // Ignore errors when compiling to CommonJS.
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -496,6 +868,15 @@ if (import.meta.vitest) {
     );
 
     return writeKeyId;
+  }
+
+  function withoutSegmentMarkers(className: string): string {
+    return className
+      .split(/\s+/)
+      .filter(
+        (token) => token.length > 0 && !token.startsWith(SEGMENT_MARKER_PREFIX)
+      )
+      .join(" ");
   }
 
   describe("createEngineMetadata", () => {
@@ -651,42 +1032,94 @@ if (import.meta.vitest) {
       expect(metadata.getCachedFullResult("repeat")).toBe(undefined);
     });
 
-    it("clears stale segment and full-result caches when atomics are registered or hydrated", () => {
+    it("bounds merge markers without evicting registered segment markers", () => {
+      const metadata = createEngineMetadata({ segmentCacheSize: 2 });
+      registerAtomicPair(metadata, "color", "color_red", "color_blue");
+      registerAtomicPair(metadata, "display", "display_block", "display_flex");
+      registerAtomicPair(metadata, "padding", "padding_1", "padding_2");
+      const registeredSegment = metadata.compileSegment("color_red");
+      const registeredMarker = metadata.registerSegment(
+        "registered-color",
+        registeredSegment
+      );
+      const registeredSegmentSize = metadata.registeredSegmentSize;
+      const firstMergeMarker = metadata
+        .mergeCompiledSegments([
+          metadata.compileSegment("color_blue display_flex")
+        ])
+        .split(/\s+/)[0];
+
+      metadata.mergeCompiledSegments([
+        metadata.compileSegment("display_block padding_2")
+      ]);
+      metadata.mergeCompiledSegments([
+        metadata.compileSegment("padding_1 color_red")
+      ]);
+
+      expect(firstMergeMarker).toBeDefined();
+      expect(metadata.registeredSegmentSize).toBe(registeredSegmentSize);
+      expect(
+        metadata.getSegmentByMarkerToken(firstMergeMarker ?? "")
+      ).toBeUndefined();
+      expect(
+        metadata.getSegmentByMarkerToken(registeredMarker ?? "")
+      ).toMatchObject(registeredSegment);
+    });
+
+    it("keeps all-known cached segments and full results after later atomic registration", () => {
+      const metadata = createEngineMetadata();
+      registerAtomicPair(metadata, "color", "color_red", "color_blue");
+      const input = "color_red color_blue";
+      const cachedSegment = metadata.getCompiledSegment(input);
+      const cachedResult = metadata.mergeClassList(input);
+      const conditionId = metadata.internCondition(baseCondition());
+      const propertyId = metadata.internProperty("padding");
+      const writeKeyId = metadata.internWriteKey(conditionId, propertyId);
+
+      metadata.registerAtomicClass("padding_1", writeKeyId);
+
+      expect(metadata.getCompiledSegment(input)).toBe(cachedSegment);
+      expect(metadata.getCachedFullResult(input)).toBe(cachedResult);
+      expect(metadata.mergeClassList(input)).toBe(cachedResult);
+    });
+
+    it("lazily recompiles unknown cached segments after direct atomic registration", () => {
       const metadata = createEngineMetadata();
       const conditionId = metadata.internCondition(baseCondition());
       const propertyId = metadata.internProperty("color");
       const writeKeyId = metadata.internWriteKey(conditionId, propertyId);
+      const input = "color_red color_blue";
 
-      expect(metadata.mergeClassList("color_red color_blue")).toBe(
-        "color_red color_blue"
-      );
+      metadata.registerAtomicClass("color_blue", writeKeyId);
+      const cachedSegment = metadata.getCompiledSegment(input);
+
+      expect(metadata.mergeClassList(input)).toBe(input);
       expect(metadata.segmentCacheSize).toBeGreaterThan(0);
       expect(metadata.fullResultCacheSize).toBeGreaterThan(0);
 
       metadata.registerAtomicClass("color_red", writeKeyId);
 
-      expect(metadata.segmentCacheSize).toBe(0);
-      expect(metadata.fullResultCacheSize).toBe(0);
-
-      metadata.registerAtomicClass("color_blue", writeKeyId);
-
-      expect(metadata.mergeClassList("color_red color_blue")).toBe(
+      expect(metadata.getCompiledSegment(input)).not.toBe(cachedSegment);
+      expect(metadata.getCachedFullResult(input)).toBe(undefined);
+      expect(withoutSegmentMarkers(metadata.mergeClassList(input))).toBe(
         "color_blue"
       );
+    });
 
+    it("lazily recompiles unknown cached full results after hydration", () => {
       const source = createEngineMetadata();
       registerAtomicPair(source, "display", "display_block", "display_flex");
       const hydrated = createEngineMetadata();
+      const input = "display_block display_flex";
 
-      hydrated.mergeClassList("display_block display_flex");
+      hydrated.mergeClassList(input);
       expect(hydrated.segmentCacheSize).toBeGreaterThan(0);
       expect(hydrated.fullResultCacheSize).toBeGreaterThan(0);
 
       hydrated.hydrateAtomicClassesFromArtifact(source.exportArtifact());
 
-      expect(hydrated.segmentCacheSize).toBe(0);
-      expect(hydrated.fullResultCacheSize).toBe(0);
-      expect(hydrated.mergeClassList("display_block display_flex")).toBe(
+      expect(hydrated.getCachedFullResult(input)).toBe(undefined);
+      expect(withoutSegmentMarkers(hydrated.mergeClassList(input))).toBe(
         "display_flex"
       );
     });

--- a/packages/css/src/defineRules/runtime.ts
+++ b/packages/css/src/defineRules/runtime.ts
@@ -9,7 +9,6 @@ import {
   hasFileScope,
   setFileScope
 } from "@vanilla-extract/css/fileScope";
-import { cx as rootCx } from "../classname/cx.js";
 import type {
   ClassMultipleInput,
   ClassMultipleResult,
@@ -25,8 +24,8 @@ import { isUnSafeObjectKey } from "../utils.js";
 import { registerDefineRulesRegistryInstance } from "./registry.js";
 import { normalizeDefineRulesConditions } from "./conditions.js";
 import { createCanonicalStyleCache } from "./utils.js";
-import { createEngineMetadata } from "./metadata.js";
-import type { EngineMetadata } from "./metadata.js";
+import { createEngineMetadata, SEGMENT_MARKER_PREFIX } from "./metadata.js";
+import type { CompiledSegment, EngineMetadata } from "./metadata.js";
 import type {
   DefineRulesCss,
   DefineRulesComplexCssInput,
@@ -172,16 +171,18 @@ export function createDefineRulesRuntime<
     }
 
     const className = entries.map((entry) => entry.className).join(" ");
-    metadata.registerSegment(className, {
+    const marker = metadata.registerSegment(className, {
       entries,
       hasKnownAtomicClass: entries.length > 0
     });
+    const markedClassName =
+      marker === undefined ? className : `${marker} ${className}`;
 
     if (didAddAtomicCacheEntry) {
       syncPresetArtifact(presetArtifact, metadata.exportArtifact());
     }
 
-    return className;
+    return markedClassName;
   }
 
   const css = Object.assign(cssImpl, {
@@ -193,8 +194,9 @@ export function createDefineRulesRuntime<
 
 function createDefineRulesCx(metadata: EngineMetadata): DefineRulesRuntimeCx {
   const cxImpl = ((...inputs: ClassValue[]) => {
-    const className = rootCx(...inputs);
-    return metadata.mergeClassList(className);
+    return metadata.mergeCompiledSegments(
+      collectClassValueSegments(metadata, inputs)
+    );
   }) as (...inputs: ClassValue[]) => string;
 
   function cxMultiple<T extends ClassMultipleInput>(
@@ -254,6 +256,138 @@ function createDefineRulesCx(metadata: EngineMetadata): DefineRulesRuntimeCx {
     multiple: cxMultiple,
     with: cxWith
   }) as DefineRulesRuntimeCx;
+}
+
+function collectClassValueSegments(
+  metadata: EngineMetadata,
+  inputs: readonly ClassValue[]
+): CompiledSegment[] {
+  const segments: CompiledSegment[] = [];
+
+  for (const input of inputs) {
+    pushClassValueSegments(metadata, segments, input);
+  }
+
+  return segments;
+}
+
+function pushClassValueSegments(
+  metadata: EngineMetadata,
+  segments: CompiledSegment[],
+  input: ClassValue
+): void {
+  if (typeof input === "string") {
+    pushClassStringSegments(metadata, segments, input);
+    return;
+  }
+
+  if (typeof input === "number") {
+    if (input) {
+      segments.push(metadata.getCompiledSegment(String(input)));
+    }
+    return;
+  }
+
+  if (typeof input === "bigint") {
+    if (input !== 0n) {
+      segments.push(metadata.getCompiledSegment(String(input)));
+    }
+    return;
+  }
+
+  if (
+    input === null ||
+    input === undefined ||
+    input === false ||
+    input === true
+  ) {
+    return;
+  }
+
+  if (Array.isArray(input)) {
+    for (const item of input) {
+      pushClassValueSegments(metadata, segments, item);
+    }
+    return;
+  }
+
+  for (const className in input) {
+    if (input[className]) {
+      pushClassStringSegments(metadata, segments, className);
+    }
+  }
+}
+
+function pushClassStringSegments(
+  metadata: EngineMetadata,
+  segments: CompiledSegment[],
+  className: string
+): void {
+  if (className.length === 0) {
+    return;
+  }
+
+  const registeredSegment = metadata.getRegisteredSegment(className);
+
+  if (registeredSegment !== undefined) {
+    segments.push(registeredSegment);
+    return;
+  }
+
+  const tokens = className.trim().split(/\s+/);
+  const externalTokens: string[] = [];
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+
+    if (token === undefined || token.length === 0) {
+      continue;
+    }
+
+    const markedSegment = metadata.getSegmentByMarkerToken(token);
+
+    if (markedSegment === undefined) {
+      externalTokens.push(token);
+      continue;
+    }
+
+    flushClassTokens(metadata, segments, externalTokens);
+    segments.push(markedSegment);
+    index = skipSegmentPayload(tokens, index + 1, markedSegment) - 1;
+  }
+
+  flushClassTokens(metadata, segments, externalTokens);
+}
+
+function flushClassTokens(
+  metadata: EngineMetadata,
+  segments: CompiledSegment[],
+  tokens: string[]
+): void {
+  if (tokens.length === 0) {
+    return;
+  }
+
+  segments.push(metadata.getCompiledSegment(tokens.join(" ")));
+  tokens.length = 0;
+}
+
+function skipSegmentPayload(
+  tokens: readonly string[],
+  startIndex: number,
+  segment: CompiledSegment
+): number {
+  let index = startIndex;
+
+  for (const entry of segment.entries) {
+    if (tokens[index] !== entry.className) {
+      return startIndex;
+    }
+
+    index += 1;
+  }
+
+  return index;
 }
 
 // == Define Rules Impl ========================================================
@@ -975,7 +1109,22 @@ if (import.meta.vitest) {
     return clonePresetArtifact(artifact);
   }
 
+  function withoutSegmentMarkers(className: string): string {
+    return className
+      .split(/\s+/)
+      .filter(
+        (token) => token.length > 0 && !token.startsWith(SEGMENT_MARKER_PREFIX)
+      )
+      .join(" ");
+  }
+
   describe("defineRules runtime presets", () => {
+    it("keeps truthy bigint class values and ignores zero bigint", () => {
+      const runtime = createDefineRulesRuntime({ properties: {} });
+
+      expect(runtime.cx(0n, 42n)).toBe("42");
+    });
+
     it("skips unsafe object keys while merging style fragments", () => {
       const objectPrototype = Object.prototype as Record<string, unknown>;
       const source: Record<string, unknown> = { color: "red" };
@@ -1039,7 +1188,9 @@ if (import.meta.vitest) {
       expect(artifact).not.toHaveProperty("cx");
       expect(artifact).not.toHaveProperty("atomicClassByClassName");
       expect(artifact.version).toBe(4);
-      expect(Object.values(artifact.classNameByCache)).toEqual([className]);
+      expect(Object.values(artifact.classNameByCache)).toEqual([
+        withoutSegmentMarkers(className)
+      ]);
       expect(Object.keys(artifact.writeKeyByCacheKey)).toEqual(
         Object.keys(artifact.classNameByCache)
       );
@@ -1050,7 +1201,7 @@ if (import.meta.vitest) {
           propertyById: artifact.propertyById,
           writeKeyById: artifact.writeKeyById
         })
-      ).not.toContain(className);
+      ).not.toContain(withoutSegmentMarkers(className));
     });
 
     it("remaps colliding artifact-local IDs from imported v4 presets", () => {
@@ -1121,9 +1272,17 @@ if (import.meta.vitest) {
       consumer.preset.conditionById = {};
       consumer.preset.propertyById = {};
       consumer.preset.writeKeyById = {};
-      expect(
-        consumer.cx(colorClassName, backgroundClassName, colorClassName)
-      ).toBe(`${backgroundClassName} ${colorClassName}`);
+      const result = consumer.cx(
+        colorClassName,
+        backgroundClassName,
+        colorClassName
+      );
+
+      expect(withoutSegmentMarkers(result)).toBe(
+        `${withoutSegmentMarkers(backgroundClassName)} ${withoutSegmentMarkers(
+          colorClassName
+        )}`
+      );
     });
   });
 }

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -1320,11 +1320,15 @@ if (import.meta.vitest) {
     className: string
   ): void {
     expectSourceToContainV4PresetArtifact(source);
-    expect(source).toMatch(
-      new RegExp(
-        `["']?classNameByCache["']?\\s*:\\s*\\{[\\s\\S]*["']${escapeRegExp(className)}["']`
-      )
-    );
+    for (const atomicClassName of splitClassNames(className).filter(
+      (token) => !isSegmentMarker(token)
+    )) {
+      expect(source).toMatch(
+        new RegExp(
+          `["']?classNameByCache["']?\\s*:\\s*\\{[\\s\\S]*["']${escapeRegExp(atomicClassName)}["']`
+        )
+      );
+    }
   }
 
   function countV4PresetArtifacts(source: string): number {
@@ -1904,11 +1908,17 @@ if (import.meta.vitest) {
     return className.split(/\s+/).filter(Boolean);
   }
 
+  function isSegmentMarker(className: string): boolean {
+    return className.startsWith("__mincho_seg_");
+  }
+
   function expectCssSourceToContainClassNames(
     source: string,
     className: string
   ): void {
-    for (const fragmentClassName of splitClassNames(className)) {
+    for (const fragmentClassName of splitClassNames(className).filter(
+      (token) => !isSegmentMarker(token)
+    )) {
       expect(source).toContain(`.${fragmentClassName}`);
     }
   }
@@ -3815,7 +3825,11 @@ if (import.meta.vitest) {
       expect(loadResult.loader).toBe("js");
       expect(loadResult.resolveDir).toBe(dirname(resolveResult.path));
       expect(fillBlueInit).toMatch(/^(?:"[^"]+"|'[^']+')$/);
-      expect(fillBlueClassName.split(/\s+/)).toHaveLength(1);
+      const fillBlueClassNames = splitClassNames(fillBlueClassName);
+      expect(fillBlueClassNames.filter(isSegmentMarker)).toHaveLength(1);
+      expect(
+        fillBlueClassNames.filter((token) => !isSegmentMarker(token))
+      ).toHaveLength(1);
       expect(
         hasCssCallWithStringProperty(loadResult.contents, "background", "blue")
       ).toBe(false);

--- a/packages/integration/src/babel.ts
+++ b/packages/integration/src/babel.ts
@@ -180,6 +180,7 @@ export type BabelOptions = Omit<
   | "inputSourceMap"
 > & {
   jsxCssProp?: boolean;
+  optimize?: PluginOptions["optimize"];
   staticCssEvalProvider?: PluginOptions["staticCssEvalProvider"];
   /** @internal Async source provider used to prepare imported css eval data. */
   staticCssEvalSourceProvider?: StaticCssEvalSourceProvider;
@@ -199,6 +200,7 @@ export async function babelTransform(
 ): Promise<BabelTransformResult> {
   const {
     jsxCssProp = false,
+    optimize,
     staticCssEvalProvider,
     staticCssEvalSourceProvider,
     staticCssEvalProjectEngine,
@@ -225,11 +227,10 @@ export async function babelTransform(
         observedStaticCssEvalMetadata
       )
     : undefined;
-  const options: PluginOptions & {
-    jsxCssProp?: boolean;
-  } = {
+  const options: PluginOptions = {
     result: ["", ""],
     jsxCssProp,
+    ...(optimize ? { optimize } : {}),
     staticCssEvalProvider: observedStaticCssEvalProvider
   };
   let result;
@@ -592,6 +593,42 @@ if (import.meta.vitest) {
       });
     });
 
+    it("leaves output unchanged when defineRules cx optimization is inactive", async () => {
+      const fixturePath = await createBabelFixture(
+        `
+          import { defineRules } from "@mincho-js/css";
+
+          const { css, cx } = defineRules({
+            properties: { color: true }
+          });
+          const idleClass = css({ color: "blue" });
+          const activeClass = css({ color: "red" });
+
+          export function button(active: boolean) {
+            return cx(idleClass, active && activeClass);
+          }
+        `,
+        "define-rules-cx-optimize-option"
+      );
+      const omitted = await babelTransform(fixturePath);
+      const emptyOptimize = await babelTransform(fixturePath, { optimize: {} });
+      const disabledOptimize = await babelTransform(fixturePath, {
+        optimize: { defineRulesCxConditions: false }
+      });
+      const enabledOptimize = await babelTransform(fixturePath, {
+        jsxCssProp: false,
+        optimize: { defineRulesCxConditions: true }
+      });
+
+      expect(emptyOptimize.result).toEqual(omitted.result);
+      expect(emptyOptimize.code).toBe(omitted.code);
+      expect(disabledOptimize.result).toEqual(omitted.result);
+      expect(disabledOptimize.code).toBe(omitted.code);
+      expect(enabledOptimize.result).toEqual(omitted.result);
+      expect(enabledOptimize.code).toContain("const _minchoDefineRulesCx = [");
+      expect(enabledOptimize.code).toContain("return _minchoDefineRulesCx[");
+    });
+
     it("extracts css prop generated css calls into sidecar output", async () => {
       const fixturePath = await createBabelFixture(
         `
@@ -642,6 +679,69 @@ if (import.meta.vitest) {
       expect(code).not.toContain(" css=");
       expect(code).not.toContain("css={{");
       expect(code).not.toContain('color: "red"');
+    });
+
+    it("emits dynamic declaration leaves as merged inline style vars", async () => {
+      const fixturePath = await createBabelFixture(
+        `
+          type Props = {
+            readonly color: string;
+            readonly gap: number;
+            readonly style?: { readonly opacity?: number };
+          };
+
+          function App(props: Props) {
+            return <div className="base" style={props.style} css={{ color: props.color, marginTop: \`\${props.gap}px\` }} />;
+          }
+        `,
+        "dynamic-css-var-style"
+      );
+      const { result, code } = await babelTransform(fixturePath, {
+        jsxCssProp: true
+      });
+      const [sidecarFile, sidecarSource] = result;
+
+      expect(sidecarFile).toMatch(/^extracted_[a-z0-9]+\.css\.ts$/);
+      expect(code).not.toContain(" css=");
+      expect(code).toContain('from "@mincho-js/transform-runtime"');
+      expect(code).toMatch(
+        /className=\{[A-Za-z_$][\w$]*\("base", [A-Za-z_$][\w$]*\)\}/
+      );
+      expect(code).toMatch(
+        /style=\{\{\s*\.\.\.props\.style,\s*\[[A-Za-z_$][\w$]*\]: [A-Za-z_$][\w$]*\(props\.color\),\s*\[[A-Za-z_$][\w$]*\]: [A-Za-z_$][\w$]*\(props\.gap, "px"\)\s*\}\}/s
+      );
+      expect(sidecarSource).toMatch(/[A-Za-z_$][\w$]*\("color"\)/);
+      expect(sidecarSource).toMatch(/[A-Za-z_$][\w$]*\("marginTop"\)/);
+      expect(sidecarSource).toMatch(/[A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*\)/);
+      expect(sidecarSource).toMatch(
+        /[A-Za-z_$][\w$]*\(\{\s*color: [A-Za-z_$][\w$]*,\s*marginTop: [A-Za-z_$][\w$]*\s*\}\)/s
+      );
+    });
+
+    it("merges pre and post spread className around explicit css output", async () => {
+      const fixturePath = await createBabelFixture(
+        `
+          const preProps = { className: "pre", css: "ignored-pre", id: "root" };
+          const postProps = { className: "post", css: "ignored-post", title: "done" };
+
+          function App() {
+            return <div {...preProps} css={{ color: "red" }} {...postProps} />;
+          }
+        `,
+        "pre-post-spread-merge"
+      );
+      const { result, code } = await babelTransform(fixturePath, {
+        jsxCssProp: true
+      });
+      const [, sidecarSource] = result;
+
+      expect(code).not.toContain(" css=");
+      expect(code).toContain("const _minchoPreProps = {");
+      expect(code).toContain("const _minchoPostProps = {");
+      expect(code).toMatch(
+        /<div \{\.\.\._minchoPreRest\} \{\.\.\._minchoPostRest\} className=\{[A-Za-z_$][\w$]*\(_minchoPreClassName, _minchoCssClassName, _minchoPostClassName\)\} \/>/
+      );
+      expect(sidecarSource).toContain('color: "red"');
     });
 
     it("emits sidecar build-time call-valued leaf and spread call css prop rules", async () => {

--- a/packages/integration/src/defineRulesPreset.ts
+++ b/packages/integration/src/defineRulesPreset.ts
@@ -330,6 +330,27 @@ if (import.meta.vitest) {
     return source.replace(/\s+/g, " ").trim();
   }
 
+  function expectSerializedMarkerClassName(
+    source: string,
+    bindingName: string,
+    expectedClassName: string
+  ): void {
+    const match = new RegExp(`\\b${bindingName} = '([^']*)'`).exec(source);
+
+    if (match === null || match[1] === undefined) {
+      throw new Error(`Missing serialized class binding ${bindingName}`);
+    }
+
+    const tokens = match[1].split(/\s+/).filter(Boolean);
+    const markers = tokens.filter((token) => token.startsWith("__mincho_seg_"));
+    const classNames = tokens.filter(
+      (token) => !token.startsWith("__mincho_seg_")
+    );
+
+    expect(markers).toHaveLength(1);
+    expect(classNames.join(" ")).toBe(expectedClassName);
+  }
+
   function expectSourceToContainSnippet(source: string, snippet: string): void {
     expect(normalizeRegistryFixtureSource(source)).toContain(
       normalizeRegistryFixtureSource(snippet)
@@ -968,8 +989,8 @@ if (import.meta.vitest) {
 
       expect(providerClassNames.length).toBeGreaterThan(0);
       expect(consumerClassNames).toEqual(providerClassNames);
-      expect(source).toContain(`providerClass = '${reusedClassName}'`);
-      expect(source).toContain(`consumerClass = '${reusedClassName}'`);
+      expectSerializedMarkerClassName(source, "providerClass", reusedClassName);
+      expectSerializedMarkerClassName(source, "consumerClass", reusedClassName);
     });
 
     it("reuses conditional provider preset metadata across package fixture boundaries", async () => {
@@ -1026,9 +1047,15 @@ if (import.meta.vitest) {
 
         expect(consumerTabletClass).toBe(providerTabletClass);
         expect(consumerDesktopClass).toBe(providerDesktopClass);
-        expect(source).toContain(`consumerClass = '${reusedClassName}'`);
-        expect(source).toContain(
-          `importedProviderClass = '${reusedClassName}'`
+        expectSerializedMarkerClassName(
+          source,
+          "consumerClass",
+          reusedClassName
+        );
+        expectSerializedMarkerClassName(
+          source,
+          "importedProviderClass",
+          reusedClassName
         );
         expect(countV4PresetArtifacts(source)).toBe(2);
         expect(emittedCss).toMatch(/@media\s+screen and \(min-width: 768px\)/);
@@ -1093,24 +1120,31 @@ if (import.meta.vitest) {
           }
         );
 
-        expect(source).toContain(
-          `importedProviderClass = '${providerTabletClass} ${providerDesktopClass}'`
+        expectSerializedMarkerClassName(
+          source,
+          "importedProviderClass",
+          `${providerTabletClass} ${providerDesktopClass}`
         );
         expect(countV4PresetArtifacts(source)).toBe(2);
-        expect(source).toContain(
-          `consumerDesktopOverride = '${consumerDesktopOverride}'`
+        expectSerializedMarkerClassName(
+          source,
+          "consumerDesktopOverride",
+          consumerDesktopOverride
         );
-        expect(source).toContain(
-          `consumerTabletOverride = '${consumerTabletOverride}'`
+        expectSerializedMarkerClassName(
+          source,
+          "consumerTabletOverride",
+          consumerTabletOverride
         );
-        expect(source).toContain(
-          `mergedSameCondition = '${providerTabletClass} ${consumerDesktopOverride}'`
+        expectSerializedMarkerClassName(
+          source,
+          "mergedSameCondition",
+          `${providerTabletClass} ${consumerDesktopOverride}`
         );
-        expect(source).not.toContain(
-          `mergedSameCondition = '${providerTabletClass} ${providerDesktopClass} ${consumerDesktopOverride}'`
-        );
-        expect(source).toContain(
-          `mergedDifferentCondition = '${providerDesktopClass} ${consumerTabletOverride}'`
+        expectSerializedMarkerClassName(
+          source,
+          "mergedDifferentCondition",
+          `${providerDesktopClass} ${consumerTabletOverride}`
         );
         expect(emittedCss).toMatch(/font-size:\s*18(?:px)?/);
         expect(emittedCss).toMatch(/font-size:\s*24(?:px)?/);

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -110,7 +110,7 @@ function extractedCssFileFilter(filePath: string) {
   return true;
 }
 
-type MinchoBabelOptions = BabelOptions & { jsxCssProp?: boolean };
+type MinchoBabelOptions = BabelOptions;
 
 interface StaticCssEvalSourceResolution {
   id: string;
@@ -1407,11 +1407,15 @@ if (import.meta.vitest) {
     className: string
   ): void {
     expectSourceToContainV4PresetArtifact(source);
-    expect(source).toMatch(
-      new RegExp(
-        `["']?classNameByCache["']?\\s*:\\s*\\{[\\s\\S]*["']${escapeRegExp(className)}["']`
-      )
-    );
+    for (const atomicClassName of splitClassNames(className).filter(
+      (token) => !isSegmentMarker(token)
+    )) {
+      expect(source).toMatch(
+        new RegExp(
+          `["']?classNameByCache["']?\\s*:\\s*\\{[\\s\\S]*["']${escapeRegExp(atomicClassName)}["']`
+        )
+      );
+    }
   }
 
   function createLivePresetSmokeEntrySource(): string {
@@ -2257,11 +2261,17 @@ if (import.meta.vitest) {
     return className.split(/\s+/).filter(Boolean);
   }
 
+  function isSegmentMarker(className: string): boolean {
+    return className.startsWith("__mincho_seg_");
+  }
+
   function expectCssSourceToContainClassNames(
     source: string,
     className: string
   ): void {
-    for (const fragmentClassName of splitClassNames(className)) {
+    for (const fragmentClassName of splitClassNames(className).filter(
+      (token) => !isSegmentMarker(token)
+    )) {
       expect(source).toContain(`.${fragmentClassName}`);
     }
   }
@@ -3826,9 +3836,37 @@ if (import.meta.vitest) {
       const disabledCases: {
         label: string;
         pluginOptions?: MinchoVitePluginOptions;
+        expectedOptions?: MinchoBabelOptions;
       }[] = [
         { label: "default" },
-        { label: "explicit false", pluginOptions: { jsxCssProp: false } }
+        {
+          label: "empty optimize",
+          pluginOptions: { babel: { optimize: {} } },
+          expectedOptions: { optimize: {} }
+        },
+        {
+          label: "inactive optimize",
+          pluginOptions: {
+            babel: { optimize: { defineRulesCxConditions: false } }
+          },
+          expectedOptions: { optimize: { defineRulesCxConditions: false } }
+        },
+        {
+          label: "explicit false",
+          pluginOptions: { jsxCssProp: false },
+          expectedOptions: { jsxCssProp: false }
+        },
+        {
+          label: "explicit false with optimize",
+          pluginOptions: {
+            babel: { optimize: { defineRulesCxConditions: true } },
+            jsxCssProp: false
+          },
+          expectedOptions: {
+            jsxCssProp: false,
+            optimize: { defineRulesCxConditions: true }
+          }
+        }
       ];
 
       try {
@@ -3848,18 +3886,13 @@ if (import.meta.vitest) {
           ).resolves.toBeNull();
         }
 
-        expect(babelTransformSpy).toHaveBeenNthCalledWith(
-          1,
-          fixture.entryPath,
-          undefined
-        );
-        expect(babelTransformSpy).toHaveBeenNthCalledWith(
-          2,
-          fixture.entryPath,
-          {
-            jsxCssProp: false
-          }
-        );
+        for (const [index, disabledCase] of disabledCases.entries()) {
+          expect(babelTransformSpy).toHaveBeenNthCalledWith(
+            index + 1,
+            fixture.entryPath,
+            disabledCase.expectedOptions
+          );
+        }
         expect(fixture.source).toContain(
           '<div className="base" css={{ color: "red" }} />'
         );
@@ -4093,7 +4126,7 @@ if (import.meta.vitest) {
         const fillBlueClassName = extractFillBlueClassName(jsOutput.code);
         expectSourceToContainV4RuntimePresetSeed(jsOutput.code);
         expect(jsOutput.code).not.toContain('background: "blue"');
-        expect(cssOutput.source).toContain(`.${fillBlueClassName}`);
+        expectCssSourceToContainClassNames(cssOutput.source, fillBlueClassName);
         expect(cssOutput.source).toContain("background: blue;");
       } finally {
         await fs.promises.rm(root, { force: true, recursive: true });
@@ -4208,7 +4241,11 @@ if (import.meta.vitest) {
         transformedExtractedCss,
         fillBlueClassName
       );
-      expect(fillBlueClassName.split(/\s+/)).toHaveLength(1);
+      const fillBlueClassNames = splitClassNames(fillBlueClassName);
+      expect(fillBlueClassNames.filter(isSegmentMarker)).toHaveLength(1);
+      expect(
+        fillBlueClassNames.filter((token) => !isSegmentMarker(token))
+      ).toHaveLength(1);
       expect(fillBlueInitializer).not.toMatch(/\bcss\s*\(/);
       expect(
         hasCssCallWithStringProperty(


### PR DESCRIPTION
## Description
This PR introduces a compiler optimization for conditional classname evaluation in `defineRules.cx(...)` calls to reduce runtime overhead.

When the `optimize.defineRulesCxConditions` option is enabled in the Babel/Vite configuration:
1. **Table Lookup Optimization (`tablePlan`)**: For expressions with conditionally combined classes, the compiler evaluates all possible conditional paths at build time and emits a static array lookup table. Key index resolution is performed using bitwise shift operations on boolean conditions (e.g., `_minchoDefineRulesCx[(!(!cond1) << 0) | (!(!cond2) << 1)]`), avoiding expensive string joins and conditional checks at runtime.
2. **Fallback Chain Optimization (`fallbackPlan`)**: If the lookup table is not applicable (e.g., due to dynamic operands or complex nesting), the compiler generates static helper modules or optimized fallback paths to avoid redundant classname evaluations.

This optimization is opt-in and configurable at the plugin level.

## Related Issue
<!-- Related or discussed issues. -->

<!-- Auto generated PR summary. See https://docs.coderabbit.ai/guides/commands/ -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional optimization for conditional `defineRules`/`cx` expressions.
  * Supports conditional, ternary, array, and CSS class combinations through optimized lookup tables or fallback handling.
  * Added configuration support across Babel, integration, and Vite tooling.
  * Improved compiled class merging with segment markers while preserving external class names.
  * Enhanced metadata, caching, and hydration behavior after registrations.

* **Bug Fixes**
  * Improved handling of marker collisions, unknown classes, cache invalidation, and unsupported or unsafe conditional expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional context
- Optimization is controlled via `babel: { optimize: { defineRulesCxConditions: true } }` in the `@mincho-js/vite` or `@mincho-js/babel` configuration.
- The core optimization compiler logic is implemented under `packages/babel/src/defineRulesCxConditions*.ts`.
- Extensive fixture snapshot tests confirm that optimized output generates appropriate lookup tables/fallbacks, and behaves correctly under varying runtime states.

## Checklist
- [x] Run `yarn test` / `yarn test:all`
- [x] Run `yarn lint` / `yarn fix`
- [x] Verified correct compile output across table/fallback code paths
- [x] Added compiler fixture tests under `packages/babel/src/__snapshots__` and unit tests
