### PR TITLE
Fix: TypeScript - Check referenced projects and resolve shared configs

### DIFF
--- a/configs/eslint-config-custom/eslint.config.typescript.d.ts
+++ b/configs/eslint-config-custom/eslint.config.typescript.d.ts
@@ -1,0 +1,6 @@
+import type { Linter } from "eslint";
+import type { InfiniteDepthConfigWithExtends } from "typescript-eslint";
+
+export declare function eslintConfig(
+  userConfigs?: InfiniteDepthConfigWithExtends,
+): Linter.Config[];

--- a/configs/eslint-config-custom/package.json
+++ b/configs/eslint-config-custom/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "exports": {
     "./typescript": {
+      "types": "./eslint.config.typescript.d.ts",
       "import": {
         "default": "./eslint.config.typescript.js"
       }

--- a/examples/react-swc/package.json
+++ b/examples/react-swc/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "vite",
     "build": "vite build",
-    "check": "tsc",
+    "check": "yarn g:check",
     "lint": "eslint . --cache --cache-location .cache/eslint --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "g:coverage": "yarn g:test --coverage",
     "g:lint": "cd $INIT_CWD && yarn run -T eslint . --cache --cache-location .cache/eslint --report-unused-disable-directives --max-warnings 0",
     "g:fix": "cd $INIT_CWD && yarn g:lint --fix",
-    "g:check": "cd $INIT_CWD && yarn run -T tsc --noEmit",
+    "g:check": "cd $INIT_CWD && yarn run -T tsc -b --noEmit",
     "g:check-trace": "cd $INIT_CWD && yarn run -T rimraf tsconfig.tsbuildinfo && yarn run -T tsc -p tsconfig.json --generateTrace traceDir && yarn run -T analyze-trace traceDir"
   },
   "prettier": "prettier-config-custom",

--- a/packages/debug-log/tsconfig.node.json
+++ b/packages/debug-log/tsconfig.node.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig-custom/tsconfig.base.json",
+  "extends": "tsconfig-custom/tsconfig.node.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./.cache/typescript/tsbuildinfo-node",
     "outDir": "./.cache/tsbuild-node"

--- a/packages/debug-log/tsconfig.node.json
+++ b/packages/debug-log/tsconfig.node.json
@@ -1,15 +1,10 @@
 {
   "extends": "tsconfig-custom/tsconfig.node.json",
   "compilerOptions": {
+    "rootDir": ".",
     "tsBuildInfoFile": "./.cache/typescript/tsbuildinfo-node",
     "outDir": "./.cache/tsbuild-node"
   },
-  "include": [
-    "vite.config.ts",
-    "eslint.config.js"
-  ],
-  "exclude": [
-    "dist",
-    "_release"
-  ]
+  "include": ["vite.config.ts", "eslint.config.js"],
+  "exclude": ["dist", "_release"]
 }


### PR DESCRIPTION
## Description

Workspace TypeScript checks currently run `tsc --noEmit` against solution configs with empty `files` lists, so referenced projects can be skipped. Run the shared check in build mode (`tsc -b --noEmit`) and route the React SWC example through it so library, application, and Node configuration projects are checked.

Use the shared Node TypeScript config for debug-log and set its local `rootDir`. Export an explicit declaration for `eslint-config-custom/typescript` so consumers can resolve the config factory's types without traversing its JavaScript implementation and dependencies.

## Related Issue

None.

## Additional context

This PR groups the three TypeScript commits from the `yarn-pnp` stack on top of `main`. It prepares shared config type resolution for the later PnP migration; validation here uses the existing `node-modules` linker.

Validated locally with Node 24.20.0 and Yarn 4.14.1. The PR contains five changed files and three linear commits.

## Checklist

- [x] `yarn install --immutable`
- [x] `yarn build` — 15 tasks passed, including the site and both React examples.
- [x] `yarn fix` — passed without additional changes.
- [x] `yarn sync:check`
- [x] `yarn workspace @mincho-js/debug-log check`
- [x] `yarn check --concurrency=2` — 24 tasks passed.
- [x] `yarn test:all --concurrency=2` — 51 tasks passed (28 cached).
- [x] `git diff origin/main --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Developer Experience**
  - Added TypeScript type support for custom ESLint configuration exports.
  - Improved project-wide type checking by using build-aware validation, including in the React example.
  - Standardized TypeScript project configuration for more consistent compilation behavior.

- **Bug Fixes**
  - Improved compatibility and reliability when consuming the custom ESLint configuration through TypeScript-aware tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->